### PR TITLE
Fix compilation of I2C code on static pinmap targets

### DIFF
--- a/connectivity/FEATURE_BLE/CMakeLists.txt
+++ b/connectivity/FEATURE_BLE/CMakeLists.txt
@@ -8,7 +8,6 @@ if(MBED_ENABLE_OS_INTERNAL_TESTS)
 endif()
 
 add_library(mbed-ble STATIC EXCLUDE_FROM_ALL)
-add_library(mbed-ble-cordio_ll STATIC EXCLUDE_FROM_ALL)
 
 add_subdirectory(libraries)
 add_subdirectory(source)

--- a/connectivity/FEATURE_BLE/libraries/TARGET_CORDIO_LL/CMakeLists.txt
+++ b/connectivity/FEATURE_BLE/libraries/TARGET_CORDIO_LL/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+add_library(mbed-ble-cordio_ll STATIC EXCLUDE_FROM_ALL)
+
 target_include_directories(mbed-ble-cordio_ll
     PUBLIC
         .

--- a/targets/TARGET_STM/stm_i2c_api.h
+++ b/targets/TARGET_STM/stm_i2c_api.h
@@ -82,6 +82,11 @@ struct i2c_s {
     /// Specifies which events (the I2C_EVENT_xxx defines) can be passed up to the application from the IRQ handler
     uint8_t available_events;
 #endif
+
+#if STATIC_PINMAP_READY
+    int sda_func;
+    int scl_func;
+#endif
 };
 
 #endif


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

In #78 , I deleted some variables because I thought they were unused.  Turns out they weren't, whoops.  This adds them back.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
Targets that are STATIC_PINMAP_READY will compile again.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
