### PR TITLE
Add Cmake config files for Disco-F746NG and Disco-F469NI into upload …

### DIFF
--- a/targets/upload_method_cfg/DISCO_F469NI.cmake
+++ b/targets/upload_method_cfg/DISCO_F469NI.cmake
@@ -1,0 +1,53 @@
+# Mbed OS upload method configuration file for target DISCO_F469NI.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. The PYOCD upload method is disabled by default, because it works only firs time after full erase from STM32Cube and failed every time after.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32F469NI)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED FALSE)
+set(PYOCD_TARGET_NAME stm32f469nihx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/stm32f4discovery.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/DISCO_F746NG.cmake
+++ b/targets/upload_method_cfg/DISCO_F746NG.cmake
@@ -1,0 +1,52 @@
+# Mbed OS upload method configuration file for target DISCO_F746NG.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32F746NG)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32F746NGHx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/stm32f7discovery.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds the cmake config files for upload method of Disco-F746NG and Disco-F469NI.
All methods have been tested (only for flash) for both boards, but the PYOCD method is not recommended to use (is disabled) for F469NI by default. Results of tests are in logs below.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
N/A
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
N/A
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
N/A
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
<details><summary>F746NG openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.189] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] Info : clock speed 2000 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.218361
[build] Warn : Silicon bug: single stepping may enter pending exception handler!
[build] Info : stm32f7x.cpu: hardware has 8 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32f7x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08003138 msp: 0x20050000
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] ** Programming Started **
[build] Info : device id = 0x10016449
[build] Info : flash size = 1024 kbytes
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>



<details><summary>F469NI openOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.284] Flashing main with OpenOCD...
[build] Open On-Chip Debugger 0.11.0 (2021-03-07-12:52)
[build] Licensed under GNU GPL v2
[build] For bug reports, read
[build] 	http://openocd.org/doc/doxygen/bugs.html
[build] Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
[build] srst_only separate srst_nogate srst_open_drain connect_deassert_srst
[build] 
[build] Info : clock speed 2000 kHz
[build] Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
[build] Info : Target voltage: 3.256805
[build] Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
[build] Info : starting gdb server for stm32f4x.cpu on 3333
[build] Info : Listening on port 3333 for gdb connections
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] target halted due to debug-request, current mode: Thread 
[build] xPSR: 0x01000000 pc: 0x08003648 msp: 0x20050000
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] Info : Unable to match requested speed 8000 kHz, using 4000 kHz
[build] ** Programming Started **
[build] Info : device id = 0x10006434
[build] Info : flash size = 2048 kbytes
[build] Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
[build] ** Programming Finished **
[build] ** Resetting Target **
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[build] shutdown command invoked
[build] Build finished with exit code 0
```
</details>

   <details><summary>F746NG pyOCD</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 8.308] Flashing main with pyOCD...
[build] 0001816 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0001856 I Target type is stm32f746nghx [board]
[build] 0002073 I DP IDR = 0x5ba02477 (v2 rev5) [dap]
[build] 0002150 I AHB-AP#0 IDR = 0x74770001 (AHB-AP var0 rev7) [ap]
[build] 0002154 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00fd000 (designer=020:ST part=449) [rom_table]
[build] 0002155 I [0]<e00fe000:ROM class=1 designer=43b:Arm part=4c8> [rom_table]
[build] 0002155 I   AHB-AP#0 Class 0x1 ROM table #1 @ 0xe00fe000 (designer=43b:Arm part=4c8) [rom_table]
[build] 0002158 I   [0]<e00ff000:ROM class=1 designer=43b:Arm part=4c7> [rom_table]
[build] 0002158 I     AHB-AP#0 Class 0x1 ROM table #2 @ 0xe00ff000 (designer=43b:Arm part=4c7) [rom_table]
[build] 0002159 I     [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002160 I     [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002161 I     [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=00e> [rom_table]
[build] 0002162 I     [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002163 I   [1]<e0041000:ETM M7 class=9 designer=43b:Arm part=975 devtype=13 archid=4a13 devid=0:0:0> [rom_table]
[build] 0002165 I [1]<e0040000:TPIU M7 class=9 designer=43b:Arm part=9a9 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0002167 I CPU core #0 is Cortex-M7 r0p1 [cortex_m]
[build] 0002168 I FPU present: FPv5-SP-D16-M [cortex_m]
[build] 0002170 I 4 hardware watchpoints [dwt]
[build] 0002173 I 8 hardware breakpoints, 1 literal comparators [fpb]
[build] 0002180 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0002958 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 38912 bytes (38 pages) at 49.81 kB/s [loader]
[build] Build finished with exit code 0

```
</details>



