### PR TITLE
DMA SPI support for STM32 devices

### DIFF
--- a/connectivity/CMakeLists.txt
+++ b/connectivity/CMakeLists.txt
@@ -11,7 +11,6 @@ if("FEATURE_BLE=1" IN_LIST MBED_TARGET_DEFINITIONS)
     add_subdirectory(FEATURE_BLE)
 endif()
 
-add_subdirectory(lorawan)
 add_subdirectory(drivers)
 add_subdirectory(libraries)
 add_subdirectory(lwipstack)

--- a/connectivity/CMakeLists.txt
+++ b/connectivity/CMakeLists.txt
@@ -11,6 +11,7 @@ if("FEATURE_BLE=1" IN_LIST MBED_TARGET_DEFINITIONS)
     add_subdirectory(FEATURE_BLE)
 endif()
 
+add_subdirectory(lorawan)
 add_subdirectory(drivers)
 add_subdirectory(libraries)
 add_subdirectory(lwipstack)

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -776,6 +776,9 @@ private:
      * Should be called with _peripherals_mutex locked.
      */
     static spi_peripheral_s *_alloc();
+    /// Deallocate the given peripheral.
+    /// Must be called from a critical section.
+    static void _dealloc(spi_peripheral_s * peripheral);
 
     /// Deallocate the given peripheral.
     /// Should be called with _peripherals_mutex locked.

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -776,9 +776,6 @@ private:
      * Should be called with _peripherals_mutex locked.
      */
     static spi_peripheral_s *_alloc();
-    /// Deallocate the given peripheral.
-    /// Must be called from a critical section.
-    static void _dealloc(spi_peripheral_s * peripheral);
 
     /// Deallocate the given peripheral.
     /// Should be called with _peripherals_mutex locked.

