### PR TITLE
Fix event queue being stuck in non-RTOS mode, causing all sorts of weird behavior

### DIFF
--- a/connectivity/FEATURE_BLE/source/cordio/TESTS/cordio_hci/driver/CMakeLists.txt
+++ b/connectivity/FEATURE_BLE/source/cordio/TESTS/cordio_hci/driver/CMakeLists.txt
@@ -8,5 +8,4 @@ mbed_greentea_add_test(
         main.cpp
     TEST_REQUIRED_LIBS
         mbed-ble
-        mbed-events
 )

--- a/connectivity/libraries/ppp/CMakeLists.txt
+++ b/connectivity/libraries/ppp/CMakeLists.txt
@@ -55,7 +55,6 @@ target_compile_definitions(mbed-ppp
 
 target_link_libraries(mbed-ppp
     PUBLIC
-        mbed-events
         mbed-netsocket-api
     PRIVATE
         mbed-rtos-flags

--- a/connectivity/lorawan/CMakeLists.txt
+++ b/connectivity/lorawan/CMakeLists.txt
@@ -35,6 +35,5 @@ target_compile_definitions(mbed-lorawan
 
 target_link_libraries(mbed-lorawan
     PUBLIC
-        mbed-events
         mbed-mbedtls
 )

--- a/connectivity/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
+++ b/connectivity/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(mbed-nanostack-hal_mbed_cmsis_rtos
         mbed-core-flags
         mbed-randlib
         mbed-nanostack-sal_stack-event_loop
-        mbed-events
         mbed-nanostack-libservice
         mbed-nanostack-sal_stack
     PRIVATE

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -53,7 +53,6 @@ target_link_libraries(mbed-netsocket-api
     PUBLIC
         mbed-core-flags
         mbed-mbedtls
-        mbed-events
 )
 
 add_library(mbed-netsocket INTERFACE)

--- a/connectivity/nfc/CMakeLists.txt
+++ b/connectivity/nfc/CMakeLists.txt
@@ -47,8 +47,3 @@ target_compile_definitions(mbed-nfc
     PUBLIC
         MBED_CONF_NFC_PRESENT=1
 )
-
-target_link_libraries(mbed-nfc
-    PUBLIC
-        mbed-events
-)

--- a/events/CMakeLists.txt
+++ b/events/CMakeLists.txt
@@ -9,31 +9,26 @@ if(MBED_ENABLE_OS_INTERNAL_TESTS)
     endif()
 endif()
 
-add_library(mbed-events STATIC EXCLUDE_FROM_ALL)
-
-target_include_directories(mbed-events
-    PUBLIC
+# Note: The event queue library gets a different implementation when the RTOS is or is not included.
+# So, we add it to the core Mbed lib so that it will be built once for each Mbed version.
+target_include_directories(mbed-core-flags
+    INTERFACE
         .
         ./include
         ./include/events
         ./include/events/internal
 )
 
-target_sources(mbed-events
-    PRIVATE
+target_compile_definitions(mbed-core-flags
+    INTERFACE
+        MBED_CONF_EVENTS_PRESENT=1
+)
+
+target_sources(mbed-core-sources
+    INTERFACE
         source/EventQueue.cpp
         source/equeue.c
         source/equeue_mbed.cpp
         source/equeue_posix.c
         source/mbed_shared_queues.cpp
-)
-
-target_compile_definitions(mbed-events
-    PUBLIC
-        MBED_CONF_EVENTS_PRESENT=1
-)
-
-target_link_libraries(mbed-events
-    PUBLIC
-        mbed-core-flags
 )

--- a/events/tests/TESTS/events/equeue/CMakeLists.txt
+++ b/events/tests/TESTS/events/equeue/CMakeLists.txt
@@ -15,6 +15,4 @@ mbed_greentea_add_test(
         ${TEST_TARGET}
     TEST_SOURCES
         main.cpp
-    TEST_REQUIRED_LIBS
-        mbed-events
 )

--- a/events/tests/TESTS/events/queue/CMakeLists.txt
+++ b/events/tests/TESTS/events/queue/CMakeLists.txt
@@ -15,6 +15,4 @@ mbed_greentea_add_test(
         ${TEST_TARGET}
     TEST_SOURCES
         main.cpp
-    TEST_REQUIRED_LIBS
-        mbed-events
 )

--- a/events/tests/TESTS/events/timing/CMakeLists.txt
+++ b/events/tests/TESTS/events/timing/CMakeLists.txt
@@ -15,6 +15,4 @@ mbed_greentea_add_test(
         ${TEST_TARGET}
     TEST_SOURCES
         main.cpp
-    TEST_REQUIRED_LIBS
-        mbed-events
 )


### PR DESCRIPTION
### Summary of changes <!-- Required -->

With the way the build system is set up now, it requires any code containing
```cpp
#ifdef MBED_CONF_RTOS_PRESENT
```
statements to be included in the mbed-core-sources CMake target.  This target gets built twice: once for baremetal, and once for RTOS.  So that way, the define actually gets triggered.  Other code is only built once, usually against the non-RTOS headers, so the define never gets triggered.  In most cases, this works, because individual libraries usually don't care if the RTOS is enabled.  I tried to clean up all the code that didn't comply with this (see #26).  But, as it turns out, mbed-events is not compatible with my scheme and uses RTOS defines.

The event queue library seems to have two different implementations: one for singlethreaded use, and one for multithreaded.  The multithreaded one has extra functionality: event queues can be used from multiple threads, and the global event queue has  its own thread to execute callbacks.  However, because of how the build was set up, only the non-RTOS version was being built, and it was being linked against the RTOS versions of everything else.  So, that extra functionality was not getting activated.

This issue caused a number of weird effects in code.  First of all, any user code that uses the Mbed event queues from multiple threads would probably get messed up.  Second, Mbed functions that try to use the global event queue (`mbed_shared_queue()`) to deliver callbacks, would never get those callbacks delivered.  This affects the NetworkStack getaddrinfo_async and gethostbyname_async functions, as well as the logic that the STM32 ETH MAC driver uses to check link status.  So, STM32 processors could not bring up an ethernet link (this is the bug I was initially trying to track down).

#### Impact of changes <!-- Optional -->
- `NetworkStack::getaddrinfo_async()` works again
- `NetworkStack::gethostbyname_async()` works again
- Ethernet works again on STM32 devices
- Event queues can be used from multiple threads again

Also, the mbed-events target no longer exists, and is part of Mbed OS.
#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JohnK1987 

----------------------------------------------------------------------------------------------------------------
