### PR TITLE
Move mbed-tools to the main requirements.txt

### DIFF
--- a/tools/requirements-ci-build.txt
+++ b/tools/requirements-ci-build.txt
@@ -1,6 +1,5 @@
 # This file contains the requirements needed to run CI builds for Mbed OS.
 # It installs flashing support through the mbed tools packages and also the mbedhtrun test runner.
-mbed-tools
 mbed-host-tests
 mbed-greentea
 mbed-ls

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@ prettytable>=2.0,<3.0; python_version >= '3.6'
 future>=0.18.0,<1.0
 jinja2>=2.11.3
 intelhex>=2.3.0,<3.0.0
+mbed-tools


### PR DESCRIPTION
It's needed for local development (so that people can run mbedtools configure).