### PR TITLE
SPI Driver API bugfixes and cleanup, part 2

### DIFF
--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -753,6 +753,9 @@ protected:
     void (*_init_func)(SPI *);
 
 private:
+
+    rtos::Mutex & _get_peripherals_mutex();
+
     void _do_construct();
 
     /** Private acquire function without locking/unlocking.
@@ -762,13 +765,17 @@ private:
     void _set_ssel(int);
 
     /** Private lookup in the static _peripherals table.
+     * Should be called with _peripherals_mutex locked.
      */
     static spi_peripheral_s *_lookup(SPIName name);
+
     /** Allocate an entry in the static _peripherals table.
+     * Should be called with _peripherals_mutex locked.
      */
     static spi_peripheral_s *_alloc();
+
     /// Deallocate the given peripheral.
-    /// Must be called from a critical section.
+    /// Should be called with _peripherals_mutex locked.
     static void _dealloc(spi_peripheral_s *peripheral);
 
     static void _do_init(SPI *obj);

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -681,9 +681,13 @@ protected:
         SPIName name = SPIName(0);
         /* Internal SPI object handling the resources' state. */
         spi_t spi{};
+        /* Number of SPI objects that have been created which reference this peripheral. */
+        uint8_t numUsers;
+        /* True iff anyone has ever called spi_init() / spi_init_direct() for this peripheral */
+        bool initialized;
         /* Used by lock and unlock for thread safety */
         SingletonPtr<rtos::Mutex> mutex;
-        /* Current user of the SPI */
+        /* Current user of the SPI, if any. */
         SPI *owner = nullptr;
 #if DEVICE_SPI_ASYNCH && MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
         /* Queue of pending transfers */
@@ -758,6 +762,9 @@ private:
     /** Allocate an entry in the static _peripherals table.
      */
     static spi_peripheral_s *_alloc();
+    /// Deallocate the given peripheral.
+    /// Must be called from a critical section.
+    static void _dealloc(spi_peripheral_s * peripheral);
 
     static void _do_init(SPI *obj);
     static void _do_init_direct(SPI *obj);

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -754,7 +754,10 @@ protected:
 
 private:
 
-    rtos::Mutex & _get_peripherals_mutex();
+    /**
+     * Get a reference to the mutex used to protect the peripherals array.
+     */
+    rtos::Mutex &_get_peripherals_mutex();
 
     void _do_construct();
 

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -681,14 +681,14 @@ protected:
         SPIName name = SPIName(0);
         /* Internal SPI object handling the resources' state. */
         spi_t spi{};
-        /* Number of SPI objects that have been created which reference this peripheral. */
-        uint8_t numUsers;
-        /* True iff anyone has ever called spi_init() / spi_init_direct() for this peripheral */
-        bool initialized;
         /* Used by lock and unlock for thread safety */
         SingletonPtr<rtos::Mutex> mutex;
         /* Current user of the SPI, if any. */
         SPI *owner = nullptr;
+        /* Number of SPI objects that have been created which reference this peripheral. */
+        uint8_t numUsers = 0;
+        /* True iff anyone has ever called spi_init() / spi_init_direct() for this peripheral */
+        bool initialized = false;
 #if DEVICE_SPI_ASYNCH && MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
         /* Queue of pending transfers */
         SingletonPtr<CircularBuffer<Transaction<SPI>, MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN> > transaction_buffer;
@@ -732,7 +732,7 @@ protected:
 
     /* Size of the SPI frame */
     int _bits;
-    /* Clock polairy and phase */
+    /* Clock polarity and phase */
     int _mode;
     /* Clock frequency */
     int _hz;
@@ -764,7 +764,7 @@ private:
     static spi_peripheral_s *_alloc();
     /// Deallocate the given peripheral.
     /// Must be called from a critical section.
-    static void _dealloc(spi_peripheral_s * peripheral);
+    static void _dealloc(spi_peripheral_s *peripheral);
 
     static void _do_init(SPI *obj);
     static void _do_init_direct(SPI *obj);
@@ -787,7 +787,7 @@ private:
      *      The number of bytes written and read from the device. This is
      *      maximum of tx_length and rx_length.
      */
-    virtual int write_internal(const void * tx_buffer, int tx_length, void * rx_buffer, int rx_length);
+    virtual int write_internal(const void *tx_buffer, int tx_length, void *rx_buffer, int rx_length);
 
 
 #endif //!defined(DOXYGEN_ONLY)

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -144,7 +144,7 @@ void SPI::_do_construct()
         _peripheral->name = _peripheral_name;
     }
 
-    if(_peripheral->numUsers == std::numeric_limits<uint8_t>::max()) {
+    if (_peripheral->numUsers == std::numeric_limits<uint8_t>::max()) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "Ref count at max!");
     }
 
@@ -163,7 +163,7 @@ void SPI::_do_construct()
 
 SPI::~SPI()
 {
-    if(_peripheral->numUsers == 0){
+    if (_peripheral->numUsers == 0) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_MUTEX_UNLOCK_FAILED), "Ref count at 0?");
     }
 
@@ -174,8 +174,7 @@ SPI::~SPI()
         _peripheral->owner = nullptr;
     }
 
