### PR TITLE
add custom linker script

### DIFF
--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -81,7 +81,10 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
     foreach(TARGET ${mbed_baremetal_target} ${mbed_os_target})
         add_dependencies(${TARGET} mbed-linker-script)
 
-        # store LINKER_SCRIPT_PATH
+        # When building the Mbed internal tests, the tests get created before the mbed-os target does.  So, the normal logic 
+        # in mbed_set_post_build() to set the linker script does not work.  So, we need to instead attach the linker script to 
+        # the mbed-os and mbed-baremetal libraries themselves, so it will get picked up automatically.
+        # This prevents a custom linker script from being used in STANDALONE mode, but we don't need to do that.
         set_target_properties(${TARGET} PROPERTIES LINKER_SCRIPT_PATH  ${LINKER_SCRIPT_PATH})
 
         #  add linker script only for tests

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -73,6 +73,7 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
         VERBATIM
     )
 
+    
     # The job to create the linker script gets attached to the mbed-linker-script target,
     # which is then added as a dependency of the MCU target.  This ensures the linker script will exist
     # by the time we need it.
@@ -80,11 +81,66 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
     foreach(TARGET ${mbed_baremetal_target} ${mbed_os_target})
         add_dependencies(${TARGET} mbed-linker-script)
 
-        # Add linker flags to the MCU target to pick up the preprocessed linker script
-        target_link_options(${TARGET}
+        # store LINKER_SCRIPT_PATH
+        set_target_properties(${TARGET} PROPERTIES LINKER_SCRIPT_PATH  ${LINKER_SCRIPT_PATH})
+
+        #  add linker script only for tests
+        if(MBED_IS_STANDALONE)
+            target_link_options(${TARGET}
             INTERFACE
                 "-T" "${LINKER_SCRIPT_PATH}"
-        )
+            )
+        endif()
     endforeach()
 
 endfunction(mbed_setup_linker_script)
+
+
+#
+# Change the linker script to a custom supplied script instead of the built in.
+# this function is called by mbed_set_post_build(target linker_script)
+#
+# target: CMake target for Mbed OS
+# new_linker_script_path: raw linker script
+#
+function(mbed_set_custom_linker_script target new_linker_script_path)
+
+    set(RAW_LINKER_SCRIPT_PATHS  ${CMAKE_CURRENT_SOURCE_DIR}/${new_linker_script_path})
+    set(CUSTOM_LINKER_SCRIPT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${target}.link_spript.ld)
+
+    # To avoid path limits on Windows, we create a "response file" and set the path to it as a
+    # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
+    # so it can expand any macro definitions in the linker script.
+    get_property(linker_defs_response_file GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
+
+    get_filename_component(RAW_LINKER_SCRIPT_NAME ${RAW_LINKER_SCRIPT_PATHS} NAME)
+    get_filename_component(LINKER_SCRIPT_NAME ${CUSTOM_LINKER_SCRIPT_PATH} NAME)
+
+    add_custom_command(
+        TARGET
+            ${target}
+        PRE_LINK
+        COMMAND
+            ${CMAKE_C_COMPILER} @${linker_defs_response_file}
+            -E -x assembler-with-cpp
+            -include ${CMAKE_BINARY_DIR}/mbed-os/mbed-target-config.h
+            -P ${RAW_LINKER_SCRIPT_PATHS}
+            -o ${CUSTOM_LINKER_SCRIPT_PATH}
+        DEPENDS
+            ${RAW_LINKER_SCRIPT_PATHS}
+            ${linker_defs_response_file}
+            ${target_defines_header}
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT
+            "Preprocess custom linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
+        VERBATIM
+    )
+
+    # Add linker flags to the target to pick up the preprocessed linker script
+    target_link_options(${target}
+        PRIVATE
+            "-T" "${CUSTOM_LINKER_SCRIPT_PATH}"
+    )
+
+endfunction(mbed_set_custom_linker_script)

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -56,6 +56,8 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
         OUTPUT
             ${LINKER_SCRIPT_PATH}
         PRE_LINK
+        COMMAND 
+            ${CMAKE_COMMAND} -E echo "Preprocess linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
         COMMAND
             ${CMAKE_C_COMPILER} @${linker_defs_response_file}
             -E -x assembler-with-cpp
@@ -68,8 +70,6 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
             ${target_defines_header}
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT
-            "Preprocess linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
         VERBATIM
     )
 