<details><summary>F469NI pyOCD</summary>

```python
OK:
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 10.281] Flashing main with pyOCD...
[build] 0001949 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0001984 I Target type is stm32f469nihx [board]
[build] 0002203 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002268 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002272 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=020:ST part=411) [rom_table]
[build] 0002273 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
[build] 0002274 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
[build] 0002275 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
[build] 0002276 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
[build] 0002278 I [4]<e0040000:TPIU M4 class=9 designer=43b:Arm part=9a1 devtype=11 archid=0000 devid=ca1:0:0> [rom_table]
[build] 0002279 I [5]<e0041000:ETM M4 class=9 designer=43b:Arm part=925 devtype=13 archid=0000 devid=0:0:0> [rom_table]
[build] 0002281 I CPU core #0 is Cortex-M4 r0p1 [cortex_m]
[build] 0002282 I FPU present: FPv4-SP-D16-M [cortex_m]
[build] 0002284 I 4 hardware watchpoints [dwt]
[build] 0002287 I 6 hardware breakpoints, 4 literal comparators [fpb]
[build] 0002294 I Loading C:\Users\User\MbedCE_Test\build\main.bin [load_cmd]
[build] [---|---|---|---|---|---|---|---|---|----]
[build] [========================================]
[build] 0004974 I Erased 49152 bytes (3 sectors), programmed 39936 bytes (39 pages), skipped 0 bytes (0 pages) at 14.63 kB/s [loader]
[build] Build finished with exit code 0

Error:
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.345] Flashing main with pyOCD...
[build] FAILED: CMakeFiles/flash-main C:/Users/User/MbedCE_Test/build/CMakeFiles/flash-main 
[build] cmd.exe /C "cd /D C:\Users\User\MbedCE_Test\build && C:\Users\User\AppData\Local\Programs\Python\Python310\python.exe -m pyocd flash -v --no-wait -f 4000k -t stm32f469nihx C:/Users/User/MbedCE_Test/build/main.bin"
[build] 0001715 W Overlapping memory regions in file C:\Users\User\AppData\Local\cmsis-pack-manager\cmsis-pack-manager\Keil\STM32L4xx_DFP\2.5.0.pack (STM32L412C8Tx); deleting outer region. Further warnings will be suppressed for this file. [cmsis_pack]
[build] 0001748 I Target type is stm32f469nihx [board]
[build] 0001916 I DP IDR = 0x2ba01477 (v1 rev2) [dap]
[build] 0002030 I AHB-AP#0 IDR = 0x24770011 (AHB-AP var1 rev2) [ap]
[build] 0002042 E Transfer error while reading AHB-AP#0 ROM table: STLink error (16): AP wait [ap]
[build] Traceback (most recent call last):
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\coresight\ap.py", line 797, in find_components
[build]     cmpid.read_id_registers()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\coresight\rom_table.py", line 124, in read_id_registers
[build]     regs = self.ap.read_memory_block32(self.top_address + self.IDR_READ_START, self.IDR_READ_COUNT)
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\utility\concurrency.py", line 29, in _locking
[build]     return func(self, *args, **kwargs)
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\coresight\ap.py", line 1216, in _accelerated_read_memory_block32
[build]     return self._accelerated_memory_interface.read_memory_block32(addr, size,
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\probe\stlink_probe.py", line 301, in read_memory_block32
[build]     return conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, size * 4, self._apsel, csw))
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\probe\stlink\stlink.py", line 473, in read_mem32
[build]     return self._read_mem(addr, size, Commands.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel, csw)
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\probe\stlink\stlink.py", line 425, in _read_mem
[build]     raise self._ERROR_CLASSES[status](error_message)
[build] pyocd.core.exceptions.TransferTimeoutError: STLink error (16): AP wait
[build] 0002044 C No cores were discovered! [__main__]
[build] Traceback (most recent call last):
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\__main__.py", line 161, in run
[build]     status = cmd.invoke()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\subcommands\load_cmd.py", line 96, in invoke
[build]     with session:
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\core\session.py", line 391, in __enter__
[build]     self.open()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\core\session.py", line 529, in open
[build]     self._board.init()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\board\board.py", line 139, in init
[build]     self.target.init()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\core\soc_target.py", line 147, in init
[build]     seq.invoke()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\utility\sequencer.py", line 208, in invoke
[build]     resultSequence = call()
[build]   File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pyocd\coresight\coresight_target.py", line 256, in check_for_cores
[build]     raise exceptions.DebugError("No cores were discovered!")
[build] pyocd.core.exceptions.DebugError: No cores were discovered!
[build] ninja: build stopped: subcommand failed.
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main -- exited with code: 1 and signal: null
[build] Build finished with exit code 1
```
</details>