--- a/drivers/source/I2C.cpp
+++ b/drivers/source/I2C.cpp
@@ -245,7 +245,7 @@ void I2C::abort_transfer(void)
 I2C::Result I2C::transfer_and_wait(int address, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout, bool repeated)
 {
     // Use EventFlags to suspend the thread until the transfer finishes
-    rtos::EventFlags transferResultFlags("I2C::Result EvFlags");
+    rtos::EventFlags transferResultFlags("I2C::transfer_and_wait EvFlags");
 
     // Simple callback from the transfer that sets the EventFlags using the I2C result event
     event_callback_t transferCallback([&](int event) {

--- a/hal/include/hal/spi_api.h
+++ b/hal/include/hal/spi_api.h
@@ -261,6 +261,9 @@ int  spi_master_write(spi_t *obj, int value);
  *  tx_length and rx_length. The bytes written will be padded with the
  *  value 0xff.
  *
+ * Note: Even if the word size / bits per frame is not 8, \c rx_length and \c tx_length
+ * still give lengths in bytes of input data, not numbers of words.
+ *
  * @param[in] obj        The SPI peripheral to use for sending
  * @param[in] tx_buffer  Pointer to the byte-array of data to write to the device
  * @param[in] tx_length  Number of bytes to write, may be zero

--- a/targets/TARGET_STM/CMakeLists.txt
+++ b/targets/TARGET_STM/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(mbed-stm
         trng_api.c
         us_ticker.c
         watchdog_api.c
+		stm_dma_utils.c
 )
 
 target_link_libraries(mbed-stm INTERFACE mbed-cmsis-cortex-m)

--- a/targets/TARGET_STM/TARGET_STM32F0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/objects.h
@@ -44,20 +44,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F0/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word length capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F0/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/stm_dma_info.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2019 STMicroelectronics
+ * Copyright (c) 2016-2023 STMicroelectronics
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +15,24 @@
  * limitations under the License.
  */
 
-#ifndef MBED_SPI_DEVICE_H
-#define MBED_SPI_DEVICE_H
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
 
-#include "stm32wbxx_ll_spi.h"
+#include "cmsis.h"
+#include "stm_dma_utils.h"
 
-// Defines the word legnth capability of the device where Nth bit allows for N window size
-#define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
+// See STM32F0 reference manual Table 26.
 
-// We have DMA support
-#define STM32_SPI_CAPABILITY_DMA 1
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3}, // SPI1 Tx is DMA1 Channel 3
+        {1, 5}, // SPI2 Tx is DMA1 Channel 5
+};
 
-#endif
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2}, // SPI1 Rx is DMA1 Channel 2
+        {1, 4}, // SPI2 Rx is DMA1 Channel 4
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32F1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/objects.h
@@ -89,20 +89,6 @@ struct serial_s {
 #endif
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct i2c_s {
     /*  The 1st 2 members I2CName i2c
      *  and I2C_HandleTypeDef handle should

--- a/targets/TARGET_STM/TARGET_STM32F1/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/spi_device.h
@@ -35,4 +35,7 @@
 // Defines the word length capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x00008080)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/stm_dma_info.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// See STM32F1 reference manual Tables 78 and 79.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3}, // SPI1 Tx is DMA1 Channel 3
+        {1, 5}, // SPI2 Tx is DMA1 Channel 5
+        {2, 2}, // SPI3 Tx is DMA2 Channel 2
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2}, // SPI1 Rx is DMA1 Channel 2
+        {1, 4}, // SPI2 Rx is DMA1 Channel 4
+        {2, 1}, // SPI3 Rx is DMA2 Channel 1
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -95,20 +95,6 @@ struct serial_s {
 #endif
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct i2c_s {
     /*  The 1st 2 members I2CName i2c
      *  and I2C_HandleTypeDef handle should

--- a/targets/TARGET_STM/TARGET_STM32F2/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/spi_device.h
@@ -35,4 +35,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x00008080)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F2/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/stm_dma_info.h
@@ -21,45 +21,20 @@
 #include "cmsis.h"
 #include "stm_dma_utils.h"
 
-#ifdef DMAMUX1
-
-// STM32L4+ devices, with DMAMUX feature.
-// On this device, the DMA channels may be chosen arbitrarily.
+// See STM32F2 reference manual Tables 22 and 23
 
 /// Mapping from SPI index to DMA link info for Tx
 static const DMALinkInfo SPITxDMALinks[] = {
-        {1, 1, DMA_REQUEST_SPI1_TX},
-        {1, 3, DMA_REQUEST_SPI2_TX},
-        {2, 5, DMA_REQUEST_SPI3_TX}
+        {2, 3, 3}, // SPI1 Tx is DMA2 Stream 3 Channel 3
+        {1, 4, 0}, // SPI2 Tx is DMA1 Stream 3 Channel 0
+        {1, 5, 0}  // SPI3 Tx is DMA1 Stream 5 Channel 0
 };
 
 /// Mapping from SPI index to DMA link info for Rx
 static const DMALinkInfo SPIRxDMALinks[] = {
-        {1, 2, DMA_REQUEST_SPI1_RX},
-        {1, 4, DMA_REQUEST_SPI2_RX},
-        {1, 6, DMA_REQUEST_SPI3_RX}
+        {2, 0, 3}, // SPI1 Rx is DMA2 Stream 0 Channel 3
+        {1, 3, 0}, // SPI2 Rx is DMA1 Stream 3 Channel 0
+        {1, 0, 0}  // SPI3 Rx is DMA2 Stream 0 Channel 0
 };
-
-#else
-
-
-// Base model STM32L4 devices, with fixed DMA line mapping
-// See STM32L4 reference manual Tables 41 and 42.
-
-/// Mapping from SPI index to DMA link info for Tx
-static const DMALinkInfo SPITxDMALinks[] = {
-        {1, 3, 1}, // SPI1 Tx is DMA1 Ch3 Request 1
-        {1, 5, 1}, // SPI2 Tx is DMA1 Ch5 Request 1
-        {2, 2, 3}  // SPI3 Tx is DMA2 Ch2 Request 3
-};
-
-/// Mapping from SPI index to DMA link info for Rx
-static const DMALinkInfo SPIRxDMALinks[] = {
-        {1, 2, 1}, // SPI1 Rx is DMA1 Ch2 Request 1
-        {1, 4, 1}, // SPI2 Rx is DMA1 Ch4 Request 1
-        {2, 1, 3}  // SPI3 Rx is DMA2 Ch1 Request 3
-};
-
-#endif
 
 #endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32F3/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/objects.h
@@ -57,20 +57,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F3/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/spi_device.h
@@ -35,4 +35,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F3/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/stm_dma_info.h
@@ -1,0 +1,42 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// See STM32F3 reference manual Tables 78 and 79.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3}, // SPI1 Tx is DMA1 Channel 3
+        {1, 5}, // SPI2 Tx is DMA1 Channel 5
+        {2, 2}, // SPI3 Tx is DMA2 Channel 2
+        {2, 5}, // SPI4 Tx is DMA2 Channel 5
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2}, // SPI1 Rx is DMA1 Channel 2
+        {1, 4}, // SPI2 Rx is DMA1 Channel 4
+        {2, 1}, // SPI3 Rx is DMA2 Channel 1
+        {2, 4}, // SPI4 Rx is DMA2 Channel 4
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -76,20 +76,6 @@ struct serial_s {
 #endif
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct i2c_s {
     /*  The 1st 2 members I2CName i2c
      *  and I2C_HandleTypeDef handle should

--- a/targets/TARGET_STM/TARGET_STM32F4/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x00008080)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/stm_dma_info.h
@@ -21,20 +21,31 @@
 #include "cmsis.h"
 #include "stm_dma_utils.h"
 
-// See STM32F2 reference manual Tables 22 and 23
+// See STM32F4 reference manual Tables 42 and 43.
+// Note: For each SPI and each direction, there are two possible assignments to a DMA channel.
+// We need to assign them here so that no combination would ever conflict and use the same DMA channel.
+
+// Exception: SPI5 and SPI6 use the same DMA channels in hardware and there's no way to deconflict them.
+// So, SPI5 and SPI6 cannot be used with DMA at the same time.
 
 /// Mapping from SPI index to DMA link info for Tx
 static const DMALinkInfo SPITxDMALinks[] = {
         {2, 3, 3}, // SPI1 Tx is DMA2 Stream 3 Channel 3
         {1, 4, 0}, // SPI2 Tx is DMA1 Stream 4 Channel 0
-        {1, 5, 0}  // SPI3 Tx is DMA1 Stream 5 Channel 0
+        {1, 5, 0}, // SPI3 Tx is DMA1 Stream 5 Channel 0
+        {2, 1, 4}, // SPI4 Tx is DMA2 Stream 1 Channel 4
+        {2, 6, 7}, // SPI5 Tx is DMA2 Stream 6 Channel 7
+        {2, 5, 1}, // SPI6 Tx is DMA2 Stream 5 Channel 1
 };
 
 /// Mapping from SPI index to DMA link info for Rx
 static const DMALinkInfo SPIRxDMALinks[] = {
-        {2, 0, 3}, // SPI1 Rx is DMA2 Stream 0 Channel 3
+        {2, 2, 3}, // SPI1 Rx is DMA2 Stream 2 Channel 3
         {1, 3, 0}, // SPI2 Rx is DMA1 Stream 3 Channel 0
-        {1, 0, 0}  // SPI3 Rx is DMA2 Stream 0 Channel 0
+        {1, 0, 0}, // SPI3 Rx is DMA1 Stream 0 Channel 0
+        {2, 0, 4}, // SPI4 Rx is DMA2 Stream 0 Channel 4
+        {2, 5, 7}, // SPI5 Rx is DMA2 Stream 5 Channel 7
+        {2, 6, 1}, // SPI6 Rx is DMA2 Stream 6 Channel 1
 };
 
 #endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_dma.c
@@ -479,8 +479,19 @@ HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress,
     
     /* Enable Common interrupts*/
     hdma->Instance->CR  |= DMA_IT_TC | DMA_IT_TE | DMA_IT_DME;
-    hdma->Instance->FCR |= DMA_IT_FE;
-    
+
+    /* Mbed CE mod: Only enable the FIFO Error interrupt if the FIFO is actually enabled.
+     * If it's not enabled, then this interrupt can trigger spuriously from memory bus
+     * stalls that the DMA engine encounters, and this creates random DMA failures.
+     * Reference forum thread here:
+     * https://community.st.com/t5/stm32-mcus-products/spi-dma-fifo-error-issue-feifx/td-p/537074
+     * also: https://community.st.com/t5/stm32-mcus-touch-gfx-and-gui/spi-dma-error-is-occurred-when-the-other-dma-memory-to-memory-is/td-p/191590
+     */
+    if(hdma->Instance->FCR & DMA_SxFCR_DMDIS)
+    {
+      hdma->Instance->FCR |= DMA_IT_FE;
+    }
+
     if(hdma->XferHalfCpltCallback != NULL)
     {
       hdma->Instance->CR  |= DMA_IT_HT;

--- a/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_dma_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/stm32f7xx_hal_dma_ex.c
@@ -197,7 +197,18 @@ HAL_StatusTypeDef HAL_DMAEx_MultiBufferStart_IT(DMA_HandleTypeDef *hdma, uint32_
     
     /* Enable Common interrupts*/
     hdma->Instance->CR  |= DMA_IT_TC | DMA_IT_TE | DMA_IT_DME;
-    hdma->Instance->FCR |= DMA_IT_FE;
+
+    /* Mbed CE mod: Only enable the FIFO Error interrupt if the FIFO is actually enabled.
+     * If it's not enabled, then this interrupt can trigger spuriously from memory bus
+     * stalls that the DMA engine encounters, and this creates random DMA failures.
+     * Reference forum thread here:
+     * https://community.st.com/t5/stm32-mcus-products/spi-dma-fifo-error-issue-feifx/td-p/537074
+     * also: https://community.st.com/t5/stm32-mcus-touch-gfx-and-gui/spi-dma-error-is-occurred-when-the-other-dma-memory-to-memory-is/td-p/191590
+     */
+    if(hdma->Instance->FCR & DMA_SxFCR_DMDIS)
+    {
+      hdma->Instance->FCR |= DMA_IT_FE;
+    }
     
     if((hdma->XferHalfCpltCallback != NULL) || (hdma->XferM1HalfCpltCallback != NULL))
     {

--- a/targets/TARGET_STM/TARGET_STM32F7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/objects.h
@@ -75,20 +75,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F7/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/spi_device.h
@@ -35,4 +35,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/stm_dma_info.h
@@ -1,0 +1,51 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// See STM32F7 reference manual Tables 27 and 28.
+// Note: For each SPI and each direction, there are two possible assignments to a DMA channel.
+// We need to assign them here so that no combination would ever conflict and use the same DMA channel.
+
+// Exception: SPI5 and SPI6 use the same DMA channels in hardware and there's no way to deconflict them.
+// So, SPI5 and SPI6 cannot be used with DMA at the same time.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {2, 3, 3}, // SPI1 Tx is DMA2 Stream 3 Channel 3
+        {1, 4, 0}, // SPI2 Tx is DMA1 Stream 4 Channel 0
+        {1, 5, 0}, // SPI3 Tx is DMA1 Stream 5 Channel 0
+        {2, 1, 4}, // SPI4 Tx is DMA2 Stream 1 Channel 4
+        {2, 6, 7}, // SPI5 Tx is DMA2 Stream 6 Channel 7
+        {2, 5, 1}, // SPI6 Tx is DMA2 Stream 5 Channel 1
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {2, 2, 3}, // SPI1 Rx is DMA2 Stream 2 Channel 3
+        {1, 3, 0}, // SPI2 Rx is DMA1 Stream 3 Channel 0
+        {1, 0, 0}, // SPI3 Rx is DMA1 Stream 0 Channel 0
+        {2, 0, 4}, // SPI4 Rx is DMA2 Stream 0 Channel 4
+        {2, 5, 7}, // SPI5 Rx is DMA2 Stream 5 Channel 7
+        {2, 6, 1}, // SPI6 Rx is DMA2 Stream 6 Channel 1
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -56,20 +56,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32G0/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/stm_dma_info.h
@@ -1,0 +1,52 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// STM32G0 devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+        {1, 3, DMA_REQUEST_SPI2_TX},
+#ifdef DMA2
+        // For better performance, on devices with DMA2 (STM32G0Bxx/Cxx), put SPI3 on DMA2
+        {2, 1, DMA_REQUEST_SPI3_TX}
+#else
+        {1, 5, DMA_REQUEST_SPI3_TX}
+#endif
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+        {1, 4, DMA_REQUEST_SPI2_RX},
+#ifdef DMA2
+        // For better performance, on devices with DMA2 (STM32G0Bxx/Cxx), put SPI3 on DMA2
+        {2, 2, DMA_REQUEST_SPI3_RX}
+#else
+        {1, 6, DMA_REQUEST_SPI3_RX}
+#endif
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32G4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/objects.h
@@ -55,20 +55,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32G4/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32G4/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/stm_dma_info.h
@@ -1,0 +1,48 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// STM32G4 devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+        {1, 3, DMA_REQUEST_SPI2_TX},
+        {1, 5, DMA_REQUEST_SPI3_TX},
+#ifdef SPI4
+        {2, 1, DMA_REQUEST_SPI4_TX}
+#endif
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+        {1, 4, DMA_REQUEST_SPI2_RX},
+        {1, 6, DMA_REQUEST_SPI3_RX},
+#ifdef SPI4
+        {2, 2, DMA_REQUEST_SPI4_RX}
+#endif
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -64,20 +64,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32H7/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/spi_device.h
@@ -24,4 +24,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0xFFFFFFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32H7/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/stm_dma_info.h
@@ -21,45 +21,28 @@
 #include "cmsis.h"
 #include "stm_dma_utils.h"
 
-#ifdef DMAMUX1
-
-// STM32L4+ devices, with DMAMUX feature.
+// STM32H7 devices, with DMAMUX feature.
 // On this device, the DMA channels may be chosen arbitrarily.
 
 /// Mapping from SPI index to DMA link info for Tx
 static const DMALinkInfo SPITxDMALinks[] = {
         {1, 1, DMA_REQUEST_SPI1_TX},
         {1, 3, DMA_REQUEST_SPI2_TX},
-        {1, 5, DMA_REQUEST_SPI3_TX}
+        {1, 5, DMA_REQUEST_SPI3_TX},
+        {1, 7, DMA_REQUEST_SPI4_TX},
+        {2, 1, DMA_REQUEST_SPI5_TX},
+        {3, 1, BDMA_REQUEST_SPI6_TX}, // SPI6 must be used through BDMA
 };
 
 /// Mapping from SPI index to DMA link info for Rx
 static const DMALinkInfo SPIRxDMALinks[] = {
-        {1, 2, DMA_REQUEST_SPI1_RX},
-        {1, 4, DMA_REQUEST_SPI2_RX},
-        {1, 6, DMA_REQUEST_SPI3_RX}
+        {1, 0, DMA_REQUEST_SPI1_RX},
+        {1, 2, DMA_REQUEST_SPI2_RX},
+        {1, 4, DMA_REQUEST_SPI3_RX},
+        {1, 6, DMA_REQUEST_SPI4_RX},
+        {2, 0, DMA_REQUEST_SPI5_RX},
+        {3, 0, BDMA_REQUEST_SPI6_TX}, // SPI6 must be used through BDMA
 };
 
-#else
-
-
-// Base model STM32L4 devices, with fixed DMA line mapping
-// See STM32L4 reference manual Tables 41 and 42.
-
-/// Mapping from SPI index to DMA link info for Tx
-static const DMALinkInfo SPITxDMALinks[] = {
-        {1, 3, 1}, // SPI1 Tx is DMA1 Ch3 Request 1
-        {1, 5, 1}, // SPI2 Tx is DMA1 Ch5 Request 1
-        {2, 2, 3}  // SPI3 Tx is DMA2 Ch2 Request 3
-};
-
-/// Mapping from SPI index to DMA link info for Rx
-static const DMALinkInfo SPIRxDMALinks[] = {
-        {1, 2, 1}, // SPI1 Rx is DMA1 Ch2 Request 1
-        {1, 4, 1}, // SPI2 Rx is DMA1 Ch4 Request 1
-        {2, 1, 3}  // SPI3 Rx is DMA2 Ch1 Request 3
-};
-
-#endif
 
 #endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32H7/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/stm_dma_info.h
@@ -31,7 +31,6 @@ static const DMALinkInfo SPITxDMALinks[] = {
         {1, 5, DMA_REQUEST_SPI3_TX},
         {1, 7, DMA_REQUEST_SPI4_TX},
         {2, 1, DMA_REQUEST_SPI5_TX},
-        {3, 1, BDMA_REQUEST_SPI6_TX}, // SPI6 must be used through BDMA
 };
 
 /// Mapping from SPI index to DMA link info for Rx
@@ -41,7 +40,6 @@ static const DMALinkInfo SPIRxDMALinks[] = {
         {1, 4, DMA_REQUEST_SPI3_RX},
         {1, 6, DMA_REQUEST_SPI4_RX},
         {2, 0, DMA_REQUEST_SPI5_RX},
-        {3, 0, BDMA_REQUEST_SPI6_TX}, // SPI6 must be used through BDMA
 };
 
 

--- a/targets/TARGET_STM/TARGET_STM32L0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/objects.h
@@ -58,20 +58,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L0/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/spi_device.h
@@ -20,4 +20,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x00008080)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L0/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/stm_dma_info.h
@@ -1,0 +1,38 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// See STM32L0 reference manual Table 51
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3, 1}, // SPI1 Tx is DMA1 Channel 3 Request 1
+        {1, 5, 2}, // SPI2 Tx is DMA1 Channel 5 Request 2
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, 1}, // SPI1 Rx is DMA1 Channel 2 Request 1
+        {1, 4, 2}, // SPI2 Tx is DMA1 Channel 4 Request 2
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32L1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/objects.h
@@ -76,20 +76,6 @@ struct serial_s {
 #endif
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct i2c_s {
     /*  The 1st 2 members I2CName i2c
      *  and I2C_HandleTypeDef handle should

--- a/targets/TARGET_STM/TARGET_STM32L1/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x00008080)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/stm_dma_info.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// See STM32L1 reference manual Tables 55 and 56
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3}, // SPI1 Tx is DMA1 Channel 3
+        {1, 5}, // SPI2 Tx is DMA1 Channel 5
+        {2, 2}, // SPI3 Tx is DMA2 Channel 2
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2}, // SPI1 Rx is DMA1 Channel 2
+        {1, 4}, // SPI2 Rx is DMA1 Channel 4
+        {2, 1}, // SPI3 Rx is DMA2 Channel 1
+};
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32L4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/objects.h
@@ -54,20 +54,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L4/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/stm_dma_info.h
@@ -1,0 +1,76 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+#ifdef DMAMUX1
+
+// STM32L4+ devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+// Always use DMA1 for SPI transactions
+#define SPI1_DMA_CLK_Enable() __HAL_RCC_DMA1_CLK_ENABLE()
+#define SPI2_DMA_CLK_Enable() __HAL_RCC_DMA1_CLK_ENABLE()
+#define SPI3_DMA_CLK_Enable() __HAL_RCC_DMA1_CLK_ENABLE()
+
+// DMA requests are DMAMUX definitions
+#define SPI1_DMA_TX_Request DMA_REQUEST_SPI1_TX
+#define SPI2_DMA_TX_Request DMA_REQUEST_SPI2_TX
+#define SPI3_DMA_TX_Request DMA_REQUEST_SPI3_TX
+
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+        {1, 3, DMA_REQUEST_SPI2_TX},
+        {2, 5, DMA_REQUEST_SPI3_TX}
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+        {1, 4, DMA_REQUEST_SPI2_RX},
+        {1, 6, DMA_REQUEST_SPI3_RX}
+};
+
+#else
+
+
+// Base model STM32L4 devices, with fixed DMA line mapping
+// See STM32L4 reference manual Tables 41 and 42.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 3, 1}, // SPI1 Tx is DMA1 Ch3 Request 1
+        {1, 5, 1}, // SPI2 Tx is DMA1 Ch5 Request 1
+        {2, 2, 3}  // SPI2 Tx is DMA2 Ch2 Request 3
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, 1}, // SPI1 Rx is DMA1 Ch2 Request 1
+        {1, 4, 1}, // SPI2 Rx is DMA1 Ch4 Request 1
+        {2, 1, 3}  // SPI2 Rx is DMA2 Ch1 Request 3
+};
+
+#endif
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32L5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/objects.h
@@ -64,20 +64,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L5/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L5/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/stm_dma_info.h
@@ -1,0 +1,42 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// STM32L5 devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+        {1, 3, DMA_REQUEST_SPI2_TX},
+        {1, 5, DMA_REQUEST_SPI3_TX},
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+        {1, 4, DMA_REQUEST_SPI2_RX},
+        {1, 6, DMA_REQUEST_SPI3_RX},
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32U5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/objects.h
@@ -64,20 +64,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32U5/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/spi_device.h
@@ -23,4 +23,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32U5/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/stm_dma_info.h
@@ -1,0 +1,42 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// STM32U5+ devices.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 0, GPDMA1_REQUEST_SPI1_TX},
+        {1, 2, GPDMA1_REQUEST_SPI2_TX},
+        {1, 4, GPDMA1_REQUEST_SPI3_TX}
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 1, GPDMA1_REQUEST_SPI1_RX},
+        {1, 3, GPDMA1_REQUEST_SPI2_RX},
+        {1, 5, GPDMA1_REQUEST_SPI3_TX}
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32WB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/objects.h
@@ -47,20 +47,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32WB/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/stm_dma_info.h
@@ -1,0 +1,44 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
+
+#include "cmsis.h"
+#include "stm_dma_utils.h"
+
+// STM32WB devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
+
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+#ifdef SPI2
+        {1, 3, DMA_REQUEST_SPI2_TX}
+#endif
+};
+
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+#ifdef SPI4
+        {1, 4, DMA_REQUEST_SPI2_RX}
+#endif
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/TARGET_STM32WL/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/objects.h
@@ -50,20 +50,6 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-struct spi_s {
-    SPI_HandleTypeDef handle;
-    IRQn_Type spiIRQ;
-    SPIName spi;
-    PinName pin_miso;
-    PinName pin_mosi;
-    PinName pin_sclk;
-    PinName pin_ssel;
-#if DEVICE_SPI_ASYNCH
-    uint32_t event;
-    uint8_t transfer_type;
-#endif
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32WL/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/spi_device.h
@@ -21,4 +21,7 @@
 // Defines the word legnth capability of the device where Nth bit allows for N window size
 #define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
 
+// We have DMA support
+#define STM32_SPI_CAPABILITY_DMA 1
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32WL/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/stm_dma_info.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2019 STMicroelectronics
+ * Copyright (c) 2016-2023 STMicroelectronics
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +15,26 @@
  * limitations under the License.
  */
 
-#ifndef MBED_SPI_DEVICE_H
-#define MBED_SPI_DEVICE_H
+#ifndef MBED_OS_STM_DMA_INFO_H
+#define MBED_OS_STM_DMA_INFO_H
 
-#include "stm32wbxx_ll_spi.h"
+#include "cmsis.h"
+#include "stm_dma_utils.h"
 
-// Defines the word legnth capability of the device where Nth bit allows for N window size
-#define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
+// STM32WB devices, with DMAMUX feature.
+// On this device, the DMA channels may be chosen arbitrarily.
 
-// We have DMA support
-#define STM32_SPI_CAPABILITY_DMA 1
+/// Mapping from SPI index to DMA link info for Tx
+static const DMALinkInfo SPITxDMALinks[] = {
+        {1, 1, DMA_REQUEST_SPI1_TX},
+        {1, 3, DMA_REQUEST_SPI2_TX}
+};
 
-#endif
+/// Mapping from SPI index to DMA link info for Rx
+static const DMALinkInfo SPIRxDMALinks[] = {
+        {1, 2, DMA_REQUEST_SPI1_RX},
+        {1, 4, DMA_REQUEST_SPI2_RX}
+};
+
+
+#endif //MBED_OS_STM_DMA_INFO_H

--- a/targets/TARGET_STM/device.h
+++ b/targets/TARGET_STM/device.h
@@ -37,6 +37,7 @@
 
 #include "objects.h"
 #include "stm_i2c_api.h"
+#include "stm_spi_api.h"
 
 #if DEVICE_USTICKER
 #include "us_ticker_defines.h"

--- a/targets/TARGET_STM/stm_dma_ip_v1.h
+++ b/targets/TARGET_STM/stm_dma_ip_v1.h
@@ -24,27 +24,30 @@
 #ifndef MBED_OS_STM_DMA_IP_V1_H
 #define MBED_OS_STM_DMA_IP_V1_H
 
-// Determine max channels per DMA controller.
-// We have to do this by just counting the macros.
-#if defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5) && defined(DMA1_Stream6) && defined(DMA1_Stream7)
+// Devices with DMA IP v1 have at most 8 channels per controller.
 #define MAX_DMA_CHANNELS_PER_CONTROLLER 8
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5) && defined(DMA1_Stream6)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 7
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 6
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 5
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 4
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
-#elif defined(DMA1_Stream0) && defined(DMA1_Stream1)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 2
+
+// Count DMA controllers
+#ifdef DMA1
+#ifdef DMA2
+#define NUM_DMA_CONTROLLERS 2
 #else
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 1
+#define NUM_DMA_CONTROLLERS 1
+#endif
+#else
+#define NUM_DMA_CONTROLLERS 0
 #endif
 
 // Provide an alias so that code can always use the v2 name for this structure
 #define DMA_Channel_TypeDef DMA_Stream_TypeDef
+
+// On some smaller devices, e.g. STM32L1 family, DMA channels are simply logically ORed rather than
+// muxed, so we don't need the "sourceNumber" field.
+// We can check if this is the case by the absence of specific peripherals/registers.
+#if defined(DMAMUX1_BASE) || defined(DMA_SxCR_CHSEL_Msk)
+#define STM_DEVICE_HAS_DMA_SOURCE_SELECTION 1
+#else
+#define STM_DEVICE_HAS_DMA_SOURCE_SELECTION 0
+#endif
 
 #endif //MBED_OS_STM_DMA_IP_V1_H

--- a/targets/TARGET_STM/stm_dma_ip_v1.h
+++ b/targets/TARGET_STM/stm_dma_ip_v1.h
@@ -1,0 +1,50 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This header contains constants and defines specific to processors with the v1 DMA IP.
+ * The v1 IP has DMA controllers with multiple streams, where each "stream" has a "channel selection"
+ * to determine what triggers DMA requests.
+ */
+
+#ifndef MBED_OS_STM_DMA_IP_V1_H
+#define MBED_OS_STM_DMA_IP_V1_H
+
+// Determine max channels per DMA controller.
+// We have to do this by just counting the macros.
+#if defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5) && defined(DMA1_Stream6) && defined(DMA1_Stream7)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 8
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5) && defined(DMA1_Stream6)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 7
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4) && defined(DMA1_Stream5)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 6
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3) && defined(DMA1_Stream4)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 5
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2) && defined(DMA1_Stream3)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 4
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1) && defined(DMA1_Stream2)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
+#elif defined(DMA1_Stream0) && defined(DMA1_Stream1)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 2
+#else
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 1
+#endif
+
+// Provide an alias so that code can always use the v2 name for this structure
+#define DMA_Channel_TypeDef DMA_Stream_TypeDef
+
+#endif //MBED_OS_STM_DMA_IP_V1_H

