### PR TITLE
Fix issue with Python exit codes that masked failures

### DIFF
--- a/tools/cmake/mbed-run-greentea-test.in.cmake
+++ b/tools/cmake/mbed-run-greentea-test.in.cmake
@@ -18,6 +18,6 @@ message("Executing: mbedhtrun ${MBEDHTRUN_ARGS_FOR_DISPLAY}")
 
 # Note: For this command, we need to survive mbedhtrun not being on the PATH, so we import the package and call the main function using "python -c"
 execute_process(
-	COMMAND @Python3_EXECUTABLE@ -c "import mbed_host_tests.mbedhtrun; mbed_host_tests.mbedhtrun.main()" ${MBEDHTRUN_ARGS}
+	COMMAND @Python3_EXECUTABLE@ -c "import mbed_host_tests.mbedhtrun; exit(mbed_host_tests.mbedhtrun.main())" ${MBEDHTRUN_ARGS}
 	WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@"
 	COMMAND_ERROR_IS_FATAL ANY)

--- a/tools/cmake/mbed_generate_configuration.cmake
+++ b/tools/cmake/mbed_generate_configuration.cmake
@@ -91,7 +91,7 @@ if(MBED_NEED_TO_RECONFIGURE)
     file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/mbed_config.cmake)
 
     set(MBEDTOOLS_CONFIGURE_COMMAND ${Python3_EXECUTABLE}
-        -c "import mbed_tools.cli.main\; mbed_tools.cli.main.cli()" # This is used instead of invoking mbed_tools as a script, because it might not be on the user's PATH.
+        -c "import mbed_tools.cli.main\; exit(mbed_tools.cli.main.cli())" # This is used instead of invoking mbed_tools as a script, because it might not be on the user's PATH.
         configure
         -t GCC_ARM # GCC_ARM is currently the only supported toolchain
         -m "${MBED_TARGET}"


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This MR fixes a bug with some recent changes involving the Python test runner.  Basically, calling it through `python -c` caused the exit code from the test runner to not be returned from Python.  So if tests failed, the command would still return exit code 0, and the test would be marked as passed.  Whoops.

To fix it, I added an exit() call, and did the same in another place vulnerable to this issue.

#### Impact of changes <!-- Optional -->
Makes tests able to fail again.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
   
I tested locally, and with this change, it's possible for a test to fail again, while before this change failing tests were marked as Passed.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

----------------------------------------------------------------------------------------------------------------
