### PR TITLE
Improve usability and documentation of the SPI API

### DIFF
--- a/drivers/include/drivers/I2C.h
+++ b/drivers/include/drivers/I2C.h
@@ -396,7 +396,7 @@ public:
      * @param tx_length The length of TX buffer in bytes.  If 0, no transmission is done.
      * @param rx_buffer The RX buffer, which is used for received data.  May be nullptr if tx_length is 0.
      * @param rx_length The length of RX buffer in bytes  If 0, no reception is done.
-     * @param event     The logical OR of events to modify.  May be I2C_EVENT_ALL, or some combination
+     * @param event     The logical OR of events to subscribe to.  May be I2C_EVENT_ALL, or some combination
      *        of the flags I2C_EVENT_ERROR, I2C_EVENT_ERROR_NO_SLAVE, I2C_EVENT_TRANSFER_COMPLETE, or I2C_EVENT_TRANSFER_EARLY_NACK
      * @param callback  The event callback function
      * @param repeated Set up for a repeated start.  If true, the Mbed processor does not relinquish the bus after

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -393,7 +393,7 @@ public:
      * @param rx_buffer Pointer to the byte-array of data to read from the device.
      * @param rx_length Number of bytes to read, may be zero.
      * @return
-     *      The number of bytes written and read from the device. This is
+     *      The number of bytes written and read from the device (as an int). This is
      *      maximum of tx_length and rx_length.
      */
     template<typename WordT>
@@ -445,12 +445,13 @@ public:
      *                  received data are ignored.
      * @param rx_length The length of RX buffer in bytes.
      * @param callback  The event callback function.
-     * @param event     The event mask of events to modify. @see spi_api.h for SPI events.
+     * @param event     The logical OR of events to subscribe to.  May be #SPI_EVENT_ALL, or some combination
+     *        of the flags #SPI_EVENT_ERROR, #SPI_EVENT_COMPLETE, or #SPI_EVENT_RX_OVERFLOW
      *
      * \warning Be sure to call this function with pointer types matching the frame size set for the SPI bus,
      * or undefined behavior may occur!
      *
-     * @return Operation result.
+     * @return Operation result (integer)
      * @retval 0 If the transfer has started.
      * @retval -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
      */
@@ -482,10 +483,11 @@ public:
      * \warning Be sure to call this function with pointer types matching the frame size set for the SPI bus,
      * or undefined behavior may occur!
      *
-     * @return -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
-     * @return 1 on timeout
-     * @return 2 on other error
-     * @return 0 on success
+     * @return Operation result (integer)
+     * @retval -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
+     * @retval 1 on timeout
+     * @retval 2 on other error
+     * @retval 0 on success
      */
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -42,6 +42,7 @@
 #include "platform/CircularBuffer.h"
 #include "platform/Callback.h"
 #include "platform/Transaction.h"
