### PR TITLE
Add Cmake config files for Nucleo-L152RE and Nucleo-F303K8 into upload methods

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_F303K8.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F303K8.cmake
@@ -1,0 +1,55 @@
+# Mbed OS upload method configuration file for target NUCLEO_F303K8.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
+#   If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32f3".Then just type "pyocd pack find STM32f3" or "pyocd pack find STM32f303" and you will see the part name of your target.
+#   Alternqativly you can type command "pyocd list" whne your board is connected. You will see state of your board.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32F303K8)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32F303K8Ux)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_f3.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/NUCLEO_L152RE.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L152RE.cmake
@@ -1,0 +1,56 @@
+# Mbed OS upload method configuration file for target NUCLEO_L152RE.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. Type "pyocd pack show" to console and you will see a list of already installed packages.
+#   If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32l1".Then just type "pyocd pack find STM32l1" or "pyocd pack find STM32l152" and you will see the part name of your target.
+#   Alternqativly you can type command "pyocd list" whne your board is connected. You will see state of your board.
+# 3. The STLINK upload method is disabled by default, because it is not usable on this target. ST-link keeps flashing and never stops.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L152RE)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32L152RETx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+-f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_l1.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED FALSE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds the cmake config files for upload method of Nucleo-L152RE and Nucleo-F303K8 (Nucleo 32).
All methods have been tested (only for flash) for both boards, but the ST-link (stlink.org release 1.7.0) method is not recommended to use (is disabled) for L152. The ST-link keeps flashing and never stops.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
N/A
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
N/A
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
N/A
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

#### F303K8:

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.208] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 1000 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.263810
[build] Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32f3x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 1000 kHz, using 950 kHz
[build] Info : Unable to match requested speed 1000 kHz, using 950 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08002eac msp: 0x20003000
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] ** Programming Started **
[build] Info : device id = 0x10016438
[build] Info : flash size = 64kbytes
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 1000 kHz, using 950 kHz
[build] Info : Unable to match requested speed 1000 kHz, using 950 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/3  33% :: 1.468] Building CXX object CMakeFiles/main.dir/main.cpp.obj
[build] [2/3  66% :: 3.042] Linking CXX executable main.elf
[build] -- built: C:/Users/User/MbedCE_Test/build/main.bin
[build] -- built: C:/Users/User/MbedCE_Test/build/main.hex
[build] | Module                         |     .text |   .data |     .bss |
[build] |--------------------------------|-----------|---------|----------|
[build] | [fill]                         |    46(+0) |   0(+0) |   23(+0) |
[build] | [lib]\c_nano.a                 |  2842(+0) | 100(+0) |   21(+0) |
[build] | [lib]\gcc.a                    |   760(+0) |   0(+0) |    0(+0) |
[build] | [lib]\mbed-baremetal.a         | 10730(+0) | 264(+0) | 1210(+0) |
[build] | [lib]\mbed-nucleo-f303k8-lib.a |  9648(+0) |   8(+0) |  562(+0) |
[build] | [lib]\misc                     |   188(+0) |   4(+0) |   28(+0) |
[build] | main.cpp.obj                   |   114(+0) |   0(+0) |   28(+0) |
[build] | Subtotals                      | 24328(+0) | 376(+0) | 1872(+0) |
[build] Total Static RAM memory (data + bss): 2248(+0) bytes
[build] Total Flash memory (text + data): 24704(+0) bytes
[build] 
[build] [3/3 100% :: 13.451] Flashing main with pyOCD...
[build] 0002581 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0002613 I Target type is stm32f303k8ux [board]
[build] 0002731 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002749 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002752 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=020:ST part=438) [rom_table]
[build] 0002754 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002755 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002756 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
[build] 0002757 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002759 I [4]<e0040000:TPIU M4 class=9 designer=43b:Arm part=9a1 devtype=11 archid=0000 devid=ca0:0:0> [rom_table]
[build] 0002760 I CPU core #0 is Cortex-M4 r0p1 [cortex_m]
[build] 0002761 I FPU present: FPv4-SP-D16-M [cortex_m]
[build] 0002763 I 4 hardware watchpoints [dwt]
[build] 0002765 I 6 hardware breakpoints, 4 literal comparators [fpb]
[build] 0002771 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0005228 I Erased 28672 bytes (14 sectors), programmed 28672 bytes (28 pages), skipped 0 bytes (0 pages) at 11.42 kB/s [loader]
[build] Build finished with exit code 0
```
</details>

<details><summary>J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 3.424] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 773669436
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32F303K8" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] Error while checking CPU state.
[build] Can not attach to CPU. Trying connect under reset.
[build] InitTarget() end
[build] Found SW-DP with ID 0x4BA01477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x24770011)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FF000
[build] CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
[build] Found Cortex-M4 r0p1, Little endian.
[build] FPUnit: 6 code (BP) slots and 2 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FF000
[build] [0][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [0][1]: E0001000 CID B105E00D PID 003BB002 DWT
[build] [0][2]: E0002000 CID B105E00D PID 002BB003 FPB
[build] [0][3]: E0000000 CID B105E00D PID 003BB001 ITM
[build] [0][4]: E0040000 CID B105900D PID 000BB9A1 TPIU
[build] Cortex-M4 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>

<details><summary>ST-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.311] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-15T17:23:59 INFO common.c: F334 medium density: 12 KiB SRAM, 64 KiB flash in at least 2 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: 205520fb7e12956ebb8e5d1298c29753, stlink checksum: 0x002ae620
[build] 2022-09-15T17:23:59 INFO common.c: Attempting to write 27844 (0x6cc4) bytes to stm32 address: 134217728 (0x8000000)
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08000000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08000800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08001000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08001800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08002000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08002800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08003000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08003800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08004000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08004800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08005000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08005800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08006000 erased
[build] 2022-09-15T17:23:59 INFO common.c: Flash page at addr: 0x08006800 erased
[build] 2022-09-15T17:23:59 INFO common.c: Finished erasing 14 pages of 2048 (0x800) bytes
[build] 2022-09-15T17:23:59 INFO common.c: Starting Flash write for VL/F0/F3/F1_XL
[build] 2022-09-15T17:23:59 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-15T17:23:59 INFO flash_loader.c: Clear DFSR
[build] 
  1/ 14 pages written
  2/ 14 pages written
  3/ 14 pages written
  4/ 14 pages written
  5/ 14 pages written
  6/ 14 pages written
  7/ 14 pages written
  8/ 14 pages written
  9/ 14 pages written
 10/ 14 pages written
 11/ 14 pages written
 12/ 14 pages written
 13/ 14 pages written
 14/ 14 pages written
[build] 2022-09-15T17:24:01 INFO common.c: Starting verification of write complete
[build] 2022-09-15T17:24:01 INFO common.c: Flash written and verified! jolly good!
[build] Build finished with exit code 0
```
</details>