<details><summary>F746NG J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.775] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 775013795
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32F746NG" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] Can not attach to CPU. Trying connect under reset.
[build] InitTarget() end
[build] Found SW-DP with ID 0x9BA02477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x74770001)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FD000
[build] CPUID register: 0x410FC271. Implementer code: 0x41 (ARM)
[build] Found Cortex-M7 r0p1, Little endian.
[build] FPUnit: 8 code (BP) slots and 0 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FD000
[build] [0][0]: E00FE000 CID B105100D PID 000BB4C8 ROM Table
[build] ROMTbl[1] @ E00FE000
[build] [1][0]: E00FF000 CID B105100D PID 000BB4C7 ROM Table
[build] ROMTbl[2] @ E00FF000
[build] [2][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [2][1]: E0001000 CID B105E00D PID 000BB002 DWT
[build] [2][2]: E0002000 CID B105E00D PID 000BB00E FPB-M7
[build] [2][3]: E0000000 CID B105E00D PID 000BB001 ITM
[build] [1][1]: E0041000 CID B105900D PID 000BB975 ETM-M7
[build] [0][1]: E0040000 CID B105900D PID 000BB9A9 TPIU-M7
[build] Cache: Separate I- and D-cache.
[build] I-Cache L1: 4 KB, 64 Sets, 32 Bytes/Line, 2-Way
[build] D-Cache L1: 4 KB, 32 Sets, 32 Bytes/Line, 4-Way
[build] Cortex-M7 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>



<details><summary>F469NI J-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 6.976] Flashing main with J-Link...
[build] SEGGER J-Link Commander V7.70e (Compiled Aug 31 2022 17:13:04)
[build] DLL version V7.70e, compiled Aug 31 2022 17:11:40
[build] 
[build] J-Link Commander will now exit on Error
[build] 
[build] J-Link Command File read successfully.
[build] Processing script file...
[build] J-Link>loadfile C:/Users/User/MbedCE_Test/build/main.hex
[build] J-Link connection not established yet but required for command.
[build] Connecting to J-Link via USB...O.K.
[build] Firmware: J-Link STLink V21 compiled Aug 12 2019 10:29:20
[build] Hardware version: V1.00
[build] J-Link uptime (since boot): N/A (Not supported by this model)
[build] S/N: 773087613
[build] VTref=3.300V
[build] Target connection not established yet but required for command.
[build] Device "STM32F469NI" selected.
[build] 
[build] 
[build] Connecting to target via SWD
[build] InitTarget() start
[build] InitTarget() end
[build] Found SW-DP with ID 0x4BA01477
[build] DPv0 detected
[build] CoreSight SoC-400 or earlier
[build] Scanning AP map to find all available APs
[build] AP[1]: Stopped AP scan as end of AP map has been reached
[build] AP[0]: AHB-AP (IDR: 0x24770011)
[build] Iterating through AP map to find AHB-AP to use
[build] AP[0]: Core found
[build] AP[0]: AHB-AP ROM base: 0xE00FF000
[build] CPUID register: 0x410FC241. Implementer code: 0x41 (ARM)
[build] Found Cortex-M4 r0p1, Little endian.
[build] FPUnit: 6 code (BP) slots and 2 literal slots
[build] CoreSight components:
[build] ROMTbl[0] @ E00FF000
[build] [0][0]: E000E000 CID B105E00D PID 000BB00C SCS-M7
[build] [0][1]: E0001000 CID B105E00D PID 003BB002 DWT
[build] [0][2]: E0002000 CID B105E00D PID 002BB003 FPB
[build] [0][3]: E0000000 CID B105E00D PID 003BB001 ITM
[build] [0][4]: E0040000 CID B105900D PID 000BB9A1 TPIU
[build] [0][5]: E0041000 CID B105900D PID 000BB925 ETM
[build] Cortex-M4 identified.
[build] 'loadfile': Performing implicit reset & halt of MCU.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] Downloading file [C:/Users/User/MbedCE_Test/build/main.hex]...
[build] J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
[build] O.K.
[build] J-Link>r
[build] Reset delay: 0 ms
[build] Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
[build] Reset: Halt core after reset via DEMCR.VC_CORERESET.
[build] Reset: Reset device via AIRCR.SYSRESETREQ.
[build] J-Link>exit
[build] 
[build] Script processing completed.
[build] 
[build] OnDisconnectTarget() start
[build] OnDisconnectTarget() end
[build] Build finished with exit code 0
```
</details>


<details><summary>F746NG ST-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.011] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-17T13:47:01 INFO common.c: F7xx: 320 KiB SRAM, 1024 KiB flash in at least 2 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: 6ec035365cb6abb3bffcd1ad3f30362c, stlink checksum: 0x00391a71
[build] 2022-09-17T13:47:01 INFO common.c: Attempting to write 38676 (0x9714) bytes to stm32 address: 134217728 (0x8000000)
[build] EraseFlash - Sector:0x0 Size:0x8000 2022-09-17T13:47:02 INFO common.c: Flash page at addr: 0x08000000 erased
[build] EraseFlash - Sector:0x1 Size:0x8000 2022-09-17T13:47:02 INFO common.c: Flash page at addr: 0x08008000 erased
[build] 2022-09-17T13:47:02 INFO common.c: Finished erasing 2 pages of 32768 (0x8000) bytes
[build] 2022-09-17T13:47:02 INFO common.c: Starting Flash write for F2/F4/F7/L4
[build] 2022-09-17T13:47:02 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-17T13:47:02 INFO flash_loader.c: Clear DFSR
[build] 2022-09-17T13:47:02 INFO common.c: enabling 32-bit flash writes
[build] 2022-09-17T13:47:03 INFO common.c: Starting verification of write complete
[build] 2022-09-17T13:47:03 INFO common.c: Flash written and verified! jolly good!
[build] Build finished with exit code 0
```
</details>


