### PR TITLE
Disable mbed semihosting interface in tests, so as not to mess up their timing

### DIFF
--- a/hal/tests/TESTS/mbed_hal/sleep/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep/main.cpp
@@ -228,9 +228,9 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
     ticker_suspend(get_us_ticker_data());
 
 #ifdef DEVICE_SEMIHOST
-	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
-	// cause said call to take several milliseconds, leading to a test failure.
-	mbed_interface_disconnect();
+    // Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+    // cause said call to take several milliseconds, leading to a test failure.
+    mbed_interface_disconnect();
 #endif
 
     us_ticker_init();

--- a/hal/tests/TESTS/mbed_hal/sleep/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep/main.cpp
@@ -227,6 +227,12 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 #endif
     ticker_suspend(get_us_ticker_data());
 
+#ifdef DEVICE_SEMIHOST
+	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+	// cause said call to take several milliseconds, leading to a test failure.
+	mbed_interface_disconnect();
+#endif
+
     us_ticker_init();
 #if DEVICE_LPTICKER
     lp_ticker_init();

--- a/rtos/tests/TESTS/mbed_rtos/MemoryPool/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/MemoryPool/main.cpp
@@ -677,9 +677,9 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
     GREENTEA_SETUP(20, "default_auto");
 
 #ifdef DEVICE_SEMIHOST
-	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
-	// cause said call to take several milliseconds, leading to a test failure.
-	mbed_interface_disconnect();
+    // Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+    // cause said call to take several milliseconds, leading to a test failure.
+    mbed_interface_disconnect();
 #endif
 
     return greentea_test_setup_handler(number_of_cases);

--- a/rtos/tests/TESTS/mbed_rtos/MemoryPool/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/MemoryPool/main.cpp
@@ -675,6 +675,13 @@ Case cases[] = {
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(20, "default_auto");
+
+#ifdef DEVICE_SEMIHOST
+	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+	// cause said call to take several milliseconds, leading to a test failure.
+	mbed_interface_disconnect();
+#endif
+
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/rtos/tests/TESTS/mbed_rtos/mail/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/mail/main.cpp
@@ -480,9 +480,9 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
     GREENTEA_SETUP(10, "default_auto");
 
 #ifdef DEVICE_SEMIHOST
-	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
-	// cause said call to take several milliseconds, leading to a test failure.
-	mbed_interface_disconnect();
+    // Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+    // cause said call to take several milliseconds, leading to a test failure.
+    mbed_interface_disconnect();
 #endif
 
     return verbose_test_setup_handler(number_of_cases);

--- a/rtos/tests/TESTS/mbed_rtos/mail/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/mail/main.cpp
@@ -478,6 +478,13 @@ void test_mail_full()
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(10, "default_auto");
+
+#ifdef DEVICE_SEMIHOST
+	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+	// cause said call to take several milliseconds, leading to a test failure.
+	mbed_interface_disconnect();
+#endif
+
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/rtos/tests/TESTS/mbed_rtos/queue/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/queue/main.cpp
@@ -318,6 +318,13 @@ void test_queue_full()
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(5, "default_auto");
+
+#ifdef DEVICE_SEMIHOST
+	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+	// cause said call to take several milliseconds, leading to a test failure.
+	mbed_interface_disconnect();
+#endif
+
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/rtos/tests/TESTS/mbed_rtos/queue/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/queue/main.cpp
@@ -320,9 +320,9 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
     GREENTEA_SETUP(5, "default_auto");
 
 #ifdef DEVICE_SEMIHOST
-	// Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
-	// cause said call to take several milliseconds, leading to a test failure.
-	mbed_interface_disconnect();
+    // Disconnect semihosting now, because otherwise it will get disconnected on the first sleep call and
+    // cause said call to take several milliseconds, leading to a test failure.
+    mbed_interface_disconnect();
 #endif
 
     return verbose_test_setup_handler(number_of_cases);

--- a/targets/upload_method_cfg/LPC1768.cmake
+++ b/targets/upload_method_cfg/LPC1768.cmake
@@ -26,8 +26,13 @@ set(MBED_RESET_BAUDRATE 115200)
 # Config options for OPENOCD
 # -------------------------------------------------------------
 
+# One note about OpenOCD for LPC1768:
+# If you issue a "monitor reset" command, GDB will think that the program is halted, but it actually will have
+# resumed.  So, issue a "c" command after "monitor reset" to get things synchronized again.
+
 set(OPENOCD_UPLOAD_ENABLED TRUE)
 set(OPENOCD_CHIP_CONFIG_COMMANDS
     -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/lpc1768.cfg
     -c "gdb_memory_map disable" # prevents OpenOCD crash on GDB connect
+	-c "gdb_breakpoint_override hard" # Make sure GDB uses HW breakpoints
     )


### PR DESCRIPTION


### Summary of changes <!-- Required -->

This adds a workaround for #32

#### Impact of changes <!-- Optional -->
Should stop some of the LPC1768 tests from failing!

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
