### PR TITLE
Fix warnings from kill and getpid not being implemented

### DIFF
--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -1531,7 +1531,7 @@ extern "C" WEAK caddr_t _sbrk(int incr)
 
 #if defined(TOOLCHAIN_GCC_ARM)
 
-// Implementation of getpid for Newlib, following signature here: 
+// Implementation of getpid for Newlib, following signature here:
 // https://github.com/bminor/newlib/blob/55485616ba2afedca05da40f5cde59ee336b9f28/newlib/libc/sys/arm/syscalls.c#L32
 extern "C" pid_t _getpid()
 {
@@ -1539,6 +1539,8 @@ extern "C" pid_t _getpid()
     return 0;
 }
 
+// Implementation of kill for Newlib, following signature here:
+// https://github.com/bminor/newlib/blob/55485616ba2afedca05da40f5cde59ee336b9f28/newlib/libc/sys/arm/syscalls.c#L33
 extern "C" int _kill(int pid, int signal)
 {
     // Always return error

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -1464,6 +1464,10 @@ extern "C" WEAK void __cxa_pure_virtual(void)
 // SP.  This make it compatible with RTX RTOS thread stacks.
 #if defined(TOOLCHAIN_GCC_ARM)
 
+// Turn off the errno macro and use actual global variable instead.
+#undef errno
+extern "C" int errno;
+
 #if defined(MBED_SPLIT_HEAP)
 
 // Default RAM memory used for heap
@@ -1506,10 +1510,6 @@ extern "C" WEAK caddr_t _sbrk(int incr)
 extern "C" uint32_t         __end__;
 extern "C" uint32_t         __HeapLimit;
 
-// Turn off the errno macro and use actual global variable instead.
-#undef errno
-extern "C" int errno;
-
 // Weak attribute allows user to override, e.g. to use external RAM for dynamic memory.
 extern "C" WEAK caddr_t _sbrk(int incr)
 {
@@ -1527,6 +1527,25 @@ extern "C" WEAK caddr_t _sbrk(int incr)
     return (caddr_t) prev_heap;
 }
 #endif
+#endif
+
+#if defined(TOOLCHAIN_GCC_ARM)
+
+// Implementation of getpid for Newlib, following signature here: 
+// https://github.com/bminor/newlib/blob/55485616ba2afedca05da40f5cde59ee336b9f28/newlib/libc/sys/arm/syscalls.c#L32
+extern "C" pid_t _getpid()
+{
+    // Since PIDs aren't a thing on embedded, just return 0
+    return 0;
+}
+
+extern "C" int _kill(int pid, int signal)
+{
+    // Always return error
+    errno = ENOSYS;
+    return -1;
+}
+
 #endif
 
 #if defined(TOOLCHAIN_GCC_ARM)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Versions of GCC which supply newer Newlib versions (unsure of the exact Newlib version, I think it's the one included with GCC 11 and newer) now appear to want the _getpid() and _kill() functions defined.  I checked using radare, and it appears they get pulled in as dependencies of the C++ standard library, which has been built with exception handling enabled and therefore calls things like abort().  So, these warnings will show up whenever someone links an application which uses STL features.

In the long term the best solution is to rebuild the STL with exceptions disabled, or switch to a toolchain which has that done for us, but in the meantime this will stop the warnings from bothering people.

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None
### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
