### PR TITLE
Refactor flash setup for MIMXRT105x devices, add flash API support for MIMXRT1062 EVK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,11 +187,8 @@ if(NOT MBED_IS_NATIVE_BUILD)
     # We must set this global property before the targets subdirectory is added to the project. This is
     # required because the MBED_TARGET depends on the response file. If the path to the response file
     # is not defined when the target requests it the config definitions will not be passed to CPP.
-    #
-    # TODO: Remove this and find a more idiomatic way of passing compile definitions to CPP without
-    # using response files or global properties.
     mbed_generate_options_for_linker(mbed-core-flags RESPONSE_FILE_PATH)
-    set_property(GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE ${RESPONSE_FILE_PATH})
+    set_property(GLOBAL PROPERTY LINKER_SCRIPT_PREPROCESS_FLAGS_RESPONSE_FILE ${RESPONSE_FILE_PATH})
 
     # Add compile definitions for backward compatibility with the toolchain
     # supported. New source files should instead check for __GNUC__ and __clang__

--- a/drivers/include/drivers/FlashIAP.h
+++ b/drivers/include/drivers/FlashIAP.h
@@ -32,7 +32,8 @@
 #include "platform/NonCopyable.h"
 #include <algorithm>
 
-// Export ROM end address
+// Export ROM end address, if not defined by HAL layer
+#ifndef FLASHIAP_APP_ROM_END_ADDR
 #if defined(TOOLCHAIN_GCC_ARM)
 extern uint32_t __etext;
 extern uint32_t __data_start__;
@@ -47,6 +48,7 @@ extern uint32_t Load$$LR$$LR_IROM1$$Limit[];
 #pragma section=".init_array"
 #define FLASHIAP_APP_ROM_END_ADDR std::max(std::max((uint32_t) __section_end(".rodata"), (uint32_t) __section_end(".text")), \
                                   (uint32_t) __section_end(".init_array"))
+#endif
 #endif
 
 namespace mbed {

--- a/hal/include/hal/flash_api.h
+++ b/hal/include/hal/flash_api.h
@@ -111,7 +111,10 @@ uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address);
  */
 uint32_t flash_get_page_size(const flash_t *obj);
 
