### PR TITLE
Fix overflow issue causing common tickers test to intermittently fail

### DIFF
--- a/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
@@ -221,9 +221,10 @@ void ticker_interrupt_test(void)
     uint8_t run_count = 0;
     const ticker_info_t *p_ticker_info = intf->get_info();
 
-    overflow_protect();
-
     for (uint32_t i = 0; i < (sizeof(ticker_timeout) / sizeof(uint32_t)); i++) {
+
+		// If needed, delay until we can run the test without overflowing the ticker.
+		overflow_protect();
 
         /* Skip timeout if less than max allowed execution time of set_interrupt() - 20 us */
         if (TICKS_TO_US(ticker_timeout[i], p_ticker_info->frequency) < (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)) {

--- a/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
@@ -222,9 +222,8 @@ void ticker_interrupt_test(void)
     const ticker_info_t *p_ticker_info = intf->get_info();
 
     for (uint32_t i = 0; i < (sizeof(ticker_timeout) / sizeof(uint32_t)); i++) {
-
-		// If needed, delay until we can run the test without overflowing the ticker.
-		overflow_protect();
+        // If needed, delay until we can run the test without overflowing the ticker.
+        overflow_protect();
 
         /* Skip timeout if less than max allowed execution time of set_interrupt() - 20 us */
         if (TICKS_TO_US(ticker_timeout[i], p_ticker_info->frequency) < (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)) {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

In #44, @JohnK1987 noticed an issue where the LP Ticker test would intermittently hang on STMicro devices.  Scarily, this issue would go away from any of the following:
- Using an older GCC (<= 9.x)
- Adding any printfs in the test body
- Changing the serial baudrate to something other than 9600
- Running the test in the debugger from the start

Finally, I managed to isolate the problem by running the test normally, then connecting OpenOCD after it had already hung.

As it turns out, this is actually an integer overflow issue in the `ticker_interrupt_test()` test!  This test basically works by reading the current time into a variable (`tick_count`), setting some interrupts, waiting until the time is equal to `tick_count` plus some amount, and then reading flags from the interrupts.

Since the LP ticker is only 16 bits wide, and the test is operating on times 1000s of ticks in the future, it isn't too hard to see the problem: the ticker is at, say, 31000, then the test spinlocks until 33000, but the ticker rolls over to 0 before it hits that value and you get an infinite hang. 

But the funny thing is, the Mbed devs actually saw this issue and got *so close*  to preventing it.  They added a function called `overflow_protect()`, which makes sure that (for a 16 bit ticker) that the tick value is under 28767 before starting the test.  Alas!  They forgot to put this function in the body of the loop, so while the first few iterations are protected, the last few iterations can trigger the issue.  Whether this happens or not is very sensitive to the time that elapses in the body of the test, which explains why so many things perturbed the issue and stopped it from happening.

Luckily, the fix is pretty simple: just move the existing overflow_protect() issue into the body of the loop, making sure every iteration is protected.

#### Impact of changes <!-- Optional -->
mbed-hal-common-tickers test will stop intermittently failing.

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
