### PR TITLE
Fix MIMXRT105x serial_format() not working

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/serial_api.c
@@ -91,7 +91,7 @@ void serial_baud(serial_t *obj, int baudrate)
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
 {
     LPUART_Type *base = uart_addrs[obj->index];
-    uint8_t temp;
+    uint32_t temp;
     /* Set bit count and parity mode. */
     temp = base->CTRL & ~(LPUART_CTRL_PE_MASK | LPUART_CTRL_PT_MASK | LPUART_CTRL_M_MASK);
     if (parity != ParityNone) {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This applies the patch found in this issue: https://github.com/ARMmbed/mbed-os/issues/15342 .  The code for MIMRT serial_format() was obviously broken as it is using a uint8_t to store the 32-bit CTRL register:
![image](https://user-images.githubusercontent.com/2099358/219882629-c29323af-d3ce-4f36-a2c8-f20a6797cf8d.png)


#### Impact of changes <!-- Optional -->
serial_format() was obviously broken on MIMXRT105x targets.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Was tested by @grumpyengineer in their issue.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
