### PR TITLE
Change linker script handling logic to use only one linker script target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,9 @@ if(NOT MBED_IS_NATIVE_BUILD)
     # Create a distro for the microcontroller cmake target, ensuring its sources are only compiled once
     mbed_create_distro(${MBED_TARGET_CMAKE_NAME}-lib ${MBED_TARGET_CMAKE_NAME} mbed-core-flags)
 
+    # Set up the linker script and hook it up to the MCU cmake target
+    mbed_setup_linker_script(${MBED_TARGET_CMAKE_NAME}-lib)
+
     # Now make the Mbed OS code depend on the target, ensuring everything has access to the uC's flags and objects.
     target_link_libraries(mbed-core-flags INTERFACE ${MBED_TARGET_CMAKE_NAME}-lib)
 

--- a/tools/cmake/mbed_create_distro.cmake
+++ b/tools/cmake/mbed_create_distro.cmake
@@ -48,6 +48,9 @@ function(mbed_create_distro NAME) # ARGN: modules...
 
 		get_property(CURR_MODULE_TYPE TARGET ${CURR_MODULE} PROPERTY TYPE)
 
+		# Pass up mbed linker script property, which is used by the top level code to select the linker script
+		copy_append_property(INTERFACE_MBED_LINKER_SCRIPT ${CURR_MODULE} ${NAME})
+
 		if("${CURR_MODULE_TYPE}" STREQUAL "STATIC_LIBRARY")
 			# Don't need to do anything other than linking it
 			target_link_libraries(${NAME} PUBLIC ${CURR_MODULE})

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -2,53 +2,88 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
-# Preprocesses and sets the linker script for an Mbed target.
-# Called once for each MCU target in the build system.
+# Sets the linker script for an Mbed target.
+# Called once by the buildscripts for each MCU target in the build system.
+# Note: Linker script path may be absolute or relative.  If relative, it will be interpreted relative to the current source dir.
 #
 function(mbed_set_linker_script input_target raw_linker_script_path)
 
-    set(LINKER_SCRIPT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${input_target}.link_script.ld)
+    # Make sure that we have an absolute path so that it can be used from a different directory
+    get_filename_component(raw_linker_script_path ${raw_linker_script_path} ABSOLUTE)
+
+    # Use a custom property to store the linker script.  This property will be read and passed up by mbed_create_distro()
+    set_property(TARGET ${input_target} PROPERTY INTERFACE_MBED_LINKER_SCRIPT ${raw_linker_script_path})
+
+endfunction(mbed_set_linker_script)
+
+
+#
+# Set up the linker script for the top-level Mbed MCU target.
+# If needed, this also creates another target to preprocess the linker script.
+#
+function(mbed_setup_linker_script mbed_mcu_target)
+
+    # Find the path to the desired linker script
+    get_property(RAW_LINKER_SCRIPT_PATHS TARGET ${mbed_mcu_target} PROPERTY INTERFACE_MBED_LINKER_SCRIPT)
+
+    # Check if two (or more) different linker scripts got used
+    list(REMOVE_DUPLICATES RAW_LINKER_SCRIPT_PATHS)
+    list(LENGTH RAW_LINKER_SCRIPT_PATHS NUM_RAW_LINKER_SCRIPT_PATHS)
+    if(NUM_RAW_LINKER_SCRIPT_PATHS GREATER 1)
+        message(FATAL_ERROR "More than one linker script selected for the current MCU target.  Perhaps multiple targets with linker scripts set were linked together?")
+    endif()
+
+    # Make sure the linker script exists
+    if(NOT EXISTS "${RAW_LINKER_SCRIPT_PATHS}")
+        message(FATAL_ERROR "Selected linker script ${RAW_LINKER_SCRIPT_PATHS} does not exist!")
+    endif()
+
+    set(LINKER_SCRIPT_PATH ${CMAKE_BINARY_DIR}/${MBED_TARGET_CMAKE_NAME}.link_script.ld)
+
     # To avoid path limits on Windows, we create a "response file" and set the path to it as a
     # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
     # so it can expand any macro definitions in the linker script.
