### PR TITLE
Fix LoRaWan compile error, add DISCO_L072CZ_LRWAN1 upload method configuration

### DIFF
--- a/connectivity/CMakeLists.txt
+++ b/connectivity/CMakeLists.txt
@@ -1,17 +1,17 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# These five directories create targets that are then used by buildfiles under drivers/
+# These six directories create targets that are then used by buildfiles under drivers/
 add_subdirectory(nanostack)
 add_subdirectory(cellular)
 add_subdirectory(mbedtls)
 add_subdirectory(nfc)
+add_subdirectory(lorawan)
 if("FEATURE_BLE=1" IN_LIST MBED_TARGET_DEFINITIONS)
     add_subdirectory(FEATURE_BLE)
 endif()
 
 add_subdirectory(drivers)
 add_subdirectory(libraries)
-add_subdirectory(lorawan)
 add_subdirectory(lwipstack)
 add_subdirectory(netsocket)

--- a/targets/upload_method_cfg/DISCO_L072CZ_LRWAN1.cmake
+++ b/targets/upload_method_cfg/DISCO_L072CZ_LRWAN1.cmake
@@ -1,0 +1,54 @@
+# Mbed OS upload method configuration file for target DISCO_L072CZ_LRWAN1.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. To use this target with PyOCD, you need to install a pack: `python -m pyocd pack install STM32L072CZTx`.
+#    You might also need to run `pyocd pack update` first.
+# 2. To use J-Link you must convert your board's ST-Link into a J-Link using the reflash program.
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L072CZ)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32L072CZTx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+-f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_l073rz.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED FALSE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

@tim35ca on the forums reported this compile error, turns out that the subdirectory order has been incorrect since I refactored that part of the build system.  Easily fixed by reordering the add_subdirectory() calls.

I also threw in an upload configuration file for DISCO_L072CZ_LRWAN1, so uploading to the board should work properly now.

#### Impact of changes <!-- Optional -->
Mbed CE now compiles for boards with LoRaWan

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
