### PR TITLE
mbed-ce@master + fixes + gcc 11 support 

### DIFF
--- a/cmsis/device/rtos/source/mbed_rtx_idle.cpp
+++ b/cmsis/device/rtos/source/mbed_rtx_idle.cpp
@@ -148,7 +148,7 @@ extern "C" {
         // critical section to complete sleep with locked deepsleep
         core_util_critical_section_enter();
         sleep_manager_lock_deep_sleep();
-        sleep();
+        mbed_sleep();
         sleep_manager_unlock_deep_sleep();
         core_util_critical_section_exit();
     }

--- a/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
+++ b/connectivity/FEATURE_BLE/include/ble/gatt/GattCharacteristic.h
@@ -1915,7 +1915,7 @@ public:
      * attribute value that equals sizeof(T). For a variable length alternative,
      * use GattCharacteristic directly.
      */
-    ReadOnlyGattCharacteristic<T>(
+    ReadOnlyGattCharacteristic(
         const UUID &uuid,
         T *valuePtr,
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,
@@ -1958,7 +1958,7 @@ public:
      * attribute value with maximum size equal to sizeof(T). For a fixed length
      * alternative, use GattCharacteristic directly.
      */
-    WriteOnlyGattCharacteristic<T>(
+    WriteOnlyGattCharacteristic(
         const UUID &uuid,
         T *valuePtr,
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,
@@ -2000,7 +2000,7 @@ public:
      * attribute value with maximum size equal to sizeof(T). For a fixed length
      * alternative, use GattCharacteristic directly.
      */
-    ReadWriteGattCharacteristic<T>(
+    ReadWriteGattCharacteristic(
         const UUID &uuid,
         T *valuePtr,
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,
@@ -2043,7 +2043,7 @@ public:
      * attribute value with maximum size equal to sizeof(T) * NUM_ELEMENTS.
      * For a fixed length alternative, use GattCharacteristic directly.
      */
-    WriteOnlyArrayGattCharacteristic<T, NUM_ELEMENTS>(
+    WriteOnlyArrayGattCharacteristic(
         const UUID &uuid,
         T valuePtr[NUM_ELEMENTS],
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,
@@ -2087,7 +2087,7 @@ public:
      * attribute value that equals sizeof(T) * NUM_ELEMENTS. For a variable
      * length alternative, use GattCharacteristic directly.
      */
-    ReadOnlyArrayGattCharacteristic<T, NUM_ELEMENTS>(
+    ReadOnlyArrayGattCharacteristic(
         const UUID    &uuid,
         T valuePtr[NUM_ELEMENTS],
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,
@@ -2132,7 +2132,7 @@ public:
      * attribute value with maximum size equal to sizeof(T) * NUM_ELEMENTS.
      * For a fixed length alternative, use GattCharacteristic directly.
      */
-    ReadWriteArrayGattCharacteristic<T, NUM_ELEMENTS>(
+    ReadWriteArrayGattCharacteristic(
         const UUID    &uuid,
         T valuePtr[NUM_ELEMENTS],
         uint8_t additionalProperties = BLE_GATT_CHAR_PROPERTIES_NONE,

--- a/drivers/tests/UNITTESTS/doubles/drivers/LowPowerTicker.h
+++ b/drivers/tests/UNITTESTS/doubles/drivers/LowPowerTicker.h
@@ -17,6 +17,8 @@
 #ifndef MBED_LOWPOWERTICKER_H
 #define MBED_LOWPOWERTICKER_H
 
+#include <chrono>
+
 #include "hal/ticker_api.h"
 #include "Callback.h"
 
@@ -28,21 +30,23 @@ namespace mbed {
 class LowPowerTicker {
 
 public:
-    LowPowerTicker()
-    {
-    }
+    LowPowerTicker() = default;
 
-    virtual ~LowPowerTicker()
+    virtual ~LowPowerTicker() = default;
+
+    void attach(Callback<void()> func, std::chrono::microseconds t)
     {
+        func();
     }
 
     void attach_us(Callback<void()> func, us_timestamp_t t)
     {
-
+        func(); 
     }
+
     void detach()
     {
-
+        // nothing to do
     }
 };
 

--- a/drivers/tests/UNITTESTS/doubles/drivers/LowPowerTicker.h
+++ b/drivers/tests/UNITTESTS/doubles/drivers/LowPowerTicker.h
@@ -41,7 +41,7 @@ public:
 
     void attach_us(Callback<void()> func, us_timestamp_t t)
     {
-        func(); 
+        func();
     }
 
     void detach()

--- a/events/source/equeue_mbed.cpp
+++ b/events/source/equeue_mbed.cpp
@@ -218,7 +218,7 @@ bool equeue_sema_wait(equeue_sema_t *s, int ms)
 
     core_util_critical_section_enter();
     while (!*s && ms != 0) {
-        sleep();
+        mbed_sleep();
         core_util_critical_section_exit();
         __ISB();
         core_util_critical_section_enter();

--- a/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -142,7 +142,7 @@ void lp_ticker_deepsleep_test()
     TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
 
     while (!intFlag) {
-        sleep();
+        mbed_sleep();
     }
 
     TEST_ASSERT_EQUAL(1, intFlag);

--- a/hal/tests/TESTS/mbed_hal/rtc/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/rtc/main.cpp
@@ -80,7 +80,7 @@ void rtc_sleep_test_support(bool deepsleep_mode)
     TEST_ASSERT(sleep_manager_can_deep_sleep_test_check() == deepsleep_mode);
 
     while (!expired) {
-        sleep();
+        mbed_sleep();
     }
 
     const auto stop = RealTimeClock::now();

--- a/hal/tests/TESTS/mbed_hal/sleep/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep/main.cpp
@@ -79,7 +79,7 @@ void sleep_usticker_test()
 
         us_ticker_set_interrupt(next_match_timestamp);
 
-        sleep();
+        mbed_sleep();
 
         const unsigned int wakeup_timestamp = us_ticker_read();
 
@@ -130,7 +130,7 @@ void deepsleep_lpticker_test()
            Since this interrupt wakes-up the board from the sleep we need to go to sleep after CMPOK is handled. */
         TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
 
-        sleep();
+        mbed_sleep();
 
         /* On some targets like STM family boards with LPTIM enabled an interrupt is triggered on counter rollover.
            We need special handling for cases when next_match_timestamp < start_timestamp (interrupt is to be fired after rollover).
@@ -140,7 +140,7 @@ void deepsleep_lpticker_test()
         if ((next_match_timestamp < start_timestamp) && lp_ticker_read() < next_match_timestamp) {
             lp_ticker_set_interrupt(next_match_timestamp);
             wait_ns(200000);
-            sleep();
+            mbed_sleep();
         }
 #endif
 
@@ -182,7 +182,7 @@ void deepsleep_high_speed_clocks_turned_off_test()
 
     const unsigned int us_ticks_before_sleep = us_ticker_read();
 
-    sleep();
+    mbed_sleep();
 
     const unsigned int us_ticks_after_sleep = us_ticker_read();
     const unsigned int lp_ticks_after_sleep = lp_ticker_read();

--- a/platform/cxxsupport/mstd_type_traits
+++ b/platform/cxxsupport/mstd_type_traits
@@ -210,7 +210,6 @@ using std::is_trivial;
 using std::is_trivially_copyable;
 using std::is_standard_layout;
 using std::is_pod;
-using std::is_literal_type;
 using std::is_empty;
 using std::is_polymorphic;
 using std::is_abstract;
@@ -274,8 +273,6 @@ using std::decay;
 using std::decay_t;
 using std::common_type;
 using std::common_type_t;
-using std::result_of;
-using std::result_of_t;
 
 /* C++20 remove_cvref */
 template <typename T>

--- a/platform/include/platform/mbed_power_mgmt.h
+++ b/platform/include/platform/mbed_power_mgmt.h
@@ -192,7 +192,7 @@ void sleep_manager_sleep_auto(void);
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
-static inline void sleep(void)
+static inline void mbed_sleep(void)
 {
 #if DEVICE_SLEEP
 #if (MBED_CONF_RTOS_PRESENT == 0) || (DEVICE_SYSTICK_CLK_OFF_DURING_SLEEP == 0) || defined(MBED_TICKLESS)

--- a/platform/source/mbed_os_timer.cpp
+++ b/platform/source/mbed_os_timer.cpp
@@ -170,7 +170,7 @@ void do_sleep_operation(OpT &op)
             // we go round to set the timer again.
             if (op.sleep_prepared()) {
                 // Enter HAL sleep (normal or deep)
-                sleep();
+                mbed_sleep();
             }
         }
 

--- a/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
+++ b/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
@@ -20,6 +20,8 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#pragma GCC diagnostic ignored "-Winvalid-noreturn"
+
 bool mbed_assert_throw_errors = false;
 
 extern "C" void mbed_assert_internal(const char *expr, const char *file, int line)

--- a/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
+++ b/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
@@ -19,25 +19,25 @@
 
 rtos::Mutex::Mutex()
 {
-	return;
+    return;
 }
 
 rtos::Mutex::~Mutex()
 {
-	return;
+    return;
 }
 
 osStatus rtos::Mutex::lock()
 {
-	return osOK;
+    return osOK;
 }
 
 osStatus rtos::Mutex::unlock()
 {
-	return osOK;
+    return osOK;
 }
 
 bool rtos::Mutex::trylock()
 {
-	return true;
+    return true;
 }

--- a/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
+++ b/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
@@ -19,20 +19,25 @@
 
 rtos::Mutex::Mutex()
 {
-    return;
+	return;
 }
 
 rtos::Mutex::~Mutex()
 {
-    return;
+	return;
 }
 
 osStatus rtos::Mutex::lock()
 {
-    return osOK;
+	return osOK;
 }
 
 osStatus rtos::Mutex::unlock()
 {
-    return osOK;
+	return osOK;
+}
+
+bool rtos::Mutex::trylock()
+{
+	return true;
 }


### PR DESCRIPTION
This PR adds various fixes that we needed for our project (https://github.com/leka/LekaOS) to be able to use GCC v11 and C++20

- Fix rtos::Mutex stub, add trylock() method
- LowPowerTicker - Add ::attach(...) method + call callback
- mbed_power_management - rename sleep --> mbed_sleep to avoid conflicts
- GCC 11/C++ 20 - Remove deprecated type_traits
- GCC 11/C++ 20 - Remove redundant templating of methods
- Warning - pragma ignore invalid-noreturn for unit tests
