### PR TITLE
Add Cmake config for Nucleo-F446RE into upload methods

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_F446RE.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F446RE.cmake
@@ -1,0 +1,56 @@
+# Mbed OS upload method configuration file for target NUCLEO_F446RE.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32F446RE)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+# If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. 
+# Type "pyocd pack show" to console and you will see a list of already installed packages.
+# If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32f4".
+# Then just type "pyocd pack find STM32f4" or "pyocd pack find STM32f446" or "pyocd pack find STM32f446RE" and you will see the part name of your target.
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32F446RETx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_f4.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+# It is working, but for some reason is no much stable and I do not know why!
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds the cmake config for upload method of Nucleo-F446RE
All methods have been tested (only for flash), but **for some reason ST-link method is not stable**, for more see logs below.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
N/A

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
N/A

### Documentation <!-- Required -->
* The list may need to be updated - https://github.com/mbed-ce/mbed-os/wiki/Mbed-CE-Officially-Supported-Targets-&-Features.
* **For pyOCD is necessary to manually install a keil package**. It is descripted directly in Cmake config for now.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

<details><summary>STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.519] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 066CFF525750877267225142
[build] ST-LINK FW  : V2J40M27
[build] Board       : NUCLEO-F446RE
[build] Voltage     : 3.27V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x421
[build] Revision ID : Rev A
[build] Device name : STM32F446xx
[build] Flash size  : 512 KBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M4
[build] BL Version  : --
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 41.20 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 2]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.133
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 3.588] Flashing main with pyOCD...
[build] 0002084 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0002114 I Target type is stm32f446retx [board]
[build] 0002276 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002314 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002318 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=020:ST part=411) [rom_table]
[build] 0002319 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002320 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002321 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
[build] 0002322 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002324 I [4]<e0040000:TPIU M4 class=9 designer=43b:Arm part=9a1 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0002325 I [5]<e0041000:ETM M4 class=9 designer=43b:Arm part=925 devtype=13 archid=0000 devid=0:0:0> [rom_table]
[build] 0002327 I CPU core #0 is Cortex-M4 r0p1 [cortex_m]
[build] 0002328 I FPU present: FPv4-SP-D16-M [cortex_m]
[build] 0002329 I 4 hardware watchpoints [dwt]
[build] 0002332 I 6 hardware breakpoints, 4 literal comparators [fpb]
[build] 0002338 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0003200 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 43008 bytes (42 pages) at 48.76 kB/s [loader]
[build] Build finished with exit code 0
```
</details>

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.478] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 2000 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.265833
[build] Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32f4x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08004ad8 msp: 0x20020000
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] ** Programming Started **
[build] Info : device id = 0x10006421
[build] Info : flash size = 512 kbytes
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

<details><summary>ST-link</summary>

```python
First run:
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.535] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-08T22:28:36 INFO common.c: F446: 128 KiB SRAM, 512 KiB flash in at least 128 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: 612f4b99d602c6d54624b5f950c3da, stlink checksum: 0x003f30e9
[build] 2022-09-08T22:28:36 INFO common.c: Attempting to write 42180 (0xa4c4) bytes to stm32 address: 134217728 (0x8000000)
[build] EraseFlash - Sector:0x0 Size:0x4000 2022-09-08T22:28:36 INFO common.c: Flash page at addr: 0x08000000 erased
[build] EraseFlash - Sector:0x1 Size:0x4000 2022-09-08T22:28:36 INFO common.c: Flash page at addr: 0x08004000 erased
[build] EraseFlash - Sector:0x2 Size:0x4000 2022-09-08T22:28:37 INFO common.c: Flash page at addr: 0x08008000 erased
[build] 2022-09-08T22:28:37 INFO common.c: Finished erasing 3 pages of 16384 (0x4000) bytes
[build] 2022-09-08T22:28:37 INFO common.c: Starting Flash write for F2/F4/F7/L4
[build] 2022-09-08T22:28:37 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-08T22:28:37 INFO flash_loader.c: Clear DFSR
[build] 2022-09-08T22:28:37 INFO flash_loader.c: Clear CFSR
[build] 2022-09-08T22:28:37 INFO flash_loader.c: Clear HFSR
[build] 2022-09-08T22:28:37 INFO common.c: enabling 32-bit flash writes
[build] 2022-09-08T22:28:37 INFO common.c: Starting verification of write complete
[build] 2022-09-08T22:28:38 INFO common.c: Flash written and verified! jolly good!
[build] Build finished with exit code 0

