### PR TITLE
Print the command when a greentea test is being run.  Also fix mbedhtrun not being on PATH causing all tests to pass!

### DIFF
--- a/tools/cmake/mbed-run-greentea-test.in.cmake
+++ b/tools/cmake/mbed-run-greentea-test.in.cmake
@@ -10,7 +10,7 @@ execute_process(
 
 # Then run and communicate with the test
 # -----------------------------------------------------------------------
-set(MBEDHTRUN_ARGS --skip-flashing -f @MBED_GREENTEA_TEST_IMAGE_NAME@ @MBED_HTRUN_ARGUMENTS@) # filled in by configure script
+set(MBEDHTRUN_ARGS --skip-flashing @MBED_HTRUN_ARGUMENTS@) # filled in by configure script
 
 # Print out command
 string(REPLACE ";" " " MBEDHTRUN_ARGS_FOR_DISPLAY "${MBEDHTRUN_ARGS}")

--- a/tools/cmake/mbed-run-greentea-test.in.cmake
+++ b/tools/cmake/mbed-run-greentea-test.in.cmake
@@ -1,6 +1,7 @@
 # This file is configured by CMake to create the script used to execute each Greentea test.
 
 # First flash the target using its configured Mbed OS upload method
+# -----------------------------------------------------------------------
 execute_process(
 	# Note: we don't use cmake --build because that performs a reconfigure of the build system each time
 	COMMAND @CMAKE_MAKE_PROGRAM@ flash-@MBED_GREENTEA_TEST_NAME@
@@ -8,7 +9,15 @@ execute_process(
 	COMMAND_ERROR_IS_FATAL ANY)
 
 # Then run and communicate with the test
+# -----------------------------------------------------------------------
+set(MBEDHTRUN_ARGS --skip-flashing -f @MBED_GREENTEA_TEST_IMAGE_NAME@ @MBED_HTRUN_ARGUMENTS@) # filled in by configure script
+
+# Print out command
+string(REPLACE ";" " " MBEDHTRUN_ARGS_FOR_DISPLAY "${MBEDHTRUN_ARGS}")
+message("Executing: mbedhtrun ${MBEDHTRUN_ARGS_FOR_DISPLAY}")
+
+# Note: For this command, we need to survive mbedhtrun not being on the PATH, so we import the package and call the main function using "python -c"
 execute_process(
-	COMMAND mbedhtrun --skip-flashing -f @MBED_GREENTEA_TEST_IMAGE_NAME@ @MBED_HTRUN_ARGUMENTS@
+	COMMAND @Python3_EXECUTABLE@ -c "import mbed_host_tests.mbedhtrun; mbed_host_tests.mbedhtrun.main()" ${MBEDHTRUN_ARGS}
 	WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@"
 	COMMAND_ERROR_IS_FATAL ANY)

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -103,12 +103,6 @@ function(mbed_greentea_add_test)
 
     mbed_set_post_build(${MBED_GREENTEA_TEST_NAME})
 
-    if(NOT ${MBED_OUTPUT_EXT} STREQUAL "")
-        set(MBED_GREENTEA_TEST_IMAGE_NAME "${MBED_GREENTEA_TEST_NAME}.${MBED_OUTPUT_EXT}")
-    else()
-        set(MBED_GREENTEA_TEST_IMAGE_NAME "${MBED_GREENTEA_TEST_NAME}.bin")
-    endif()
-
     # User can set this cache variable to supply extra arguments to greentea.
     # such as: -d to set the drive path
     list(APPEND MBED_HTRUN_ARGUMENTS -p ${MBED_GREENTEA_SERIAL_PORT})

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -139,13 +139,6 @@ function(mbed_greentea_add_test)
     endif()
 
 
-    list(APPEND CONFIG_DEFS_COPY ${MBED_CONFIG_DEFINITIONS})
-    list(FILTER CONFIG_DEFS_COPY INCLUDE REGEX "MBED_CONF_PLATFORM_STDIO_BAUD_RATE")
-    if(NOT ${CONFIG_DEFS_COPY} STREQUAL "")
-        string(REGEX MATCH "[0-9]*$" BAUD_RATE ${CONFIG_DEFS_COPY})
-        list(APPEND MBED_HTRUN_ARGUMENTS "--baud-rate=${BAUD_RATE}")
-    endif()
-
     # Configure the CMake script which runs the test.
     # We have to use a helper script in order to run both the flashing and htrun in one test
     configure_file(


### PR DESCRIPTION

### Summary of changes <!-- Required -->

- Print the command when a host test is being run.  This makes it easier to understand what the test runner is doing behind the scenes.  It looks like:
```
Executing: mbedhtrun --skip-flashing -f testshield-spi.bin -p COM3 -m NUCLEO_L452RE_P --baud-rate=115200
```
- While developing this, I noticed that one could get a free pass on all tests if `mbedhtrun` was not in your PATH.  Apparently failing to find an executable does not count as a "command error" in CMake?? I changed how it invokes mbedhtrun to fix this.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

Working on testing documentation rn

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@JohnK1987 
@jay-sridharan 

----------------------------------------------------------------------------------------------------------------