-    get_property(_linker_preprocess_definitions GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
+    get_property(linker_defs_response_file GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
     if(MBED_TOOLCHAIN STREQUAL "GCC_ARM")
+
+        get_filename_component(RAW_LINKER_SCRIPT_NAME ${RAW_LINKER_SCRIPT_PATHS} NAME)
+        get_filename_component(LINKER_SCRIPT_NAME ${LINKER_SCRIPT_PATH} NAME)
         add_custom_command(
             OUTPUT
                 ${LINKER_SCRIPT_PATH}
             PRE_LINK
             COMMAND
-                ${CMAKE_C_COMPILER} ${_linker_preprocess_definitions}
+                ${CMAKE_C_COMPILER} @${linker_defs_response_file}
                 -E -x assembler-with-cpp
-                -P ${raw_linker_script_path}
+                -P ${RAW_LINKER_SCRIPT_PATHS}
                 -o ${LINKER_SCRIPT_PATH}
             DEPENDS
-                ${raw_linker_script_path}
+                ${RAW_LINKER_SCRIPT_PATHS}
+                ${linker_defs_response_file}
             WORKING_DIRECTORY
                 ${CMAKE_CURRENT_SOURCE_DIR}
             COMMENT
-                "Link line:"
+                "Preprocess linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
             VERBATIM
         )
-        # CMake will not let us add PRE_LINK commands to INTERFACE targets, and input_target could
-        # be an INTERFACE target.
-        # To get around this we create an intermediate custom target depending on the preprocessed
-        # linker script output by CPP. We add this custom target as a dependency of input_target.
-        # This ensures CMake runs our custom command to preprocess the linker script before trying
-        # to build input_target.
-        set(LinkerScriptTarget ${input_target}LinkerScript)
-        add_custom_target(${LinkerScriptTarget} DEPENDS ${LINKER_SCRIPT_PATH} VERBATIM)
-        add_dependencies(${input_target} ${LinkerScriptTarget})
-        target_link_options(${input_target}
+
+        # The job to create the linker script gets attached to the mbed-linker-script target,
+        # which is then added as a dependency of the MCU target.  This ensures the linker script will exist
+        # by the time we need it.
+        add_custom_target(mbed-linker-script DEPENDS ${LINKER_SCRIPT_PATH} VERBATIM)
+        add_dependencies(${mbed_mcu_target} mbed-linker-script)
+
+        # Add linker flags to the MCU target to pick up the preprocessed linker script
+        target_link_options(${mbed_mcu_target}
             INTERFACE
                 "-T" "${LINKER_SCRIPT_PATH}"
         )
     elseif(MBED_TOOLCHAIN STREQUAL "ARM")
-        target_link_options(${input_target}
+        target_link_options(${mbed_mcu_target}
             INTERFACE
                 "--scatter=${raw_linker_script_path}"
                 "--predefine=${_linker_preprocess_definitions}"
                 "--map"
         )
     endif()
-endfunction()
+endfunction(mbed_setup_linker_script)

--- a/tools/cmake/mbed_toolchain.cmake
+++ b/tools/cmake/mbed_toolchain.cmake
@@ -12,7 +12,7 @@ function(mbed_generate_options_for_linker target output_response_file_path)
         "$<$<BOOL:${_compile_definitions}>:'-D$<JOIN:${_compile_definitions},' '-D>'>"
     )
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt" CONTENT "${_compile_definitions}\n")
-    set(${output_response_file_path} @${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)
+    set(${output_response_file_path} ${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)
 endfunction()
 
 # Backward compatibility with older CMake which uses CMAKE_SYSTEM_PROCESSOR to


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This change rethinks how Mbed OS handles linker scripts with the GCC compiler, resolving #8.  Before, it would create one CMake target for each possible linker script.  Then, which of these got linked in to the final executable would determine which linker script was actually built and used.  This worked, but cluttered up the build with 50+ targets when only one was needed at any one time.

The new code works a bit differently.  Instead of actually creating a linker script target, `mbed_set_linker_script()` just sets an interface property on the MCU's CMake target.  This property is passed up to the top level by mbed_create_distro(), where it is then read out and used to set up one single `mbed-linker-script` target that points to the linker script we want to use.  This target is created with the correct dependencies so that it gets rebuilt when the #defines or the linker script change, but no other time.

#### Impact of changes <!-- Optional -->
Removal of the mbed-xxxLinkerScript targets

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@JohnK1987
----------------------------------------------------------------------------------------------------------------
