### PR TITLE
Enable disabling target files for custom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,15 @@ target_include_directories(mbed-core-flags
 # mbed_set_post_build().
 add_subdirectory(targets)
 
+if(NOT TARGET ${MBED_TARGET_CMAKE_NAME})
+    message(FATAL_ERROR "CMake target ${MBED_TARGET_CMAKE_NAME} was not found after scanning the mbed-os/targets \
+directory.  If this is a custom target, you need to define a target called ${MBED_TARGET_CMAKE_NAME} before doing:
+add_subdirectory(mbed-os)")
+endif()
+
+# Disable any requested files from the targets/ directory.
+mbed_apply_mcu_target_file_disables()
+
 add_subdirectory(cmsis)
 add_subdirectory(drivers)
 add_subdirectory(hal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,9 +246,9 @@ target_include_directories(mbed-core-flags
 # mbed_set_post_build().
 add_subdirectory(targets)
 
-if(NOT TARGET ${MBED_TARGET_CMAKE_NAME})
+if((NOT MBED_IS_NATIVE_BUILD) AND (NOT TARGET ${MBED_TARGET_CMAKE_NAME}))
     message(FATAL_ERROR "CMake target ${MBED_TARGET_CMAKE_NAME} was not found after scanning the mbed-os/targets \
-directory.  If this is a custom target, you need to define a target called ${MBED_TARGET_CMAKE_NAME} before doing:
+directory.  If this is a custom target, you need to define a target called ${MBED_TARGET_CMAKE_NAME} before doing: \
 add_subdirectory(mbed-os)")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,8 +252,10 @@ directory.  If this is a custom target, you need to define a target called ${MBE
 add_subdirectory(mbed-os)")
 endif()
 
-# Disable any requested files from the targets/ directory.
-mbed_apply_mcu_target_file_disables()
+if(NOT MBED_IS_NATIVE_BUILD)
+    # Disable any requested files from the targets/ directory.
+    mbed_apply_mcu_target_file_disables()
+endif()
 
 add_subdirectory(cmsis)
 add_subdirectory(drivers)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This MR adds a feature for users to disable files that are part of one of the MCU targets (e.g. `mbed-stm32l4` or `mbed-stm32l452xe`.  It's as simple as:
```cpp
mbed_disable_mcu_target_file(mbed-stm32l452xe system_clock.c)
```
Then, you can add your own system_clock.c as part of a custom target.  No fuss, no muss!

#### Impact of changes <!-- Optional -->
It's now possible to replicate the 'override' functionality that custom targets had in Mbed CLI 1 and mbed-cmake!

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
None

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
This is documented through the mbed-ce-custom-targets example project.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

I tested this locally by confirming that the L452RE_CUSTOM_CLOCK target builds in the example repo, and system_clock.c from Mbed is not compiled as part of it.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