@@ -123,6 +123,8 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
         TARGET
             ${target}
         PRE_LINK
+        COMMAND 
+            ${CMAKE_COMMAND} -E echo "Preprocess custom linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
         COMMAND
             ${CMAKE_C_COMPILER} @${linker_defs_response_file}
             -E -x assembler-with-cpp
@@ -135,8 +137,6 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
             ${target_defines_header}
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT
-            "Preprocess custom linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
         VERBATIM
     )
 

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -127,6 +127,25 @@ endfunction()
 # Set post build operations
 #
 function(mbed_set_post_build target)
+    if("${ARGN}" STREQUAL "")
+        if(TARGET mbed-os)
+            get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
+            target_link_options(${target}
+            PRIVATE
+                "-T" "${LINKER_SCRIPT_PATH}"
+        )
+        elseif(TARGET mbed-baremetal)
+            get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
+            target_link_options(${target}
+            PRIVATE
+                "-T" "${LINKER_SCRIPT_PATH}"
+        )
+        endif()
+    else()
+        message(STATUS "${target} uses custom linker script  ${ARGV2}")
+        mbed_set_custom_linker_script(${target} ${ARGV2})
+    endif()
+
     # The mapfile name includes the top-level target name and the
     # executable suffix for all toolchains as CMake hardcodes the name of the
     # diagnostic output file for some toolchains.

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -126,24 +126,30 @@ endfunction()
 #
 # Set post build operations
 #
+# target: the affected target
+# 2nd arg: optional, linker script path 
+#
 function(mbed_set_post_build target)
-    if("${ARGN}" STREQUAL "")
-        if(TARGET mbed-os)
-            get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
-            target_link_options(${target}
-            PRIVATE
-                "-T" "${LINKER_SCRIPT_PATH}"
-        )
-        elseif(TARGET mbed-baremetal)
-            get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
-            target_link_options(${target}
-            PRIVATE
-                "-T" "${LINKER_SCRIPT_PATH}"
-        )
+    # add linker script. Skip for greentea test code, there the linker script is set in mbed_setup_linker_script()
+    if (NOT MBED_IS_STANDALONE)
+        if("${ARGN}" STREQUAL "")
+            if(TARGET mbed-os)
+                get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
+                target_link_options(${target}
+                PRIVATE
+                    "-T" "${LINKER_SCRIPT_PATH}"
+            )
+            elseif(TARGET mbed-baremetal)
+                get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
+                target_link_options(${target}
+                PRIVATE
+                    "-T" "${LINKER_SCRIPT_PATH}"
+            )
+            endif()
+        else()
+            message(STATUS "${target} uses custom linker script  ${ARGV2}")
+            mbed_set_custom_linker_script(${target} ${ARGV2})
         endif()
-    else()
-        message(STATUS "${target} uses custom linker script  ${ARGV2}")
-        mbed_set_custom_linker_script(${target} ${ARGV2})
     endif()
 
     # The mapfile name includes the top-level target name and the


### PR DESCRIPTION
This is a PR for an additional feature:
a custom linker script can be applied by adding the .ld filepath as 2nd argument to mbed_set_post_build.

This PR replaces the draft #93 

E.g. in CMakeLists.txt for an executable:
```cmake
add_executable(Hello main.cpp)

target_link_libraries(Hello mbed-os)

mbed_set_post_build(Hello mbed-disco-f769ni-SRAM2.ld)
```

In this case, the .ld file must exist in the source dir of the project. The linker script is processed by the linker, so defines like in the mbed-os linkerscript templates can used in the same way.

The custom linker script is not applied to mbed built-in tests.

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

adding a custom linker script is supported now.
It is necessary to map variables or code to linker supplied sections. Especially for M4 or M7 MCUs with serveral busses and DMA constraints makes it mandatory to specify memory addresses.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

This feature is optional and existing linker script is not changed unless a custom linker script is set.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Will be updated when this feature is merged.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    Tested with DISCO_F769NI

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