-    if(--_peripheral->numUsers == 0)
-    {
+    if (--_peripheral->numUsers == 0) {
         _dealloc(_peripheral);
     }
 
@@ -196,13 +195,13 @@ SPI::spi_peripheral_s *SPI::_lookup(SPI::SPIName name)
     return result;
 }
 
-SPI::spi_peripheral_s * SPI::_alloc()
+SPI::spi_peripheral_s *SPI::_alloc()
 {
     MBED_ASSERT(_peripherals_used < SPI_PERIPHERALS_USED);
 
     // Find an unused peripheral to return
-    for(spi_peripheral_s & peripheral : _peripherals) {
-        if(peripheral.numUsers == 0) {
+    for (spi_peripheral_s &peripheral : _peripherals) {
+        if (peripheral.numUsers == 0) {
             _peripherals_used++;
             return &peripheral;
         }
@@ -213,7 +212,7 @@ SPI::spi_peripheral_s * SPI::_alloc()
 
 void SPI::_dealloc(SPI::spi_peripheral_s *peripheral)
 {
-    if(peripheral->initialized) {
+    if (peripheral->initialized) {
         spi_free(&peripheral->spi);
         peripheral->initialized = false;
     }
@@ -270,12 +269,12 @@ int SPI::write(int value)
     return ret;
 }
 
-int SPI::write_internal(const void * tx_buffer, int tx_length, void * rx_buffer, int rx_length)
+int SPI::write_internal(const void *tx_buffer, int tx_length, void *rx_buffer, int rx_length)
 {
     select();
     int ret = spi_master_block_write(&_peripheral->spi,
                                      reinterpret_cast<char const *>(tx_buffer), tx_length,
-                                     reinterpret_cast<char*>(rx_buffer), rx_length,
+                                     reinterpret_cast<char *>(rx_buffer), rx_length,
                                      _write_fill);
     deselect();
     return ret;
@@ -381,11 +380,11 @@ void SPI::abort_transfer()
     // Then, we check _transfer_in_progress again.  If it is true, then it means the ISR
     // fired during the call to spi_abort_async, so the transfer has already completed normally.
 
-    if(_transfer_in_progress) {
+    if (_transfer_in_progress) {
         spi_abort_asynch(&_peripheral->spi);
     }
 
-    if(_transfer_in_progress) {
+    if (_transfer_in_progress) {
         // End-of-transfer ISR never fired, clean up.
         unlock_deep_sleep();
 

--- a/hal/include/hal/spi_api.h
+++ b/hal/include/hal/spi_api.h
@@ -214,9 +214,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 /** Release a SPI object
  *
- * TODO: spi_free is currently unimplemented
- * This will require reference counting at the C++ level to be safe
- *
  * Return the pins owned by the SPI object to their reset state
  * Disable the SPI peripheral
  * Disable the SPI clock


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This MR performs more cleanups to the SPI driver which are required for DMA SPI to work correctly.  While running tests, I noticed a number of issues that have just got to get fixed.

<h3>Interaction between async APIs and the SPI::select() function</h3>
Previously, the asynchronous APIs did not know about the select() function -- they would always deselect the chip at the end of a transfer, regardless of whether you had called select() before or not.

Now, I've implemented a new mechanism in the async IRQ handler which checks if the select count was more than 1 before and doesn't deselect the chip if so.  This allows an asynchronous operation to be used as only *part* of a larger transfer, which opens up some new ways to use SPI.

<h3>spi_free() never called</h3>
For whatever reason, the original authors of SPI meant to implement reference counting to call spi_free(), but didn't, leaving this as a TODO (since 2015!).  This means that even if you delete an SPI object, the underlying hardware resources remain configured.  This is a problem since, for DMA, we rely on spi_free() to release used DMA channels.

I implemented the missing reference counting, using a new "numUsers" counter.  It's reasonably simple because SPI cannot be copied or assigned, so we just have to increment the reference count in _do_construct() and decrease it in the destructor.  The reference count is always protected by a mutex.

Additionally, I added a new "initialized" boolean to track whether spi_init() has actually been called on the peripheral.  This is done lazily so it might never have been initialized when we try to free it.

<h3>abort_transfer() leaves GPIO CS in a bad state</h3>
I found a long-standing bug where, if GPIO CS is used, the abort_transfer() function does not bring the CS line high again.  This means that if you abort a running transfer, the chip will stay selected until you call select() and deselect(), or do another asynchronous transfer.  Not exactly what you'd want to see in this situation!

I fixed this by adding coordination between irq_handler_asynch() and abort transfer() so that, if the async IRQ has not yet fired for the transfer being aborted, abort_transfer() will take care of bringing CS high again and decrementing the select count.

<h3>Overloads for nullptr</h3>
With the previous MR that made SPI::write() and SPI::transfer_and_wait() templates, weird stuff happened if you tried to pass nullptr to these functions.  I changed it around so each function has two overloads that accept nullptr, making this case work without weird template errors.


#### Impact of changes <!-- Optional -->
- If your HAL has a non-working spi_free() implementation, that could cause problems.  spi_free() has never actually been called up till now.
- Semantics for passing nullptr to SPI transfer functions have changed a bit.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
Hopefully none

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
See in-code docs

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