--- a/targets/TARGET_STM/stm_dma_ip_v2.h
+++ b/targets/TARGET_STM/stm_dma_ip_v2.h
@@ -31,12 +31,6 @@
 // Only 5 channels usable, the other 2 lack interrupts
 #define MAX_DMA_CHANNELS_PER_CONTROLLER 5
 
-#elif defined(TARGET_MCU_STM32G0)
-
-// STM32G0 is weird and does its own thing.
-// Only 3 channels usable, the other 4 lack interrupts
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
-
 #else
 
 // Devices with DMA IP v2 have at most 7 channels per controller.

--- a/targets/TARGET_STM/stm_dma_ip_v2.h
+++ b/targets/TARGET_STM/stm_dma_ip_v2.h
@@ -1,0 +1,62 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This header contains constants and defines specific to processors with the v2 DMA IP.
+ *
+ * The v2 DMA IP has DMA controllers with multiple channels, where each channel has a request source
+ * that determines what triggers DMA transactions
+ */
+
+#ifndef MBED_OS_STM_DMA_IP_V2_H
+#define MBED_OS_STM_DMA_IP_V2_H
+
+#ifdef TARGET_MCU_STM32F0
+
+// STM32F0 is weird and does its own thing.
+// Only 5 channels usable, the other 2 lack interrupts
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 5
+
+#elif defined(TARGET_MCU_STM32G0)
+
+// STM32G0 is weird and does its own thing.
+// Only 3 channels usable, the other 4 lack interrupts
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
+
+#else
+
+// Determine max channels per DMA controller.
+// We have to do this by just counting the macros.
+#if defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5) && defined(DMA1_Channel6) && defined(DMA1_Channel7)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 7
+#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5) && defined(DMA1_Channel6)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 6
+#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 5
+#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 4
+#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
+#elif defined(DMA1_Channel1) && defined(DMA1_Channel2)
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 2
+#else
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 1
+#endif
+
+#endif
+
+#endif //MBED_OS_STM_DMA_IP_V2_H