+#include "rtos/EventFlags.h"
 #endif
 
 namespace mbed {
@@ -54,46 +55,205 @@ namespace mbed {
 struct use_gpio_ssel_t { };
 const use_gpio_ssel_t use_gpio_ssel;
 
-/** A SPI Master, used for communicating with SPI slave devices.
+/**
+ * @brief An %SPI Master, used for communicating with %SPI slave devices.
  *
  * The default format is set to 8-bits, mode 0, and a clock frequency of 1MHz.
  *
- * Most SPI devices will also require Chip Select and Reset signals. These
- * can be controlled using DigitalOut pins.
- *
  * @note Synchronization level: Thread safe
  *
- * Example of how to send a byte to a SPI slave and record the response:
- * @code
+ * %SPI allows you to transfer data to and from peripheral devices using single-word transfers, transactions,
+ * or an asynchronous API.
+ *
+ * Here's how to talk to a chip using the single-word API:
+ * @code{.cpp}
  * #include "mbed.h"
  *
- * SPI device(SPI_MOSI, SPI_MISO, SPI_SCLK)
- *
- * DigitalOut chip_select(SPI_CS);
+ * SPI device(SPI_MOSI, SPI_MISO, SPI_SCLK, SPI_CS, use_gpio_ssel)
  *
  * int main() {
+ *     device.format(8, 0);
+ *
  *     device.lock();
- *     chip_select = 0;
- *
- *     int response = device.write(0xFF);
- *
- *     chip_select = 1;
+ *     device.select();
+ *     int response = device.write(0x0A);
+ *     int response2 = device.write(0x0B);
+ *     device.deselect();
  *     device.unlock();
  * }
  * @endcode
  *
- * Example using hardware Chip Select line:
+ * And here's how to do the same thing using a transaction:
  * @code
  * #include "mbed.h"
  *
- * SPI device(SPI_MOSI, SPI_MISO, SPI_SCLK, SPI_CS)
+ * SPI device(SPI_MOSI, SPI_MISO, SPI_SCLK, SPI_CS, use_gpio_ssel)
  *
  * int main() {
- *     device.lock();
- *     int response = device.write(0xFF);
- *     device.unlock();
+ *     device.format(8, 0);
+ *
+ *     uint8_t command[2] = {0x0A, 0x0B};
+ *     uint8_t response[2];
+ *     int result = device.write(command, sizeof(command), response, sizeof(response));
  * }
  * @endcode
+ *
+ * <h1>Hardware vs Software Chip Selects</h1>
+ * <p>Most ARM chips have specific pins marked as "hardware chip selects".  This means that they are connected
+ * to the %SPI peripheral and are automatically brought low by hardware when data is sent.  However, chips
+ * often only have only one pin for each SPI bus that can be used as a hardware chip select.  If you wish to
+ * use multiple peripheral devices with one SPI bus, or just don't have access to the HW CS pin, you must use the
+ * %SPI object in "GPIO chip select" mode.</p>
+ *
+ * <p>To use GPIO CS mode, simply pass the CS pin as the 4th constructor parameter, then pass the
+ * special constant \c use_gpio_ssel as the 5th parameter.  This puts the object in GPIO mode, where
+ * it will operate the CS line as a regular GPIO pin before and after doing an SPI transfer.  This mode
+ * is marginally slower than HW CS mode, but otherwise should offer the same functionality.  In fact,
+ * since the pin mapping is more flexible, it may be advisable to use GPIO CS mode by default.</p>
+ *
+ * \warning It is not recommended to control the CS line using a separate DigitalOut instance!
+ * This was needed in very old Mbed versions but should now be considered a legacy practice.
+ * Not only does it make it difficult to use the asynchronous API, but it can also lead to corner
+ * cases which corrupt data.  The CS line, whether done through GPIO or HW, should always be managed through
+ * the SPI class.
+ *
+ * <h1>Sharing a Bus</h1>
+ * <p>Multiple %SPI devices may share the same physical bus, so long as each has its own dedicated chip select
+ * (CS) pin.  To implement this sharing, each chip should create its own instance of the SPI class, passing
+ * the same MOSI, MISO, and SCLK pins but a different CS pin.  Mbed OS will internally share the %SPI hardware
+ * between these objects.  Note that this is <i>completely different</i> from how the I2C class handles
+ * sharing.</p>
+ *
+ * <h1>Frame/Word Size</h1>
+ * <p>Mbed OS supports configuration of the %SPI frame size, also known as the word size, which controls how
+ * many bits are sent in one transfer operation (one call to SPI::write()).  This parameter should match
+ * the "register size" of the %SPI peripheral that you are talking to.  For example, if you're working with a chip
+ * which uses 16-bit registers, you should set the frame size to 16 using SPI::format().  Some Mbed devices also
+ * support 32-bit frames -- use the \c DEVICE_SPI_32BIT_WORDS feature macro to test if yours does.</p>
+ *
+ * <p>The frame size controls the effective width of data written and read from the chip.  For example, if you set
+ * frame size to 8, SPI::write(int) will take one byte and return one byte, but if you set it to 16, SPI::write(int)
+ * will take a 16 bit value and return a 16 bit value. You can also do complete transactions
+ * (e.g. SPI::write(const char *, int, char *, int)) with frame sizes other than 8.  Just be sure to pass the
+ * length in bytes, not words!</p>
+ *
+ * <p>It should be noted that changing the frame size can perform an apparent "endian swap" on data being
+ * transmitted.  For example, suppose you have the 32-bit integer 0x01020408.  On a little-endian processor,
+ * this will be encoded with the LSByte <i>first</i> in memory: <tt>08 04 02 01</tt>.  If you send that
+ * integer using one-byte word size, it will appear as such.  Consider the following example:</p>
+ * @code{.cpp}
+ * spi.format(8, 0);
+ * uint32_t myInteger = 0x01020408;
+ * spi.write(reinterpret_cast<const char *>(&myInteger), sizeof(myInteger), nullptr, 0);
+ * @endcode
+ *
+ * <p>If you ran this code, then used a logic analyzer to view the bytes on the MOSI line, it would show bytes
+ * matching the layout of the integer in memory:</p>
+ * <pre>
+ * MOSI -> 08 04 02 01
+ * </pre>
+ *
+ * <p>But what about if you used a 32-bit frame size?</p>
+ * @code{.cpp}
+ * spi.format(32, 0);
+ * uint32_t myInteger = 0x01020408;
+ * spi.write<uint32_t>(&myInteger, sizeof(myInteger), nullptr, 0);
+ * @endcode
+ *
+ * <p>In this case, the complete 32-bit integer is sent as a single unit, from its MSBit to its LSBit, without
+ * breaking it into bytes.  This will send the data in an order different from the order in memory.  Viewed as
+ * bytes, it would look like:</p>
+ *
+ * <pre>
+ * MOSI -> 01 02 04 08
+ * </pre>
+ *
+ * <p>But viewed by a peripheral chip which uses 32-bit SPI words, it would look like:</p>
+ *
+ * <pre>
+ * MOSI -> 0x01020408
+ * </pre>
+ *
+ * <p>When viewed as bytes, it's almost as if you did an endian swap on the data before sending it,
+ * but in fact it's standard %SPI behavior when using frame sizes greater than one byte.  This same rule
+ * applies to receiving data, so be sure to check examples in the datasheet to determine what frame
+ * size to use and whether byte swapping is needed when working with an external chip.</p>
+ *
+ * <p>Note: Some Mbed targets support frame sizes that are not standard integer sizes, e.g. 4 bits, 7 bits, or
+ * 24 bits.  However, the behavior of these frame sizes is not well defined and may differ across targets
+ * or across API calls (e.g. single-byte vs transaction vs async).  More work is needed to make these consistent.</p>
+ *
+ * <h1>Asynchronous API</h1>
+ * <p>On many processors, Mbed OS also supports asynchronous %SPI.  This feature allows you to run %SPI
+ * transfers completely in the background, while other threads execute in the foreground.  This can
+ * be extremely useful if you need to send large amounts of data over the %SPI bus but don't want to
+ * block your main thread for ages.  To see if your processor supports async %SPI, look for the
+ * DEVICE_SPI_ASYNCH macro.</p>
+ *
+ * <p>The asynchronous API has two different modes: nonblocking (where your thread can keep running, and
+ * the transfer calls a callback when finished) and blocking (where your thread blocks for the duration of
+ * the transfer but others can execute).  Here's a sample of how to send the same data as above
+ * using the blocking async API:</p>
+ *
+ * @code
+ * #include "mbed.h"
+ *
+ * SPI device(SPI_MOSI, SPI_MISO, SPI_SCLK, SPI_CS, use_gpio_ssel)
+ *
+ * int main() {
+ *     device.format(8, 0);
+ *
+ *     uint8_t command[2] = {0x0A, 0x0B};
+ *     uint8_t response[2];
+ *     int result = device.transfer_and_wait(command, sizeof(command), response, sizeof(response));
+ * }
+ * @endcode
+ *
+ * <p>This code will cause the data in \c command to be sent to the device and the response to be received into
+ * \c response .  During the transfer, the current thread is paused, but other threads can execute.
+ * The non-blocking API does not pause the current thread, but is a bit more complicated to use.
+ * See the SPI::transfer_and_wait() implementation in the header file for an example.</p>
+ *
+ * <h3>Async: DMA vs Interrupts</h3>
+ * <p>Some processors only provide asynchronous %SPI via interrupts, some only support DMA, and some offer both.
+ * Using interrupts is simpler and generally doesn't require additional resources from the chip, however,
+ * some CPU time will be spent servicing the interrupt while the transfer is running.  This can become very
+ * performance-intensive -- on some chips, running async %SPI at frequencies of just a few MHz can be enough
+ * to make the interrupt use 100% of CPU time.  In contrast, DMA can require additional resources to be allocated,
+ * (e.g. chips with few DMA channels might only support DMA on one or two %SPI busses at a time), but
+ * can run the bus at full speed without any CPU overhead.  Generally, DMA should be preferred if available,
+ * especially if medium to fast bus speeds are needed.</p>
+ *
+ * <p>Consult your chip documentation and the Mbed port docs for your target to find out what is needed to enable
+ * DMA support.  For example, for STMicro targets, see
+ * <a href="https://github.com/mbed-ce/mbed-os/wiki/STM32-DMA-SPI-Support">here</a>.To select DMA or interrupts,
+ * use the SPI::set_dma_usage() function.  By default, interrupt %SPI will be used unless you change the
+ * setting.</p>
+ *
+ * <h3>Async: Queueing</h3>
+ * <p>The async %SPI system supports an optional transaction queueing mechanism.  When this is enabled,
+ * Mbed will allow multiple transactions to be queued up on a single bus, and will execute each one
+ * and deliver the appropriate callback in series.  This is mainly useful for the non-blocking
+ * async api (SPI::transfer()), though you can also use it with the blocking API by having multiple
+ * threads call it at once.</p>
+ *
+ * <p>The transaction queue size defaults to 2 on most devices, but you can change that using the
+ * \c drivers.spi_transaction_queue_len option, e.g.</p>
+ * \code{.json}
+ * {
+ *     "target_overrides": {
+ *          "*": {
+ *              "drivers.spi_transaction_queue_len": 3
+ *          }
+ *     }
+ * }
+ * \endcode
+ *
+ * <p>To save a little bit of memory, you can also set the queue length to 0 to disable the queueing mechanism.</p>
+ *
+ * \warning Currently, the value set by SPI::set_default_write_value() is
+ * <a href="https://github.com/ARMmbed/mbed-os/issues/13941">not respected</a> by the asynchronous %SPI
+ * code.  This needs to be fixed.
  */
 class SPI : private NonCopyable<SPI> {
 
@@ -162,10 +322,11 @@ public:
 
     virtual ~SPI();
 
-    /** Configure the data transmission format.
+    /**
+     * @brief Configure the data transmission format.
      *
-     *  @param bits Number of bits per SPI frame (4 - 32, target dependent).
-     *  @param mode Clock polarity and phase mode (0 - 3).
+     * @param bits Number of bits per %SPI frame (4 - 32, target dependent).
+     * @param mode Clock polarity and phase mode (0 - 3).
      *
      * @code
      * mode | POL PHA
@@ -178,35 +339,69 @@ public:
      */
     void format(int bits, int mode = 0);
 
-    /** Set the SPI bus clock frequency.
+    /**
+     * @brief Set the %SPI bus clock frequency.
      *
-     *  @param hz Clock frequency in Hz (default = 1MHz).
+     * @param hz Clock frequency in Hz (default = 1MHz).
      */
     void frequency(int hz = 1000000);
 
-    /** Write to the SPI Slave and return the response.
+    /**
+     * @brief Write to the %SPI Slave and return the response.
      *
-     *  @param value Data to be sent to the SPI slave.
+     * @param value Data to be sent to the SPI slave.  The number of significant bits in this
+     *     value depend on the \c bits parameter to format().
      *
-     *  @return Response from the SPI slave.
+     * @return Response from the %SPI slave.  The number of significant bits in this
+     *     value depend on the \c bits parameter to format().
      */
     virtual int write(int value);
 
-    /** Write to the SPI Slave and obtain the response.
+    /**
+     * @brief Write to the SPI Slave and obtain the response.
      *
-     *  The total number of bytes sent and received will be the maximum of
-     *  tx_length and rx_length. The bytes written will be padded with the
-     *  value 0xff.
+     * The total number of bytes sent and received will be the maximum of
+     * tx_length and rx_length. The bytes written will be padded with the
+     * value 0xff.
      *
-     *  @param tx_buffer Pointer to the byte-array of data to write to the device.
-     *  @param tx_length Number of bytes to write, may be zero.
-     *  @param rx_buffer Pointer to the byte-array of data to read from the device.
-     *  @param rx_length Number of bytes to read, may be zero.
-     *  @return
+     * Note: Even if the word size / bits per frame is not 8, \c rx_length and \c tx_length
+     * still count bytes of input data, not numbers of words.
+     *
+     * @param tx_buffer Pointer to the byte-array of data to write to the device.
+     * @param tx_length Number of bytes to write, may be zero.
+     * @param rx_buffer Pointer to the byte-array of data to read from the device.
+     * @param rx_length Number of bytes to read, may be zero.
+     * @return
      *      The number of bytes written and read from the device. This is
      *      maximum of tx_length and rx_length.
      */
     virtual int write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length);
+
+    // Convenience overload of the above for any integer type instead of char*
+    /**
+     * @brief Write to the SPI Slave and obtain the response.
+     *
+     * The total number of bytes sent and received will be the maximum of
+     * tx_length and rx_length. The bytes written will be padded with the
+     * value 0xff.
+     *
+     * Note: Even if the word size / bits per frame is not 8, \c rx_length and \c tx_length
+     * still count bytes of input data, not numbers of words.
+     *
+     * @param tx_buffer Pointer to the byte-array of data to write to the device.
+     * @param tx_length Number of bytes to write, may be zero.
+     * @param rx_buffer Pointer to the byte-array of data to read from the device.
+     * @param rx_length Number of bytes to read, may be zero.
+     * @return
+     *      The number of bytes written and read from the device. This is
+     *      maximum of tx_length and rx_length.
+     */
+    template<typename WordT>
+    typename std::enable_if<std::is_integral<WordT>::value, int>::type
+    write(const WordT *tx_buffer, int tx_length, WordT *rx_buffer, int rx_length)
+    {
+        return write(reinterpret_cast<char const *>(tx_buffer), tx_length, reinterpret_cast<char *>(rx_buffer), rx_length);
+    }
 
     /** Acquire exclusive access to this SPI bus.
      */
@@ -219,7 +414,7 @@ public:
     /** Assert the Slave Select line, acquiring exclusive access to this SPI bus.
      *
      * If use_gpio_ssel was not passed to the constructor, this only acquires
-     * exclusive access; it cannot assert the Slave Select line.
+     * exclusive access; the Slave Select line will not activate until data is transferred.
      */
     void select(void);
 
@@ -238,7 +433,8 @@ public:
 
 #if DEVICE_SPI_ASYNCH
 
-    /** Start non-blocking SPI transfer using 8bit buffers.
+    /**
+     * @brief Start non-blocking SPI transfer.
      *
      * This function locks the deep sleep until any event has occurred.
      *
@@ -251,18 +447,86 @@ public:
      * @param callback  The event callback function.
      * @param event     The event mask of events to modify. @see spi_api.h for SPI events.
      *
+     * \warning Be sure to call this function with pointer types matching the frame size set for the SPI bus,
+     * or undefined behavior may occur!
+     *
      * @return Operation result.
      * @retval 0 If the transfer has started.
-     * @retval -1 If SPI peripheral is busy.
+     * @retval -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
      */
-    template<typename Type>
-    int transfer(const Type *tx_buffer, int tx_length, Type *rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    template<typename WordT>
+    typename std::enable_if<std::is_integral<WordT>::value, int>::type
+    transfer(const WordT *tx_buffer, int tx_length, WordT *rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
         if (spi_active(&_peripheral->spi)) {
-            return queue_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type) * 8, callback, event);
+            return queue_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(WordT) * 8, callback, event);
         }
-        start_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type) * 8, callback, event);
+        start_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(WordT) * 8, callback, event);
         return 0;