-/** Get start address for the flash region
+/** Get start address for the flash region (as in, where the flash is mapped in main memory).
+ *
+ * \note This should return the start address of the entire flash region, not
+ *   the first address after the end of the program in flash.
  *
  * @param obj The flash object
  * @return The start address for the flash region

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/CMakeLists.txt
@@ -12,8 +12,7 @@ target_include_directories(mbed-mimxrt1050-evk
 target_sources(mbed-mimxrt1050-evk
     INTERFACE
 		fsl_flexspi_nor_boot.c
-
-	    TARGET_1050_EVK/flash_api.c
+		flash_api.c
 
         TARGET_1050_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
         TARGET_1050_EVK/xip/evkbimxrt1050_sdram_ini_dcd.c
@@ -35,6 +34,7 @@ target_include_directories(mbed-mimxrt1060-evk
 target_sources(mbed-mimxrt1060-evk
     INTERFACE
 		fsl_flexspi_nor_boot.c
+		flash_api.c
 
         TARGET_1060_EVK/xip/evkbmimxrt1060_flexspi_nor_config.c
         TARGET_1060_EVK/xip/dcd.c

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1050_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1050_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
@@ -12,6 +12,8 @@
 #define FSL_COMPONENT_ID "platform.drivers.xip_board"
 #endif
 
+#include "mimxrt_memory_info.h"
+
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -37,7 +39,7 @@ const flexspi_nor_config_t hyperflash_config = {
         (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
         .sflashPadType = kSerialFlash_8Pads,
         .serialClkFreq = kFlexSpiSerialClk_133MHz,
-        .sflashA1Size = 64u * 1024u * 1024u,
+        .sflashA1Size = BOARD_FLASH_SIZE,
         .dataValidTime = {16u, 16u},
         .lookupTable = {
             // Read LUTs
@@ -66,7 +68,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .sflashPadType = kSerialFlash_4Pads,
         .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .lutCustomSeqEnable = 0u,
-        .sflashA1Size = 0x00800000u, /* 8MB/64Mbit */
+        .sflashA1Size = BOARD_FLASH_SIZE,
         .lookupTable = {
             // Fast read sequence
             [0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1060_EVK/xip/evkbmimxrt1060_flexspi_nor_config.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1060_EVK/xip/evkbmimxrt1060_flexspi_nor_config.c
@@ -6,6 +6,7 @@
  */
 
 #include "evkbmimxrt1060_flexspi_nor_config.h"
+#include "mimxrt_memory_info.h"
 
 /* Component ID definition, used by tools. */
 #ifndef FSL_COMPONENT_ID
@@ -34,7 +35,7 @@ const flexspi_nor_config_t qspiflash_config = {
             .deviceType           = kFlexSpiDeviceType_SerialNOR,
             .sflashPadType        = kSerialFlash_4Pads,
             .serialClkFreq        = kFlexSpiSerialClk_120MHz,
-            .sflashA1Size         = 8u * 1024u * 1024u,
+            .sflashA1Size         = BOARD_FLASH_SIZE,
             .lookupTable =
                 {
                     // Read LUTs

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/device.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/device.h
@@ -19,25 +19,9 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define DEVICE_ID_LENGTH       24
+#include <stdint.h>
 
-#ifdef HYPERFLASH_BOOT
-/* 64MB HyperFlash, 4MB reserved for mbed-os */
-#define BOARD_FLASH_SIZE             (0x4000000U)
-#define BOARD_FLASH_START_ADDR       (0x60000000U)
-#define BOARD_FLASHIAP_SIZE          (0x3C00000U)
-#define BOARD_FLASHIAP_START_ADDR    (0x60400000U)
-#define BOARD_FLASH_PAGE_SIZE        (512)
-#define BOARD_FLASH_SECTOR_SIZE      (262144)
-#else
-/* 8MB QSPI Flash, 64KB reserved for mbed_bootloader */
-#define BOARD_FLASH_SIZE             (0x800000U)
-#define BOARD_FLASH_START_ADDR       (0x60000000U)
-#define BOARD_FLASHIAP_SIZE          (0x7F0000U)
-#define BOARD_FLASHIAP_START_ADDR    (0x60010000U)
-#define BOARD_FLASH_PAGE_SIZE        (256)
-#define BOARD_FLASH_SECTOR_SIZE      (4096)
-#endif
+#define DEVICE_ID_LENGTH       24
 
 #define BOARD_ENET_PHY_ADDR    (2)
 
@@ -45,6 +29,12 @@
  to be as vector table */
 #undef __VECTOR_TABLE
 
+// The MIMXRT linker script provides the __USED_FLASH_END symbol to
+// indicate where application data ends in flash
+extern uint8_t __USED_FLASH_END[0];
+#define FLASHIAP_APP_ROM_END_ADDR ((uint32_t)__USED_FLASH_END)
+
+#include "mimxrt_memory_info.h"
 #include "objects.h"
 
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
@@ -336,16 +336,15 @@ status_t flexspi_nor_flash_page_program_ram(uint32_t address, const uint32_t *sr
 AT_QUICKACCESS_SECTION_CODE(status_t flexspi_nor_enable_quad_mode_ram(void));
 AT_QUICKACCESS_SECTION_CODE(status_t flexspi_nor_read_status_register_ram(uint32_t * result));
 
-//uint32_t readStatusResult;
-
 /*
  * Check if quad SPI mode is enabled and, if not, enable it.
  *
  * Note that I'm not totally sure if this function is needed because I don't think
  * that the application could boot without quad mode enabled, but this might be
  * useful for programming non-boot-device flashes at a later date.
- * Or, if you must run the application on a flash which does not have quad mode,
- * you could temporarily change the read command to use 1-pad read during initial provisioning.
+ * Or, if you must run the application on a flash which does not have quad mode enabled,
+ * you could temporarily change the boot header read command to use 1-pad read,
+ * then rely on this function to update the setting.
  */
 status_t flexspi_nor_enable_quad_mode_ram(void)
 {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
@@ -24,6 +24,10 @@
 #include "fsl_flexspi.h"
 #include "fsl_cache.h"
 #include "flash_defines.h"
+#include "mimxrt_flash_api.h"
+
+#include <inttypes.h>
+#include <stdio.h>
 
 AT_QUICKACCESS_SECTION_CODE(void flexspi_update_lut_ram(void));
 AT_QUICKACCESS_SECTION_CODE(status_t flexspi_nor_write_enable_ram(uint32_t baseAddr));
@@ -103,6 +107,13 @@ void flexspi_update_lut_ram(void)
     config.enableSckBDiffOpt = true;
     config.rxSampleClock     = kFLEXSPI_ReadSampleClkExternalInputFromDqsPad;
     config.enableCombination = true;
+
+    /* Wait for bus idle.  It seems to be important to hold off on calling
+     * FLEXSPI_Init() until after the bus is idle; I was getting random crashes
+     * until I added this. */
+    while (!FLEXSPI_GetBusIdleStatus(FLEXSPI)) {
+    }
+
     FLEXSPI_Init(FLEXSPI, &config);
 
     /* Configure flash settings according to serial flash feature. */
@@ -116,6 +127,10 @@ void flexspi_update_lut_ram(void)
     /* Wait for bus idle. */
     while (!FLEXSPI_GetBusIdleStatus(FLEXSPI)) {
     }
+
+    // Just in case any bad data got into the I-cache while we were reconfiguring
+    // the flash, wipe it.
+    SCB_InvalidateICache();
 }
 
 status_t flexspi_nor_write_enable_ram(uint32_t baseAddr)
@@ -319,13 +334,32 @@ status_t flexspi_nor_flash_page_program_ram(uint32_t address, const uint32_t *sr
 
 #else
 AT_QUICKACCESS_SECTION_CODE(status_t flexspi_nor_enable_quad_mode_ram(void));
+AT_QUICKACCESS_SECTION_CODE(status_t flexspi_nor_read_status_register_ram(uint32_t * result));
+
+//uint32_t readStatusResult;
+
+/*
+ * Check if quad SPI mode is enabled and, if not, enable it.
+ *
+ * Note that I'm not totally sure if this function is needed because I don't think
+ * that the application could boot without quad mode enabled, but this might be
+ * useful for programming non-boot-device flashes at a later date.
+ * Or, if you must run the application on a flash which does not have quad mode,
+ * you could temporarily change the read command to use 1-pad read during initial provisioning.
+ */
 status_t flexspi_nor_enable_quad_mode_ram(void)
 {
-    flexspi_transfer_t flashXfer;
-    uint32_t writeValue = FLASH_QUAD_ENABLE;
-    status_t status = kStatus_Success;
+    uint32_t readResult = 0;
+    status_t status = flexspi_nor_read_status_register_ram(&readResult);
+    if (status != kStatus_Success) {
+        return status;
+    }
 
-    flexspi_memset(&flashXfer, 0, sizeof(flashXfer));
+    if(readResult & (1 << FLASH_QE_STATUS_OFFSET)) {
+        // QSPI mode already enabled, don't need to do anything
+        return kStatus_Success;
+    }
+
     /* Write enable */
     status = flexspi_nor_write_enable_ram(0);
 
@@ -334,6 +368,8 @@ status_t flexspi_nor_enable_quad_mode_ram(void)
     }
 
     /* Enable quad mode. */
+    flexspi_transfer_t flashXfer = {};
+    uint32_t writeValue = (1 << FLASH_QE_STATUS_OFFSET);
     flashXfer.deviceAddress = 0;
     flashXfer.port          = kFLEXSPI_PortA1;
     flashXfer.cmdType       = kFLEXSPI_Write;
@@ -349,17 +385,12 @@ status_t flexspi_nor_enable_quad_mode_ram(void)
 
     status = flexspi_nor_wait_bus_busy_ram();
 
-    /* Do software reset. */
-    FLEXSPI_SoftwareReset(FLEXSPI);
-
     return status;
 }
 
 void flexspi_update_lut_ram(void)
 {
-    flexspi_config_t config;
-
-    flexspi_memset(&config, 0, sizeof(config));
+    flexspi_config_t config = {};
 
     /*Get FLEXSPI default settings and configure the flexspi. */
     FLEXSPI_GetDefaultConfig(&config);
@@ -370,6 +401,15 @@ void flexspi_update_lut_ram(void)
     config.ahbConfig.enableReadAddressOpt = true;
     config.ahbConfig.enableAHBCachable    = true;
     config.rxSampleClock                  = kFLEXSPI_ReadSampleClkLoopbackFromDqsPad;
+    config.enableDoze                     = false; // matches boot rom setting
+    config.seqTimeoutCycle                = 0xee6c; // matches boot rom setting
+
+    /* Wait for bus idle.  It seems to be important to hold off on calling
+     * FLEXSPI_Init() until after the bus is idle; I was getting random crashes
+     * until I added this. */
+    while (!FLEXSPI_GetBusIdleStatus(FLEXSPI)) {
+    }
+
     FLEXSPI_Init(FLEXSPI, &config);
 
     /* Configure flash settings according to serial flash feature. */
@@ -383,7 +423,12 @@ void flexspi_update_lut_ram(void)
     /* Wait for bus idle. */
     while (!FLEXSPI_GetBusIdleStatus(FLEXSPI)) {
     }
+
     flexspi_nor_enable_quad_mode_ram();
+
+    // Just in case any bad data got into the I-cache while we were reconfiguring
+    // the flash, wipe it.
+    SCB_InvalidateICache();
 }
 
 status_t flexspi_nor_write_enable_ram(uint32_t baseAddr)
@@ -404,47 +449,46 @@ status_t flexspi_nor_write_enable_ram(uint32_t baseAddr)
     return status;
 }
 
-status_t flexspi_nor_wait_bus_busy_ram(void)
+// Read the status register and save the result into the given pointer
+status_t flexspi_nor_read_status_register_ram(uint32_t * result)
 {
-    /* Wait status ready. */
-    bool isBusy;
-    uint32_t readValue;
-    status_t status = kStatus_Success;
-    flexspi_transfer_t flashXfer;
-
-    flexspi_memset(&flashXfer, 0, sizeof(flashXfer));
+    flexspi_transfer_t flashXfer = {};
 
     flashXfer.deviceAddress = 0;
     flashXfer.port          = kFLEXSPI_PortA1;
     flashXfer.cmdType       = kFLEXSPI_Read;
     flashXfer.SeqNumber     = 1;
     flashXfer.seqIndex      = NOR_CMD_LUT_SEQ_IDX_READSTATUSREG;
-    flashXfer.data          = &readValue;
+    flashXfer.data          = result;
     flashXfer.dataSize      = 1;
 
+    return FLEXSPI_TransferBlocking(FLEXSPI, &flashXfer);
+}
+
+status_t flexspi_nor_wait_bus_busy_ram(void)
+{
+    /* Wait status ready. */
+    bool isBusy;
+
     do {
-        status = FLEXSPI_TransferBlocking(FLEXSPI, &flashXfer);
+        uint32_t readResult;
+        status_t status = flexspi_nor_read_status_register_ram(&readResult);
 
         if (status != kStatus_Success) {
             return status;
         }
-        if (FLASH_BUSY_STATUS_POL) {
-            if (readValue & (1U << FLASH_BUSY_STATUS_OFFSET)) {
-                isBusy = true;
-            } else {
-                isBusy = false;
-            }
-        } else {
-            if (readValue & (1U << FLASH_BUSY_STATUS_OFFSET)) {
-                isBusy = false;
-            } else {
-                isBusy = true;
-            }
+
+        if(readResult & (1U << FLASH_BUSY_STATUS_OFFSET)) {
+            isBusy = FLASH_BUSY_STATUS_POL;
+        }
+        else
+        {
+            isBusy = !FLASH_BUSY_STATUS_POL;
         }
 
     } while (isBusy);
 
-    return status;
+    return kStatus_Success;
 }
 
 
@@ -540,12 +584,18 @@ void flexspi_nor_flash_read_data_ram(uint32_t addr, uint32_t *buffer, uint32_t s
     memcpy(buffer, (void *)addr, size);
 }
 
-int32_t flash_init(flash_t *obj)
+void mimxrt_flash_setup(void)
 {
     core_util_critical_section_enter();
     flexspi_update_lut_ram();
     core_util_critical_section_exit();
+}
 
+int32_t flash_init(flash_t *obj)
+{
+    // Setup is already done when the application boots by flash_setup().
+    // Nothing left to do.
+    (void)obj;
     return 0;
 }
 
@@ -581,6 +631,8 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
     if (status != kStatus_Success) {
         ret = -1;
     } else {
+        SCB_InvalidateICache_by_Addr((void*)address, (int32_t)size);
+        SCB_InvalidateDCache_by_Addr((void*)address, (int32_t)size);
         DCACHE_InvalidateByRange(address, size);
     }
 
@@ -604,8 +656,8 @@ int32_t flash_free(flash_t *obj)
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
 {
     uint32_t sectorsize = MBED_FLASH_INVALID_SIZE;
-    uint32_t devicesize = BOARD_FLASHIAP_SIZE;
-    uint32_t startaddr = BOARD_FLASHIAP_START_ADDR;
+    uint32_t devicesize = BOARD_FLASH_SIZE;
+    uint32_t startaddr = BOARD_FLASH_START_ADDR;
 
     if ((address >= startaddr) && (address < (startaddr + devicesize))) {
         sectorsize = BOARD_FLASH_SECTOR_SIZE;
@@ -621,12 +673,12 @@ uint32_t flash_get_page_size(const flash_t *obj)
 
 uint32_t flash_get_start_address(const flash_t *obj)
 {
-    return BOARD_FLASHIAP_START_ADDR;
+    return BOARD_FLASH_START_ADDR;
 }
 
 uint32_t flash_get_size(const flash_t *obj)
 {
-    return BOARD_FLASHIAP_SIZE;
+    return BOARD_FLASH_SIZE;
 }
 
 uint8_t flash_get_erase_value(const flash_t *obj)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_defines.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_defines.h
@@ -19,7 +19,7 @@
 
 #include "fsl_common.h"
 
-#ifdef HYPERFLASH_BOOT /* 64MB Hyperflash */
+#ifdef HYPERFLASH_BOOT /* 64MB Hyperflash S26KS512SDPBHI02 */
 #define HYPERFLASH_CMD_LUT_SEQ_IDX_READDATA 0
 #define HYPERFLASH_CMD_LUT_SEQ_IDX_WRITEDATA 1
 #define HYPERFLASH_CMD_LUT_SEQ_IDX_READSTATUS 2
@@ -177,7 +177,7 @@ flexspi_device_config_t deviceconfig = {
     .AHBWriteWaitUnit     = kFLEXSPI_AhbWriteWaitUnit2AhbCycle,
     .AHBWriteWaitInterval = 20,
 };
-#else /* 8MB QSPI flash */
+#else /* 8MB QSPI flash IS25WP064AJBLE */
 
 #define NOR_CMD_LUT_SEQ_IDX_READ_NORMAL 7
 #define NOR_CMD_LUT_SEQ_IDX_READ_FAST 13
@@ -194,9 +194,15 @@ flexspi_device_config_t deviceconfig = {
 #define NOR_CMD_LUT_SEQ_IDX_READSTATUSREG 12
 #define NOR_CMD_LUT_SEQ_IDX_ERASECHIP 5
 #define CUSTOM_LUT_LENGTH 60
-#define FLASH_QUAD_ENABLE 0x40
+
+// Polarity of the BUSY bit in the status register -- 1 here means the flash is BUSY wheb
 #define FLASH_BUSY_STATUS_POL 1
+
+// Shift of the BUSY bit in the status register
 #define FLASH_BUSY_STATUS_OFFSET 0
+
+// Shift of the Quad Enable bit in the status register
+#define FLASH_QE_STATUS_OFFSET 6
 
 static uint32_t customLUT[CUSTOM_LUT_LENGTH] = {
     /* Normal read mode -SDR */
@@ -245,7 +251,7 @@ static uint32_t customLUT[CUSTOM_LUT_LENGTH] = {
     [4 * NOR_CMD_LUT_SEQ_IDX_READID] =
     FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x9F, kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x04),
 
-    /* Enable Quad mode */
+    /* Write Status Register (used to enable quad mode) */
     [4 * NOR_CMD_LUT_SEQ_IDX_WRITESTATUSREG] =
     FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x01, kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_1PAD, 0x04),
 
@@ -270,14 +276,14 @@ flexspi_device_config_t deviceconfig = {
     .flexspiRootClk       = 120000000,
     .flashSize            = (BOARD_FLASH_SIZE/1024),
     .CSIntervalUnit       = kFLEXSPI_CsIntervalUnit1SckCycle,
-    .CSInterval           = 2,
+    .CSInterval           = 0,
     .CSHoldTime           = 3,
     .CSSetupTime          = 3,
     .dataValidTime        = 0,
     .columnspace          = 0,
     .enableWordAddress    = 0,
-    .AWRSeqIndex          = 0,
-    .AWRSeqNumber         = 0,
+    .AWRSeqIndex          = NOR_CMD_LUT_SEQ_IDX_PAGEPROGRAM_SINGLE,
+    .AWRSeqNumber         = 1,
     .ARDSeqIndex          = NOR_CMD_LUT_SEQ_IDX_READ_FAST_QUAD,
     .ARDSeqNumber         = 1,
     .AHBWriteWaitUnit     = kFLEXSPI_AhbWriteWaitUnit2AhbCycle,

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_flash_api.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_flash_api.h
@@ -1,0 +1,51 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2023 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_MIMXRT_FLASH_API_H
+#define MBED_OS_MIMXRT_FLASH_API_H
+
+#include <fsl_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * When the MIMXRT initially boots, the flash peripheral (FlexSPI) has been configured
+ * by the ROM bootloader based on the boot header attached to the program image.
+ *
+ * This function "takes over" control of the peripheral from the bootloader, and
+ * uses the app-level FLEXSPI HAL driver to reconfigure it with settings from flash_defines.h.
+ * Note that we need to be careful that this is done correctly because these settings are
+ * used for the instruction read pipeline as well as for writing the flash, so if we mess up,
+ * the code will crash in an ugly way.  When debugging this code, I recommend using a register
+ * viewer to view the state of FLEXSPI before and after this function runs and verify that
+ * there are no significant differences.
+ *
+ * The main "reason" this exists is that the boot rom apparently doesn't insert the
+ * sequences for erasing & programming pages into the FlexSPI sequence LUT when it
+ * jumps to the application, *even if* those sequences exist in the boot header (????).
+ * So, we need to build our own sequences in the application and use them instead of
+ * what we booted up with.
+ */
+void mimxrt_flash_setup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //MBED_OS_MIMXRT_FLASH_API_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_memory_info.h
@@ -1,0 +1,47 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2023 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_MIMXRT_MEMORY_INFO_H
+#define MBED_OS_MIMXRT_MEMORY_INFO_H
+
+#ifdef HYPERFLASH_BOOT
+/* 64MB HyperFlash */
+#define BOARD_FLASH_SIZE             (0x4000000)
+#define BOARD_FLASH_START_ADDR       (0x60000000)
+#define BOARD_FLASH_PAGE_SIZE        (512)
+#define BOARD_FLASH_SECTOR_SIZE      (262144)
+#else
+/* 8MB QSPI Flash */
+#define BOARD_FLASH_SIZE             (0x800000)
+#define BOARD_FLASH_START_ADDR       (0x60000000)
+#define BOARD_FLASH_PAGE_SIZE        (256)
+#define BOARD_FLASH_SECTOR_SIZE      (4096)
+#endif
+
+// Unless the user overrides it, define the app to use the entire flash space.
+#ifndef MBED_APP_START
+#define MBED_APP_START BOARD_FLASH_START_ADDR
+#endif
+
+#ifndef MBED_APP_SIZE
+#define MBED_APP_SIZE BOARD_FLASH_SIZE
+#endif
+
+#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 1
+#define MIMXRT105X_EXTERNAL_RAM_SIZE 0x02000000
+
+#endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_40/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_40/mimxrt_memory_info.h
@@ -1,7 +1,5 @@
-// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
-// Check the 'features' section of the target description in 'targets.json' for more details.
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2023 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_DEVICE_H
-#define MBED_DEVICE_H
 
-#define DEVICE_ID_LENGTH       24
+#ifndef MBED_OS_MIMXRT_MEMORY_INFO_H
+#define MBED_OS_MIMXRT_MEMORY_INFO_H
 
-/* CMSIS defines this, we use it as linker symbol, undefined it and let a linker symbol
- to be as vector table */
-#undef __VECTOR_TABLE
+/* 2MB QSPI Flash */
+#define BOARD_FLASH_SIZE             (0x1F0000) // 1984k
+#define BOARD_FLASH_START_ADDR       (0x60000000)
+#define BOARD_FLASH_PAGE_SIZE        (256)
+#define BOARD_FLASH_SECTOR_SIZE      (4096)
 
-// Set to 1 by MIMXRT pullups/pulldowns on CRS_DV and RXD0
-#define BOARD_ENET_PHY_ADDR 1
-
-#include "mimxrt_memory_info.h"
-
-#include "objects.h"
-
+// Unless the user overrides it, define the app to use the entire flash space.
+#ifndef MBED_APP_START
+#define MBED_APP_START BOARD_FLASH_START_ADDR
 #endif
+
+#ifndef MBED_APP_SIZE
+#define MBED_APP_SIZE BOARD_FLASH_SIZE
+#endif
+
+#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 0
+
+#endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_41/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_41/mimxrt_memory_info.h
@@ -1,7 +1,5 @@
-// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
-// Check the 'features' section of the target description in 'targets.json' for more details.
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2023 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_DEVICE_H
-#define MBED_DEVICE_H
 
-#define DEVICE_ID_LENGTH       24
+#ifndef MBED_OS_MIMXRT_MEMORY_INFO_H
+#define MBED_OS_MIMXRT_MEMORY_INFO_H
 
-/* CMSIS defines this, we use it as linker symbol, undefined it and let a linker symbol
- to be as vector table */
-#undef __VECTOR_TABLE
+/* 8MB QSPI Flash */
+#define BOARD_FLASH_SIZE             (0x7C0000) // 7936k
+#define BOARD_FLASH_START_ADDR       (0x60000000)
+#define BOARD_FLASH_PAGE_SIZE        (256)
+#define BOARD_FLASH_SECTOR_SIZE      (4096)
 
-// Set to 1 by MIMXRT pullups/pulldowns on CRS_DV and RXD0
-#define BOARD_ENET_PHY_ADDR 1
-
-#include "mimxrt_memory_info.h"
-
-#include "objects.h"
-
+// Unless the user overrides it, define the app to use the entire flash space.
+#ifndef MBED_APP_START
+#define MBED_APP_START BOARD_FLASH_START_ADDR
 #endif
+
+#ifndef MBED_APP_SIZE
+#define MBED_APP_SIZE BOARD_FLASH_SIZE
+#endif
+
+#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 0
+
+#endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/bootdata.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/bootdata.c
@@ -6,6 +6,7 @@
 // - #define names had to be modified to match Mbed
 // - _flashimagelen replaced with __USED_FLASH_SIZE
 // - ResetHandler replaced with Reset_Handler
+// - hardcoded flash size replaced with BOARD_FLASH_SIZE
 
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
@@ -40,6 +41,7 @@
  */
 
 #include <stdint.h>
+#include <mimxrt_flash_info.h>
 
 extern void Reset_Handler(void);
 extern unsigned long _estack;
@@ -105,7 +107,7 @@ uint32_t FlexSPI_NOR_Config[128] = {
 #elif defined(TARGET_TEENSY_41)
 	0x00800000,		// sflashA1Size			0x50
 #else
-#error "Unknow flash chip size";
+#error "Unknown flash chip size";
 #endif
 	0,			// sflashA2Size
 	0,			// sflashB1Size

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/bootdata.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/bootdata.c
@@ -6,7 +6,6 @@
 // - #define names had to be modified to match Mbed
 // - _flashimagelen replaced with __USED_FLASH_SIZE
 // - ResetHandler replaced with Reset_Handler
-// - hardcoded flash size replaced with BOARD_FLASH_SIZE
 
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -25,18 +25,13 @@
 ** ###################################################################
 */
 
+/* Pick up memory info for this specific device */
+#include <mimxrt_memory_info.h>
+
 /* Entry Point */
 ENTRY(Reset_Handler)
 
 __ram_vector_table__ = 1;
-
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x60000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x400000
-#endif
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
     #define MBED_CONF_TARGET_BOOT_STACK_SIZE 0x400
@@ -50,31 +45,21 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-#if !defined(MBED_APP_COMPILE)
   m_flash_config        (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x00001000
   m_ivt                 (RX)  : ORIGIN = MBED_APP_START + 0x1000, LENGTH = 0x00001000
   m_interrupts          (RX)  : ORIGIN = MBED_APP_START + 0x2000, LENGTH = 0x00000400
   m_text                (RX)  : ORIGIN = MBED_APP_START + 0x2400, LENGTH = MBED_APP_SIZE - 0x2400
-#else
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x00000400
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = MBED_APP_SIZE - 0x400
-#endif
+
+/* DTCM memory.
+     Startup code configures size to 256k (stealing space from OCRAM). */
+  m_dtcm                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00040000
 
 #if MIMXRT105X_BOARD_HAS_EXTERNAL_RAM
   /* Use the external RAM as main memory */
   m_data                (RW)  : ORIGIN = 0x80000000, LENGTH = MIMXRT105X_EXTERNAL_RAM_SIZE
-
-  /* DTCM memory.
-     Startup code configures size to 256k (stealing space from OCRAM). */
-  m_dtcm                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00040000
 #else
-  /* Use DTCM as main memory (significantly faster than OCRAM).
-     Startup code configures size to 256k (stealing space from OCRAM). */
-  m_dtcm                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00040000
-
-  /* No external data memory, store data in DTCM */
+  /* No external data memory, store data in DTCM (significantly faster than OCRAM)*/
 #define m_data m_dtcm
-
 #endif
 
   /* ITCM bank -- used for functions that need to execute from RAM

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/drivers/fsl_flexspi.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/drivers/fsl_flexspi.c
@@ -268,6 +268,10 @@ void FLEXSPI_Init(FLEXSPI_Type *base, const flexspi_config_t *config)
                   FLEXSPI_MCR0_ARDFEN(config->ahbConfig.enableAHBWriteIpRxFifo) |
 #endif
                   FLEXSPI_MCR0_MDIS_MASK;
+
+    /* Bit 15 is reserved and must be set to 1 */
+    configValue |= (1 << 15);
+
     base->MCR0 = configValue;
 
     /* Configure MCR1 configurations. */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.c
@@ -336,6 +336,8 @@ void LPM_AdjustSystemSettings(lpm_power_mode_t curRunMode, lpm_power_mode_t targ
             }
             break;
         case LPM_PowerModeLowPowerRun:
+             /* Disable FET ODRIVE */
+            PMU->REG_CORE_CLR = PMU_REG_CORE_FET_ODRIVE_MASK;
             if (targetMode == LPM_PowerModeOverRun)
             {
                 /* Adjust SOC voltage to 1.275V */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.c
@@ -195,15 +195,8 @@ void LPM_Init(void)
 
     /* DCM Mode */
     DCDC_BootIntoDCM(DCDC);
-    /* Adjust SOC voltage to 1.275V */
-    DCDC_AdjustTargetVoltage(DCDC, 0x13, 0x1);
     /* Disconnect internal the load resistor */
     DCDC->REG1 &= ~DCDC_REG1_REG_RLOAD_SW_MASK;
-
-    /* Enable FET ODRIVE */
-    PMU->REG_CORE_SET = PMU_REG_CORE_FET_ODRIVE_MASK;
-    /* Connect vdd_high_in and connect vdd_snvs_in */
-    PMU->MISC0_CLR = PMU_MISC0_DISCON_HIGH_SNVS_MASK;
 }
 
 void LPM_EnableWakeupSource(uint32_t irq)
@@ -308,6 +301,10 @@ void LPM_AdjustSystemSettings(lpm_power_mode_t curRunMode, lpm_power_mode_t targ
                 ClockSelectRcOsc();
                 /* Adjust SOC voltage to 0.95V */
                 DCDC_AdjustTargetVoltage(DCDC, 0x6, 0x1);
+
+                /* Enable FET ODRIVE */
+                PMU->REG_CORE_SET = PMU_REG_CORE_FET_ODRIVE_MASK;
+
                 EnableWeakLDO();
                 DisableRegularLDO();
                 BandgapOff();
@@ -329,6 +326,10 @@ void LPM_AdjustSystemSettings(lpm_power_mode_t curRunMode, lpm_power_mode_t targ
                 ClockSelectRcOsc();
                 /* Adjust SOC voltage to 0.95V */
                 DCDC_AdjustTargetVoltage(DCDC, 0x6, 0x1);
+
+                /* Enable FET ODRIVE */
+                PMU->REG_CORE_SET = PMU_REG_CORE_FET_ODRIVE_MASK;
+
                 EnableWeakLDO();
                 DisableRegularLDO();
                 BandgapOff();

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/lpm.h
@@ -16,9 +16,6 @@
  * Definitions
  ******************************************************************************/
 
-#define LPM_EnterCritical()
-#define LPM_ExitCritical()
-
 /*
  * Power mode definition of low power management.
  */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
@@ -26,6 +26,11 @@
 #include "usb_device_config.h"
 #include "us_ticker_defines.h"
 #include "us_ticker_api.h"
+#include "flash_api.h"
+
+#if DEVICE_FLASH
+#include "mimxrt_flash_api.h"
+#endif
 
 #define LPSPI_CLOCK_SOURCE_DIVIDER (7U)
 #define LPI2C_CLOCK_SOURCE_DIVIDER (5U)
@@ -183,9 +188,13 @@ void mbed_sdk_init()
     BOARD_ClockFullSpeed();
 #endif
 
+    // Switch to using an application-owned flexspi config instead of what the bootloader sets up
+#if DEVICE_FLASH
+    mimxrt_flash_setup();
+#endif
+
     // Initialize us ticker before LPM, because LPM uses it for timing
     us_ticker_init();
-
 
 #if TARGET_EVK
     /* Since SNVS_PMIC_STBY_REQ_GPIO5_IO02 will output a high-level signal under Stop Mode(Suspend Mode) and this pin is
@@ -283,7 +292,7 @@ void mbed_mac_address(char *mac) {
 
 uint8_t mbed_otp_mac_address(char *mac) {
 
-#if TARGET_MIMXRT1050_EVK
+#if TARGET_EVK
     /* Check if a valid MAC address is programmed to the fuse bank */
     if ((OCOTP->MAC0 != 0) &&
         (OCOTP->MAC1 != 0) &&

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5149,7 +5149,6 @@
             "FSL_RTOS_MBED",
             "XIP_BOOT_HEADER_ENABLE=1",
             "XIP_EXTERNAL_FLASH=1",
-            "HYPERFLASH_BOOT",
             "FSL_SDK_DRIVER_QUICK_ACCESS_ENABLE=1",
             "SKIP_SYSCLK_INIT",
             "__STARTUP_INITIALIZE_RAMFUNCTION",
@@ -5214,10 +5213,9 @@
             "ARDUINO_UNO"
         ],
         "macros_add": [
+            "HYPERFLASH_BOOT",
             "XIP_BOOT_HEADER_DCD_ENABLE=1",
-            "FSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE",
-            "MIMXRT105X_BOARD_HAS_EXTERNAL_RAM=1",
-            "MIMXRT105X_EXTERNAL_RAM_SIZE=0x02000000"
+            "FSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE"
         ],
         "device_has_add": [
             "FLASH"
@@ -5244,10 +5242,10 @@
         ],
         "macros_add": [
             "XIP_BOOT_HEADER_DCD_ENABLE=1",
-            "FSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE",
-            "MIMXRT105X_BOARD_HAS_EXTERNAL_RAM=1",
-            "MIMXRT105X_EXTERNAL_RAM_SIZE=0x01E00000",
-            "MBED_APP_SIZE=0x800000"
+            "FSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE"
+        ],
+        "device_has_add": [
+            "FLASH"
         ],
         "overrides": {
             "network-default-interface-type": "ETHERNET"
@@ -5261,10 +5259,6 @@
             "TEENSY_4X",
             "TEENSY_40",
             "MIMXRT1060"
-        ],
-        "macros_add": [
-            "MIMXRT105X_BOARD_HAS_EXTERNAL_RAM=0",
-            "MBED_APP_SIZE=0x1f0000"
         ],
         "overrides": {
             "console-usb": true,
@@ -5282,10 +5276,6 @@
             "TEENSY_4X",
             "TEENSY_41",
             "MIMXRT1060"
-        ],
-        "macros_add": [
-            "MIMXRT105X_BOARD_HAS_EXTERNAL_RAM=0",
-            "MBED_APP_SIZE=0x7C0000"
         ],
         "overrides": {
             "console-usb": true,

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -46,9 +46,9 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
     set(LINKER_SCRIPT_PATH ${CMAKE_BINARY_DIR}/${MBED_TARGET_CMAKE_NAME}.link_script.ld)
 
     # To avoid path limits on Windows, we create a "response file" and set the path to it as a
-    # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
-    # so it can expand any macro definitions in the linker script.
-    get_property(linker_defs_response_file GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
+    # global property. We need this solely to pass the compile definitions and include paths
+    # to GCC's preprocessor, so it can expand any macro definitions in the linker script.
+    get_property(linker_defs_response_file GLOBAL PROPERTY LINKER_SCRIPT_PREPROCESS_FLAGS_RESPONSE_FILE)
 
     get_filename_component(RAW_LINKER_SCRIPT_NAME ${RAW_LINKER_SCRIPT_PATHS} NAME)
     get_filename_component(LINKER_SCRIPT_NAME ${LINKER_SCRIPT_PATH} NAME)
@@ -114,7 +114,7 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
     # To avoid path limits on Windows, we create a "response file" and set the path to it as a
     # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
     # so it can expand any macro definitions in the linker script.
-    get_property(linker_defs_response_file GLOBAL PROPERTY COMPILE_DEFS_RESPONSE_FILE)
+    get_property(linker_defs_response_file GLOBAL PROPERTY LINKER_SCRIPT_PREPROCESS_FLAGS_RESPONSE_FILE)
 
     get_filename_component(RAW_LINKER_SCRIPT_NAME ${RAW_LINKER_SCRIPT_PATHS} NAME)
     get_filename_component(LINKER_SCRIPT_NAME ${CUSTOM_LINKER_SCRIPT_PATH} NAME)

--- a/tools/cmake/mbed_toolchain.cmake
+++ b/tools/cmake/mbed_toolchain.cmake
@@ -1,18 +1,28 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Generate a file containing compile definitions
+# Generate a file containing compile definitions and include paths
 function(mbed_generate_options_for_linker target output_response_file_path)
     set(_compile_definitions
         "$<TARGET_PROPERTY:${target},INTERFACE_COMPILE_DEFINITIONS>"
+    )
+    set(_include_directories
+        "$<TARGET_PROPERTY:${target},INTERFACE_INCLUDE_DIRECTORIES>"
     )
 
     # Append -D to all macros and quote them as we pass these as response file to cxx compiler
     set(_compile_definitions
         "$<$<BOOL:${_compile_definitions}>:'-D$<JOIN:${_compile_definitions},' '-D>'>"
     )
-    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt" CONTENT "${_compile_definitions}\n")
-    set(${output_response_file_path} ${CMAKE_CURRENT_BINARY_DIR}/compile_time_defs.txt PARENT_SCOPE)
+    # Prepend -I to all macros and quote them as we pass these as response file to cxx compiler
+    set(_include_directories
+        "$<$<BOOL:${_compile_definitions}>:'-I$<JOIN:${_include_directories},' '-I>'>"
+    )
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/linker_script_preprocess_flags.txt" CONTENT
+"${_compile_definitions}
+${_include_directories}
+")
+    set(${output_response_file_path} ${CMAKE_CURRENT_BINARY_DIR}/linker_script_preprocess_flags.txt PARENT_SCOPE)
 endfunction()
 
 # Compiler setup

--- a/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
+++ b/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
@@ -60,6 +60,12 @@ set(UPLOAD_LAUNCH_COMMANDS
 	"load"
 	"break main"
 	"monitor reset"
+
+	# Workaround for LinkServer supplying incomplete memory information to GDB
+	# (in particular, seems to be missing the peripheral memory space and external RAM).
+	# Without this command, GDB will block the user from accessing values in any of these
+	# memory spaces.
+	"set mem inaccessible-by-default off"
 )
 set(UPLOAD_RESTART_COMMANDS
 	"monitor reset"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I will say that, this PR was a journey.  I started off with a simple-ish goal: adding Flash API support for the MIMRT1060 EVK.  Since the MIMXRT1050, which is basically the same silicon, already supports Flash, this should be easy... right?

Well, not so much.  I started by doing a bit of a refactor of how flash information is tracked for MIMXRT105x devices.  Instead of putting some of it it as defines in targets.json, and some of it in device.h, it all now lives in a header which is specific to each target, `mimxrt_memory_info.h`.  This way we can collect all of these constants in one place that's easy to modify when adding a new MIMXRT105x family target (and hopefully other MIMXRT targets later on as well!).  This basically worked, and meant that I could easily adapt the MIMXRT1050_EVK flash_api.c to work for MIMXRT1060_EVK as well.

But, when I tried to use this code, bad stuff happened.  You see, the 1050 EVK board uses a different type of flash chip (OSPI) by default.  And, while NXP did implement flash stuff for QSPI, they apparently didn't test it very well, because it did not work when I tried to use it.  Or, more specifically, it mostly worked, BUT whenever I initialized a flash_t, the application would sometimes randomly crash at a later point in the execution.  From what I could tell, it would crash because it didn't execute the correct instructions from the program image, e.g. it would go right over a branch instruction without branching.  But, it was quite difficult to nail down the issue, because it would happen repeatably with the same compiled program but would vanish and come back if you changed unrelated parts of the code.

After about 6 hours of debugging and A-B testing, I was able to narrow this down to the FLEXSPI_Init() call in flash_init().  Removing this call caused the issue to not happen anymore.  My suspicion is that this call was resetting the FLEXSPI peripheral while background accesses to it were still happening, causing invalid data to get transferred to the processor instruction cache, where it would later be executed.  I tested two mitigations: waiting to reset the peripheral until it was no longer busy, and clearing the I-cache after doing the initialization.  Both of these fixed the issue on their own, so I added both (only way to be sure!).

I also made another largeish change to improve reliability: until now, the MIMXRT would use the boot rom's configuration for the flash peripheral *until* you called flash_init() for the first time in code.  This means that applications which use the flash API are potentially operating using a different flash configuration than those that don't.  This feels like a source of heisenbugs, since only 1 test uses the flash API and all the rest don't.  So, I moved the flash config code into a new function `mimxrt_flash_setup()` which is always called at boot.  So, now every application will always use the full-featured flash config with write and erase support.

That did seem to fix the issues with the flash API, but I then started getting a bunch of new failures in the test suite for basically any code that uses deep sleep.  This made me do a little more digging through the deep sleep code, which I have a little more insight into now that I found AN12085, which seems to be the "implementation guide" for doing deep sleep on MIMXRT.  I discovered that the deep sleep code also resets the FlexSPI peripheral when changing its clock, so it could have the same type of issue as with the flash API.  Adding the "wait until not busy" loop didn't seem to do anything, but clearing the I-cache helped a lot.

Now, both the tests that used to be flaky (hal-sleep, rtos-mutex, etc) and the other deep sleep tests that newly started failing seem to work reliably.  The only two exceptions are `hal-lp-ticker` and `hal-rtc`.  Both of these seem to suffer some sort of stack corruption after coming out of deep sleep.  I think that a future effort will be needed to dive deeper into MIMXRT deep sleep and debug these issues.

Ultimately, while this MR doesn't fix every test issue on the MIMXRT, I think it still makes a significant improvement.  It trades some flaky, nebulous issues for ones which occur more repeatably, which seems like a win in my book.  And it also lays the groundwork for adding flash support in the future for other MIMXRT targets such as Teensy!

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
MIMXRT1060_EVK now supports Flash IAP API.  Some deep sleep weirdness on MIMXRT105x family devices fixed.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
```
96% tests passed, 3 tests failed out of 81

Total Test time (real) = 1487.79 sec

The following tests did not run:
          8 - mbed-hal-crc (Skipped)
         13 - mbed-hal-mpu (Skipped)
         14 - mbed-hal-ospi (Skipped)
         16 - mbed-hal-qspi (Skipped)
         17 - mbed-hal-reset-reason (Skipped)
         19 - mbed-hal-rtc-reset (Skipped)
         43 - mbed-platform-crash-reporting (Skipped)
         53 - mbed-platform-stats-cpu (Skipped)
         54 - mbed-platform-stats-heap (Skipped)
         55 - mbed-platform-stats-sys (Skipped)
         56 - mbed-platform-stats-thread (Skipped)
         72 - mbed-connectivity-mbedtls-sanity (Skipped)
         74 - mbed-connectivity-nfc-eeprom (Skipped)
         76 - mbed-connectivity-netsocket-nidd (Skipped)

The following tests FAILED:
         11 - mbed-hal-lp-ticker (Failed)
         18 - mbed-hal-rtc (Failed)
         27 - mbed-hal-trng (Failed)
Errors while running CTest
```
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