--- a/targets/TARGET_STM/stm_dma_ip_v2.h
+++ b/targets/TARGET_STM/stm_dma_ip_v2.h
@@ -39,24 +39,29 @@
 
 #else
 
-// Determine max channels per DMA controller.
-// We have to do this by just counting the macros.
-#if defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5) && defined(DMA1_Channel6) && defined(DMA1_Channel7)
+// Devices with DMA IP v2 have at most 7 channels per controller.
 #define MAX_DMA_CHANNELS_PER_CONTROLLER 7
-#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5) && defined(DMA1_Channel6)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 6
-#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4) && defined(DMA1_Channel5)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 5
-#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3) && defined(DMA1_Channel4)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 4
-#elif defined(DMA1_Channel1) && defined(DMA1_Channel2) && defined(DMA1_Channel3)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 3
-#elif defined(DMA1_Channel1) && defined(DMA1_Channel2)
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 2
-#else
-#define MAX_DMA_CHANNELS_PER_CONTROLLER 1
+
 #endif
 
+// Count DMA controllers
+#ifdef DMA1
+#ifdef DMA2
+#define NUM_DMA_CONTROLLERS 2
+#else
+#define NUM_DMA_CONTROLLERS 1
+#endif
+#else
+#define NUM_DMA_CONTROLLERS 0
+#endif
+
+// On some smaller devices, e.g. STM32L1 family, DMA channels are simply logically ORed rather than
+// muxed, so we don't need the "sourceNumber" field.
+// We can check if this is the case by the absence of specific peripherals/registers.
+#if defined(DMA1_CSELR) || defined(DMAMUX1_BASE)
+#define STM_DEVICE_HAS_DMA_SOURCE_SELECTION 1
+#else
+#define STM_DEVICE_HAS_DMA_SOURCE_SELECTION 0
 #endif
 
 #endif //MBED_OS_STM_DMA_IP_V2_H

--- a/targets/TARGET_STM/stm_dma_ip_v3.h
+++ b/targets/TARGET_STM/stm_dma_ip_v3.h
@@ -1,0 +1,37 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This header contains constants and defines specific to processors with the v3 DMA IP.
+ *
+ * The v3 DMA IP has one DMA controller with multiple channels, where each channel has a request source
+ * that determines what triggers DMA transactions.  Any DMA channel can connect to any request source,
+ * unlike many other STM32 chips.
+ */
+
+#ifndef MBED_OS_STM_DMA_IP_V3_H
+#define MBED_OS_STM_DMA_IP_V3_H
+
+// Devices with DMA IP v2 have at most 7 channels per controller.
+#define MAX_DMA_CHANNELS_PER_CONTROLLER 16
+
+#define NUM_DMA_CONTROLLERS 1
+
+// Currently all known IPv3 devices have source selection
+#define STM_DEVICE_HAS_DMA_SOURCE_SELECTION 1
+
+#endif //MBED_OS_STM_DMA_IP_V3_H

--- a/targets/TARGET_STM/stm_dma_ip_v3.h
+++ b/targets/TARGET_STM/stm_dma_ip_v3.h
@@ -26,7 +26,7 @@
 #ifndef MBED_OS_STM_DMA_IP_V3_H
 #define MBED_OS_STM_DMA_IP_V3_H
 
-// Devices with DMA IP v2 have at most 7 channels per controller.
+// Devices with DMA IP v3 have at most 16 channels per controller.
 #define MAX_DMA_CHANNELS_PER_CONTROLLER 16
 
 #define NUM_DMA_CONTROLLERS 1

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -209,8 +209,10 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 7:
 #ifdef DMA2
                     return DMA1_Ch4_7_DMA2_Ch1_5_DMAMUX1_OVR_IRQn;
+#elif DMA1_Channel7
+                    return DMA1_Ch4_7_DMAMUX1_OVR_IRQn;
 #else
-                    return DMA1_Channel4_5_6_7_IRQn;
+                    return DMA1_Ch4_5_DMAMUX1_OVR_IRQn;
 #endif
 
 // STM32L0 has shared ISRs for Ch2-Ch3 and Ch4-Ch7
@@ -746,7 +748,7 @@ void DMA1_Ch4_7_DMA2_Ch1_5_DMAMUX1_OVR_IRQHandler(void)
         HAL_DMA_IRQHandler(stmDMAHandles[1][4]);
     }
 }
-#else
+#elif defined(DMA1_Channel7)
 void DMA1_Ch4_7_DMAMUX1_OVR_IRQHandler(void)
 {
     if(stmDMAHandles[0][3] != NULL) {
@@ -760,6 +762,16 @@ void DMA1_Ch4_7_DMAMUX1_OVR_IRQHandler(void)
     }
     if(stmDMAHandles[0][6] != NULL) {
         HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+    }
+}
+#else
+void DMA1_Ch4_5_DMAMUX1_OVR_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
     }
 }
 #endif

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -959,7 +959,7 @@ void DMA1_Stream7_IRQHandler(void)
 #ifdef DMA2_Stream0
 void DMA2_Stream0_IRQHandler(void)
 {
-    // Note: Unlike both IP v1 and IP v3, IP v2 channels are 0-indexed.
+    // Note: Unlike both IP v2 and IP v3, IP v1 channels are 0-indexed.
     HAL_DMA_IRQHandler(stmDMAHandles[1][0]);
 }
 #endif

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -209,7 +209,7 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 7:
 #ifdef DMA2
                     return DMA1_Ch4_7_DMA2_Ch1_5_DMAMUX1_OVR_IRQn;
-#elif DMA1_Channel7
+#elif defined(DMA1_Channel7)
                     return DMA1_Ch4_7_DMAMUX1_OVR_IRQn;
 #else
                     return DMA1_Ch4_5_DMAMUX1_OVR_IRQn;

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -168,6 +168,14 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
 #endif
+#ifdef BDMA
+        case 3:
+            switch(dmaLink->channelIdx)
+            {
+                case 0:
+                    return BDMA_Channel0;
+            }
+#endif
         default:
             mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
 
@@ -464,6 +472,11 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 #ifdef GPDMA1
         case 1:
             __HAL_RCC_GPDMA1_CLK_ENABLE();
+            break;
+#endif
+#ifdef BDMA
+        case 3:
+            __HAL_RCC_BDMA_CLK_ENABLE();
             break;
 #endif
         default:

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -168,6 +168,78 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
 #endif
+#ifdef GPDMA1
+        case 1:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef GPDMA1_Channel0
+                case 0:
+                    return GPDMA1_Channel0;
+#endif
+#ifdef GPDMA1_Channel1
+                case 1:
+                    return GPDMA1_Channel1;
+#endif
+#ifdef GPDMA1_Channel2
+                case 2:
+                    return GPDMA1_Channel2;
+#endif
+#ifdef GPDMA1_Channel3
+                case 3:
+                    return GPDMA1_Channel3;
+#endif
+#ifdef GPDMA1_Channel4
+                case 4:
+                    return GPDMA1_Channel4;
+#endif
+#ifdef GPDMA1_Channel5
+                case 5:
+                    return GPDMA1_Channel5;
+#endif
+#ifdef GPDMA1_Channel6
+                case 6:
+                    return GPDMA1_Channel6;
+#endif
+#ifdef GPDMA1_Channel7
+                case 7:
+                    return GPDMA1_Channel7;
+#endif
+#ifdef GPDMA1_Channel8
+                case 8:
+                    return GPDMA1_Channel8;
+#endif
+#ifdef GPDMA1_Channel9
+                case 9:
+                    return GPDMA1_Channel9;
+#endif
+#ifdef GPDMA1_Channel10
+                case 10:
+                    return GPDMA1_Channel10;
+#endif
+#ifdef GPDMA1_Channel11
+                case 11:
+                    return GPDMA1_Channel11;
+#endif
+#ifdef GPDMA1_Channel12
+                case 12:
+                    return GPDMA1_Channel12;
+#endif
+#ifdef GPDMA1_Channel13
+                case 13:
+                    return GPDMA1_Channel13;
+#endif
+#ifdef GPDMA1_Channel14
+                case 14:
+                    return GPDMA1_Channel14;
+#endif
+#ifdef GPDMA1_Channel15
+                case 15:
+                    return GPDMA1_Channel15;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
         default:
             mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
 
@@ -568,14 +640,14 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 
         switch(memDataAlignment) {
             case 4:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
                 break;
             case 2:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
                 break;
             case 1:
             default:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
                 break;
 
         }
@@ -586,14 +658,14 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 
         switch(periphDataAlignment) {
             case 4:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
                 break;
             case 2:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
                 break;
             case 1:
             default:
-                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
                 break;
 
         }

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -348,6 +348,79 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
 #endif
+
+#ifdef GPDMA1
+        case 1:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef GPDMA1_Channel0
+                case 0:
+                    return GPDMA1_Channel0_IRQn;
+#endif
+#ifdef GPDMA1_Channel1
+                case 1:
+                    return GPDMA1_Channel1_IRQn;
+#endif
+#ifdef GPDMA1_Channel2
+                case 2:
+                    return GPDMA1_Channel2_IRQn;
+#endif
+#ifdef GPDMA1_Channel3
+                case 3:
+                    return GPDMA1_Channel3_IRQn;
+#endif
+#ifdef GPDMA1_Channel4
+                case 4:
+                    return GPDMA1_Channel4_IRQn;
+#endif
+#ifdef GPDMA1_Channel5
+                case 5:
+                    return GPDMA1_Channel5_IRQn;
+#endif
+#ifdef GPDMA1_Channel6
+                case 6:
+                    return GPDMA1_Channel6_IRQn;
+#endif
+#ifdef GPDMA1_Channel7
+                case 7:
+                    return GPDMA1_Channel7_IRQn;
+#endif
+#ifdef GPDMA1_Channel8
+                case 8:
+                    return GPDMA1_Channel8_IRQn;
+#endif
+#ifdef GPDMA1_Channel9
+                case 9:
+                    return GPDMA1_Channel9_IRQn;
+#endif
+#ifdef GPDMA1_Channel10
+                case 10:
+                    return GPDMA1_Channel10_IRQn;
+#endif
+#ifdef GPDMA1_Channel11
+                case 11:
+                    return GPDMA1_Channel11_IRQn;
+#endif
+#ifdef GPDMA1_Channel12
+                case 12:
+                    return GPDMA1_Channel12_IRQn;
+#endif
+#ifdef GPDMA1_Channel13
+                case 13:
+                    return GPDMA1_Channel13_IRQn;
+#endif
+#ifdef GPDMA1_Channel14
+                case 14:
+                    return GPDMA1_Channel14_IRQn;
+#endif
+#ifdef GPDMA1_Channel15
+                case 15:
+                    return GPDMA1_Channel15_IRQn;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
         default:
             mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
 
@@ -372,6 +445,11 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 #ifdef DMA2
         case 2:
             __HAL_RCC_DMA2_CLK_ENABLE();
+            break;
+#endif
+#ifdef GPDMA1
+        case 1:
+            __HAL_RCC_GPDMA1_CLK_ENABLE();
             break;
 #endif
         default:
