### PR TITLE
Change default serial baudrate to 115200

### DIFF
--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -61,7 +61,8 @@ public:
      *  @param tx Transmit pin
      *  @param rx Receive pin
      *  @param baud The baud rate of the serial port (optional, defaults to
-     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
+     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE, which is set via
+     *              platform.default-serial-baud-rate in mbed_app.json)
      */
     BufferedSerial(
         PinName tx,
@@ -73,7 +74,8 @@ public:
      *  receive pins, with a particular baud rate.
      *  @param static_pinmap reference to structure which holds static pinmap
      *  @param baud The baud rate of the serial port (optional, defaults to
-     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
+     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE, which is set via
+     *              platform.default-serial-baud-rate in mbed_app.json)
      */
     BufferedSerial(
         const serial_pinmap_t &static_pinmap,

--- a/drivers/include/drivers/SerialBase.h
+++ b/drivers/include/drivers/SerialBase.h
@@ -48,7 +48,7 @@ class SerialBase : private NonCopyable<SerialBase> {
 public:
     /** Set the baud rate of the serial port
      *
-     *  @param baudrate The baudrate of the serial port (default = 9600).
+     *  @param baudrate The baudrate of the serial port (default = platform.default-serial-baud-rate).
      */
     void baud(int baudrate);
 

--- a/drivers/include/drivers/UnbufferedSerial.h
+++ b/drivers/include/drivers/UnbufferedSerial.h
@@ -55,7 +55,8 @@ public:
      *
      *  @param tx Transmit pin
      *  @param rx Receive pin
-     *  @param baud The baud rate of the serial port (optional, defaults to MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
+     *  @param baud The baud rate of the serial port (optional, defaults to MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE,
+     *              which is set via platform.default-serial-baud-rate in mbed_app.json)
      *
      *  @note
      *    Either tx or rx may be specified as NC if unused
@@ -70,7 +71,8 @@ public:
      *  receive pins, with a particular baud rate.
      *  @param static_pinmap reference to structure which holds static pinmap
      *  @param baud The baud rate of the serial port (optional, defaults to
-     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
+     *              MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE, which is set via
+     *              platform.default-serial-baud-rate in mbed_app.json)
      */
     UnbufferedSerial(
         const serial_pinmap_t &static_pinmap,

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -23,7 +23,7 @@
 
         "stdio-baud-rate": {
             "help": "(Applies if target.console-uart is true.) Baud rate for stdio",
-            "value": 9600
+            "value": 115200
         },
 
         "stdio-flush-at-exit": {
@@ -33,7 +33,7 @@
 
         "default-serial-baud-rate": {
             "help": "Default baud rate for a serial object (if not specified in the constructor)",
-            "value": 9600
+            "value": 115200
         },
 
         "poll-use-lowpower-timer": {
@@ -170,15 +170,6 @@
         "STM": {
             "deepsleep-stats-verbose": false
         },
-        "EFM32": {
-            "stdio-baud-rate": 115200
-        },
-        "EFR32": {
-            "stdio-baud-rate": 115200
-        },
-        "UNO_91H": {
-            "stdio-baud-rate": 115200
-        },
         "DISCO_L475VG_IOT01A": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
@@ -219,12 +210,6 @@
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
-        "NU_PFM_M2351": {
-            "stdio-baud-rate": 115200
-        },
-        "NU_M2354": {
-            "stdio-baud-rate": 115200
-        },
         "NRF52840_DK": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
@@ -245,27 +230,19 @@
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
-        "S5JS100": {
-            "stdio-baud-rate": 115200
-        },
         "NUCLEO_L452RE-P": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
         "ARM_MUSCA_B1": {
-            "stdio-convert-newlines": true,
-            "stdio-baud-rate": 115200
+            "stdio-convert-newlines": true
         },
         "ARM_MUSCA_S1": {
-            "stdio-convert-newlines": true,
-            "stdio-baud-rate": 115200
+            "stdio-convert-newlines": true
         },
         "MTS_DRAGONFLY_L471QG": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
-        },
-        "CY8CKIT064B0S2_4343W": {
-            "stdio-baud-rate": 115200
         }
     }
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This is something I've wanted to do for an eternity and a half.  It changes the default serial baudrate of Mbed to 115200 baud, instead of 9600 baud.  In recognition of the fact that it's not the 90s anymore, using 115200 baud allows you to print a lot more stuff without slowing your app down.  It should also provide a pretty significant speed boost to the test suite by making all the data print from the test 10x faster

#### Impact of changes <!-- Optional -->
stdio printfs will use 115200 baud unless configured otherwise.  BufferedSerial and UnbufferedSerial objects will use 115200 baud if the baudrate parameter is not set.

#### Migration actions required <!-- Optional -->
If anyone was relying on 9600 baud, they will have to add
```json
"platform.default-serial-baud-rate": 9600,
"platform.stdio-baud-rate": 115200
```
to their mbed_app.json in order to reenable the old behavior.  

### Documentation <!-- Required -->

Updated a few places in the Serial classes to indicate the change

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

Confirm that tests work fine with STM32F4 and LPC1768 targets.  However, not so much on STM32L4.  Filed #67 about this.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
