### PR TITLE
Bug fix/lorawan sx127x get status type

### DIFF
--- a/connectivity/drivers/lora/COMPONENT_SX1272/SX1272_LoRaRadio.cpp
+++ b/connectivity/drivers/lora/COMPONENT_SX1272/SX1272_LoRaRadio.cpp
@@ -297,7 +297,7 @@ void SX1272_LoRaRadio::set_channel(uint32_t freq)
 /**
  * Returns current status of the radio state machine
  */
-uint8_t SX1272_LoRaRadio::get_status(void)
+radio_state_t SX1272_LoRaRadio::get_status(void)
 {
     return _rf_settings.state;
 }

--- a/connectivity/drivers/lora/COMPONENT_SX1276/SX1276_LoRaRadio.cpp
+++ b/connectivity/drivers/lora/COMPONENT_SX1276/SX1276_LoRaRadio.cpp
@@ -309,7 +309,7 @@ bool SX1276_LoRaRadio::check_rf_frequency(uint32_t frequency)
 /**
  * Returns current status of the radio state machine
  */
-uint8_t SX1276_LoRaRadio::get_status(void)
+radio_state_t SX1276_LoRaRadio::get_status(void)
 {
     return _rf_settings.state;
 }

--- a/connectivity/lorawan/include/lorawan/LoRaRadio.h
+++ b/connectivity/lorawan/include/lorawan/LoRaRadio.h
@@ -349,7 +349,7 @@ typedef struct radio_settings {
     /**
      * Current state of the radio, such as RF_IDLE.
      */
-    uint8_t                     state;
+    radio_state_t               state;
 
     /**
      * Current modem operation, such as MODEM_LORA.


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Compiling using arm gnu toolchain arm-none-eabi/12.2 and target DISCO_L072CZ_LRWAN1 produced errors for SX1276 modem::get_status() return type, i.e. two places declared as uint8_t and another radio_status_t.

Same fix for SX1272 modem.

Fixes #20741.  

#### Impact of changes <!-- Optional -->

Mbed CE now compiles for boards with LoRaWan and 

#### Migration actions required <!-- Optional -->
None.

### Documentation <!-- Required -->
None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @multiplemonomials
-->

----------------------------------------------------------------------------------------------------------------