@@ -400,8 +478,8 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 #endif
     dmaHandle->Init.Direction = direction;
 
-    // STM32U5 uses different fields for... basically everything in this struct
-#ifdef STM32U5
+    // IP v3 uses different fields for... basically everything in this struct
+#ifdef DMA_IP_VERSION_V3
     if(direction == DMA_MEMORY_TO_PERIPH || direction == DMA_MEMORY_TO_MEMORY)
     {
         // Source is memory
@@ -480,6 +558,10 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 
     dmaHandle->Init.SrcBurstLength = 1;
     dmaHandle->Init.DestBurstLength = 1;
+    dmaHandle->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+    dmaHandle->Init.Priority = DMA_LOW_PRIORITY_HIGH_WEIGHT;
+    dmaHandle->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT1|DMA_DEST_ALLOCATED_PORT0;
+    dmaHandle->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
 
 #else
     dmaHandle->Init.PeriphInc = periphInc ? DMA_PINC_ENABLE : DMA_PINC_DISABLE;
@@ -751,6 +833,7 @@ void DMA1_Stream7_IRQHandler(void)
 #ifdef DMA2_Stream0
 void DMA2_Stream0_IRQHandler(void)
 {
+    // Note: Unlike both IP v1 and IP v3, IP v2 channels are 0-indexed.
     HAL_DMA_IRQHandler(stmDMAHandles[1][0]);
 }
 #endif
@@ -801,5 +884,117 @@ void DMA2_Stream6_IRQHandler(void)
 void DMA2_Stream7_IRQHandler(void)
 {
     HAL_DMA_IRQHandler(stmDMAHandles[1][7]);
+}
+#endif
+
+#ifdef GPDMA1_Channel0
+void GPDMA1_Channel0_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][0]);
+}
+#endif
+
+#ifdef GPDMA1_Channel1
+void GPDMA1_Channel1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+}
+#endif
+
+#ifdef GPDMA1_Channel2
+void GPDMA1_Channel2_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+}
+#endif
+
+#ifdef GPDMA1_Channel3
+void GPDMA1_Channel3_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+}
+#endif
+
+#ifdef GPDMA1_Channel4
+void GPDMA1_Channel4_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+}
+#endif
+
+#ifdef GPDMA1_Channel5
+void GPDMA1_Channel5_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+}
+#endif
+
+#ifdef GPDMA1_Channel6
+void GPDMA1_Channel6_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+}
+#endif
+
+#ifdef GPDMA1_Channel7
+void GPDMA1_Channel7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][7]);
+}
+#endif
+
+#ifdef GPDMA1_Channel8
+void GPDMA1_Channel8_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][8]);
+}
+#endif
+
+#ifdef GPDMA1_Channel9
+void GPDMA1_Channel9_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][9]);
+}
+#endif
+
+#ifdef GPDMA1_Channel10
+void GPDMA1_Channel10_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][10]);
+}
+#endif
+
+#ifdef GPDMA1_Channel11
+void GPDMA1_Channel11_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][11]);
+}
+#endif
+
+#ifdef GPDMA1_Channel12
+void GPDMA1_Channel12_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][12]);
+}
+#endif
+
+#ifdef GPDMA1_Channel13
+void GPDMA1_Channel13_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][13]);
+}
+#endif
+
+#ifdef GPDMA1_Channel14
+void GPDMA1_Channel14_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][14]);
+}
+#endif
+
+#ifdef GPDMA1_Channel15
+void GPDMA1_Channel15_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][15]);
 }
 #endif

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -484,7 +484,7 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
     // Most devices with IP v1 call this member "Channel" and most with IP v2 call it "Request".
     // But not STM32H7!
 #if defined(DMA_IP_VERSION_V1) && !defined(TARGET_MCU_STM32H7)
-    dmaHandle->Init.Channel = dmaLink->sourceNumber;
+    dmaHandle->Init.Channel = dmaLink->sourceNumber << DMA_SxCR_CHSEL_Pos;
 #else
     dmaHandle->Init.Request = dmaLink->sourceNumber;
 #endif

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -168,14 +168,6 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
 #endif
-#ifdef BDMA
-        case 3:
-            switch(dmaLink->channelIdx)
-            {
-                case 0:
-                    return BDMA_Channel0;
-            }
-#endif
         default:
             mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
 

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -1,0 +1,285 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stm_dma_utils.h"
+
+#include "mbed_error.h"
+
+#include <stdbool.h>
+#include <malloc.h>
+#include <string.h>
+
+// Array to store pointer to DMA handle for each DMA channel.
+// Note: arrays are 0-indexed, so DMA1 Channel2 is at stmDMAHandles[0][1].
+static DMA_HandleTypeDef * stmDMAHandles[NUM_DMA_CONTROLLERS][NUM_DMA_CHANNELS_PER_CONTROLLER];
+
+DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
+{
+    switch(dmaLink->dmaIdx)
+    {
+#ifdef DMA1
+        case 1:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef DMA1_Channel1
+                case 1:
+                    return DMA1_Channel1;
+#endif
+#ifdef DMA1_Channel2
+                case 2:
+                    return DMA1_Channel2;
+#endif
+#ifdef DMA1_Channel3
+                case 3:
+                    return DMA1_Channel3;
+#endif
+#ifdef DMA1_Channel4
+                case 4:
+                    return DMA1_Channel4;
+#endif
+#ifdef DMA1_Channel5
+                case 5:
+                    return DMA1_Channel5;
+#endif
+#ifdef DMA1_Channel6
+                case 6:
+                    return DMA1_Channel6;
+#endif
+#ifdef DMA1_Channel7
+                case 7:
+                    return DMA1_Channel7;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
+
+#ifdef DMA2
+        case 2:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef DMA2_Channel1
+                case 1:
+                    return DMA2_Channel1;
+#endif
+#ifdef DMA2_Channel2
+                case 2:
+                    return DMA2_Channel2;
+#endif
+#ifdef DMA2_Channel3
+                case 3:
+                    return DMA2_Channel3;
+#endif
+#ifdef DMA2_Channel4
+                case 4:
+                    return DMA2_Channel4;
+#endif
+#ifdef DMA2_Channel5
+                case 5:
+                    return DMA2_Channel5;
+#endif
+#ifdef DMA2_Channel6
+                case 6:
+                    return DMA2_Channel6;
+#endif
+#ifdef DMA2_Channel7
+                case 7:
+                    return DMA2_Channel7;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
+        default:
+            mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
+
+    }
+}
+
+DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direction, bool periphInc, bool memInc,
+                                     uint32_t periphDataAlignment, uint32_t memDataAlignment){
+     // Enable DMA mux clock for devices with it
+#ifdef DMAMUX1
+    __HAL_RCC_DMAMUX1_CLK_ENABLE()
+#endif
+
+    // Turn on clock for the DMA module
+    switch(dmaLink->dmaIdx)
+    {
+#ifdef DMA1
+        case 1:
+            __HAL_RCC_DMA1_CLK_ENABLE();
+            break;
+#endif
+#ifdef DMA2
+        case 2:
+            __HAL_RCC_DMA2_CLK_ENABLE();
+            break;
+#endif
+        default:
+            mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
+    }
+
+    // Allocate DMA handle.
+    // Yes it's a little gross that we have to allocate on the heap, but this structure uses quite a lot of memory,
+    // so we don't want to allocate DMA handles until they're needed.
+    DMA_HandleTypeDef * dmaHandle = malloc(sizeof(DMA_HandleTypeDef));
+    memset(dmaHandle, 0, sizeof(DMA_HandleTypeDef));
+    stmDMAHandles[dmaLink->dmaIdx - 1][dmaLink->channelIdx - 1] = dmaHandle;
+
+    // Configure handle
+    dmaHandle->Instance = stm_get_dma_channel(dmaLink);
+    dmaHandle->Init.Request = dmaLink->sourceNumber;
+    dmaHandle->Init.Direction = direction;
+    dmaHandle->Init.PeriphInc = periphInc ? DMA_PINC_ENABLE : DMA_PINC_DISABLE;
+    dmaHandle->Init.MemInc = memInc ? DMA_MINC_ENABLE : DMA_MINC_DISABLE;
+    dmaHandle->Init.PeriphDataAlignment = periphDataAlignment;
+    dmaHandle->Init.MemDataAlignment = memDataAlignment;
+    dmaHandle->Init.Mode = DMA_NORMAL;
+    dmaHandle->Init.Priority = DMA_PRIORITY_MEDIUM;
+
+    HAL_DMA_Init(dmaHandle);
+
+    // TODO set up interrupt
+
+    return dmaHandle;
+}
+
+#ifdef DMA1_Channel1
+void DMA1_Channel1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][0]);
+}
+#endif
+
+// STM32F0 has shared ISRs for Ch2-Ch3 and Ch4-Ch5
+#ifdef TARGET_MCU_STM32F0
+
+void DMA1_Channel2_3_IRQHandler(void)
+{
+    if(stmDMAHandles[0][1] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+    }
+    if(stmDMAHandles[0][2] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+    }
+}
+
+void DMA1_Channel4_5_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+    }
+}
+
+#else
+
+#ifdef DMA1_Channel2
+void DMA1_Channel2_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+}
+#endif
+
+#ifdef DMA1_Channel3
+void DMA1_Channel3_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+}
+#endif
+
+#ifdef DMA1_Channel4
+void DMA1_Channel4_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+}
+#endif
+
+#ifdef DMA1_Channel5
+void DMA1_Channel5_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+}
+#endif
+
+#endif
+
+#ifdef DMA1_Channel6
+void DMA1_Channel6_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+}
+#endif
+
+#ifdef DMA1_Channel7
+void DMA1_Channel7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+}
+#endif
+
+#ifdef DMA2_Channel1
+void DMA2_Channel1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][0]);
+}
+#endif
+
+#ifdef DMA2_Channel2
+void DMA2_Channel2_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][1]);
+}
+#endif
+
+#ifdef DMA2_Channel3
+void DMA2_Channel3_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][2]);
+}
+#endif
+
+#ifdef DMA2_Channel4
+void DMA2_Channel4_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][3]);
+}
+#endif
+
+#ifdef DMA2_Channel5
+void DMA2_Channel5_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][4]);
+}
+#endif
+
+#ifdef DMA2_Channel6
+void DMA2_Channel6_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][5]);
+}
+#endif
+
+#ifdef DMA2_Channel7
+void DMA2_Channel7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][6]);
+}
+#endif

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -110,6 +110,101 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
     }
 }
 
+IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
+{
+    switch(dmaLink->dmaIdx)
+    {
+#ifdef DMA1
+        case 1:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef DMA1_Channel1
+                case 1:
+                    return DMA1_Channel1_IRQn;
+#endif
+
+// STM32F0 has shared ISRs for Ch2-Ch3 and Ch4-Ch5
+#ifdef TARGET_MCU_STM32F0
+                case 2:
+                case 3:
+                    return DMA1_Channel2_3_IRQn;
+                case 4:
+                case 5:
+                    return DMA1_Channel4_5_IRQn;
+#else
+#ifdef DMA1_Channel2
+                case 2:
+                    return DMA1_Channel2_IRQn;
+#endif
+#ifdef DMA1_Channel3
+                case 3:
+                    return DMA1_Channel3_IRQn;
+#endif
+#ifdef DMA1_Channel4
+                case 4:
+                    return DMA1_Channel4_IRQn;
+#endif
+#ifdef DMA1_Channel5
+                case 5:
+                    return DMA1_Channel5_IRQn;
+#endif
+#endif
+
+#ifdef DMA1_Channel6
+                case 6:
+                    return DMA1_Channel6_IRQn;
+#endif
+#ifdef DMA1_Channel7
+                case 7:
+                    return DMA1_Channel7_IRQn;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
+
+#ifdef DMA2
+        case 2:
+            switch(dmaLink->channelIdx)
+            {
+#ifdef DMA2_Channel1
+                case 1:
+                    return DMA2_Channel1_IRQn;
+#endif
+#ifdef DMA2_Channel2
+                case 2:
+                    return DMA2_Channel2_IRQn;
+#endif
+#ifdef DMA2_Channel3
+                case 3:
+                    return DMA2_Channel3_IRQn;
+#endif
+#ifdef DMA2_Channel4
+                case 4:
+                    return DMA2_Channel4_IRQn;
+#endif
+#ifdef DMA2_Channel5
+                case 5:
+                    return DMA2_Channel5_IRQn;
+#endif
+#ifdef DMA2_Channel6
+                case 6:
+                    return DMA2_Channel6_IRQn;
+#endif
+#ifdef DMA2_Channel7
+                case 7:
+                    return DMA2_Channel7_IRQn;
+#endif
+                default:
+                    mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
+            }
+#endif
+        default:
+            mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA controller", dmaLink->dmaIdx, MBED_FILENAME, __LINE__);
+
+    }
+}
+
 DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direction, bool periphInc, bool memInc,
                                      uint32_t periphDataAlignment, uint32_t memDataAlignment){
      // Enable DMA mux clock for devices with it
@@ -154,7 +249,10 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 
     HAL_DMA_Init(dmaHandle);
 
-    // TODO set up interrupt
+    // Set up interrupt
+    IRQn_Type irqNum = stm_get_dma_irqn(dmaLink);
+    NVIC_EnableIRQ(irqNum);
+    NVIC_SetPriority(irqNum, 7);
 
     return dmaHandle;
 }

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -25,7 +25,7 @@
 
 // Array to store pointer to DMA handle for each DMA channel.
 // Note: arrays are 0-indexed, so DMA1 Channel2 is at stmDMAHandles[0][1].
-static DMA_HandleTypeDef * stmDMAHandles[NUM_DMA_CONTROLLERS][NUM_DMA_CHANNELS_PER_CONTROLLER];
+static DMA_HandleTypeDef * stmDMAHandles[NUM_DMA_CONTROLLERS][MAX_DMA_CHANNELS_PER_CONTROLLER];
 
 DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
 {
@@ -62,6 +62,38 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
 #ifdef DMA1_Channel7
                 case 7:
                     return DMA1_Channel7;
+#endif
+#ifdef DMA1_Stream0
+                case 0:
+                    return DMA1_Stream0;
+#endif
+#ifdef DMA1_Stream1
+                case 1:
+                    return DMA1_Stream1;
+#endif
+#ifdef DMA1_Stream2
+                case 2:
+                    return DMA1_Stream2;
+#endif
+#ifdef DMA1_Stream3
+                case 3:
+                    return DMA1_Stream3;
+#endif
+#ifdef DMA1_Stream4
+                case 4:
+                    return DMA1_Stream4;
+#endif
+#ifdef DMA1_Stream5
+                case 5:
+                    return DMA1_Stream5;
+#endif
+#ifdef DMA1_Stream6
+                case 6:
+                    return DMA1_Stream6;
+#endif
+#ifdef DMA1_Stream7
+                case 7:
+                    return DMA1_Stream7;
 #endif
                 default:
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
@@ -100,6 +132,38 @@ DMA_Channel_TypeDef * stm_get_dma_channel(const DMALinkInfo *dmaLink)
                 case 7:
                     return DMA2_Channel7;
 #endif
+#ifdef DMA2_Stream0
+                case 0:
+                    return DMA2_Stream0;
+#endif
+#ifdef DMA2_Stream1
+                case 1:
+                    return DMA2_Stream1;
+#endif
+#ifdef DMA2_Stream2
+                case 2:
+                    return DMA2_Stream2;
+#endif
+#ifdef DMA2_Stream3
+                case 3:
+                    return DMA2_Stream3;
+#endif
+#ifdef DMA2_Stream4
+                case 4:
+                    return DMA2_Stream4;
+#endif
+#ifdef DMA2_Stream5
+                case 5:
+                    return DMA2_Stream5;
+#endif
+#ifdef DMA2_Stream6
+                case 6:
+                    return DMA2_Stream6;
+#endif
+#ifdef DMA2_Stream7
+                case 7:
+                    return DMA2_Stream7;
+#endif
                 default:
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
@@ -123,7 +187,7 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                     return DMA1_Channel1_IRQn;
 #endif
 
-// STM32F0 has shared ISRs for Ch2-Ch3 and Ch4-Ch5
+// STM32F0 has shared ISRs for Ch2-Ch3 and Ch4-Ch5, and NO ISRs for channels 6 and 7
 #ifdef TARGET_MCU_STM32F0
                 case 2:
                 case 3:
@@ -131,6 +195,24 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 4:
                 case 5:
                     return DMA1_Channel4_5_IRQn;
+
+// STM32G0 has shared ISRs for Ch2-Ch3 and and NO ISRs for channels 4 through 7
+#elif defined(TARGET_MCU_STM32G0)
+                case 2:
+                case 3:
+                    return DMA1_Channel2_3_IRQn;
+
+// STM32L0 has shared ISRs for Ch2-Ch3 and Ch4-Ch7
+#elif defined(TARGET_MCU_STM32L0)
+                case 2:
+                case 3:
+                    return DMA1_Channel2_3_IRQn;
+
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                    return DMA1_Channel4_5_6_7_IRQn;
 #else
 #ifdef DMA1_Channel2
                 case 2:
@@ -148,8 +230,6 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 5:
                     return DMA1_Channel5_IRQn;
 #endif
-#endif
-
 #ifdef DMA1_Channel6
                 case 6:
                     return DMA1_Channel6_IRQn;
@@ -158,6 +238,41 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 7:
                     return DMA1_Channel7_IRQn;
 #endif
+#endif
+
+#ifdef DMA1_Stream0
+                case 0:
+                    return DMA1_Stream0_IRQn;
+#endif
+#ifdef DMA1_Stream1
+                case 1:
+                    return DMA1_Stream1_IRQn;
+#endif
+#ifdef DMA1_Stream2
+                case 2:
+                    return DMA1_Stream2_IRQn;
+#endif
+#ifdef DMA1_Stream3
+                case 3:
+                    return DMA1_Stream3_IRQn;
+#endif
+#ifdef DMA1_Stream4
+                case 4:
+                    return DMA1_Stream4_IRQn;
+#endif
+#ifdef DMA1_Stream5
+                case 5:
+                    return DMA1_Stream5_IRQn;
+#endif
+#ifdef DMA1_Stream6
+                case 6:
+                    return DMA1_Stream6_IRQn;
+#endif
+#ifdef DMA1_Stream7
+                case 7:
+                    return DMA1_Stream7_IRQn;
+#endif
+
                 default:
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
@@ -195,6 +310,40 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
                 case 7:
                     return DMA2_Channel7_IRQn;
 #endif
+
+#ifdef DMA2_Stream0
+                    case 0:
+                    return DMA2_Stream0_IRQn;
+#endif
+#ifdef DMA2_Stream1
+                    case 1:
+                    return DMA2_Stream1_IRQn;
+#endif
+#ifdef DMA2_Stream2
+                    case 2:
+                    return DMA2_Stream2_IRQn;
+#endif
+#ifdef DMA2_Stream3
+                    case 3:
+                    return DMA2_Stream3_IRQn;
+#endif
+#ifdef DMA2_Stream4
+                    case 4:
+                    return DMA2_Stream4_IRQn;
+#endif
+#ifdef DMA2_Stream5
+                    case 5:
+                    return DMA2_Stream5_IRQn;
+#endif
+#ifdef DMA2_Stream6
+                    case 6:
+                    return DMA2_Stream6_IRQn;
+#endif
+#ifdef DMA2_Stream7
+                    case 7:
+                    return DMA2_Stream7_IRQn;
+#endif
+
                 default:
                     mbed_error(MBED_ERROR_ITEM_NOT_FOUND, "Invalid DMA channel", dmaLink->channelIdx, MBED_FILENAME, __LINE__);
             }
@@ -206,10 +355,10 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
 }
 
 DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direction, bool periphInc, bool memInc,
-                                     uint32_t periphDataAlignment, uint32_t memDataAlignment){
+                                     uint8_t periphDataAlignment, uint8_t memDataAlignment){
      // Enable DMA mux clock for devices with it
-#ifdef DMAMUX1
-    __HAL_RCC_DMAMUX1_CLK_ENABLE()
+#ifdef __HAL_RCC_DMAMUX1_CLK_ENABLE
+    __HAL_RCC_DMAMUX1_CLK_ENABLE();
 #endif
 
     // Turn on clock for the DMA module
@@ -238,14 +387,136 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
 
     // Configure handle
     dmaHandle->Instance = stm_get_dma_channel(dmaLink);
+#if STM_DEVICE_HAS_DMA_SOURCE_SELECTION
+
+    // Most devices with IP v1 call this member "Channel" and most with IP v2 call it "Request".
+    // But not STM32H7!
+#if defined(DMA_IP_VERSION_V1) && !defined(TARGET_MCU_STM32H7)
+    dmaHandle->Init.Channel = dmaLink->sourceNumber;
+#else
     dmaHandle->Init.Request = dmaLink->sourceNumber;
+#endif
+
+#endif
     dmaHandle->Init.Direction = direction;
+
+    // STM32U5 uses different fields for... basically everything in this struct
+#ifdef STM32U5
+    if(direction == DMA_MEMORY_TO_PERIPH || direction == DMA_MEMORY_TO_MEMORY)
+    {
+        // Source is memory
+        dmaHandle->Init.SrcInc = memInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+
+        switch(memDataAlignment) {
+            case 4:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                break;
+            case 2:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                break;
+            case 1:
+            default:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                break;
+
+        }
+    }
+    else {
+        // Source is a peripheral
+        dmaHandle->Init.SrcInc = periphInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+
+        switch(periphDataAlignment) {
+            case 4:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                break;
+            case 2:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                break;
+            case 1:
+            default:
+                dmaHandle->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                break;
+
+        }
+    }
+
+    if(direction == DMA_PERIPH_TO_MEMORY || direction == DMA_MEMORY_TO_MEMORY)
+    {
+        // Destination is memory
+        dmaHandle->Init.DestInc = memInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+
+        switch(memDataAlignment) {
+            case 4:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                break;
+            case 2:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                break;
+            case 1:
+            default:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                break;
+
+        }
+    }
+    else {
+        // Destination is a peripheral
+        dmaHandle->Init.DestInc = periphInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+
+        switch(periphDataAlignment) {
+            case 4:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_WORD;
+                break;
+            case 2:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+                break;
+            case 1:
+            default:
+                dmaHandle->Init.DestDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+                break;
+
+        }
+    }
+
+    dmaHandle->Init.SrcBurstLength = 1;
+    dmaHandle->Init.DestBurstLength = 1;
+
+#else
     dmaHandle->Init.PeriphInc = periphInc ? DMA_PINC_ENABLE : DMA_PINC_DISABLE;
     dmaHandle->Init.MemInc = memInc ? DMA_MINC_ENABLE : DMA_MINC_DISABLE;
-    dmaHandle->Init.PeriphDataAlignment = periphDataAlignment;
-    dmaHandle->Init.MemDataAlignment = memDataAlignment;
-    dmaHandle->Init.Mode = DMA_NORMAL;
     dmaHandle->Init.Priority = DMA_PRIORITY_MEDIUM;
+
+    switch(periphDataAlignment) {
+        case 4:
+            dmaHandle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
+            break;
+        case 2:
+            dmaHandle->Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+            break;
+        case 1:
+        default:
+            dmaHandle->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+            break;
+
+    }
+
+    switch(memDataAlignment) {
+        case 4:
+            dmaHandle->Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
+            break;
+        case 2:
+            dmaHandle->Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+            break;
+        case 1:
+        default:
+            dmaHandle->Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+            break;
+
+    }
+
+#endif
+
+    dmaHandle->Init.Mode = DMA_NORMAL;
 
     HAL_DMA_Init(dmaHandle);
 
@@ -287,6 +558,46 @@ void DMA1_Channel4_5_IRQHandler(void)
     }
 }
 
