### PR TITLE
add HW reset to upload for DISCO_F769NI STM32CUBE

### DIFF
--- a/targets/upload_method_cfg/DISCO_F769NI.cmake
+++ b/targets/upload_method_cfg/DISCO_F769NI.cmake
@@ -41,7 +41,7 @@ set(OPENOCD_CHIP_CONFIG_COMMANDS
 # -------------------------------------------------------------
 
 set(STM32CUBE_UPLOAD_ENABLED TRUE)
-set(STM32CUBE_CONNECT_COMMAND -c port=SWD)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
 set(STM32CUBE_GDBSERVER_ARGS --swd)
 
 # Config options for stlink


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

small fix for upload method STM32CUBE on DISCO_F769NI:
add hwreset again. swreset did work only on every 2nd attempt.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
