### PR TITLE
:wrench: (profiles): Remove debug symbols from release profile, compr…

### DIFF
--- a/tools/cmake/profiles/release.cmake
+++ b/tools/cmake/profiles/release.cmake
@@ -8,6 +8,7 @@ function(mbed_set_profile_options target mbed_toolchain)
     if(${mbed_toolchain} STREQUAL "GCC_ARM")
         list(APPEND profile_c_compile_options
             "-Os"
+            "-g0"
         )
         target_compile_options(${target}
             INTERFACE
@@ -18,6 +19,7 @@ function(mbed_set_profile_options target mbed_toolchain)
             "-fno-rtti"
             "-Wvla"
             "-Os"
+            "-g0"
         )
         target_compile_options(${target}
             INTERFACE
@@ -33,6 +35,7 @@ function(mbed_set_profile_options target mbed_toolchain)
         )
 
         list(APPEND profile_link_options
+            "-Wl,--compress-debug-sections=zlib"
             "-Wl,--gc-sections"
             "-Wl,--wrap,main"
             "-Wl,--wrap,_malloc_r"


### PR DESCRIPTION
…ess debug sections

### Summary of changes <!-- Required -->

Using mbed-ce in our project resulted in a build directory growing over 38Gb in size because of debug info/symbols

This PR removes the debug info/symbols from the release profile.

#### Impact of changes <!-- Optional -->

n/a

#### Migration actions required <!-- Optional -->

n/a

### Documentation <!-- Required -->

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