+#elif defined(TARGET_MCU_STM32G0)
+
+void DMA1_Channel2_3_IRQHandler(void)
+{
+    if(stmDMAHandles[0][1] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+    }
+    if(stmDMAHandles[0][2] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+    }
+}
+
+#elif defined(TARGET_MCU_STM32L0)
+
+void DMA1_Channel2_3_IRQHandler(void)
+{
+    if(stmDMAHandles[0][1] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+    }
+    if(stmDMAHandles[0][2] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+    }
+}
+
+void DMA1_Channel4_5_6_7_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+    }
+    if(stmDMAHandles[0][5] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+    }
+    if(stmDMAHandles[0][6] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+    }
+}
+
 #else
 
 #ifdef DMA1_Channel2
@@ -317,8 +628,6 @@ void DMA1_Channel5_IRQHandler(void)
 }
 #endif
 
-#endif
-
 #ifdef DMA1_Channel6
 void DMA1_Channel6_IRQHandler(void)
 {
@@ -331,6 +640,7 @@ void DMA1_Channel7_IRQHandler(void)
 {
     HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
 }
+#endif
 #endif
 
 #ifdef DMA2_Channel1
@@ -379,5 +689,117 @@ void DMA2_Channel6_IRQHandler(void)
 void DMA2_Channel7_IRQHandler(void)
 {
     HAL_DMA_IRQHandler(stmDMAHandles[1][6]);
+}
+#endif
+
+#ifdef DMA1_Stream0
+void DMA1_Stream0_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][0]);
+}
+#endif
+
+#ifdef DMA1_Stream1
+void DMA1_Stream1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+}
+#endif
+
+#ifdef DMA1_Stream2
+void DMA1_Stream2_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+}
+#endif
+
+#ifdef DMA1_Stream3
+void DMA1_Stream3_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+}
+#endif
+
+#ifdef DMA1_Stream4
+void DMA1_Stream4_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+}
+#endif
+
+#ifdef DMA1_Stream5
+void DMA1_Stream5_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+}
+#endif
+
+#ifdef DMA1_Stream6
+void DMA1_Stream6_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+}
+#endif
+
+#ifdef DMA1_Stream7
+void DMA1_Stream7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[0][7]);
+}
+#endif
+
+#ifdef DMA2_Stream0
+void DMA2_Stream0_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][0]);
+}
+#endif
+
+#ifdef DMA2_Stream1
+void DMA2_Stream1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][1]);
+}
+#endif
+
+#ifdef DMA2_Stream2
+void DMA2_Stream2_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][2]);
+}
+#endif
+
+#ifdef DMA2_Stream3
+void DMA2_Stream3_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][3]);
+}
+#endif
+
+#ifdef DMA2_Stream4
+void DMA2_Stream4_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][4]);
+}
+#endif
+
+#ifdef DMA2_Stream5
+void DMA2_Stream5_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][5]);
+}
+#endif
+
+#ifdef DMA2_Stream6
+void DMA2_Stream6_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][6]);
+}
+#endif
+
+#ifdef DMA2_Stream7
+void DMA2_Stream7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(stmDMAHandles[1][7]);
 }
 #endif

--- a/targets/TARGET_STM/stm_dma_utils.h
+++ b/targets/TARGET_STM/stm_dma_utils.h
@@ -92,7 +92,8 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink);
  * @param periphDataAlignment Alignment value of the peripheral data.  1, 2, or 4.
  * @param memDataAlignment \c DMA_MDATAALIGN_BYTE, \c DMA_MDATAALIGN_HALFWORD, or \c DMA_MDATAALIGN_WORD
  *
- * @return Pointer to DMA handle allocated by this module
+ * @return Pointer to DMA handle allocated by this module.
+ * @return NULL if the DMA channel used by the link has already been allocated by something else.
  */
 DMA_HandleTypeDef * stm_init_dma_link(DMALinkInfo const * dmaLink, uint32_t direction, bool periphInc, bool memInc, uint8_t periphDataAlignment, uint8_t memDataAlignment);
 

--- a/targets/TARGET_STM/stm_dma_utils.h
+++ b/targets/TARGET_STM/stm_dma_utils.h
@@ -1,0 +1,96 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016-2023 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MBED_OS_STM_DMA_UTILS_H
+#define MBED_OS_STM_DMA_UTILS_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "cmsis.h"
+
+/*
+ * Structure containing info about a peripheral's link to the DMA controller.
+ */
+typedef struct DMALinkInfo {
+
+    /// Index of the DMA module that the DMA link uses.
+    /// Note: 1-indexed.
+    uint8_t dmaIdx;
+
+    /// Index of the channel on the DMA module.
+    /// Note that some STMicro chips have a DMA mux allowing any DMA peripheral to be used with
+    /// any channel, and others have a semi-fixed architecture with just some basic multiplexing.
+    /// Note: 1-indexed.
+    uint8_t channelIdx;
+
+    /// Request source number.  This is either a DMA mux input number, or a mux selection number
+    /// on devices without a DMA mux.
+    /// Note: 0-indexed.
+    uint8_t sourceNumber;
+
+} DMALinkInfo;
+
+// DMA and DMA channel counts.  On MOST devices DMA controllers have 7 channels each...
+#ifdef DMA1
+#ifdef DMA2
+#define NUM_DMA_CONTROLLERS 2
+#else
+#define NUM_DMA_CONTROLLERS 1
+#endif
+#else
+#define NUM_DMA_CONTROLLERS 0
+#endif
+
+#ifdef TARGET_MCU_STM32F0
+#define NUM_DMA_CHANNELS_PER_CONTROLLER 5
+#else
+#define NUM_DMA_CHANNELS_PER_CONTROLLER 7
+#endif
+
+/**
+ * @brief Get the DMA channel instance for a DMA link
+ *
+ * @param dmaLink DMA link instance
+ */
+DMA_Channel_TypeDef * stm_get_dma_channel(DMALinkInfo const * dmaLink);
+
+/**
+ * @brief Initialize a DMA link for use.
+ *
+ * This enables and sets up the interrupt, allocates a DMA handle, and returns the handle pointer.
+ * Arguments are based on the parameters used for the DMA_InitTypeDef structure.
+ *
+ * @param dmaLink DMA link instance
+ * @param direction \c DMA_PERIPH_TO_MEMORY, \c DMA_MEMORY_TO_PERIPH, or \c DMA_MEMORY_TO_MEMORY
+ * @param periphInc Whether the Peripheral address register should be incremented or not.
+ * @param memInc Whether the Memory address register should be incremented or not.
+ * @param periphDataAlignment \c DMA_PDATAALIGN_BYTE, \c DMA_PDATAALIGN_HALFWORD, or \c DMA_PDATAALIGN_WORD
+ * @param memDataAlignment \c DMA_MDATAALIGN_BYTE, \c DMA_MDATAALIGN_HALFWORD, or \c DMA_MDATAALIGN_WORD
+ *
+ * @return Pointer to DMA handle allocated by this module
+ */
+DMA_HandleTypeDef * stm_init_dma_link(DMALinkInfo const * dmaLink, uint32_t direction, bool periphInc, bool memInc, uint32_t periphDataAlignment, uint32_t memDataAlignment);
+
+/**
+ * Free the underlying resources for a DMA link.  Disables interrupt and frees memory.
+ */
+void stm_free_dma_link(DMALinkInfo const * dmaLink);
+
+
+#endif //MBED_OS_STM_DMA_UTILS_H

--- a/targets/TARGET_STM/stm_dma_utils.h
+++ b/targets/TARGET_STM/stm_dma_utils.h
@@ -98,9 +98,12 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink);
 DMA_HandleTypeDef * stm_init_dma_link(DMALinkInfo const * dmaLink, uint32_t direction, bool periphInc, bool memInc, uint8_t periphDataAlignment, uint8_t memDataAlignment);
 
 /**
- * Free the underlying resources for a DMA link.  Disables interrupt and frees memory.
+ * @brief Free a DMA link.
+ *
+ * This frees memory associated with it and unlocks the hardware DMA channel so that it can be used by somebody else.
+ *
+ * @param dmaLink DMA link ponter to free.
  */
 void stm_free_dma_link(DMALinkInfo const * dmaLink);
-
 
 #endif //MBED_OS_STM_DMA_UTILS_H

--- a/targets/TARGET_STM/stm_dma_utils.h
+++ b/targets/TARGET_STM/stm_dma_utils.h
@@ -26,11 +26,11 @@
 
 // determine DMA IP version using the available constants in the chip header
 #if defined(GPDMA1)
-#define DMA_IP_VERSION_V3
+#define DMA_IP_VERSION_V3 1
 #elif defined(DMA1_Channel1)
-#define DMA_IP_VERSION_V2
+#define DMA_IP_VERSION_V2 1
 #else
-#define DMA_IP_VERSION_V1
+#define DMA_IP_VERSION_V1 1
 #endif
 
 // Include correct header for the IP version

