### PR TITLE
STM32F7 QSPI flash timeouts and 4-byte addressing

### DIFF
--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1095,7 +1095,6 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             _needs_fast_mode = true;
             _num_status_registers = 3;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
-            _attempt_4_byte_addressing = false;
             break;
         case 0x9d:
             // ISSI devices have only one status register

--- a/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_qspi.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_qspi.c
@@ -571,10 +571,8 @@ void HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi)
         __HAL_DMA_DISABLE(hqspi->hdma);
       }
 
-#if  defined(QSPI1_V1_0)
       /* Clear Busy bit */
       HAL_QSPI_Abort_IT(hqspi);
-#endif
 
       /* Change state of QSPI */
       hqspi->State = HAL_QSPI_STATE_READY;
@@ -616,10 +614,8 @@ void HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi)
         }
       }
 
-#if  defined(QSPI1_V1_0)
       /* Workaround - Extra data written in the FIFO at the end of a read transfer */
       HAL_QSPI_Abort_IT(hqspi);
-#endif
 
       /* Change state of QSPI */
       hqspi->State = HAL_QSPI_STATE_READY;
@@ -1021,10 +1017,8 @@ HAL_StatusTypeDef HAL_QSPI_Transmit(QSPI_HandleTypeDef *hqspi, uint8_t *pData, u
           /* Clear Transfer Complete bit */
           __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
 
-#if  defined(QSPI1_V1_0)
           /* Clear Busy bit */
           status = HAL_QSPI_Abort(hqspi);
-#endif
         }
       }
 
@@ -1112,10 +1106,8 @@ HAL_StatusTypeDef HAL_QSPI_Receive(QSPI_HandleTypeDef *hqspi, uint8_t *pData, ui
           /* Clear Transfer Complete bit */
           __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
 
-#if  defined(QSPI1_V1_0)
           /* Workaround - Extra data written in the FIFO at the end of a read transfer */
           status = HAL_QSPI_Abort(hqspi);
-#endif
         }
       }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

On the STM32769NI the STM32 BSP has an issue where QSPI accesses timeout and require a chip reset. Mbed use to contain a patch to fix this similar to this one but the change was lost during an update.

Enable the workaround ST uses for specific F7 chips but on all chips. There's no downside to this from what I can tell.

The 4-byte addressing was disabled because of timeouts which I think are due to this issue but falsely misattributed to 4-byte addressing. Enable that again.

Further discussions:

https://github.com/ARMmbed/mbed-os/issues/10049
https://github.com/ARMmbed/mbed-os/issues/15108

https://github.com/STMicroelectronics/STM32CubeF7/issues/52
https://github.com/STMicroelectronics/STM32CubeF7/issues/82

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

### Documentation <!-- Required -->

None

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

I'm not sure how to make a test for this yet. The issue takes an hour to recreate.