### PR TITLE
Fix declaring OSPIFBlockDevice and QSPIFBlockDevice as globals, fix some STM32U585 issues

### DIFF
--- a/connectivity/drivers/wifi/CMakeLists.txt
+++ b/connectivity/drivers/wifi/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 add_subdirectory(esp8266-driver)
 
 target_link_libraries(mbed-wifi
-    INTERFACE
+    PUBLIC
+        mbed-rtos-flags
         mbed-netsocket-api
 )

--- a/rtos/tests/UNITTESTS/doubles/rtos/Mutex.h
+++ b/rtos/tests/UNITTESTS/doubles/rtos/Mutex.h
@@ -20,8 +20,12 @@
 #include <inttypes.h>
 #include "rtos/mbed_rtos_types.h"
 #include "rtos/internal/mbed_rtos1_types.h"
+#include "ScopedLock.h"
 
 namespace rtos {
+
+class Mutex;
+typedef mbed::ScopedLock<Mutex> ScopedMutexLock;
 
 class Mutex {
 public:

--- a/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
@@ -404,12 +404,8 @@ private:
     // OSPI Driver Object
     mbed::OSPI _ospi;
 
-    // Static List of different OSPI based Flash devices csel that already exist
-    // Each OSPI Flash device csel can have only 1 OSPIFBlockDevice instance
-    // _devices_mutex is used to lock csel list - only one OSPIFBlockDevice instance per csel is allowed
-    static SingletonPtr<rtos::Mutex> _devices_mutex;
+    // Number of active OSPIFBlockDevice chip select pins
     static int _number_of_active_ospif_flash_csel;
-    static PinName *_active_ospif_flash_csel_arr;
 
     int _unique_device_status;
     PinName _csel;

--- a/storage/blockdevice/COMPONENT_OSPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_OSPIF/mbed_lib.json
@@ -28,6 +28,19 @@
     "target_overrides": {
         "MX25LM51245G": {
             "OSPI_FREQ": "66000000"
+        },
+        "B_U585_IOT02A": {
+            "OSPI_IO0": "PF_0",
+            "OSPI_IO1": "PF_1",
+            "OSPI_IO2": "PF_2",
+            "OSPI_IO3": "PF_3",
+            "OSPI_IO4": "PH_9",
+            "OSPI_IO5": "PH_10",
+            "OSPI_IO6": "PH_11",
+            "OSPI_IO7": "PH_12",
+            "OSPI_SCK": "PF_4",
+            "OSPI_CSN": "PI_5",
+            "OSPI_DQS": "PF_12"
         }
     }
 }

--- a/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
@@ -182,7 +182,7 @@ static const uint8_t _sfdp_4_byte_inst_table[8] = {0x7F, 0xEF, 0xFF, 0xFF, 0x21,
  * Get the global mutex used to protect the chip select pin array (below).
  * It will be initialized on first use.
  */
-static rtos::Mutex & get_devices_mutex();
+static rtos::Mutex &get_devices_mutex();
 
 /*
  * Get the global array of active chip select pins.
@@ -190,7 +190,7 @@ static rtos::Mutex & get_devices_mutex();
  *
  * This function should be called with the devices mutex locked.
  */
-static PinName * get_active_ospif_csel_arr();
+static PinName *get_active_ospif_csel_arr();
 
 
 int OSPIFBlockDevice::_number_of_active_ospif_flash_csel = 0;
@@ -869,14 +869,14 @@ int OSPIFBlockDevice::change_mode(int mode)
 /*   Different Device Csel Mgmt */
 /********************************/
 
-static rtos::Mutex & get_devices_mutex()
+static rtos::Mutex &get_devices_mutex()
 {
     static rtos::Mutex devicesMutex;
     return devicesMutex;
 }
 
 
-static PinName * get_active_ospif_csel_arr()
+static PinName *get_active_ospif_csel_arr()
 {
     // Declare the active csel array info as local static variables.
     // This makes sure it's initialized on first use, so even if an OSPIFBlockDevice is declared
@@ -884,7 +884,7 @@ static PinName * get_active_ospif_csel_arr()
     static bool active_csel_arr_initialized = false;
     static PinName active_csel_arr[OSPIF_MAX_ACTIVE_FLASH_DEVICES];
 
-    if(!active_csel_arr_initialized) {
+    if (!active_csel_arr_initialized) {
         for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
             active_csel_arr[i_ind] = NC;
         }
@@ -898,7 +898,7 @@ int OSPIFBlockDevice::add_new_csel_instance(PinName csel)
 {
     rtos::ScopedMutexLock lock(get_devices_mutex());
 
-    PinName * active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
+    PinName *active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
 
     if (_number_of_active_ospif_flash_csel >= OSPIF_MAX_ACTIVE_FLASH_DEVICES) {
         return -2;
@@ -927,7 +927,7 @@ int OSPIFBlockDevice::remove_csel_instance(PinName csel)
 {
     rtos::ScopedMutexLock lock(get_devices_mutex());
 
-    PinName * active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
+    PinName *active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
 
     // remove the csel from existing device list
     for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {

--- a/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
@@ -178,13 +178,22 @@ static const uint8_t _sfdp_basic_param_table[64] = {0x30, 0xFF, 0xFB, 0xFF, 0xFF
 static const uint8_t _sfdp_4_byte_inst_table[8] = {0x7F, 0xEF, 0xFF, 0xFF, 0x21, 0x5C, 0xDC, 0x14};
 #endif
 
-/* Init function to initialize Different Devices CS static list */
-static PinName *generate_initialized_active_ospif_csel_arr();
-// Static Members for different devices csel
-// _devices_mutex is used to lock csel list - only one OSPIFBlockDevice instance per csel is allowed
-SingletonPtr<rtos::Mutex> OSPIFBlockDevice::_devices_mutex;
+/*
+ * Get the global mutex used to protect the chip select pin array (below).
+ * It will be initialized on first use.
+ */
+static rtos::Mutex & get_devices_mutex();
+
+/*
+ * Get the global array of active chip select pins.
+ * Each OSPI Flash device csel can have only 1 OSPIFBlockDevice instance.
+ *
+ * This function should be called with the devices mutex locked.
+ */
+static PinName * get_active_ospif_csel_arr();
+
+
 int OSPIFBlockDevice::_number_of_active_ospif_flash_csel = 0;
-PinName *OSPIFBlockDevice::_active_ospif_flash_csel_arr = generate_initialized_active_ospif_csel_arr();
 
 /********* Public API Functions *********/
 /****************************************/
@@ -859,63 +868,79 @@ int OSPIFBlockDevice::change_mode(int mode)
 /********************************/
 /*   Different Device Csel Mgmt */
 /********************************/
-static PinName *generate_initialized_active_ospif_csel_arr()
+
+static rtos::Mutex & get_devices_mutex()
 {
-    PinName *init_arr = new PinName[OSPIF_MAX_ACTIVE_FLASH_DEVICES];
-    for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
-        init_arr[i_ind] = NC;
+    static rtos::Mutex devicesMutex;
+    return devicesMutex;
+}
+
+
+static PinName * get_active_ospif_csel_arr()
+{
+    // Declare the active csel array info as local static variables.
+    // This makes sure it's initialized on first use, so even if an OSPIFBlockDevice is declared
+    // globally and constructed before the globals in this file, things will still work correctly.
+    static bool active_csel_arr_initialized = false;
+    static PinName active_csel_arr[OSPIF_MAX_ACTIVE_FLASH_DEVICES];
+
+    if(!active_csel_arr_initialized) {
+        for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
+            active_csel_arr[i_ind] = NC;
+        }
+        active_csel_arr_initialized = true;
     }
-    return init_arr;
+
+    return active_csel_arr;
 }
 
 int OSPIFBlockDevice::add_new_csel_instance(PinName csel)
 {
-    int status = 0;
-    _devices_mutex->lock();
+    rtos::ScopedMutexLock lock(get_devices_mutex());
+
+    PinName * active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
+
     if (_number_of_active_ospif_flash_csel >= OSPIF_MAX_ACTIVE_FLASH_DEVICES) {
-        status = -2;
-        goto exit_point;
+        return -2;
     }
 
     // verify the device is unique(no identical csel already exists)
     for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
-        if (_active_ospif_flash_csel_arr[i_ind] == csel) {
-            status = -1;
-            goto exit_point;
+        if (active_ospif_flash_csel_arr[i_ind] == csel) {
+            return -1;
         }
     }
 
     // Insert new csel into existing device list
     for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
-        if (_active_ospif_flash_csel_arr[i_ind] == NC) {
-            _active_ospif_flash_csel_arr[i_ind] = csel;
+        if (active_ospif_flash_csel_arr[i_ind] == NC) {
+            active_ospif_flash_csel_arr[i_ind] = csel;
             break;
         }
     }
     _number_of_active_ospif_flash_csel++;
 
-exit_point:
-    _devices_mutex->unlock();
-    return status;
+    return 0;
 }
 
 int OSPIFBlockDevice::remove_csel_instance(PinName csel)
 {
-    int status = -1;
-    _devices_mutex->lock();
+    rtos::ScopedMutexLock lock(get_devices_mutex());
+
+    PinName * active_ospif_flash_csel_arr = get_active_ospif_csel_arr();
+
     // remove the csel from existing device list
     for (int i_ind = 0; i_ind < OSPIF_MAX_ACTIVE_FLASH_DEVICES; i_ind++) {
-        if (_active_ospif_flash_csel_arr[i_ind] == csel) {
-            _active_ospif_flash_csel_arr[i_ind] = NC;
+        if (active_ospif_flash_csel_arr[i_ind] == csel) {
+            active_ospif_flash_csel_arr[i_ind] = NC;
             if (_number_of_active_ospif_flash_csel > 0) {
                 _number_of_active_ospif_flash_csel--;
             }
-            status = 0;
-            break;
+            return 0;
         }
     }
-    _devices_mutex->unlock();
-    return status;
+
+    return -1;
 }
 
 /*********************************************************/

--- a/storage/blockdevice/COMPONENT_QSPIF/include/QSPIF/QSPIFBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_QSPIF/include/QSPIF/QSPIFBlockDevice.h
@@ -343,12 +343,8 @@ private:
     // QSPI Driver Object
     mbed::QSPI _qspi;
 
-    // Static List of different QSPI based Flash devices csel that already exist
-    // Each QSPI Flash device csel can have only 1 QSPIFBlockDevice instance
-    // _devices_mutex is used to lock csel list - only one QSPIFBlockDevice instance per csel is allowed
-    static SingletonPtr<rtos::Mutex> _devices_mutex;
+    // Number of active OSPIFBlockDevice chip select pins
     static int _number_of_active_qspif_flash_csel;
-    static PinName *_active_qspif_flash_csel_arr;
 
     int _unique_device_status;
     PinName _csel;

--- a/storage/platform/CMakeLists.txt
+++ b/storage/platform/CMakeLists.txt
@@ -25,6 +25,10 @@ if("QSPIF" IN_LIST MBED_TARGET_LABELS)
     list(APPEND mbed-storage-libs mbed-storage-qspif)
 endif()
 
+if("OSPIF" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed-storage-libs mbed-storage-ospif)
+endif()
+
 if("SD" IN_LIST MBED_TARGET_LABELS)
     list(APPEND mbed-storage-libs mbed-storage-sd)
 endif()

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4902,13 +4902,13 @@
             "MX25LM51245G"
         ],
         "components_add": [
-            "OSPIF"
+            "OSPIF",
+            "EMW3080B"
         ],
         "device_has_add": [
             "QSPI",
             "OSPI"
         ],
-        "components_add": ["EMW3080B"],
         "overrides": {
             "network-default-interface-type": "WIFI"
         },

--- a/targets/upload_method_cfg/B_U585I_IOT02A.cmake
+++ b/targets/upload_method_cfg/B_U585I_IOT02A.cmake
@@ -1,0 +1,47 @@
+# Mbed OS upload method configuration file for target B_U585_IOT02A.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. To use this target with PyOCD, you need to install a pack: `pyocd pack install STM32U585AIIxQ`.
+#    You might also need to run `pyocd pack update` first.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32U585AIIxQ)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/interface/stlink.cfg
+	-c "transport select hla_swd"
+	-f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/stm32u5x.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/openocd_cfgs/stm32u5x.cfg
+++ b/targets/upload_method_cfg/openocd_cfgs/stm32u5x.cfg
@@ -1,0 +1,58 @@
+# From: https://github.com/STMicroelectronics/OpenOCD/blob/openocd-cubeide-r6/tcl/target/stm32u5x.cfg
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# script for stm32u5x family
+# stm32u5x devices support both JTAG and SWD transports.
+
+source [find target/swj-dp.tcl]
+source [find mem_helper.tcl]
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME stm32u5x
+}
+
+source [find target/stm32x5x_common.cfg]
+
+proc stm32u5x_clock_config {} {
+	set offset [expr {[stm32x5x_is_secure] ? 0x10000000 : 0}]
+	# MCU clock is at MSI 4MHz after reset, set MCU freq at 160 MHz with PLL
+
+	# Enable voltage range 1 for frequency above 100 Mhz
+	# RCC_AHB3ENR = PWREN
+	mww [expr {0x46020C94 + $offset}] 0x00000004
+	# delay for register clock enable (read back reg)
+	mrw [expr {0x46020C94 + $offset}]
+	# PWR_VOSR : VOS Range 1
+	mmw [expr {0x4602080C + $offset}] 0x00030000 0
+	# while !(PWR_VOSR & VOSRDY)
+	while {!([mrw [expr {0x4602080C + $offset}]] & 0x00008000)} {}
+	# FLASH_ACR : 4 WS for 160 MHz HCLK
+	mww [expr {0x40022000 + $offset}] 0x00000004
+	# RCC_PLL1CFGR => PLL1MBOOST=0, PLL1M=0=/1, PLL1FRACEN=0, PLL1SRC=MSI 4MHz
+	#                 PLL1REN=1, PLL1RGE => VCOInputRange=PLLInputRange_4_8
+	mww [expr {0x46020C28 + $offset}] 0x00040009
+	# Enable EPOD Booster
+	mmw [expr {0x4602080C + $offset}] 0x00040000 0
+	# while !(PWR_VOSR & BOOSTRDY)
+	while {!([mrw [expr {0x4602080C + $offset}]] & 0x00004000)} {}
+	# RCC_PLL1DIVR => PLL1P=PLL1Q=PLL1R=000001=/2, PLL1N=0x4F=80
+	# fVCO = 4 x 80 /1 = 320
+	# SYSCLOCK = fVCO/PLL1R = 320/2 = 160 MHz
+	mww [expr {0x46020C34 + $offset}] 0x0101024F
+	# RCC_CR |= PLL1ON
+	mmw [expr {0x46020C00 + $offset}] 0x01000000 0
+	# while !(RCC_CR & PLL1RDY)
+	while {!([mrw [expr {0x46020C00 + $offset}]] & 0x02000000)} {}
+	# RCC_CFGR1 |= SW_PLL
+	mmw [expr {0x46020C1C + $offset}] 0x00000003 0
+	# while ((RCC_CFGR1 & SWS) != PLL)
+	while {([mrw [expr {0x46020C1C + $offset}]] & 0x0C) != 0x0C} {}
+}
+
+$_TARGETNAME configure -event reset-init {
+	stm32u5x_clock_config
+	# Boost JTAG frequency
+	adapter speed 4000
+}

--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -14,6 +14,14 @@ set(UPLOAD_METHOD "${UPLOAD_METHOD_DEFAULT}" CACHE STRING "Method for uploading 
 # use a higher numbered port to allow use without root on Linux/Mac
 set(GDB_PORT 23331 CACHE STRING "Port that the GDB server will be started on.")
 
+# Upload methods must be uppercase, guard against the user making a mistake (since Windows will allow opening
+# an include file with the wrong case, the error message gets confusing)
+string(TOUPPER "${UPLOAD_METHOD}" UPLOAD_METHOD_UCASE)
+if(NOT "${UPLOAD_METHOD_UCASE}" STREQUAL "${UPLOAD_METHOD}")
+	message(WARNING "UPLOAD_METHOD value should be uppercase.  It has been automatically changed to \"${UPLOAD_METHOD_UCASE}\".")
+	set(UPLOAD_METHOD "${UPLOAD_METHOD_UCASE}" CACHE STRING "" FORCE)
+endif()
+
 # Load the upload method.  This is expected to set the following variables:
 # UPLOAD_${UPLOAD_METHOD}_FOUND - True iff the dependencies for this upload method were found
 # UPLOAD_SUPPORTS_DEBUG - True iff this upload method supports debugging


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

@tim35ca on the forums [pointed out](https://forums.mbed.com/t/octal-spi-on-b-u585/20539/4) that declaring an OSPIFBlockDevice as a global object can cause it to not work correctly.  This is because the author of OSPIFBlockDevice made a common mistake: interacting with global variables in an object constructor, without realizing that those global variables might not yet have been initialized.  The C++ environment is free to initialize globals in any order it wants, so depending on your luck for the day and the direction of the wind, the globals in OSPIFBlockDevice.cpp may or may not have been initialized by the time your globally declared block device instance gets constructed.

If they aren't, you will likely get a HardFault due to accessing a null `_active_ospif_flash_csel_arr` pointer.

In this PR, I changed the code around a bit so that the global variables (the mutex and the csel array) are now stored as local static variables in functions.  This gives them a well-defined init order -- they will always be initialized the first time the function is called.  I also cleaned up the code a bit (hello ScopedMutexLock, goodbye `goto`) and fixed an issue where OSPIFBlockDevice wasn't available on my test target due to an error in targets.json.

Also applied fixes for some other issues that @tim35 was running into with the U585 board, including:
- mbed-wifi not compiling
- No upload method configuration for B_U585I_IOT02A
- B_U585I_IOT02A missing OSPIF component due to a typo in targets.json

Update: Since QSPIFBlockDevice was found to have the same problem, I also applied this fix there.

#### Impact of changes <!-- Optional -->
OSPIFBlockDevice should no longer hardfault when declared globally.

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