--- a/targets/TARGET_STM/stm_dma_utils.h
+++ b/targets/TARGET_STM/stm_dma_utils.h
@@ -71,6 +71,13 @@ typedef struct DMALinkInfo {
 DMA_Channel_TypeDef * stm_get_dma_channel(DMALinkInfo const * dmaLink);
 
 /**
+ * @brief Get the interrupt number for a DMA link
+ *
+ * @param dmaLink DMA link instance
+ */
+IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink);
+
+/**
  * @brief Initialize a DMA link for use.
  *
  * This enables and sets up the interrupt, allocates a DMA handle, and returns the handle pointer.

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -525,7 +525,7 @@ static void spi_init_tx_dma(struct spi_s * obj)
         DMALinkInfo const *dmaLink = &SPITxDMALinks[obj->spiIndex - 1];
 
         // Initialize DMA channel
-        DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_MEMORY_TO_PERIPH, false, true, DMA_PDATAALIGN_BYTE, DMA_MDATAALIGN_BYTE);
+        DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_MEMORY_TO_PERIPH, false, true, 1, 1);
         __HAL_LINKDMA(&obj->handle, hdmatx, *dmaHandle);
     }
 }
@@ -542,7 +542,7 @@ static void spi_init_rx_dma(struct spi_s * obj)
         DMALinkInfo const *dmaLink = &SPIRxDMALinks[obj->spiIndex - 1];
 
         // Initialize DMA channel
-        DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_PERIPH_TO_MEMORY, false, true, DMA_PDATAALIGN_BYTE, DMA_MDATAALIGN_BYTE);
+        DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_PERIPH_TO_MEMORY, false, true, 1, 1);
         __HAL_LINKDMA(&obj->handle, hdmarx, *dmaHandle);
     }
 }

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -589,10 +589,12 @@ void spi_free(spi_t *obj)
     if(spiobj->txDMAInitialized)
     {
         stm_free_dma_link(&SPITxDMALinks[spiobj->spiIndex - 1]);
+        spiobj->txDMAInitialized = false;
     }
     if(spiobj->rxDMAInitialized)
     {
         stm_free_dma_link(&SPIRxDMALinks[spiobj->spiIndex - 1]);
+        spiobj->rxDMAInitialized = false;
     }
 #endif
 
@@ -1649,7 +1651,7 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
     }
 
 #if defined(STM32_SPI_CAPABILITY_DMA) && defined(__DCACHE_PRESENT)
-    if (useDMA)
+    if (useDMA && transfer_type != SPI_TRANSFER_TYPE_TX)
     {
         // For chips with a cache (e.g. Cortex-M7), we need to invalidate the Rx data in cache.
         // This ensures that the CPU will fetch the data from SRAM instead of using its cache.

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -588,6 +588,18 @@ void spi_free(spi_t *obj)
 
     DEBUG_PRINTF("spi_free\r\n");
 
+#if STM32_SPI_CAPABILITY_DMA
+    // Free DMA channels if allocated
+    if(spiobj->txDMAInitialized)
+    {
+        stm_free_dma_link(&SPITxDMALinks[spiobj->spiIndex - 1]);
+    }
+    if(spiobj->rxDMAInitialized)
+    {
+        stm_free_dma_link(&SPIRxDMALinks[spiobj->spiIndex - 1]);
+    }
+#endif
+
     __HAL_SPI_DISABLE(handle);
     HAL_SPI_DeInit(handle);
 

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -276,12 +276,6 @@ static void _spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap)
     RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
 #endif /* SPI_IP_VERSION_V2 */
 
-#ifdef STM32_SPI_CAPABILITY_DMA
-    // Every SPI starts with DMA not initialized, we do that lazily later
-    spiobj->rxDMAInitialized = false;
-    spiobj->txDMAInitialized = false;
-#endif
-
 #ifdef DEVICE_SPI_ASYNCH
     spiobj->driverCallback = NULL;
 #endif

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -526,7 +526,14 @@ static void spi_init_tx_dma(struct spi_s * obj)
 
         // Initialize DMA channel
         DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_MEMORY_TO_PERIPH, false, true, 1, 1);
+
+        if(dmaHandle == NULL)
+        {
+            mbed_error(MBED_ERROR_ALREADY_IN_USE, "Tx DMA channel already used by something else!", 0, MBED_FILENAME, __LINE__);
+        }
+
         __HAL_LINKDMA(&obj->handle, hdmatx, *dmaHandle);
+        obj->txDMAInitialized = true;
     }
 }
 
@@ -543,7 +550,14 @@ static void spi_init_rx_dma(struct spi_s * obj)
 
         // Initialize DMA channel
         DMA_HandleTypeDef *dmaHandle = stm_init_dma_link(dmaLink, DMA_PERIPH_TO_MEMORY, false, true, 1, 1);
+
+        if(dmaHandle == NULL)
+        {
+            mbed_error(MBED_ERROR_ALREADY_IN_USE, "Rx DMA channel already used by something else!", 0, MBED_FILENAME, __LINE__);
+        }
+
         __HAL_LINKDMA(&obj->handle, hdmarx, *dmaHandle);
+        obj->rxDMAInitialized = true;
     }
 }
 

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -217,6 +217,9 @@ void init_spi(spi_t *obj)
 
     __HAL_SPI_DISABLE(handle);
 
+    // Reset flag used by store_spis_pointer()
+    handle->Init.TIMode = SPI_TIMODE_DISABLE;
+
     DEBUG_PRINTF("init_spi: instance=0x%8X\r\n", (int)handle->Instance);
     if (HAL_SPI_Init(handle) != HAL_OK) {
         error("Cannot initialize SPI");
@@ -455,7 +458,6 @@ static void _spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap)
 #endif
     handle->Init.DataSize          = SPI_DATASIZE_8BIT;
     handle->Init.FirstBit          = SPI_FIRSTBIT_MSB;
-    handle->Init.TIMode            = SPI_TIMODE_DISABLE;
 
 #if defined (SPI_IP_VERSION_V2)
     handle->Init.NSSPolarity = SPI_NSS_POLARITY_LOW;

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -1843,16 +1843,8 @@ void spi_abort_asynch(spi_t *obj)
     // clean-up
     LL_SPI_Disable(SPI_INST(obj));
     HAL_SPI_DeInit(handle);
-    handle->Init.TIMode = SPI_TIMODE_DISABLE; // This will have gotten clobbered by store_spis_pointer()
-    HAL_SPI_Init(handle);
-    store_spis_pointer(handle, spiobj);
 
-    // cleanup input buffer
-    spi_flush_rx(obj);
-    // enable SPI back if it isn't 3-wire mode
-    if (handle->Init.Direction != SPI_DIRECTION_1LINE) {
-        LL_SPI_Enable(SPI_INST(obj));
-    }
+    init_spi(obj);
 }
 
 #endif //DEVICE_SPI_ASYNCH

--- a/targets/TARGET_STM/stm_spi_api.h
+++ b/targets/TARGET_STM/stm_spi_api.h
@@ -36,6 +36,12 @@ struct spi_s {
 #if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
+
+    // Callback function for when we get an interrupt on an async transfer.
+    // This will point, through a bit of indirection, to SPI::irq_handler_asynch()
+    // for the correct SPI instance.
+    void (*driverCallback)(void);
+
 #endif
     uint8_t spiIndex; // Index of the SPI peripheral, from 1-6
 #if STM32_SPI_CAPABILITY_DMA

--- a/targets/TARGET_STM/stm_spi_api.h
+++ b/targets/TARGET_STM/stm_spi_api.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2016-2020 STMicroelectronics
+ * Copyright (c) 2016-2023 STMicroelectronics
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +15,33 @@
  * limitations under the License.
  */
 
-#ifndef MBED_SPI_DEVICE_H
-#define MBED_SPI_DEVICE_H
 
-#include "stm32l4xx_ll_spi.h"
+#ifndef MBED_OS_STM_SPI_API_H
+#define MBED_OS_STM_SPI_API_H
 
-// Defines the word legnth capability of the device where Nth bit allows for N window size
-#define STM32_SPI_CAPABILITY_WORD_LENGTH (0x0000FFF8)
+#include "spi_device.h"
 
-// We have DMA support
-#define STM32_SPI_CAPABILITY_DMA 1
-
+#if STM32_SPI_CAPABILITY_DMA
+#include "stm_dma_utils.h"
 #endif
+
+struct spi_s {
+    SPI_HandleTypeDef handle;
+    IRQn_Type spiIRQ;
+    SPIName spi;
+    PinName pin_miso;
+    PinName pin_mosi;
+    PinName pin_sclk;
+    PinName pin_ssel;
+#if DEVICE_SPI_ASYNCH
+    uint32_t event;
+    uint8_t transfer_type;
+#endif
+    uint8_t spiIndex; // Index of the SPI peripheral, from 1-6
+#if STM32_SPI_CAPABILITY_DMA
+    bool txDMAInitialized;
+    bool rxDMAInitialized;
+#endif
+};
+
+#endif //MBED_OS_STM_SPI_API_H

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3224,7 +3224,8 @@
             "CRC",
             "TRNG",
             "FLASH",
-            "MPU"
+            "MPU",
+            "SPI_32BIT_WORDS"
         ]
     },
     "MCU_STM32H723xG": {
@@ -4849,7 +4850,8 @@
             "FLASH",
             "MPU",
             "TRNG",
-            "SERIAL_ASYNCH"
+            "SERIAL_ASYNCH",
+            "SPI_32BIT_WORDS"
         ]
     },
 	"MCU_STM32U575xI": {

--- a/tools/cmake/mbed-run-greentea-test.in.cmake
+++ b/tools/cmake/mbed-run-greentea-test.in.cmake
@@ -14,7 +14,7 @@ set(MBEDHTRUN_ARGS --skip-flashing @MBED_HTRUN_ARGUMENTS@) # filled in by config
 
 # Print out command
 string(REPLACE ";" " " MBEDHTRUN_ARGS_FOR_DISPLAY "${MBEDHTRUN_ARGS}")
-message("Executing: mbedhtrun ${MBEDHTRUN_ARGS_FOR_DISPLAY}")
+message("Executing: @Python3_EXECUTABLE@ -m mbed_host_tests.mbedhtrun ${MBEDHTRUN_ARGS_FOR_DISPLAY}")
 
 # Note: For this command, we need to survive mbedhtrun not being on the PATH, so we import the package and call the main function using "python -c"
 execute_process(


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This MR adds a feature that many have been requesting for years: the ability to run SPI transfers in the background via DMA on STM32 devices.  I based it on [a test implementation for STM32L4 by @ABOSTM](https://github.com/ARMmbed/mbed-os/compare/master...ABOSTM:mbed-os:I2C_SPI_DMA_IMPLEMENTATION_FOR_STM32L4)  (also credit @wdx04's [BurstSPI](https://github.com/wdx04/BurstSPI/blob/main/BurstSPI.cpp) library).  Luckily, these branches include most of the actual DMA code needed to make SPI work.  The hard part is that the ABOSTM code only works for one specific device family, STM32L4.  There are also some major bugs with how the interrupts are set up, so I don't think it actually worked.

So, to adapt that code for other STM devices, I added a new "stm_dma_utils.c" layer which abstracts the SPI code from the processor-to-processor differences.  I also moved configuration into a new "stm_dma_info.h" header which is different for each device family and contains the DMA channel mappings.

Now, with this code, you can enable DMA with `SPI::setDMAUsage()`, and the next SPI transfer after the DMA usage hint is set will allocate the needed DMA channels and structures.

Lastly, I added a new SPI::transfer_and_wait() function to match the I2C::transfer_and_wait() function added a while ago.

** Still TODOs:**
- Add stm_dma_info.h for most remaining processor targets
- Run more tests

#### Impact of changes <!-- Optional -->
STM32 devices will now support DMA.

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Currently I have tested this locally on STM32L452 and STM32H743ZI.  Pending testing on other boards.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
