### PR TITLE
Bugfix: LPC1768 IAP could not copy flash to flash

### DIFF
--- a/hal/include/hal/flash_api.h
+++ b/hal/include/hal/flash_api.h
@@ -79,7 +79,14 @@ int32_t flash_read(flash_t *obj, uint32_t address, uint8_t *data, uint32_t size)
 /** Program pages starting at defined address
  *
  * The pages should not cross multiple sectors.
- * This function does not do any check for address alignments or if size is aligned to a page size.
+ *
+ * \note The upper level FlashIAP.cpp code guarantees:
+ * <ul><li>\c data is 32-bit aligned</li>
+ * <li>\c size is a multiple of the page size</li>
+ * <li>\c address is inside a flash sector</li>
+ * <li>\c address is aligned to the page size (but not the sector size)</li>
+ * </ul>So, implementations of this function do not need to check these things.
+ *
  * @param obj The flash object
  * @param address The sector starting address
  * @param data The data buffer to be programmed

--- a/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -218,6 +218,55 @@ void flash_program_page_test()
     delete[] data_flashed;
 }
 
+// Tests that one flash page can be copied to another
+void flash_copy_flash_to_flash()
+{
+    flash_t test_flash;
+    int32_t ret = flash_init(&test_flash);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    uint32_t last_page_address = flash_get_start_address(&test_flash) + flash_get_size(&test_flash) - flash_get_page_size(&test_flash);
+    uint32_t * last_page_pointer = reinterpret_cast<uint32_t *>(last_page_address);
+    uint32_t second_to_last_page_address = last_page_address - flash_get_page_size(&test_flash);
+    uint32_t * second_to_last_page_pointer = reinterpret_cast<uint32_t *>(second_to_last_page_address);
+
+    // Erase the sector(s) which contain the last two pages
+    uint32_t last_page_sector = ALIGN_DOWN(last_page_address, flash_get_sector_size(&test_flash, last_page_address));
+    uint32_t second_to_last_page_sector = ALIGN_DOWN(second_to_last_page_address, flash_get_sector_size(&test_flash, second_to_last_page_address));
+
+    ret = flash_erase_sector(&test_flash, last_page_sector);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    if(last_page_sector != second_to_last_page_sector)
+    {
+        ret = flash_erase_sector(&test_flash, second_to_last_page_sector);
+        TEST_ASSERT_EQUAL_INT32(0, ret);
+    }
+
+    // Fill second to last page with test data
+    size_t const numDataWords = flash_get_page_size(&test_flash) / sizeof(uint32_t);
+    uint32_t * data = new uint32_t[numDataWords];
+    for(size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx)
+    {
+        data[wordIdx] = wordIdx;
+    }
+
+    ret = flash_program_page(&test_flash, second_to_last_page_address, reinterpret_cast<const uint8_t *>(data), flash_get_page_size(&test_flash));
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    // Make sure data was written
+    TEST_ASSERT_EQUAL_UINT32_ARRAY(data, second_to_last_page_pointer, numDataWords);
+
+    // Now, program last page from the second to last page
+    ret = flash_program_page(&test_flash, last_page_address,reinterpret_cast<const uint8_t *>(second_to_last_page_pointer), flash_get_page_size(&test_flash));
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+
+    // Make sure data was written
+    TEST_ASSERT_EQUAL_UINT32_ARRAY(data, last_page_pointer, numDataWords);
+
+    delete[] data;
+}
+
 // check the execution speed at the start and end of the test to make sure
 // cache settings weren't changed
 void flash_clock_and_cache_test()
@@ -232,6 +281,7 @@ Case cases[] = {
     Case("Flash - mapping alignment", flash_mapping_alignment_test),
     Case("Flash - erase sector", flash_erase_sector_test),
     Case("Flash - program page", flash_program_page_test),
+    Case("Flash - copy flash to flash", flash_copy_flash_to_flash),
     Case("Flash - clock and cache test", flash_clock_and_cache_test),
 };
 

--- a/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -244,7 +244,7 @@ void flash_copy_flash_to_flash()
 
     // Fill second to last page with test data
     size_t const numDataWords = flash_get_page_size(&test_flash) / sizeof(uint32_t);
-    uint32_t * data = new uint32_t[numDataWords];
+    uint32_t *data = new uint32_t[numDataWords];
     for (size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx) {
         data[wordIdx] = wordIdx;
     }

--- a/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -226,9 +226,9 @@ void flash_copy_flash_to_flash()
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
     uint32_t last_page_address = flash_get_start_address(&test_flash) + flash_get_size(&test_flash) - flash_get_page_size(&test_flash);
-    uint32_t * last_page_pointer = reinterpret_cast<uint32_t *>(last_page_address);
+    uint32_t *last_page_pointer = reinterpret_cast<uint32_t *>(last_page_address);
     uint32_t second_to_last_page_address = last_page_address - flash_get_page_size(&test_flash);
-    uint32_t * second_to_last_page_pointer = reinterpret_cast<uint32_t *>(second_to_last_page_address);
+    uint32_t *second_to_last_page_pointer = reinterpret_cast<uint32_t *>(second_to_last_page_address);
 
     // Erase the sector(s) which contain the last two pages
     uint32_t last_page_sector = ALIGN_DOWN(last_page_address, flash_get_sector_size(&test_flash, last_page_address));
@@ -237,8 +237,7 @@ void flash_copy_flash_to_flash()
     ret = flash_erase_sector(&test_flash, last_page_sector);
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
-    if(last_page_sector != second_to_last_page_sector)
-    {
+    if(last_page_sector != second_to_last_page_sector) {
         ret = flash_erase_sector(&test_flash, second_to_last_page_sector);
         TEST_ASSERT_EQUAL_INT32(0, ret);
     }
@@ -246,8 +245,7 @@ void flash_copy_flash_to_flash()
     // Fill second to last page with test data
     size_t const numDataWords = flash_get_page_size(&test_flash) / sizeof(uint32_t);
     uint32_t * data = new uint32_t[numDataWords];
-    for(size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx)
-    {
+    for(size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx) {
         data[wordIdx] = wordIdx;
     }
 
@@ -258,7 +256,7 @@ void flash_copy_flash_to_flash()
     TEST_ASSERT_EQUAL_UINT32_ARRAY(data, second_to_last_page_pointer, numDataWords);
 
     // Now, program last page from the second to last page
-    ret = flash_program_page(&test_flash, last_page_address,reinterpret_cast<const uint8_t *>(second_to_last_page_pointer), flash_get_page_size(&test_flash));
+    ret = flash_program_page(&test_flash, last_page_address, reinterpret_cast<const uint8_t *>(second_to_last_page_pointer), flash_get_page_size(&test_flash));
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
     // Make sure data was written

--- a/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -237,7 +237,7 @@ void flash_copy_flash_to_flash()
     ret = flash_erase_sector(&test_flash, last_page_sector);
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
-    if(last_page_sector != second_to_last_page_sector) {
+    if (last_page_sector != second_to_last_page_sector) {
         ret = flash_erase_sector(&test_flash, second_to_last_page_sector);
         TEST_ASSERT_EQUAL_INT32(0, ret);
     }
@@ -245,7 +245,7 @@ void flash_copy_flash_to_flash()
     // Fill second to last page with test data
     size_t const numDataWords = flash_get_page_size(&test_flash) / sizeof(uint32_t);
     uint32_t * data = new uint32_t[numDataWords];
-    for(size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx) {
+    for (size_t wordIdx = 0; wordIdx < numDataWords; ++wordIdx) {
         data[wordIdx] = wordIdx;
     }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes an issue reported on the forums here: https://forums.mbed.com/t/limitation-of-flash-iap-for-lpc176x-flashing-from-ram-only/19892

The LPC1768's FlashIAP implementation could not successfully copy flash data to flash.  Now, I adapted the existing RAM buffer scheme in the driver to fix this issue.  I also did a general cleanup of the lpc1768 flash code, including replacing the magic 1024 number with the page size, and fixing the reported deadlock issue if an operation fails (missed core_util_critical_section_exit() calls).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

See comment below
   
----------------------------------------------------------------------------------------------------------------
