### PR TITLE
Fix BlueNRG undefined reference to ble_cordio_get_hci_driver()

### DIFF
--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/CMakeLists.txt
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/CMakeLists.txt
@@ -1,9 +1,15 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(mbed-bluenrg-2 STATIC EXCLUDE_FROM_ALL
-	BlueNrg2HCIDriver.cpp)
+add_library(mbed-bluenrg2 STATIC EXCLUDE_FROM_ALL
+    BlueNrg2HCIDriver.cpp)
 
-target_link_libraries(mbed-bluenrg-2 PUBLIC
-	mbed-os
-	mbed-ble)
+target_link_libraries(mbed-bluenrg2 
+    PUBLIC
+        mbed-core-flags
+        mbed-ble
+    PRIVATE
+        mbed-rtos-flags)
+
+# circular dependency between mbed-ble and the BlueNRG driver, because of the ble_cordio_get_hci_driver() implementation
+target_link_libraries(mbed-ble PUBLIC mbed-bluenrg2)

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/CMakeLists.txt
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/CMakeLists.txt
@@ -4,6 +4,13 @@
 add_library(mbed-bluenrg-ms STATIC EXCLUDE_FROM_ALL
 	BlueNrgMsHCIDriver.cpp)
 
-target_link_libraries(mbed-bluenrg-ms PUBLIC
-	mbed-os
-	mbed-ble)
+target_link_libraries(mbed-bluenrg-ms
+    PUBLIC
+        mbed-core-flags
+        mbed-ble
+    PRIVATE
+        mbed-rtos-flags)
+
+
+# circular dependency between mbed-ble and the BlueNRG driver, because of the ble_cordio_get_hci_driver() implementation
+target_link_libraries(mbed-ble PUBLIC mbed-bluenrg-ms)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
Fixes #138 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
With this change, if the BlueNRG components are used, mbed-ble can now be only used with the RTOS, not with mbed-baremetal.  That's what I had tried to avoid by making BlueNRG a different library...

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