Second run (failed):
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.228] Flashing main with stlink...
[build] FAILED: CMakeFiles/flash-main C:/Users/User/MbedCE_Test/build/CMakeFiles/flash-main 
[build] cmd.exe /C "cd /D C:\Users\User\MbedCE_Test\build && "C:\Program Files\stlink-1.7.0-i686-w64-mingw32\bin\st-flash.exe" --reset write C:/Users/User/MbedCE_Test/build/main.bin 0x8000000"
[build] st-flash 1.7.0
[build] 2022-09-08T22:29:50 INFO common.c: F446: 128 KiB SRAM, 21120 KiB flash in at least 128 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: 612f4b99d602c6d54624b5f950c3da, stlink checksum: 0x003f30e9
[build] 2022-09-08T22:29:50 INFO common.c: Attempting to write 42180 (0xa4c4) bytes to stm32 address: 134217728 (0x8000000)
[build] EraseFlash - Sector:0x0 Size:0x4000 2022-09-08T22:29:51 INFO common.c: Flash page at addr: 0x08000000 erased
[build] EraseFlash - Sector:0x1 Size:0x4000 2022-09-08T22:29:51 INFO common.c: Flash page at addr: 0x08004000 erased
[build] EraseFlash - Sector:0x2 Size:0x4000 2022-09-08T22:29:51 INFO common.c: Flash page at addr: 0x08008000 erased
[build] 2022-09-08T22:29:51 INFO common.c: Finished erasing 3 pages of 16384 (0x4000) bytes
[build] 2022-09-08T22:29:51 INFO common.c: Starting Flash write for F2/F4/F7/L4
[build] 2022-09-08T22:29:51 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-08T22:29:51 INFO flash_loader.c: Clear DFSR
[build] 2022-09-08T22:29:51 INFO common.c: enabling 32-bit flash writes
[build] 2022-09-08T22:29:52 ERROR flash_loader.c: Flash loader run error
[build] 2022-09-08T22:29:52 WARN flash_loader.c: Loader state: R2 0x0 R15 0x0
[build] 2022-09-08T22:29:52 WARN flash_loader.c: MCU state: DHCSR 0x1090009 DFSR 0x0 CFSR 0x1 HFSR 0x40000000
[build] 2022-09-08T22:29:52 ERROR common.c: stlink_flash_loader_run(0x8000000) failed! == -1
[build] stlink_fwrite_flash() == -1
[build] ninja: build stopped: subcommand failed.
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main -- exited with code: 1 and signal: null
[build] Build finished with exit code 1
```
</details>

<details><summary>J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 0.810] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 773614234
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32F446RE" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] InitTarget() end
[build] Found SW-DP with ID 0x4BA01477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x24770011)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FF000
[build] CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
[build] Found Cortex-M4 r0p1, Little endian.
[build] FPUnit: 6 code (BP) slots and 2 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FF000
[build] [0][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [0][1]: E0001000 CID B105E00D PID 003BB002 DWT
[build] [0][2]: E0002000 CID B105E00D PID 002BB003 FPB
[build] [0][3]: E0000000 CID B105E00D PID 003BB001 ITM
[build] [0][4]: E0040000 CID B105900D PID 000BB9A1 TPIU
[build] [0][5]: E0041000 CID B105900D PID 000BB925 ETM
[build] Cortex-M4 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@multiplemonomials 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