<details><summary>STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.768] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 066FFF515055657867242748
[build] ST-LINK FW  : V2J40M27
[build] Board       : NUCLEO-F303K8
[build] Voltage     : 3.26V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x438
[build] Revision ID : Rev Z
[build] Device name : STM32F303x4-x6-x8/F328xx/F334xx
[build] Flash size  : 64 KBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M4
[build] BL Version  : --
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 27.19 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 13]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
████████████████ 33%█████████████████ 66%████████████████ 99%█ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.413
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>
    
#### L152RE:

<details><summary>openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 4.773] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 300 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.259513
[build] Info : stm32l1.cpu: hardware has 6 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32l1.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 300 kHz, using 240 kHz
[build] Info : Unable to match requested speed 300 kHz, using 240 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08003548 msp: 0x20014000
[build] STM32L: Enabling HSI
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] ** Programming Started **
[build] Info : Device: STM32L1xx (Cat.5/Cat.6)
[build] Info : STM32L flash has dual banks. Bank (0) size is 256kb, base address is 0x8000000
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 300 kHz, using 240 kHz
[build] Info : Unable to match requested speed 300 kHz, using 240 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

<details><summary>pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 4.204] Flashing main with pyOCD...
[build] 0002590 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0002618 I Target type is stm32l152retx [board]
[build] 0002721 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002744 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002748 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=020:ST part=436) [rom_table]
[build] 0002750 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=000> [rom_table]
[build] 0002751 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002752 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
[build] 0002753 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002754 I [4]<e0040000:TPIU M3 class=9 designer=43b:Arm part=923 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0002756 I [5]<e0041000:ETM M3 class=9 designer=43b:Arm part=924 devtype=13 archid=0000 devid=0:0:0> [rom_table]
[build] 0002758 I CPU core #0 is Cortex-M3 r2p0 [cortex_m]
[build] 0002759 I 4 hardware watchpoints [dwt]
[build] 0002762 I 6 hardware breakpoints, 4 literal comparators [fpb]
[build] 0002769 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0003752 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 36608 bytes (143 pages) at 36.59 kB/s [loader]
[build] Build finished with exit code 0

```
</details>

<details><summary>J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.987] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 778411063
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32L152RE" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] InitTarget() end
[build] Found SW-DP with ID 0x4BA01477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x24770011)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FF000
[build] CPUID register: 0x412FC230. Implementer code: 0x41 (ARM)
[build] Found Cortex-M3 r2p0, Little endian.
[build] FPUnit: 6 code (BP) slots and 2 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FF000
[build] [0][0]: E000E000 CID B105E00D PID 002BB000 SCS
[build] [0][1]: E0001000 CID B105E00D PID 002BB002 DWT
[build] [0][2]: E0002000 CID B105E00D PID 002BB003 FPB
[build] [0][3]: E0000000 CID B105E00D PID 002BB001 ITM
[build] [0][4]: E0040000 CID B105900D PID 002BB923 TPIU-Lite
[build] [0][5]: E0041000 CID B105900D PID 002BB924 ETM-M3
[build] Cortex-M3 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>

<details><summary>STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.146] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 0677FF555054877567013623
[build] ST-LINK FW  : V2J40M27
[build] Board       : NUCLEO-L152RE
[build] Voltage     : 3.26V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x437
[build] Revision ID : Rev Z
[build] Device name : STM32L15xxE/STM32L162xE
[build] Flash size  : 512 KBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M3
[build] BL Version  : --
[build] Debug in Low Power mode enabled
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 35.75 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 142]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.743
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@multiplemonomials 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
