### PR TITLE
SDBlockDevice: revert HW CS support, add async support

### DIFF
--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -731,11 +731,9 @@ uint8_t SDBlockDevice::_cmd_spi(SDBlockDevice::cmdSupported cmd, uint32_t arg)
 
     // send a command
 #if DEVICE_SPI_ASYNCH
-    if(_async_spi_enabled)
-    {
+    if (_async_spi_enabled) {
         _spi.transfer_and_wait(cmdPacket, PACKET_SIZE, nullptr, 0);
-    }
-    else
+    } else
 #endif
     {
         _spi.write(cmdPacket, PACKET_SIZE, nullptr, 0);
@@ -926,11 +924,9 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
 
     // read data
 #if DEVICE_SPI_ASYNCH
-    if(_async_spi_enabled)
-    {
+    if (_async_spi_enabled) {
         _spi.transfer_and_wait(nullptr, 0, buffer, length);
-    }
-    else
+    } else
 #endif
     {
         _spi.write(nullptr, 0, buffer, length);
@@ -971,14 +967,11 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
 
     // read data
 #if DEVICE_SPI_ASYNCH
-    if(_async_spi_enabled)
-    {
-        if(_spi.transfer_and_wait(nullptr, 0, buffer, length) != 0)
-        {
+    if (_async_spi_enabled) {
+        if (_spi.transfer_and_wait(nullptr, 0, buffer, length) != 0) {
             return SD_BLOCK_DEVICE_ERROR_WRITE;
         }
-    }
-    else
+    } else
 #endif
     {
         _spi.write(NULL, 0, (char *) buffer, length);
@@ -1016,11 +1009,9 @@ uint8_t SDBlockDevice::_write(const uint8_t *buffer, uint8_t token, uint32_t len
 
     // write the data
 #if DEVICE_SPI_ASYNCH
-    if(_async_spi_enabled)
-    {
+    if (_async_spi_enabled) {
         _spi.transfer_and_wait(buffer, length, nullptr, 0);
-    }
-    else
+    } else
 #endif
     {
         _spi.write(buffer, length, nullptr, 0);

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -166,7 +166,7 @@ using namespace std::chrono;
 
 #define SD_COMMAND_TIMEOUT                       milliseconds{MBED_CONF_SD_CMD_TIMEOUT}
 #define SD_CMD0_GO_IDLE_STATE_RETRIES            MBED_CONF_SD_CMD0_IDLE_STATE_RETRIES
-#define SD_DBG                                   0      /*!< 1 - Enable debugging */
+#define SD_DBG                                   1      /*!< 1 - Enable debugging */
 #define SD_CMD_TRACE                             0      /*!< 1 - Enable SD command tracing */
 
 #define SD_BLOCK_DEVICE_ERROR_WOULD_BLOCK        -5001  /*!< operation would block */
@@ -251,43 +251,16 @@ using namespace std::chrono;
 // Only HC block size is supported. Making this a static constant reduces code size.
 const uint32_t SDBlockDevice::_block_size = BLOCK_SIZE_HC;
 
+#if MBED_CONF_SD_CRC_ENABLED
 SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
-    : _sectors(0), _spi(mosi, miso, sclk, cs), _is_initialized(0),
-#if MBED_CONF_SD_CRC_ENABLED
-      _init_ref_count(0), _crc_on(crc_on)
-#else
-      _init_ref_count(0)
-#endif
-{
-#if !MBED_CONF_SD_CRC_ENABLED
-    // If this assert fails, this code was compiled without CRC support but you tried to use it.
-    MBED_ASSERT(!crc_on);
-#endif
-
-    _card_type = SDCARD_NONE;
-
-    // Set default to 100kHz for initialisation and 1MHz for data transfer
-    static_assert(((MBED_CONF_SD_INIT_FREQUENCY >= 100000) && (MBED_CONF_SD_INIT_FREQUENCY <= 400000)),
-                  "Initialization frequency should be between 100KHz to 400KHz");
-    _init_sck = MBED_CONF_SD_INIT_FREQUENCY;
-    _transfer_sck = hz;
-
-    _erase_size = BLOCK_SIZE_HC;
-}
-
-SDBlockDevice::SDBlockDevice(mbed::use_gpio_ssel_t, PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(mosi, miso, sclk, cs, use_gpio_ssel), _is_initialized(0),
-#if MBED_CONF_SD_CRC_ENABLED
       _init_ref_count(0), _crc_on(crc_on)
 #else
+SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
+    : _sectors(0), _spi(mosi, miso, sclk, cs, use_gpio_ssel), _is_initialized(0),
       _init_ref_count(0)
 #endif
 {
-#if !MBED_CONF_SD_CRC_ENABLED
-    // If this assert fails, this code was compiled without CRC support but you tried to use it.
-    MBED_ASSERT(!crc_on);
-#endif
-
     _card_type = SDCARD_NONE;
 
     // Set default to 100kHz for initialisation and 1MHz for data transfer
@@ -299,43 +272,16 @@ SDBlockDevice::SDBlockDevice(mbed::use_gpio_ssel_t, PinName mosi, PinName miso, 
     _erase_size = BLOCK_SIZE_HC;
 }
 
-SDBlockDevice::SDBlockDevice(const spi_pinmap_t &spi_pinmap, uint64_t hz, bool crc_on)
-        : _sectors(0), _spi(spi_pinmap), _is_initialized(0),
 #if MBED_CONF_SD_CRC_ENABLED
-          _init_ref_count(0), _crc_on(crc_on)
-#else
-_init_ref_count(0)
-#endif
-{
-#if !MBED_CONF_SD_CRC_ENABLED
-    // If this assert fails, this code was compiled without CRC support but you tried to use it.
-    MBED_ASSERT(!crc_on);
-#endif
-
-    _card_type = SDCARD_NONE;
-
-    // Set default to 100kHz for initialisation and 1MHz for data transfer
-    static_assert(((MBED_CONF_SD_INIT_FREQUENCY >= 100000) && (MBED_CONF_SD_INIT_FREQUENCY <= 400000)),
-                  "Initialization frequency should be between 100KHz to 400KHz");
-    _init_sck = MBED_CONF_SD_INIT_FREQUENCY;
-    _transfer_sck = hz;
-
-    _erase_size = BLOCK_SIZE_HC;
-}
-
-SDBlockDevice::SDBlockDevice(const spi_pinmap_t &spi_pinmap, mbed::use_gpio_ssel_t, PinName cs, uint64_t hz, bool crc_on)
+SDBlockDevice::SDBlockDevice(const spi_pinmap_t &spi_pinmap, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(spi_pinmap, cs), _is_initialized(0),
-#if MBED_CONF_SD_CRC_ENABLED
       _init_ref_count(0), _crc_on(crc_on)
 #else
+SDBlockDevice::SDBlockDevice(const spi_pinmap_t &spi_pinmap, PinName cs, uint64_t hz, bool crc_on)
+    : _sectors(0), _spi(spi_pinmap, cs), _is_initialized(0),
       _init_ref_count(0)
 #endif
 {
-#if !MBED_CONF_SD_CRC_ENABLED
-    // If this assert fails, this code was compiled without CRC support but you tried to use it.
-    MBED_ASSERT(!crc_on);
-#endif
-
     _card_type = SDCARD_NONE;
 
     // Set default to 100kHz for initialisation and 1MHz for data transfer
@@ -497,6 +443,12 @@ int SDBlockDevice::init()
 end:
     unlock();
     return BD_ERROR_OK;
+}
+
+void SDBlockDevice::set_async_spi_mode(bool enabled, DMAUsage dma_usage_hint)
+{
+    _async_spi_enabled = enabled;
+    _spi.set_dma_usage(dma_usage_hint);
 }
 
 int SDBlockDevice::deinit()
@@ -966,8 +918,15 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
     }
 
     // read data
-    for (uint32_t i = 0; i < length; i++) {
-        buffer[i] = _spi.write(SPI_FILL_CHAR);
+#if DEVICE_SPI_ASYNCH
+    if(_async_spi_enabled)
+    {
+        _spi.transfer_and_wait(nullptr, 0, buffer, length);
+    }
+    else
+#endif
+    {
+        _spi.write(nullptr, 0, buffer, length);
     }
 
     // Read the CRC16 checksum for the data block
@@ -1004,7 +963,19 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
     }
 
     // read data
-    _spi.write(NULL, 0, (char *)buffer, length);
+#if DEVICE_SPI_ASYNCH
+    if(_async_spi_enabled)
+    {
+        if(_spi.transfer_and_wait(nullptr, 0, buffer, length) != 0)
+        {
+            return SD_BLOCK_DEVICE_ERROR_WRITE;
+        }
+    }
+    else
+#endif
+    {
+        _spi.write(NULL, 0, (char *) buffer, length);
+    }
 
     // Read the CRC16 checksum for the data block
     crc = (_spi.write(SPI_FILL_CHAR) << 8);
@@ -1037,7 +1008,16 @@ uint8_t SDBlockDevice::_write(const uint8_t *buffer, uint8_t token, uint32_t len
     _spi.write(token);
 
     // write the data
-    _spi.write((char *)buffer, length, NULL, 0);
+#if DEVICE_SPI_ASYNCH
+    if(_async_spi_enabled)
+    {
+        _spi.transfer_and_wait(buffer, length, nullptr, 0);
+    }
+    else
+#endif
+    {
+        _spi.write(buffer, length, nullptr, 0);
+    }
 
 #if MBED_CONF_SD_CRC_ENABLED
     if (_crc_on) {

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -204,7 +204,7 @@ using namespace std::chrono;
 #define CARD_UNKNOWN             4           /**< Unknown or unsupported card */
 
 /* SIZE in Bytes */
-#define PACKET_SIZE              6           /*!< SD Packet size CMD+ARG+CRC */
+#define PACKET_SIZE              6U          /*!< SD Packet size CMD+ARG+CRC */
 #define R1_RESPONSE_SIZE         1           /*!< Size of R1 response */
 #define R2_RESPONSE_SIZE         2           /*!< Size of R2 response */
 #define R3_R7_RESPONSE_SIZE      5           /*!< Size of R3/R7 response */
@@ -730,8 +730,15 @@ uint8_t SDBlockDevice::_cmd_spi(SDBlockDevice::cmdSupported cmd, uint32_t arg)
     }
 
     // send a command
-    for (int i = 0; i < PACKET_SIZE; i++) {
-        _spi.write(cmdPacket[i]);
+#if DEVICE_SPI_ASYNCH
+    if(_async_spi_enabled)
+    {
+        _spi.transfer_and_wait(cmdPacket, PACKET_SIZE, nullptr, 0);
+    }
+    else
+#endif
+    {
+        _spi.write(cmdPacket, PACKET_SIZE, nullptr, 0);
     }
 
     // The received byte immediataly following CMD12 is a stuff byte,

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -166,7 +166,7 @@ using namespace std::chrono;
 
 #define SD_COMMAND_TIMEOUT                       milliseconds{MBED_CONF_SD_CMD_TIMEOUT}
 #define SD_CMD0_GO_IDLE_STATE_RETRIES            MBED_CONF_SD_CMD0_IDLE_STATE_RETRIES
-#define SD_DBG                                   1      /*!< 1 - Enable debugging */
+#define SD_DBG                                   0      /*!< 1 - Enable debugging */
 #define SD_CMD_TRACE                             0      /*!< 1 - Enable SD command tracing */
 
 #define SD_BLOCK_DEVICE_ERROR_WOULD_BLOCK        -5001  /*!< operation would block */
@@ -204,7 +204,7 @@ using namespace std::chrono;
 #define CARD_UNKNOWN             4           /**< Unknown or unsupported card */
 
 /* SIZE in Bytes */
-#define PACKET_SIZE              6U          /*!< SD Packet size CMD+ARG+CRC */
+#define PACKET_SIZE              6           /*!< SD Packet size CMD+ARG+CRC */
 #define R1_RESPONSE_SIZE         1           /*!< Size of R1 response */
 #define R2_RESPONSE_SIZE         2           /*!< Size of R2 response */
 #define R3_R7_RESPONSE_SIZE      5           /*!< Size of R3/R7 response */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Some time ago, in 0874f74a, I updated the SDBlockDevice class to support HW chip selects.  My intention was to use this as part of the CI test shield test suite, so that hardware CS functionality could be tested.  However, after looking at the SDBlockDevice code and the SPI code more closely, I realized that this cannot work.  The reason is, SDBlockDevice relies on keeping CS low across multiple transfers, but that is currently impossible when using hardware CS control with Mbed (even though I bet that most chips support it...).

So, I reverted that commit, expunging the HW CS constructors that were added.

However, for my DMA SPI test suite, I do need to be able to run at least some of the operations in SDBlockDevice with DMA, so that I can prove that DMA works the same as regular SPI.  So, this MR converts some of the long-running operations from synchronous SPI calls into transfer_and_wait() calls.  I converted every "readily convertable" call, meaning calls where it sends a multibyte buffer over the bus.  There are plenty of places where it still uses the single byte API as part of the logic which I don't want to touch as they are part of the logic.  However, trying to change that would require a broader refactor of the entire block device which I'm not signing up for (yet!).

The cool thing is, I can do these changes only because !180 adds the ability for asynchronous transfers to respect calls to the `select()` and `deselect()` functions.  Without that feature, async transfers couldn't be used here because they would always bring CS high again after the transfer.

At any rate, the goal of this change is to steal back some execution time while it's running long transfers, such as sending/receiving 512 byte data blocks.   And, even though it still isn't fully asynchronous, what I have here does that, so I'm good to ship it.

#### Impact of changes <!-- Optional -->


#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

See class docs

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran my new [SD block device test suite](https://github.com/multiplemonomials/Mbed-CI-Test-Shield/blob/master/Software/SPIMicroSDTest.cpp) with this MR and it passed!
```
7: [1692807337.44][CONN][RXD] >>> Running 9 test cases...
7: [1692807337.44][CONN][INF] found SYNC in stream: {{__sync;2fb8e63e-ed2d-4b6a-b8e5-6460d0312eaf}} it is #0 sent, queued...
7: [1692807337.44][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
7: [1692807337.44][CONN][INF] found KV pair in stream: {{__timeout;40}}, queued...
7: [1692807337.44][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
7: [1692807337.44][HTST][INF] sync KV found, uuid=2fb8e63e-ed2d-4b6a-b8e5-6460d0312eaf, timestamp=1692807337.442130
7: [1692807337.44][HTST][INF] DUT greentea-client version: 1.3.0
7: [1692807337.44][HTST][INF] setting timeout to: 40 sec
7: [1692807337.44][HTST][INF] host test class: '<class 'mbed_os_tools.test.host_tests.default_auto.DefaultAuto'>'
7: [1692807337.44][HTST][INF] host test setup() call...
7: [1692807337.44][HTST][INF] CALLBACKs updated
7: [1692807337.44][HTST][INF] host test detected: default_auto
7: [1692807337.46][CONN][INF] found KV pair in stream: {{__testcase_name;SPI - SD card present (1MHz)}}, queued...
7: [1692807337.46][CONN][INF] found KV pair in stream: {{__testcase_name;SPI - Mount FS, Create File (1MHz)}}, queued...
7: [1692807337.46][CONN][INF] found KV pair in stream: {{__testcase_name;SPI - Write, Read, and Delete File (1MHz)}}, queued...
7: [1692807337.47][CONN][INF] found KV pair in stream: {{__testcase_name;[Async Interrupts] SPI - SD card present (1MHz)}}, queued...
7: [1692807337.47][CONN][INF] found KV pair in stream: {{__testcase_name;[Async Interrupts] SPI - Mount FS, Create File (1MHz)}}, queued...
7: [1692807337.47][CONN][INF] found KV pair in stream: {{__testcase_name;[Async Interrupts] SPI - Write, Read, and Delete File (1MHz)}}, queued...       
7: [1692807337.49][CONN][INF] found KV pair in stream: {{__testcase_name;[Async DMA] SPI - SD card present (1MHz)}}, queued...
7: [1692807337.49][CONN][INF] found KV pair in stream: {{__testcase_name;[Async DMA] SPI - Mount FS, Create File (1MHz)}}, queued...
7: [1692807337.49][CONN][INF] found KV pair in stream: {{__testcase_name;[Async DMA] SPI - Write, Read, and Delete File (1MHz)}}, queued...
7: [1692807337.51][CONN][RXD] 
7: [1692807337.51][CONN][RXD] >>> Running case #1: 'SPI - SD card present (1MHz)'...
7: [1692807337.51][CONN][RXD] Card Initialized: High Capacity Card
7: [1692807337.51][CONN][RXD] init card = 1
7: [1692807337.51][CONN][INF] found KV pair in stream: {{__testcase_start;SPI - SD card present (1MHz)}}, queued...
7: [1692807337.52][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562 
7: [1692807337.52][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.52][CONN][RXD] Capacity: 3781 MB
7: [1692807337.52][CONN][RXD] >>> 'SPI - SD card present (1MHz)': 1 passed, 0 failed
7: [1692807337.52][CONN][INF] found KV pair in stream: {{__testcase_finish;SPI - SD card present (1MHz);1;0}}, queued...
7: [1692807337.54][CONN][RXD] <greentea test suite>:0::PASS
7: [1692807337.54][CONN][RXD]
7: [1692807337.54][CONN][RXD] >>> Running case #2: 'SPI - Mount FS, Create File (1MHz)'...
7: [1692807337.54][CONN][RXD] Card Initialized: High Capacity Card
7: [1692807337.54][CONN][INF] found KV pair in stream: {{__testcase_start;SPI - Mount FS, Create File (1MHz)}}, queued...
7: [1692807337.55][CONN][RXD] init card = 1
7: [1692807337.55][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562
7: [1692807337.55][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.55][CONN][RXD] Capacity: 3781 MB
7: [1692807337.58][CONN][RXD] >>> 'SPI - Mount FS, Create File (1MHz)': 1 passed, 0 failed
7: [1692807337.58][CONN][RXD] <greentea test suite>:0::PASS
7: [1692807337.58][CONN][RXD]
7: [1692807337.58][CONN][INF] found KV pair in stream: {{__testcase_finish;SPI - Mount FS, Create File (1MHz);1;0}}, queued...
7: [1692807337.60][CONN][RXD] >>> Running case #3: 'SPI - Write, Read, and Delete File (1MHz)'...
7: [1692807337.60][CONN][RXD] Card Initialized: High Capacity Card
7: [1692807337.60][CONN][RXD] init card = 1
7: [1692807337.60][CONN][INF] found KV pair in stream: {{__testcase_start;SPI - Write, Read, and Delete File (1MHz)}}, queued...
7: [1692807337.62][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562 
7: [1692807337.62][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.62][CONN][RXD] Capacity: 3781 MB
7: [1692807337.77][CONN][RXD] >>> 'SPI - Write, Read, and Delete File (1MHz)': 1 passed, 0 failed
7: [1692807337.77][CONN][RXD] <greentea test suite>:0::PASS
7: [1692807337.77][CONN][RXD]
7: [1692807337.77][CONN][INF] found KV pair in stream: {{__testcase_finish;SPI - Write, Read, and Delete File (1MHz);1;0}}, queued...
7: [1692807337.79][CONN][RXD] >>> Running case #4: '[Async Interrupts] SPI - SD card present (1MHz)'...
7: [1692807337.79][CONN][RXD] Card Initialized: High Capacity Card
7: [1692807337.79][CONN][RXD] init card = 1
7: [1692807337.79][CONN][INF] found KV pair in stream: {{__testcase_start;[Async Interrupts] SPI - SD card present (1MHz)}}, queued...
7: [1692807337.80][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562 
7: [1692807337.80][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.80][CONN][RXD] Capacity: 3781 MB
7: [1692807337.80][CONN][INF] found KV pair in stream: {{__testcase_finish;[Async Interrupts] SPI - SD card present (1MHz);1;0}}, queued...
7: [1692807337.82][CONN][RXD] >>> '[Async Interrupts] SPI - SD card present (1MHz)': 1 passed, 0 failed
7: [1692807337.82][CONN][RXD] <greentea test suite>:0::PASS
7: [1692807337.82][CONN][RXD]
7: [1692807337.82][CONN][RXD] >>> Running case #5: '[Async Interrupts] SPI - Mount FS, Create File (1MHz)'...
7: [1692807337.84][CONN][RXD] Card Initialized: High Capacity Card 
7: [1692807337.84][CONN][RXD] init card = 1
7: [1692807337.84][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562
7: [1692807337.84][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.84][CONN][RXD] Capacity: 3781 MB
7: [1692807337.84][CONN][INF] found KV pair in stream: {{__testcase_start;[Async Interrupts] SPI - Mount FS, Create File (1MHz)}}, queued...
7: [1692807337.87][CONN][INF] found KV pair in stream: {{__testcase_finish;[Async Interrupts] SPI - Mount FS, Create File (1MHz);1;0}}, queued...
7: [1692807337.88][CONN][RXD] >>> '[Async Interrupts] SPI - Mount FS, Create File (1MHz)': 1 passed, 0 failed
7: [1692807337.88][CONN][RXD] <greentea test suite>:0::PASS
7: [1692807337.88][CONN][RXD]
7: [1692807337.88][CONN][RXD] >>> Running case #6: '[Async Interrupts] SPI - Write, Read, and Delete File (1MHz)'...
7: [1692807337.90][CONN][RXD] Card Initialized: High Capacity Card 
7: [1692807337.90][CONN][RXD] init card = 1
7: [1692807337.90][CONN][RXD] SDHC/SDXC Card: hc_c_size: 7562
7: [1692807337.90][CONN][INF] found KV pair in stream: {{__testcase_start;[Async Interrupts] SPI - Write, Read, and Delete File (1MHz)}}, queued...      
7: [1692807337.91][CONN][RXD] Sectors: 0x762c00x : 7744512
7: [1692807337.91][CONN][RXD] Capacity: 3781 MB
7: [1692807338.06][CONN][INF] found KV pair in stream: {{__testcase_finish;[Async Interrupts] SPI - Write, Read, and Delete File (1MHz);1;0}}, queued...
7: [1692807338.07][CONN][RXD] >>> '[Async Interrupts] SPI - Write, Read, and Delete File (1MHz)': 1 passed, 0 failed
7: [1692807338.07][CONN][RXD] <greentea test suite>:0::PASS
```
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
