### PR TITLE
device ram size is 40 kb, not 48 kB

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TOOLCHAIN_GCC_ARM/STM32F303XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TOOLCHAIN_GCC_ARM/STM32F303XC.ld
@@ -37,8 +37,9 @@
 
 MEMORY
 {
-    FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-    RAM (rwx)    : ORIGIN = MBED_RAM_START + VECTORS_SIZE, LENGTH = MBED_RAM_SIZE - VECTORS_SIZE
+    FLASH (rx)    : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+    RAM (rwx)     : ORIGIN = MBED_RAM_START + VECTORS_SIZE, LENGTH = MBED_RAM_SIZE - VECTORS_SIZE
+    RAM_CCM (rwx) : ORIGIN = MBED_RAM1_START, LENGTH = MBED_RAM1_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -183,6 +184,15 @@ SECTIONS
         __HeapLimit = .;
     } > RAM
 
+   .ram_ccm_section  (NOLOAD):
+    { 
+        __ram_ccm_start__ = .;
+        *(.RAM_CCM_section) 
+        . = ORIGIN(RAM_CCM) + LENGTH(RAM_CCM);
+        __ram_ccm_end__ = .;
+    } >RAM_CCM
+
+ 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
      * values to stack symbols later */

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/cmsis_nvic.h
@@ -30,7 +30,7 @@
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-#define MBED_RAM_SIZE  0xc000  // 48 KB
+#define MBED_RAM_SIZE  0xa000  // 40 KB
 #endif
 
 #if !defined(MBED_RAM1_START)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This fix is for correcting the ram size of F303CC device. 
In total RAM+RAM1 it has 48 kB, but the regions are not continuous. SRAM has 40 kB, when 48 kB is set in the linker script, then the device fails to start because the stack pointer is in the Nirvana.

This error is also in arm-pack index.json in Mbed-OS.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

Important fix for this device. Currently, no boards are using this. It is a basically needed for new target ROBOTDYN_F303CC
(also called Blackpill F303, small Chinese breakout board).
 
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->


----------------------------------------------------------------------------------------------------------------
