### PR TITLE
MAX32620C: Fix ASM that interfered with the GCC linker script and made the linker try to zero the entire RAM space

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32620C/device/TOOLCHAIN_GCC_ARM/startup_max32620.S
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/device/TOOLCHAIN_GCC_ARM/startup_max32620.S
@@ -34,36 +34,6 @@
     .syntax unified
     .arch armv7-m
 
-    .section .stack
-    .align 3
-#ifdef __STACK_SIZE
-    .equ    Stack_Size, __STACK_SIZE
-#else
-    .equ    Stack_Size, 0x00001000
-#endif
-    .globl    __StackTop
-    .globl    __StackLimit
-__StackLimit:
-    .space    Stack_Size
-    .size   __StackLimit, . - __StackLimit
-__StackTop:
-    .size   __StackTop, . - __StackTop
-
-    .section .heap
-    .align 3
-#ifdef __HEAP_SIZE
-    .equ    Heap_Size, __HEAP_SIZE
-#else
-    .equ    Heap_Size, 0x00004000
-#endif
-    .globl  __HeapBase
-    .globl  __HeapLimit
-__HeapBase:
-    .space  Heap_Size
-    .size   __HeapBase, . - __HeapBase
-__HeapLimit:
-    .size __HeapLimit, . - __HeapLimit
-
     .section .isr_vector
     .align 2
     .globl  __isr_vector


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This change fixes an issue that caused the linker to try to zero essentially all of the unused RAM, causing bin files for this target to be huge.  See the forum thread on this issue here: https://forums.mbed.com/t/how-do-i-build-an-example-program-using-vscode/18380/13?u=multiplemonomials

#### Impact of changes <!-- Optional -->
Smaller bin files and -250k flash consumption on MAX32620C.

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

 While I do not have a MAX32620FTHR to test with, howard.harkness tested this on his end, and it did not seem to cause any issues.   
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JohnK1987 

----------------------------------------------------------------------------------------------------------------