+    }
+
+    /** Start %SPI transfer and wait until it is complete.  Like the transactional API this blocks the current thread,
+     * however all work is done in the background and other threads may execute.
+     *
+     * As long as there is space, this function will enqueue the transfer request onto the peripheral,
+     * and block until it is done.
+     *
+     * Internally, the chip vendor may implement this function using either DMA or interrupts.
+     *
+     * @param tx_buffer The TX buffer with data to be transferred.  May be nullptr if tx_length is 0.
+     * @param tx_length The length of TX buffer in bytes.  If 0, no transmission is done.
+     * @param rx_buffer The RX buffer, which is used for received data.  May be nullptr if tx_length is 0.
+     * @param rx_length The length of RX buffer in bytes  If 0, no reception is done.
+     * @param timeout timeout value.  Use #rtos::Kernel::wait_for_u32_forever to wait forever (the default).
+     *
+     * \warning Be sure to call this function with pointer types matching the frame size set for the SPI bus,
+     * or undefined behavior may occur!
+     *
+     * @return -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
+     * @return 1 on timeout
+     * @return 2 on other error
+     * @return 0 on success
+     */
+    template<typename WordT>
+    typename std::enable_if<std::is_integral<WordT>::value, int>::type
+    transfer_and_wait(const WordT *tx_buffer, int tx_length, WordT *rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    {
+        // Use EventFlags to suspend the thread until the transfer finishes
+        rtos::EventFlags transferResultFlags("SPI::transfer_and_wait EvFlags");
+
+        // Simple callback from the transfer that sets the EventFlags using the I2C result event
+        event_callback_t transferCallback([&](int event) {
+            transferResultFlags.set(event);
+        });
+
+        int txRet = transfer(tx_buffer, tx_length, rx_buffer, rx_length, transferCallback, SPI_EVENT_ALL);
+        if (txRet != 0) {
+            return txRet;
+        }
+
+        // Wait until transfer complete, error, or timeout
+        uint32_t result = transferResultFlags.wait_any_for(SPI_EVENT_ALL, timeout);
+
+        if (result & osFlagsError) {
+            if (result == osFlagsErrorTimeout) {
+                // Timeout expired, cancel transfer.
+                abort_transfer();
+                return 1;
+            } else {
+                // Other event flags error.  Transfer might be still running so cancel it.
+                abort_transfer();
+                return 2;
+            }
+        } else {
+            // Note: Cannot use a switch here because multiple flags might be set at the same time (possible
+            // in the STM32 HAL code at least).
+            if (result == SPI_EVENT_COMPLETE) {
+                return 0;
+            } else {
+                // SPI peripheral level error
+                return 2;
+            }
+        }
     }
 
     /** Abort the on-going SPI transfer, and continue with transfers in the queue, if any.
@@ -352,7 +616,7 @@ private:
     void unlock_deep_sleep();
 
 
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     /** Start a new transaction.
      *
      *  @param data Transaction data.
@@ -363,7 +627,7 @@ private:
      */
     void dequeue_transaction();
 
-#endif // TRANSACTION_QUEUE_SIZE_SPI
+#endif // MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
 #endif // !defined(DOXYGEN_ONLY)
 #endif // DEVICE_SPI_ASYNCH
 
@@ -392,9 +656,9 @@ protected:
         SingletonPtr<rtos::Mutex> mutex;
         /* Current user of the SPI */
         SPI *owner = nullptr;
-#if DEVICE_SPI_ASYNCH && TRANSACTION_QUEUE_SIZE_SPI
+#if DEVICE_SPI_ASYNCH && MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
         /* Queue of pending transfers */
-        SingletonPtr<CircularBuffer<Transaction<SPI>, TRANSACTION_QUEUE_SIZE_SPI> > transaction_buffer;
+        SingletonPtr<CircularBuffer<Transaction<SPI>, MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN> > transaction_buffer;
 #endif
     };
 

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -18,6 +18,10 @@
             "help": "The maximum number of SPI peripherals used at the same time. Determines RAM allocated for SPI peripheral management. If null, limit determined by hardware.",
             "value": null
         },
