### PR TITLE
Add Cmake config for Nucleo-L432KC and Nucleo-H743ZI2 into upload methods

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
+++ b/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
@@ -3,7 +3,7 @@
 # include app.cmake and where you add mbed os as a subdirectory.
 
 # Notes:
-# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link, but it is not possible with ST-link V3! I will try regular J-link in the future.
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link, but it is not possible to do that with ST-link V3! I will try regular J-link in the future.
 # 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
 # - If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32h7" (take long time).Then just type "pyocd pack find STM32h7" or "pyocd pack find STM32h743" and you will see the part name of your target.
 

--- a/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
+++ b/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
@@ -1,0 +1,54 @@
+# Mbed OS upload method configuration file for target NUCLEO_H743ZI.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link, but it is not possible with ST-link V3! I will try regular J-link in the future.
+# 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
+# - If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32h7" (take long time).Then just type "pyocd pack find STM32h7" or "pyocd pack find STM32h743" and you will see the part name of your target.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED FALSE)
+set(JLINK_CPU_NAME STM32H743ZI)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32H743ZITx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_h743zi.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/NUCLEO_L432KC.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L432KC.cmake
@@ -6,7 +6,7 @@
 # 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
 # 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
 # - If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32l4".Then just type "pyocd pack find STM32l4" or "pyocd pack find STM32l432" and you will see the part name of your target.
-# 3. ST-link option is false on default, because it is not usable on this target. There is probably a bug in ST-link (stlink.org 1.7.0) and the reset after flash is not performed.
+# 3. The STLINK upload method is disabled by default, because it is not usable on this target. There is probably a bug in ST-link (stlink.org 1.7.0) and the reset after flash is not performed.
 
 # General config parameters
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUCLEO_L432KC.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L432KC.cmake
@@ -1,0 +1,55 @@
+# Mbed OS upload method configuration file for target NUCLEO_L432KC.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
+# - If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32l4".Then just type "pyocd pack find STM32l4" or "pyocd pack find STM32l432" and you will see the part name of your target.
+# 3. ST-link option is false on default, because it is not usable on this target. There is probably a bug in ST-link (stlink.org 1.7.0) and the reset after flash is not performed.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L432KC)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32l432kc)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+-f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_l4.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED FALSE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds the cmake config for upload method of Nucleo-L432KC adn Nucleo-H743ZI2.
All methods have been tested (only for flash) for both boards, but: 
* ST-link method is not recommended to use (is disabled) for L432.There seems to be a bug in ST-link (stlink.org release 1.7.0) and because of this the board is not able to restart it self after binary upload.Maybe there is also a small difference between st-link of Nuclelo-32 and Nucleo-64.
* J-link is not possible to use for Nucleo-H743ZI2, because St-link V3  is not supported in app St-link to J-link convertor (STLinkReflash).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
N/A
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
N/A
### Documentation <!-- Required -->
N/A
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
#### L432KC:

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.259] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 500 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.254665
[build] Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32l4x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 500 kHz, using 480 kHz
[build] Info : Unable to match requested speed 500 kHz, using 480 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08005218 msp: 0x20010000
[build] ** Programming Started **
[build] Info : device idcode = 0x10016435 (STM32L43/L44xx - Rev Z : 0x1001)
[build] Info : flash size = 256kbytes
[build] Info : flash mode : single-bank
[build] Warn : Adding extra erase range, 0x0800a3a0 .. 0x0800a7ff
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 500 kHz, using 480 kHz
[build] Info : Unable to match requested speed 500 kHz, using 480 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 8.886] Flashing main with pyOCD...
[build] 0002470 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0002538 I Target type is stm32l432kcux [board]
[build] 0002686 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002778 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002781 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=020:ST part=435) [rom_table]
[build] 0002783 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002784 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002785 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
[build] 0002785 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002785 I [4]<e0040000:TPIU M4 class=9 designer=43b:Arm part=9a1 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0002789 I [5]<e0041000:ETM M4 class=9 designer=43b:Arm part=925 devtype=13 archid=0000 devid=0:0:0> [rom_table]
[build] 0002791 I CPU core #0 is Cortex-M4 r0p1 [cortex_m]
[build] 0002792 I FPU present: FPv4-SP-D16-M [cortex_m]
[build] 0002793 I 4 hardware watchpoints [dwt]
[build] 0002796 I 6 hardware breakpoints, 4 literal comparators [fpb]
[build] 0002803 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0003602 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 41984 bytes (41 pages) at 51.70 kB/s [loader]
[build] Build finished with exit code 0
```
</details>

<details><summary>STM32cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.203] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 066FFF303032424257021525
[build] ST-LINK FW  : V2J40M27
[build] Board       : NUCLEO-L432KC
[build] Voltage     : 3.26V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x435
[build] Revision ID : Rev Z
[build] Device name : STM32L43xxx/STM32L44xxx
[build] Flash size  : 256 KBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M4
[build] BL Version  : --
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 40.91 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 20]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.482
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>

<details><summary>J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 4.571] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 777712507
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32L432KC" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] Found SW-DP with ID 0x4BA01477
[build] Found SW-DP with ID 0x4BA01477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x24770011)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FF000
[build] CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
[build] Found Cortex-M4 r0p1, Little endian.
[build] FPUnit: 6 code (BP) slots and 2 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FF000
[build] [0][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [0][1]: E0001000 CID B105E00D PID 003BB002 DWT
[build] [0][2]: E0002000 CID B105E00D PID 002BB003 FPB
[build] [0][3]: E0000000 CID B105E00D PID 003BB001 ITM
[build] [0][4]: E0040000 CID B105900D PID 000BB9A1 TPIU
[build] [0][5]: E0041000 CID B105900D PID 000BB925 ETM
[build] Cortex-M4 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] Build finished with exit code 0
```
</details>

