### PR TITLE
Fix TLS example by enabling SHA-1 certificates out of the box

### DIFF
--- a/connectivity/mbedtls/platform/inc/platform_mbed.h
+++ b/connectivity/mbedtls/platform/inc/platform_mbed.h
@@ -72,6 +72,9 @@
 #include "mbedtls_device.h"
 #endif
 
+// Include SHA1 certificate support.  Used for a lot of root CAs.
+#define MBEDTLS_SHA1_C 1
+
 /*
  * MBEDTLS_ERR_PLATFORM_HW_FAILED is deprecated and should not be used.
  */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

When I attempted to run [the sockets example](https://github.com/mbed-ce/mbed-os-example-sockets) in TLS mode, I got an extremely cryptic error related to certificate parsing.  Eventually, I was able to track this down to https://github.com/ARMmbed/mbed-os/issues/8638 .  Turns out that, to save space, the Mbed devs disabled the SHA1 algorithm by default.  However, this algorithm is still used for a number of root CA certificates, including the one used in the example.  I sort of understand the motivation to leave it off, but the errors it causes are just too damn cryptic.  It should be turned on until and unless a better error handling system can be created to tell the user when it's needed.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
The TLS sockets example will now work.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Able to run the TLS socket example on a Teensy 4.1:
```
IP address: 192.168.0.249
Netmask: 255.255.255.0
Gateway: 192.168.0.1

Resolve hostname ifconfig.io
ifconfig.io address is 172.64.195.16
Opening connection to remote port 443

Sending message:
GET / HTTP/1.1
Host: ifconfig.io
Connection: close

sent 56 bytes
Complete message sent
received 100 bytes:
HTTP/1.1 200 OK

Demo concluded successfully
```
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@wwatson4506 
@JojoS62 

----------------------------------------------------------------------------------------------------------------