+        "spi_transaction_queue_len": {
+            "help": "Size of the asynchronous transaction queue for each SPI peripheral on the processor. 0 means no queueing support.  Only takes effect if the mbed target supports async SPI.",
+            "value": 2
+        },
         "qspi_io0": {
             "help": "QSPI data I/O 0 pin",
             "value": "QSPI_FLASH1_IO0"
@@ -85,6 +89,35 @@
         "ospi_dqs": {
             "help": "OSPI dqs pin",
             "value": "OSPI_FLASH1_DQS"
+        }
+    },
+    "target_overrides": {
+        "EFM32GG990F1024":{
+            "spi_transaction_queue_len": 4
+        },
+        "EFR32MG12P332F1024GL125":{
+            "spi_transaction_queue_len": 4
+        },
+        "EFM32GG11B820F2048GL192": {
+            "spi_transaction_queue_len": 4
+        },
+        "RZ_A1XX":{
+            "spi_transaction_queue_len": 16
+        },
+        "RZ_A2XX":{
+            "spi_transaction_queue_len": 16
+        },
+        "TMPM46B":{
+            "spi_transaction_queue_len": 4
+        },
+        "TMPM4G9":{
+            "spi_transaction_queue_len": 4
+        },
+        "TMPM4GR":{
+            "spi_transaction_queue_len": 4
+        },
+        "TMPM4NR":{
+            "spi_transaction_queue_len": 4
         }
     }
 }

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -137,7 +137,7 @@ void SPI::_do_construct()
     }
     core_util_critical_section_exit();
 