#### H743ZI32:

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/Odiin/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.306] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 1800 kHz
[build] Info : STLINK V3J10M3 (API v3) VID:PID 0483:374E
[build] Info : Target voltage: 3.302400
[build] Info : stm32h7x.cpu0: hardware has 8 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32h7x.cpu0 on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x0800559c msp: 0x24080000
[build] Info : Unable to match requested speed 4000 kHz, using 3300 kHz
[build] Info : Unable to match requested speed 4000 kHz, using 3300 kHz
[build] ** Programming Started **
[build] Info : Device: STM32H74x/75x
[build] Info : flash size probed value 2048
[build] Info : STM32H7 flash has dual banks
[build] Info : Bank (0) size is 1024 kb, base address is 0x08000000
[build] Warn : Adding extra erase range, 0x0800d9e0 .. 0x0801ffff
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/Odiin/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 3.351] Flashing main with pyOCD...
[build] 0001962 W Overlapping memory regions in file C:\Users\Odiin\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0001998 I Target type is stm32h743zitx [board]
[build] 0002222 I DP IDR = 0x6ba02477 (v2 rev6) [dap]
[build] 0002353 I AHB-AP#0 IDR = 0x84770001 (AHB-AP var0 rev8) [ap]
[build] 0002355 I AHB-AP#1 IDR = 0x84770001 (AHB-AP var0 rev8) [ap]
[build] 0002356 I APB-AP#2 IDR = 0x54770002 (APB-AP var0 rev5) [ap]
[build] 0002358 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00fe000 (designer=020:ST part=450) [rom_table]
[build] 0002360 I [0]<e00ff000:ROM class=1 designer=43b:Arm part=4c7> [rom_table]
[build] 0002360 I   AHB-AP#0 Class 0x1 ROM table #1 @ 0xe00ff000 (designer=43b:Arm part=4c7) [rom_table]
[build] 0002361 I   [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002362 I   [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002362 I   [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=00e> [rom_table]
[build] 0002363 I   [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002364 I [1]<e0041000:ETM M7 class=9 designer=43b:Arm part=975 devtype=13 archid=4a13 devid=0:0:0> [rom_table]
[build] 0002365 I [2]<e0043000:CTI class=9 designer=43b:Arm part=906 devtype=14 archid=0000 devid=40800:0:0> [rom_table]
[build] 0002365 I APB-AP#2 Class 0x1 ROM table #0 @ 0xe00e0000 (designer=020:ST part=450) [rom_table]
[build] 0002367 I [2]<e00e3000:SWO CS-400 class=9 designer=43b:Arm part=914 devtype=11 archid=0000 devid=ea0:0:0> [rom_table]
[build] 0002368 I [3]<e00e4000:CSTF class=9 designer=43b:Arm part=908 devtype=12 archid=0000 devid=32:0:0> [rom_table]
[build] 0002368 I [4]<e00e5000:TSGEN class=15 designer=43b:Arm part=101> [rom_table]
[build] 0002369 I [5]<e00f0000:ROM class=1 designer=020:ST part=001> [rom_table]
[build] 0002369 I   APB-AP#2 Class 0x1 ROM table #1 @ 0xe00f0000 (designer=020:ST part=001) [rom_table]
[build] 0002370 I   [0]<e00f1000:CTI class=9 designer=43b:Arm part=906 devtype=14 archid=0000 devid=40800:0:0> [rom_table]
[build] 0002371 I   [2]<e00f3000:CSTF class=9 designer=43b:Arm part=908 devtype=12 archid=0000 devid=34:0:0> [rom_table]
[build] 0002372 I   [3]<e00f4000:ETF class=9 designer=43b:Arm part=961 devtype=32 archid=0000 devid=380:0:0> [rom_table]
[build] 0002373 I   [4]<e00f5000:TPIU class=9 designer=43b:Arm part=912 devtype=11 archid=0000 devid=a0:0:0> [rom_table]
[build] 0002375 I CPU core #0 is Cortex-M7 r1p1 [cortex_m]
[build] 0002376 I FPU present: FPv5-D16-M [cortex_m]
[build] 0002376 I 4 hardware watchpoints [dwt]
[build] 0002376 I 8 hardware breakpoints, 1 literal comparators [fpb]
[build] 0002376 I Loading C:\Users\Odiin\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0003006 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 56320 bytes (55 pages) at 87.43 kB/s [loader]
[build] Build finished with exit code 0
```
</details>

<details><summary>ST-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/Odiin/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.617] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-11T15:48:31 INFO usb.c: Unable to match requested speed 1800 kHz, using 1000 kHz
[build] 2022-09-11T15:48:31 INFO common.c: H74x/H75x: 128 KiB SRAM, 2048 KiB flash in at least 128 KiB pages.
[build] file C:/Users/Odiin/MbedCE_Test/build/main.bin md5 checksum: 20cecd42fa5eac6510e5c21f135b6cbb, stlink checksum: 0x005452ff
[build] 2022-09-11T15:48:31 INFO common.c: Attempting to write 55780 (0xd9e4) bytes to stm32 address: 134217728 (0x8000000)
[build] 2022-09-11T15:48:32 INFO common.c: Flash page at addr: 0x08000000 erased
[build] 2022-09-11T15:48:32 INFO common.c: Finished erasing 1 pages of 131072 (0x20000) bytes
[build] 2022-09-11T15:48:32 INFO common.c: Starting Flash write for H7
[build] 
64/55780 bytes written
...
55780/55780 bytes written
[build] 2022-09-11T15:48:33 INFO common.c: Starting verification of write complete
[build] 2022-09-11T15:48:33 INFO common.c: Flash written and verified! jolly good!
[build] Build finished with exit code 0

```
</details>

<details><summary>STM32cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/Odiin/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.610] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 002000243156501320323443
[build] ST-LINK FW  : V3J10M3
[build] Board       : NUCLEO-H743ZI
[build] Voltage     : 3.30V
[build] SWD freq    : 24000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x450
[build] Revision ID : Rev V
[build] Device name : STM32H7xx
[build] Flash size  : 2 MBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M7
[build] BL Version  : 0x90
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build] Warning: File corrupted. Two or more segments defines the same memory zone
[build]   File          : main.elf
[build]   Size          : 54.49 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sector 0
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.055
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@multiplemonomials 
<!--
    Request additional reviewers with @username or @team
-->


----------------------------------------------------------------------------------------------------------------