<details><summary>F469NI ST-link</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 2.891] Flashing main with stlink...
[build] st-flash 1.7.0
[build] 2022-09-17T14:20:35 ERROR common.c: Soft reset failed: timeout
[build] 2022-09-17T14:20:35 INFO common.c: F46x/F47x: 256 KiB SRAM, 2048 KiB flash in at least 16 KiB pages.
[build] file C:/Users/User/MbedCE_Test/build/main.bin md5 checksum: e0657f21ea84574721c44d82ec46236, stlink checksum: 0x00399980
[build] 2022-09-17T14:20:35 INFO common.c: Attempting to write 39064 (0x9898) bytes to stm32 address: 134217728 (0x8000000)
[build] EraseFlash - Sector:0x0 Size:0x4000 2022-09-17T14:20:35 INFO common.c: Flash page at addr: 0x08000000 erased
[build] EraseFlash - Sector:0x1 Size:0x4000 2022-09-17T14:20:35 INFO common.c: Flash page at addr: 0x08004000 erased
[build] EraseFlash - Sector:0x2 Size:0x4000 2022-09-17T14:20:36 INFO common.c: Flash page at addr: 0x08008000 erased
[build] 2022-09-17T14:20:36 INFO common.c: Finished erasing 3 pages of 16384 (0x4000) bytes
[build] 2022-09-17T14:20:36 INFO common.c: Starting Flash write for F2/F4/F7/L4
[build] 2022-09-17T14:20:36 INFO flash_loader.c: Successfully loaded flash loader in sram
[build] 2022-09-17T14:20:36 INFO flash_loader.c: Clear DFSR
[build] 2022-09-17T14:20:36 INFO common.c: enabling 32-bit flash writes
[build] 2022-09-17T14:20:36 INFO common.c: Starting verification of write complete
[build] 2022-09-17T14:20:36 INFO common.c: Flash written and verified! jolly good!
[build] 2022-09-17T14:20:37 WARN common.c: NRST is not connected
[build] Build finished with exit code 0
```
</details>

<details><summary>F746NG STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.359] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 066FFF363931594E43015649
[build] ST-LINK FW  : V2J40M27
[build] Board       : 32F746GDISCOVERY
[build] Voltage     : 3.22V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x449
[build] Revision ID : Rev Z
[build] Device name : STM32F74x/STM32F75x
[build] Flash size  : 1 MBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M7
[build] BL Version  : --
[build] Debug in Low Power mode enabled
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 37.77 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 1]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.021
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>


<details><summary>F469NI STM32Cube</summary>

```python
[main] Building folder: MbedCE_Test 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/Users/User/MbedCE_Test/build --config Debug --target flash-main --
[build] [1/1 100% :: 1.411] Flashing main with STM32CubeProg...
[build]       -------------------------------------------------------------------
[build]                        STM32CubeProgrammer v2.11.0                  
[build]       -------------------------------------------------------------------
[build] 
[build] ST-LINK SN  : 066EFF525750877267022052
[build] ST-LINK FW  : V2J40M27
[build] Board       : 32F469IDISCOVERY
[build] Voltage     : 3.26V
[build] SWD freq    : 4000 KHz
[build] Connect mode: Under Reset
[build] Reset mode  : Hardware reset
[build] Device ID   : 0x434
[build] Revision ID : Rev A
[build] Device name : STM32F469xx/F467xx
[build] Flash size  : 2 MBytes
[build] Device type : MCU
[build] Device CPU  : Cortex-M4
[build] BL Version  : --
[build] 
[build] 
[build] 
[build] Memory Programming ...
[build] Opening and parsing file: main.elf
[build]   File          : main.elf
[build]   Size          : 38.16 KB 
[build]   Address       : 0x08000000 
[build] 
[build] 
[build] Erasing memory corresponding to segment 0:
[build] Erasing internal memory sectors [0 2]
[build] Download in Progress:
[build] ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ 0%
██████████████████████████████████████████████████ 100%
[build] 
[build] File download complete
[build] Time elapsed during download operation: 00:00:01.077
[build] 
[build] MCU Reset
[build] 
[build] Software reset is performed
[build] Build finished with exit code 0
```
</details>


----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