-#if DEVICE_SPI_ASYNCH && TRANSACTION_QUEUE_SIZE_SPI
+#if DEVICE_SPI_ASYNCH && MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     // prime the SingletonPtr, so we don't have a problem trying to
     // construct the buffer if asynch operation initiated from IRQ
     _peripheral->transaction_buffer.get();
@@ -291,14 +291,14 @@ void SPI::abort_transfer()
 {
     spi_abort_asynch(&_peripheral->spi);
     unlock_deep_sleep();
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     dequeue_transaction();
 #endif
 }
 
 void SPI::clear_transfer_buffer()
 {
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     _peripheral->transaction_buffer->reset();
 #endif
 }
@@ -320,7 +320,7 @@ int SPI::set_dma_usage(DMAUsage usage)
 
 int SPI::queue_transfer(const void *tx_buffer, int tx_length, void *rx_buffer, int rx_length, unsigned char bit_width, const event_callback_t &callback, int event)
 {
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     transaction_t t;
 
     t.tx_buffer = const_cast<void *>(tx_buffer);
@@ -373,7 +373,7 @@ void SPI::unlock_deep_sleep()
     }
 }
 
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
 
 void SPI::start_transaction(transaction_t *data)
 {
@@ -400,7 +400,7 @@ void SPI::irq_handler_asynch(void)
         unlock_deep_sleep();
         _callback.call(event & SPI_EVENT_ALL);
     }
