### PR TITLE
Add Cmake config for Nucleo-F767ZI into upload methods

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_F767ZI.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F767ZI.cmake
@@ -1,0 +1,51 @@
+# Mbed OS upload method configuration file for target NUCLEO_F767ZI.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK - not tested!
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED FALSE)
+set(JLINK_CPU_NAME STM32F767ZI)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32f767zi)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_f7.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)

--- a/targets/upload_method_cfg/NUCLEO_F767ZI.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F767ZI.cmake
@@ -15,10 +15,10 @@ set(UPLOAD_METHOD_DEFAULT MBED)
 set(MBED_UPLOAD_ENABLED TRUE)
 set(MBED_RESET_BAUDRATE 115200)
 
-# Config options for JLINK - not tested!
+# Config options for JLINK
 # -------------------------------------------------------------
 
-set(JLINK_UPLOAD_ENABLED FALSE)
+set(JLINK_UPLOAD_ENABLED TRUE)
 set(JLINK_CPU_NAME STM32F767ZI)
 set(JLINK_CLOCK_SPEED 4000)
 set(JLINK_UPLOAD_INTERFACE SWD)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds the cmake config for upload method of Nucleo-F767ZI
All methods except J-LINK have been tested (only for flash), for that reason is J-Link set to FALSE.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
N/A

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
N/A

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
The list may need to be updated - https://github.com/mbed-ce/mbed-os/wiki/Mbed-CE-Officially-Supported-Targets-&-Features

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

#### Console reports:
<details><summary>ST-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.294] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-08T18:17:00 INFO common.c: F76xxx: 512 KiB SRAM, 2048 KiB flash in at least 2 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: 264d2cb4bbcdc45af3a53325e5a5e518, stlink checksum: 0x004c7d02
[build] 2022-09-08T18:17:00 INFO common.c: Attempting to write 50552 (0xc578) bytes to stm32 address: 134217728 (0x8000000)
[build] EraseFlash - Sector:0x0 Size:0x8000 2022-09-08T18:17:01 INFO common.c: Flash page at addr: 0x08000000 erased
[build] EraseFlash - Sector:0x1 Size:0x8000 2022-09-08T18:17:01 INFO common.c: Flash page at addr: 0x08008000 erased
[build] 2022-09-08T18:17:01 INFO common.c: Finished erasing 2 pages of 32768 (0x8000) bytes
[build] 2022-09-08T18:17:01 INFO common.c: Starting Flash write for F2/F4/F7/L4
[build] 2022-09-08T18:17:01 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-08T18:17:01 INFO flash_loader.c: Clear DFSR
[build] 2022-09-08T18:17:01 INFO flash_loader.c: Clear CFSR
[build] 2022-09-08T18:17:01 INFO flash_loader.c: Clear HFSR
[build] 2022-09-08T18:17:01 INFO common.c: enabling 32-bit flash writes
[build] 2022-09-08T18:17:02 INFO common.c: Starting verification of write complete
[build] 2022-09-08T18:17:02 INFO common.c: Flash written and verified! jolly good!
[build] Build finished with exit code 0
```
</details>

<details><summary>J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.136] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 773941101
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32F767ZI" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] Can not attach to CPU. Trying connect under reset.
[build] InitTarget() end
[build] Found SW-DP with ID 0x9BA02477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x74770001)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FD000
[build] CPUID register: 0x411FC270. Implementer code: 0x41 (ARM)
[build] Found Cortex-M7 r1p0, Little endian.
[build] FPUnit: 8 code (BP) slots and 0 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FD000
[build] [0][0]: E00FE000 CID B105100D PID 000BB4C8 ROM Table
[build] ROMTbl[1] @ E00FE000
[build] [1][0]: E00FF000 CID B105100D PID 000BB4C7 ROM Table
[build] ROMTbl[2] @ E00FF000
[build] [2][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [2][1]: E0001000 CID B105E00D PID 000BB002 DWT
[build] [2][2]: E0002000 CID B105E00D PID 000BB00E FPB-M7
[build] [2][3]: E0000000 CID B105E00D PID 000BB001 ITM
[build] [1][1]: E0041000 CID B105900D PID 001BB975 ETM-M7
[build] [0][1]: E0040000 CID B105900D PID 000BB9A9 TPIU-M7
[build] Cache: Separate I- and D-cache.
[build] I-Cache L1: 16 KB, 256 Sets, 32 Bytes/Line, 2-Way
[build] D-Cache L1: 16 KB, 128 Sets, 32 Bytes/Line, 4-Way
[build] Cortex-M7 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>

<details><summary>STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.436] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 0671FF504955657867121730
[build] ST-LINK FW  : V2J40M27
[build] Board       : NUCLEO-F767ZI
[build] Voltage     : 3.24V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x451
[build] Revision ID : Rev Z
[build] Device name : STM32F76x/STM32F77x
[build] Flash size  : 2 MBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M7
[build] BL Version  : --
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 49.37 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 1]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.053
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 8.146] Flashing main with pyOCD...
[build] 0001699 I Target type is stm32f767zi [board]
[build] 0001716 I DP IDR = 0x5ba02477 (v2 rev5) [dap]
[build] 0001748 I AHB-AP#0 IDR = 0x74770001 (AHB-AP var0 rev7) [ap]
[build] 0001761 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00fd000 (designer=020:ST part=451) [rom_table]
[build] 0001766 I [0]<e00fe000:ROM class=1 designer=43b:Arm part=4c8> [rom_table]
[build] 0001767 I   AHB-AP#0 Class 0x1 ROM table #1 @ 0xe00fe000 (designer=43b:Arm part=4c8) [rom_table]
[build] 0001771 I   [0]<e00ff000:ROM class=1 designer=43b:Arm part=4c7> [rom_table]
[build] 0001771 I     AHB-AP#0 Class 0x1 ROM table #2 @ 0xe00ff000 (designer=43b:Arm part=4c7) [rom_table]
[build] 0001775 I     [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0001778 I     [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0001780 I     [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=00e> [rom_table]
[build] 0001783 I     [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0001787 I   [1]<e0041000:ETM M7 class=9 designer=43b:Arm part=975 devtype=13 archid=4a13 devid=0:0:0> [rom_table]
[build] 0001791 I [1]<e0040000:TPIU M7 class=9 designer=43b:Arm part=9a9 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0001798 I CPU core #0 is Cortex-M7 r1p0 [cortex_m]
[build] 0001802 I FPU present: FPv5-D16-M [cortex_m]
[build] 0001808 I 4 hardware watchpoints [dwt]
[build] 0001819 I 8 hardware breakpoints, 1 literal comparators [fpb]
[build] 0001846 I Single bank configuration detected [FLASH_OPTCR=0xffffaafd]. [target_STM32F767xx]
[build] 0001851 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0002869 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 51200 bytes (50 pages) at 49.35 kB/s [loader]
[build] Build finished with exit code 0
```
</details>

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.425] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 2000 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.243073
[build] Info : stm32f7x.cpu: hardware has 8 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32f7x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08005844 msp: 0x20080000
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] ** Programming Started **
[build] Info : device id = 0x10016451
[build] Info : flash size = 2048 kbytes
[build] Info : Single Bank 2048 kiB STM32F76x/77x found
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

    

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@multiplemonomials 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
