### PR TITLE
add depth setting, json and html output to memap report

### DIFF
--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -56,14 +56,54 @@ endfunction()
 # Parse toolchain generated map file of `target` and display a readable table format.
 #
 function(mbed_generate_map_file target)
-     add_custom_command(
-         TARGET
-             ${target}
-         POST_BUILD
-         COMMAND ${Python3_EXECUTABLE} ${mbed-os_SOURCE_DIR}/tools/memap.py -t ${MBED_TOOLCHAIN} ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map
-         WORKING_DIRECTORY
-             ${CMAKE_CURRENT_BINARY_DIR}
-)
+    # set default args for memap.py
+    set(MBED_MEMAP_DEPTH "2" CACHE STRING "directory depth level to display report")
+    set(MBED_MEMAP_CREATE_JSON FALSE CACHE BOOL "create report in json file")
+    set(MBED_MEMAP_CREATE_HTML FALSE CACHE BOOL "create report in html file")
+
+    # generate table for screen
+    add_custom_command(
+        TARGET
+            ${target}
+        POST_BUILD
+        COMMAND ${Python3_EXECUTABLE} ${mbed-os_SOURCE_DIR}/tools/memap.py 
+            -t ${MBED_TOOLCHAIN} ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map 
+            --depth ${MBED_MEMAP_DEPTH} 
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    # generate json file
+    if (${MBED_MEMAP_CREATE_JSON})
+        add_custom_command(
+            TARGET
+                ${target}
+            POST_BUILD
+            COMMAND ${Python3_EXECUTABLE} ${mbed-os_SOURCE_DIR}/tools/memap.py 
+            -t ${MBED_TOOLCHAIN} ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map 
+            --depth ${MBED_MEMAP_DEPTH} 
+            -e json
+            -o ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.memmap.json
+            WORKING_DIRECTORY
+                ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    endif()
+
+    # generate html file
+    if (${MBED_MEMAP_CREATE_HTML})
+        add_custom_command(
+            TARGET
+                ${target}
+            POST_BUILD
+            COMMAND ${Python3_EXECUTABLE} ${mbed-os_SOURCE_DIR}/tools/memap.py 
+            -t ${MBED_TOOLCHAIN} ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map 
+            --depth ${MBED_MEMAP_DEPTH} 
+            -e html
+            -o ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.memmap.html
+            WORKING_DIRECTORY
+                ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    endif()
 endfunction()
 
 #


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR is a feature upgrade to pass the depth of directory level to the memap.py. This allows a more detailed output of memory usage for compile units.
Memap.py has also the option to output a json file or a clickable html file.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Set default is set to no json, no html and depth = 2. It can be overriden in the top level CMakeLists.txt e.g.:

```
set(MBED_MEMAP_DEPTH "4" )
set(MBED_MEMAP_CREATE_JSON TRUE)
set(MBED_MEMAP_CREATE_HTML TRUE)
```

The settings are cached and can be changed also by using the CMake cache editor.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@multiplemonomials 

----------------------------------------------------------------------------------------------------------------