-#if TRANSACTION_QUEUE_SIZE_SPI
+#if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     if (event & (SPI_EVENT_ALL | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE)) {
         // SPI peripheral is free (event happened), dequeue transaction
         dequeue_transaction();

--- a/hal/include/hal/dma_api.h
+++ b/hal/include/hal/dma_api.h
@@ -1,6 +1,8 @@
-
-/** \addtogroup hal */
-/** @{*/
+/**
+ * @file
+ * \addtogroup hal
+ * @{
+ */
 /* mbed Microcontroller Library
  * Copyright (c) 2014-2015 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
@@ -24,12 +26,15 @@
 
 #define DMA_ERROR_OUT_OF_CHANNELS (-1)
 
+/**
+ * @brief Enumeration of possible DMA usage hints
+ */
 typedef enum {
-    DMA_USAGE_NEVER,
-    DMA_USAGE_OPPORTUNISTIC,
-    DMA_USAGE_ALWAYS,
-    DMA_USAGE_TEMPORARY_ALLOCATED,
-    DMA_USAGE_ALLOCATED
+    DMA_USAGE_NEVER, ///< Never use DMA
+    DMA_USAGE_OPPORTUNISTIC, ///< Use DMA if possible but deallocate DMA resources when not being used.
+    DMA_USAGE_ALWAYS, ///< Always use DMA when possible
+    DMA_USAGE_TEMPORARY_ALLOCATED, // Seems to be used as an internal state indicator for "we need to deallocate these channels."
+    DMA_USAGE_ALLOCATED // Seems to be used as an internal state indicator for "we have allocated DMA channels."
 } DMAUsage;
 
 #ifdef __cplusplus

