### PR TITLE
Fix gdbinit and make debug-xxx not working when executables are created outside of Mbed OS.

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_F429ZI.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F429ZI.cmake
@@ -35,9 +35,7 @@ set(PYOCD_CLOCK_SPEED 4000k)
 
 set(OPENOCD_UPLOAD_ENABLED TRUE)
 set(OPENOCD_CHIP_CONFIG_COMMANDS
-    -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/stm32f429-disco.cfg
-    -c "gdb_memory_map disable" # prevents OpenOCD crash on GDB connect
-    )
+    -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/stm32f429-disco.cfg)
 
 # Config options for STM32Cube
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUCLEO_L452RE_P.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L452RE_P.cmake
@@ -37,7 +37,6 @@ set(PYOCD_CLOCK_SPEED 4000k)
 set(OPENOCD_UPLOAD_ENABLED TRUE)
 set(OPENOCD_CHIP_CONFIG_COMMANDS
     -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/stm32l452re.cfg
-    -c "gdb_memory_map disable" # prevents OpenOCD crash on GDB connect
     )
 
 # Config options for STM32Cube


### PR DESCRIPTION
Also remove "gdb_memory_map disable" command that breaks breakpoints.

