### PR TITLE
STM32 I2C v2 HAL: Fix repeated starts in transaction mode

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -931,23 +931,17 @@ static void prep_for_restart_if_needed(struct i2c_s *obj_s) {
  * STOP at the end of the current transaction.
  */
 static uint32_t get_hal_xfer_options(struct i2c_s *obj_s, bool stop) {
-    if (obj_s->state == STM_I2C_SB_READ_IN_PROGRESS ||
-        obj_s->state == STM_I2C_SB_WRITE_IN_PROGRESS ||
-        obj_s->state == STM_I2C_PENDING_START) {
-        if(stop) {
-            // Generate restart condition and stop at end
-            return I2C_OTHER_AND_LAST_FRAME;
-        } else {
-            // Generate restart condition but don't send STOP
-            return I2C_OTHER_FRAME;
-        }
+    (void)obj_s;
+
+    // Note: The naming used by STM32 HAL is quite counterintuitive.  "OTHER_FRAME" means "always send a
+    // start/restart condition at the start of the frame".  In contrast, "FIRST_FRAME" means "don't send
+    // a start/restart if the previous transfer was going the same direction".
+    if(stop) {
+        // Generate start condition and stop at end
+        return I2C_OTHER_AND_LAST_FRAME;
     } else {
-        if(stop) {
-            // Generate start condition and stop at end
-            return I2C_FIRST_AND_LAST_FRAME;
-        } else {
-            return I2C_FIRST_FRAME;
-        }
+        // Generate only the start condition
+        return I2C_OTHER_FRAME;
     }
 }
 
@@ -1201,16 +1195,6 @@ int i2c_byte_write(i2c_t *obj, int data)
     return 1;
 }
 #endif //I2C_IP_VERSION_V2
-
-/* Private define for @ref PreviousState usage */
-#define I2C_STATE_MSK             ((uint32_t)((uint32_t)((uint32_t)HAL_I2C_STATE_BUSY_TX | (uint32_t)HAL_I2C_STATE_BUSY_RX) & (uint32_t)(~((uint32_t)HAL_I2C_STATE_READY)))) /*!< Mask State define, keep only RX and TX bits            */
-#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))                                                        /*!< Default Value                                          */
-#define I2C_STATE_MASTER_BUSY_TX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy TX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_MASTER_BUSY_RX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy RX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_SLAVE_BUSY_TX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy TX, combinaison of State LSB and Mode enum  */
-#define I2C_STATE_SLAVE_BUSY_RX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy RX, combinaison of State LSB and Mode enum  */
-#define I2C_STATE_MEM_BUSY_TX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy TX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_MEM_BUSY_RX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy RX, combinaison of State LSB and Mode enum */
 
 /*
  *  SYNC APIS

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -931,7 +931,9 @@ static void prep_for_restart_if_needed(struct i2c_s *obj_s) {
  * STOP at the end of the current transaction.
  */
 static uint32_t get_hal_xfer_options(struct i2c_s *obj_s, bool stop) {
-    if (obj_s->state == STM_I2C_SB_READ_IN_PROGRESS || obj_s->state == STM_I2C_SB_WRITE_IN_PROGRESS) {
+    if (obj_s->state == STM_I2C_SB_READ_IN_PROGRESS ||
+        obj_s->state == STM_I2C_SB_WRITE_IN_PROGRESS ||
+        obj_s->state == STM_I2C_PENDING_START) {
         if(stop) {
             // Generate restart condition and stop at end
             return I2C_OTHER_AND_LAST_FRAME;
@@ -944,7 +946,7 @@ static uint32_t get_hal_xfer_options(struct i2c_s *obj_s, bool stop) {
             // Generate start condition and stop at end
             return I2C_FIRST_AND_LAST_FRAME;
         } else {
-            return I2C_LAST_FRAME;
+            return I2C_FIRST_FRAME;
         }
     }
 }
@@ -1199,6 +1201,16 @@ int i2c_byte_write(i2c_t *obj, int data)
     return 1;
 }
 #endif //I2C_IP_VERSION_V2
+
+/* Private define for @ref PreviousState usage */
+#define I2C_STATE_MSK             ((uint32_t)((uint32_t)((uint32_t)HAL_I2C_STATE_BUSY_TX | (uint32_t)HAL_I2C_STATE_BUSY_RX) & (uint32_t)(~((uint32_t)HAL_I2C_STATE_READY)))) /*!< Mask State define, keep only RX and TX bits            */
+#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))                                                        /*!< Default Value                                          */
+#define I2C_STATE_MASTER_BUSY_TX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MASTER_BUSY_RX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy RX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_SLAVE_BUSY_TX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy TX, combinaison of State LSB and Mode enum  */
+#define I2C_STATE_SLAVE_BUSY_RX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy RX, combinaison of State LSB and Mode enum  */
+#define I2C_STATE_MEM_BUSY_TX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MEM_BUSY_RX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy RX, combinaison of State LSB and Mode enum */
 
 /*
  *  SYNC APIS


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When testing with a U-Blox GPS, I noticed that there's an issue in the new STM32 I2C HAL added by #78 .  Trying to do a repeated start using the transactional API:

```cpp
    // Set read address to 1
    uint8_t const readAddr = 0x01;
    TEST_ASSERT_EQUAL(I2C::Result::ACK, i2c->write(EEPROM_I2C_ADDRESS, reinterpret_cast<const char *>(&readAddr), 1, true));

    // Read the byte back
    uint8_t readByte = 0;
    TEST_ASSERT_EQUAL(I2C::Result::ACK, i2c->read(EEPROM_I2C_ADDRESS | 1, reinterpret_cast<char *>(&readByte), 1));
    TEST_ASSERT_EQUAL_UINT8(0x3, readByte);
```
simply does not work:
![image](https://user-images.githubusercontent.com/2099358/226524128-6950237a-71c6-4ac2-8759-5be07d8f3484.png)

This is because the code in get_hal_xfer_options() was returning `I2C_LAST_FRAME` for the case of stop=false, which is patently wrong -- it should be `I2C_FIRST_FRAME`, to indicate that we want a start condition but not a stop.  I think I inherited this code from the original implementation, but I should have trusted my gut that this wasn't right...

However, that wasn't the only issue.  Simply changing I2C_LAST_FRAME to I2C_FIRST_FRAME did fix the repeated starts, but created another issue where some of the test cases would time out trying to do I2C operations.  It turns out there's some really wacky logic in the STM32 HAL code where, if you pass that constant and it detects that the previous transfer was the same type of transfer, it simply won't set the START flag.  Which... causes it to hang forever and not send any data.  Really not sure why it does this.  Seriously, I'm scratching my head.

Luckily, the fix is pretty simple: use `I2C_OTHER_FRAME` instead of `I2C_FIRST_FRAME`, which activates additional logic which disables the other logic which cancels the start condition.  So, we really just want to be using OTHER_FRAME everywhere.

With the new code, I can generate repeated start conditions properly:

![image](https://user-images.githubusercontent.com/2099358/226525154-46950f45-f27e-4a12-a547-832719ac29e5.png)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran the I2C test suite (same as #78) and passed all the tests.
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JohnK1987 
@JojoS62 

----------------------------------------------------------------------------------------------------------------