--- a/hal/include/hal/spi_api.h
+++ b/hal/include/hal/spi_api.h
@@ -27,10 +27,34 @@
 
 #if DEVICE_SPI
 
+/**
+ * @defgroup hal_SPIEvents SPI Events Macros
+ *
+ * @{
+ */
+
+/**
+ * Indicates that some kind of error occurred when starting the transfer.
+ */
 #define SPI_EVENT_ERROR       (1 << 1)
+
+/**
+ * Indicates that the transfer completed successfully.
+ */
 #define SPI_EVENT_COMPLETE    (1 << 2)
+
+/**
+ * Indicates an Rx overflow: the interrupt system or DMA controller was not able to
+ * keep up with the flow of bytes from the SPI peripheral and data was lost.
+ */
 #define SPI_EVENT_RX_OVERFLOW (1 << 3)
+
+/**
+ * Union of all of the above events.
+ */
 #define SPI_EVENT_ALL         (SPI_EVENT_ERROR | SPI_EVENT_COMPLETE | SPI_EVENT_RX_OVERFLOW)
+
+/// @}
 
 #define SPI_EVENT_INTERNAL_TRANSFER_COMPLETE (1 << 30) // Internal flag to report that an event occurred
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device.h
@@ -32,8 +32,6 @@
 
 
 
-#define TRANSACTION_QUEUE_SIZE_SPI 16
-
 
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device.h
@@ -32,8 +32,6 @@
 
 
 
-#define TRANSACTION_QUEUE_SIZE_SPI 16
-
 
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A2XX/TARGET_GR_MANGO/device.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A2XX/TARGET_GR_MANGO/device.h
@@ -25,8 +25,6 @@
 
 
 
-#define TRANSACTION_QUEUE_SIZE_SPI 16
-
 
 
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device.h
@@ -16,7 +16,6 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define TRANSACTION_QUEUE_SIZE_SPI 	4
 #define DEVICE_ID_LENGTH            32
 
 #include "objects.h"

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device.h
@@ -19,7 +19,6 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define TRANSACTION_QUEUE_SIZE_SPI      4
 #define DEVICE_ID_LENGTH                32
 
 #include <stddef.h>

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/device.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/device.h
@@ -17,7 +17,6 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define TRANSACTION_QUEUE_SIZE_SPI      4
 #define DEVICE_ID_LENGTH                32
 
 #include <stddef.h>

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4NR/device.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4NR/device.h
@@ -17,7 +17,6 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define TRANSACTION_QUEUE_SIZE_SPI      4
 #define DEVICE_ID_LENGTH                32
 
 #include <stddef.h>

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1211,8 +1211,7 @@
         ],
         "macros": [
             "USE_HAL_DRIVER",
-            "USE_FULL_LL_DRIVER",
-            "TRANSACTION_QUEUE_SIZE_SPI=2"
+            "USE_FULL_LL_DRIVER"
         ],
         "bootloader_supported": true,
         "config": {
@@ -6573,8 +6572,7 @@
         ],
         "core": "Cortex-M3",
         "macros_add": [
-            "EFM32GG990F1024",
-            "TRANSACTION_QUEUE_SIZE_SPI=4"
+            "EFM32GG990F1024"
         ],
         "supported_toolchains": [
             "GCC_ARM"
@@ -6688,8 +6686,7 @@
         ],
         "core": "Cortex-M4F",
         "macros_add": [
-            "EFR32MG12P332F1024GL125",
-            "TRANSACTION_QUEUE_SIZE_SPI=4"
+            "EFR32MG12P332F1024GL125"
         ],
         "supported_toolchains": [
             "GCC_ARM"
@@ -6798,8 +6795,7 @@
         ],
         "core": "Cortex-M4F",
         "macros_add": [
-            "EFM32GG11B820F2048GL192",
-            "TRANSACTION_QUEUE_SIZE_SPI=4"
+            "EFM32GG11B820F2048GL192"
         ],
         "supported_toolchains": [
             "GCC_ARM"

--- a/tools/test/ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/ci/doxy-spellchecker/ignore.en.pws
@@ -130,3 +130,5 @@ enqueued
 enqueue
 MSBit
 LSBit
+busses
+STMicro

--- a/tools/test/ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/ci/doxy-spellchecker/ignore.en.pws
@@ -126,3 +126,7 @@ conf
 transactional
 errored
 natively
+enqueued
+enqueue
+MSBit
+LSBit


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I split this PR off from my DMA SPI PR, to try and reduce the size of that below the Schwarzschild radius.  Its goal is to improve the usability of the SPI class by adding convenience functions, and to vastly increase the amount of documentation available for SPI.  Specifically, it:

- Documents previously cryptic things like frame sizes, transaction queueing, GPIO CS usage, and DMA hints
- Provides usage examples for basically all of the major ways to use the SPI class
- Converts the `TRANSACTION_QUEUE_SIZE_SPI` define into a proper mbed_app.json option (what it should have been in the first place).  This provides a standard way for the user to modify it -- before, it was just set in a bunch of random manufacturer header files and target definitions and could not be modified.
- Provides convenience overloads of the transaction and async transaction functions which take any integer type, removing the need to cast to `char*` all the time.  Integer types are enforced using `std::enable_if`.
- Provides a new SPI::transfer_and_wait() to parallel the new I2C::transfer_and_wait().  This code wraps and shows how to use the async transfer() API, which is not super straightforward to use by itself.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
This should not cause any breaking changes, it just adds new functionality and documents the existing functionality.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
(this is mostly documentation)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran the overloads through my CI shield test suite and they passed!  More info coming soon as part of the DMA PR.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
