### PR TITLE
Reactivate some Network & Netsocket tests, Mbed TLS tests, Device Key test.  Also fix lots of deprecation warnings

### DIFF
--- a/connectivity/mbedtls/CMakeLists.txt
+++ b/connectivity/mbedtls/CMakeLists.txt
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(MBED_ENABLE_OS_INTERNAL_TESTS)
-    if(NOT MBED_BUILD_GREENTEA_TESTS)
+    if(MBED_BUILD_GREENTEA_TESTS)
+        add_subdirectory(tests/TESTS)
+    else()
         add_subdirectory(tests/UNITTESTS)
     endif()
 endif()

--- a/connectivity/mbedtls/include/mbedtls/config.h
+++ b/connectivity/mbedtls/include/mbedtls/config.h
@@ -1396,7 +1396,7 @@
  *
  * Enable the checkup functions (*_self_test).
  */
-//#define MBEDTLS_SELF_TEST
+#define MBEDTLS_SELF_TEST
 
 /**
  * \def MBEDTLS_SHA256_SMALLER

--- a/connectivity/mbedtls/tests/TESTS/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(mbedtls)

--- a/connectivity/mbedtls/tests/TESTS/mbedtls/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/mbedtls/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(multi)
+add_subdirectory(sanity)
+add_subdirectory(selftest)

--- a/connectivity/mbedtls/tests/TESTS/mbedtls/multi/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/mbedtls/multi/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-mbedtls-multi)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-mbedtls-multi
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/connectivity/mbedtls/tests/TESTS/mbedtls/sanity/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/mbedtls/sanity/CMakeLists.txt
@@ -1,20 +1,19 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-mbedtls-sanity)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
+if((NOT "FEATURE_EXPERIMENTAL_API=1" IN_LIST MBED_TARGET_DEFINITIONS)
+	OR (NOT "FEATURE_PSA=1" IN_LIST MBED_TARGET_DEFINITIONS)
+	OR (NOT "TARGET_MBED_PSA_SRV=1" IN_LIST MBED_TARGET_DEFINITIONS))
+	set(TEST_SKIPPED "Only PSA targets (Arm-v7M) in emulation mode are supported.")
+endif()
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-mbedtls-sanity
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS
         mbed-mbedtls
+	TEST_SKIPPED
+		${TEST_SKIPPED}
 )

--- a/connectivity/mbedtls/tests/TESTS/mbedtls/selftest/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/mbedtls/selftest/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-mbedtls-selftest)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-mbedtls-selftest
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/connectivity/mbedtls/tests/TESTS/mbedtls/selftest/CMakeLists.txt
+++ b/connectivity/mbedtls/tests/TESTS/mbedtls/selftest/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-mbedtls-selftest
@@ -8,4 +12,6 @@ mbed_greentea_add_test(
         main.cpp
     TEST_REQUIRED_LIBS
         mbed-mbedtls
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 # Only build the netsocket tests if this target has at least one network interface
 string(FIND "${MBED_CONFIG_DEFINITIONS}" MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE DEFAULT_IFC_IDX)
-if(NOT DEFAULT_IFC_IDX EQUAL -1)
-    add_subdirectory(netsocket)
+if(DEFAULT_IFC_IDX EQUAL -1)
+    set(TEST_SKIPPED "No default network interface on this target")
 endif()
+
+add_subdirectory(netsocket)
+add_subdirectory(network)

--- a/connectivity/netsocket/tests/TESTS/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/CMakeLists.txt
@@ -1,1 +1,5 @@
+add_subdirectory(dns)
+add_subdirectory(nidd)
+add_subdirectory(tcp)
+add_subdirectory(tls)
 add_subdirectory(udp)

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/CMakeLists.txt
@@ -1,15 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../ CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-netsocket-dns)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 list(
     APPEND 
         TEST_SOURCE_LIST
@@ -34,9 +25,11 @@ list(
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-netsocket-dns
     TEST_SOURCES
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/CMakeLists.txt
@@ -23,6 +23,10 @@ list(
             asynchronous_dns_cache.cpp
 )
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-netsocket-dns

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -41,7 +41,7 @@ void ASYNCHRONOUS_DNS_CACHE()
     data.semaphore = &semaphore;
 
     Ticker ticker;
-    ticker.attach_us(&test_dns_query_ticker, 100);
+    ticker.attach(&test_dns_query_ticker, 100us);
 
     nsapi_dns_reset();
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -85,6 +85,6 @@ void ASYNCHRONOUS_DNS_CANCEL()
 
     delete[] data;
 
-    ThisThread::sleep_for(5000);
+    ThisThread::sleep_for(5s);
 }
 #endif // defined(MBED_CONF_RTOS_PRESENT)

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_external_event_queue.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_external_event_queue.cpp
@@ -41,7 +41,7 @@ events::EventQueue *event_queue;
 static nsapi_error_t event_queue_call(int delay, mbed::Callback<void()> func)
 {
     if (delay) {
-        if (event_queue->call_in(delay, func) == 0) {
+        if (event_queue->call_in(std::chrono::milliseconds(delay), func) == 0) {
             return NSAPI_ERROR_NO_MEMORY;
         }
     } else {
@@ -73,8 +73,8 @@ void ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE()
     TEST_ASSERT_EQUAL(0, result_exp_timeout);
 
     // Give event queue time to finalise before destructors
-    ThisThread::sleep_for(2000);
+    ThisThread::sleep_for(2s);
 
-    nsapi_dns_call_in_set(0);
+    nsapi_dns_call_in_set(nullptr);
 }
 #endif // defined(MBED_CONF_RTOS_PRESENT)

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
@@ -37,7 +37,7 @@ void getaddrinfo_cb(void *data, nsapi_error_t result, SocketAddress *address)
 {
     dns_application_data_multi_ip *app_data = static_cast<dns_application_data_multi_ip *>(data);
     app_data->result = result;
-    for (unsigned int i = 0; i < result; i++) {
+    for (int i = 0; i < result; i++) {
         if (address) {
             app_data->addr[i] = address[i];
         }
@@ -86,7 +86,7 @@ void do_getaddrinfo_async(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op
                     || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result > 0) {
             (*exp_ok)++;
-            for (unsigned int results = 0; results < data[i].result; results++) {
+            for (int results = 0; results < data[i].result; results++) {
                 printf("DNS: query \"%s\" => \"%s\"\n",
                        hosts[i], data[i].addr[results].get_ip_address());
             }

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -50,7 +50,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
         TEST_ASSERT(strlen(addr.get_ip_address()) > 1);
     }
 
-    if (!semaphore.try_acquire_for(1000)) {
+    if (!semaphore.try_acquire_for(1s)) {
         get_interface()->gethostbyname_async_cancel(err);
     }
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
@@ -78,7 +78,7 @@ void ASYNCHRONOUS_DNS_TIMEOUTS()
         if (result == NSAPI_ERROR_OK) {
             return;
         }
-        ThisThread::sleep_for(1000);
+        ThisThread::sleep_for(1s);
         count--;
     } while (result != NSAPI_ERROR_OK && count);
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -38,7 +38,7 @@ void SYNCHRONOUS_DNS_CACHE()
 {
     nsapi_dns_reset();
     Ticker ticker;
-    ticker.attach_us(&test_dns_query_ticker, 100);
+    ticker.attach(&test_dns_query_ticker, 100us);
 
     for (unsigned int i = 0; i < 5; i++) {
         SocketAddress address;

--- a/connectivity/netsocket/tests/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
@@ -63,7 +63,7 @@ void do_getaddrinfo(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_count
             printf("DNS: query \"%s\" => busy\n", hosts[i]);
         } else if (err > NSAPI_ERROR_OK) {
             (*exp_ok)++;
-            for (unsigned int results = 0; results < err; results++) {
+            for (int results = 0; results < err; results++) {
                 printf("DNS: query \"%s\" => \"%s\"\n", hosts[i], result[results].get_ip_address());
             }
         } else if (err == 0) {

--- a/connectivity/netsocket/tests/TESTS/netsocket/nidd/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/nidd/CMakeLists.txt
@@ -1,14 +1,10 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+if(NOT "MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=CELLULAR" IN_LIST MBED_CONFIG_DEFINITIONS)
+	set(TEST_SKIPPED "Target's default network interface type is not CELLULAR.")
+endif()
 
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../ CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-netsocket-nidd)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
 
 list(
     APPEND
@@ -29,9 +25,11 @@ list(
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-netsocket-nidd
     TEST_SOURCES
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/CMakeLists.txt
@@ -27,6 +27,10 @@ list(
             tcpsocket_recv_100k.cpp       	
 )
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-netsocket-tcp

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/CMakeLists.txt
@@ -1,15 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../ CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-netsocket-tcp)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 list(
     APPEND
         TEST_SOURCE_LIST
@@ -38,9 +29,11 @@ list(
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-netsocket-tcp
     TEST_SOURCES
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/main.cpp
@@ -149,9 +149,9 @@ void fill_tx_buffer_ascii(char *buff, size_t len)
     }
 }
 
-int split2half_rmng_tcp_test_time()
+std::chrono::microseconds split2half_rmng_tcp_test_time()
 {
-    return (tcp_global::TESTS_TIMEOUT - tc_bucket.read()) / 2;
+    return (tcp_global::TESTS_TIMEOUT - tc_bucket.elapsed_time()) / 2;
 }
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
@@ -164,7 +164,7 @@ int fetch_stats()
 // Test setup
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(tcp_global::TESTS_TIMEOUT, "default_auto");
+    GREENTEA_SETUP(tcp_global::TESTS_TIMEOUT.count(), "default_auto");
     _ifup();
     tc_bucket.start();
     return greentea_test_setup_handler(number_of_cases);

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcp_tests.h
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcp_tests.h
@@ -44,18 +44,18 @@ int fetch_stats(void);
 /**
  * Single testcase might take only half of the remaining execution time
  */
-int split2half_rmng_tcp_test_time(); // [s]
+std::chrono::microseconds split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global {
 #ifdef MBED_GREENTEA_TEST_TCPSOCKET_TIMEOUT_S
-static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_TCPSOCKET_TIMEOUT_S;
+static const std::chrono::seconds TESTS_TIMEOUT(MBED_GREENTEA_TEST_TCPSOCKET_TIMEOUT_S);
 #else
 #define MESH 3
 #define WISUN 0x2345
 #if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH && MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == WISUN
-static const int TESTS_TIMEOUT = (25 * 60);
+static const std::chrono::seconds TESTS_TIMEOUT(25 * 60);
 #else
-static const int TESTS_TIMEOUT = (10 * 60);
+static const std::chrono::seconds TESTS_TIMEOUT(10 * 60);
 #endif
 #endif
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -79,8 +79,7 @@ void TCPSOCKET_ENDPOINT_CLOSE()
                 break;
             }
             continue;
-        }
-        else if (recvd <= 0) {
+        } else if (recvd <= 0) {
             TEST_ASSERT_EQUAL(0, recvd);
             break;
         }

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -55,7 +55,7 @@ void TCPSOCKET_ENDPOINT_CLOSE()
     SKIP_IF_TCP_UNSUPPORTED();
     static const int MORE_THAN_AVAILABLE = 30;
     char buff[MORE_THAN_AVAILABLE];
-    int time_allotted = split2half_rmng_tcp_test_time(); // [s]
+    auto time_allotted = split2half_rmng_tcp_test_time(); // [us]
     Timer tc_exec_time;
     tc_exec_time.start();
 
@@ -72,17 +72,19 @@ void TCPSOCKET_ENDPOINT_CLOSE()
         recvd = sock.recv(buff, MORE_THAN_AVAILABLE);
         if (recvd_total > 0 && recvd == 0) {
             break; // Endpoint closed socket, success
-        } else if (recvd <= 0) {
-            TEST_ASSERT_EQUAL(0, recvd);
-            break;
         } else if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-            if (tc_exec_time.read() >= time_allotted ||
+            if (tc_exec_time.elapsed_time() >= time_allotted ||
                     osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
                 TEST_FAIL();
                 break;
             }
             continue;
         }
+        else if (recvd <= 0) {
+            TEST_ASSERT_EQUAL(0, recvd);
+            break;
+        }
+
         recvd_total += recvd;
         TEST_ASSERT(recvd_total < MORE_THAN_AVAILABLE);
     }

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -145,7 +145,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
     static const size_t buff_size = 1220;
     uint8_t buff[buff_size];
     size_t recvd_size = 0;
-    int time_allotted = split2half_rmng_tcp_test_time(); // [s]
+    auto time_allotted = split2half_rmng_tcp_test_time(); // [us]
 
     Timer timer;
     timer.start();
@@ -161,7 +161,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
             check_RFC_864_pattern(buff, rd, recvd_size);
             recvd_size += rd;
         } else if (rd == NSAPI_ERROR_WOULD_BLOCK) {
-            if (timer.read() >= time_allotted) {
+            if (timer.elapsed_time() >= time_allotted) {
                 TEST_FAIL();
                 break;
             }

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -40,7 +40,7 @@ void TCPSOCKET_RECV_TIMEOUT()
     SKIP_IF_TCP_UNSUPPORTED();
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};
-    int time_allotted = split2half_rmng_tcp_test_time(); // [s]
+    auto time_allotted = split2half_rmng_tcp_test_time(); // [us]
     Timer tc_exec_time;
     tc_exec_time.start();
 
@@ -63,17 +63,17 @@ void TCPSOCKET_RECV_TIMEOUT()
             timer.stop();
 
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-                if (tc_exec_time.read() >= time_allotted ||
+                if (tc_exec_time.elapsed_time() >= time_allotted ||
                         (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout)) {
                     TEST_FAIL();
                     goto CLEANUP;
                 }
-                int recv_time_ms = (timer.read_us() + 500) / 1000;
-                tr_info("MBED: recv() took: %dus", recv_time_ms);
-                if (recv_time_ms > 150) {
-                    TEST_ASSERT(150 - recv_time_ms < 51);
+                std::chrono::microseconds recv_time = (timer.elapsed_time() + 500us);
+                tr_info("MBED: recv() took: %" PRIi64 "us", recv_time.count());
+                if (recv_time > 150ms) {
+                    TEST_ASSERT(150ms - recv_time < 51ms);
                 } else {
-                    TEST_ASSERT(recv_time_ms - 150 < 51);
+                    TEST_ASSERT(recv_time - 150ms < 51ms);
                 }
                 continue;
             } else if (recvd < 0) {

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
@@ -44,7 +44,7 @@ void TCPSOCKET_SEND_TIMEOUT()
         err = sock.send(tx_buffer, sizeof(tx_buffer));
         timer.stop();
         if ((err == sizeof(tx_buffer) || err == NSAPI_ERROR_WOULD_BLOCK) &&
-                (timer.read_ms() <= 800)) {
+                (timer.elapsed_time() <= 800ms)) {
             continue;
         }
         tr_error("send: err %d, time %d", err, timer.read_ms());

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/CMakeLists.txt
@@ -1,15 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../ CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-netsocket-tls)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 list(
     APPEND
         TEST_SOURCE_LIST
@@ -33,9 +24,11 @@ list(
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-netsocket-tls
     TEST_SOURCES
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/CMakeLists.txt
@@ -22,6 +22,10 @@ list(
             tlssocket_connect_invalid.cpp       
 )
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-netsocket-tls

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/main.cpp
@@ -151,9 +151,9 @@ void fill_tx_buffer_ascii(char *buff, size_t len)
     }
 }
 
-int split2half_rmng_tls_test_time()
+std::chrono::microseconds split2half_rmng_tls_test_time()
 {
-    return (tls_global::TESTS_TIMEOUT - tc_bucket.read()) / 2;
+    return (tls_global::TESTS_TIMEOUT - tc_bucket.elapsed_time()) / 2;
 }
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
@@ -166,7 +166,7 @@ int fetch_stats()
 // Test setup
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(tls_global::TESTS_TIMEOUT, "default_auto");
+    GREENTEA_SETUP(tls_global::TESTS_TIMEOUT.count(), "default_auto");
     _ifup();
 
 #ifdef MBED_CONF_APP_BAUD_RATE
@@ -219,22 +219,22 @@ static void test_failure_handler(const failure_t failure)
 
 Case cases[] = {
 // Disable tests temporarily till echo server is back on
-//    Case("TLSSOCKET_ECHOTEST", TLSSOCKET_ECHOTEST),
-//    Case("TLSSOCKET_ECHOTEST_NONBLOCK", TLSSOCKET_ECHOTEST_NONBLOCK),
+    Case("TLSSOCKET_ECHOTEST", TLSSOCKET_ECHOTEST),
+    Case("TLSSOCKET_ECHOTEST_NONBLOCK", TLSSOCKET_ECHOTEST_NONBLOCK),
     Case("TLSSOCKET_CONNECT_INVALID", TLSSOCKET_CONNECT_INVALID),
-//    Case("TLSSOCKET_ECHOTEST_BURST", TLSSOCKET_ECHOTEST_BURST),
-//    Case("TLSSOCKET_ECHOTEST_BURST_NONBLOCK", TLSSOCKET_ECHOTEST_BURST_NONBLOCK),
-//    Case("TLSSOCKET_RECV_TIMEOUT", TLSSOCKET_RECV_TIMEOUT),
-//    Case("TLSSOCKET_ENDPOINT_CLOSE", TLSSOCKET_ENDPOINT_CLOSE),
+    Case("TLSSOCKET_ECHOTEST_BURST", TLSSOCKET_ECHOTEST_BURST),
+    Case("TLSSOCKET_ECHOTEST_BURST_NONBLOCK", TLSSOCKET_ECHOTEST_BURST_NONBLOCK),
+    Case("TLSSOCKET_RECV_TIMEOUT", TLSSOCKET_RECV_TIMEOUT),
+    Case("TLSSOCKET_ENDPOINT_CLOSE", TLSSOCKET_ENDPOINT_CLOSE),
     Case("TLSSOCKET_HANDSHAKE_INVALID", TLSSOCKET_HANDSHAKE_INVALID),
     Case("TLSSOCKET_OPEN_TWICE", TLSSOCKET_OPEN_TWICE),
     Case("TLSSOCKET_OPEN_LIMIT", TLSSOCKET_OPEN_LIMIT),
     Case("TLSSOCKET_OPEN_DESTRUCT", TLSSOCKET_OPEN_DESTRUCT),
     Case("TLSSOCKET_SEND_UNCONNECTED", TLSSOCKET_SEND_UNCONNECTED),
-//    Case("TLSSOCKET_SEND_CLOSED", TLSSOCKET_SEND_CLOSED),
-//    Case("TLSSOCKET_SEND_REPEAT", TLSSOCKET_SEND_REPEAT),
-//    Case("TLSSOCKET_SEND_TIMEOUT", TLSSOCKET_SEND_TIMEOUT),
-//    Case("TLSSOCKET_NO_CERT", TLSSOCKET_NO_CERT),
+    Case("TLSSOCKET_SEND_CLOSED", TLSSOCKET_SEND_CLOSED),
+    Case("TLSSOCKET_SEND_REPEAT", TLSSOCKET_SEND_REPEAT),
+    Case("TLSSOCKET_SEND_TIMEOUT", TLSSOCKET_SEND_TIMEOUT),
+    Case("TLSSOCKET_NO_CERT", TLSSOCKET_NO_CERT),
 //    Temporarily removing this test, as TLS library consumes too much memory
 //    and we see frequent memory allocation failures on architectures with less
 //    RAM such as DISCO_L475VG_IOT1A and NUCLEO_F207ZG (both have 128 kB RAM)

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/tls_tests.h
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/tls_tests.h
@@ -46,18 +46,18 @@ int fetch_stats(void);
 /**
  * Single testcase might take only half of the remaining execution time
  */
-int split2half_rmng_tls_test_time(); // [s]
+std::chrono::microseconds split2half_rmng_tls_test_time(); // [s]
 
 namespace tls_global {
 #ifdef MBED_GREENTEA_TEST_TLSSOCKET_TIMEOUT_S
-static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_TLSSOCKET_TIMEOUT_S;
+static const std::chrono::seconds TESTS_TIMEOUT(MBED_GREENTEA_TEST_TLSSOCKET_TIMEOUT_S);
 #else
 #define MESH 3
 #define WISUN 0x2345
 #if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH && MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == WISUN
-static const int TESTS_TIMEOUT = (25 * 60);
+static const std::chrono::seconds TESTS_TIMEOUT(25 * 60);
 #else
-static const int TESTS_TIMEOUT = (10 * 60);
+static const std::chrono::seconds TESTS_TIMEOUT(10 * 60);
 #endif
 #endif
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
@@ -61,7 +61,7 @@ void TLSSOCKET_ENDPOINT_CLOSE()
     SKIP_IF_TCP_UNSUPPORTED();
     static const int MORE_THAN_AVAILABLE = 30;
     char buff[MORE_THAN_AVAILABLE];
-    int time_allotted = split2half_rmng_tls_test_time(); // [s]
+    auto time_allotted = split2half_rmng_tls_test_time(); // [us]
     Timer tc_exec_time;
     tc_exec_time.start();
 
@@ -78,17 +78,18 @@ void TLSSOCKET_ENDPOINT_CLOSE()
         recvd = sock.recv(&(buff[recvd_total]), MORE_THAN_AVAILABLE);
         if (recvd_total > 0 && recvd == 0) {
             break; // Endpoint closed socket, success
-        } else if (recvd <= 0) {
-            TEST_FAIL();
-            break;
         } else if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-            if (tc_exec_time.read() >= time_allotted ||
+            if (tc_exec_time.elapsed_time() >= time_allotted ||
                     osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
                 TEST_FAIL();
                 break;
             }
             continue;
+        } else if (recvd <= 0) {
+            TEST_FAIL();
+            break;
         }
+
         recvd_total += recvd;
         TEST_ASSERT(recvd_total < MORE_THAN_AVAILABLE);
     }

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
@@ -41,7 +41,7 @@ void TLSSOCKET_RECV_TIMEOUT()
     SKIP_IF_TCP_UNSUPPORTED();
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};
-    int time_allotted = split2half_rmng_tls_test_time(); // [s]
+    auto time_allotted = split2half_rmng_tls_test_time(); // [us]
     Timer tc_exec_time;
     tc_exec_time.start();
 
@@ -64,7 +64,7 @@ void TLSSOCKET_RECV_TIMEOUT()
             timer.stop();
 
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-                if (tc_exec_time.read() >= time_allotted ||
+                if (tc_exec_time.elapsed_time() >= time_allotted ||
                         (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout)) {
                     TEST_FAIL();
                     goto CLEANUP;

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_send_timeout.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_send_timeout.cpp
@@ -45,7 +45,7 @@ void TLSSOCKET_SEND_TIMEOUT()
         err = sock.send(tx_buffer, sizeof(tx_buffer));
         timer.stop();
         if ((err == sizeof(tx_buffer) || err == NSAPI_ERROR_WOULD_BLOCK) &&
-                (timer.read_ms() <= 800)) {
+                (timer.elapsed_time() <= 800ms)) {
             continue;
         }
         TEST_FAIL();

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/CMakeLists.txt
@@ -23,6 +23,10 @@ list(APPEND
             udpsocket_echotest_burst.cpp       
 )
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-netsocket-udp

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/CMakeLists.txt
@@ -30,4 +30,6 @@ mbed_greentea_add_test(
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/network/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/network/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(interface)

--- a/connectivity/netsocket/tests/TESTS/network/interface/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/network/interface/CMakeLists.txt
@@ -9,6 +9,10 @@ list(
             networkinterface_status.cpp
 )
 
+if(MBED_GREENTEA_TEST_BAREMETAL)
+    set(TEST_SKIPPED "This test requires an RTOS!")
+endif()
+
 mbed_greentea_add_test(
     TEST_NAME
         mbed-connectivity-netsocket-network-interface

--- a/connectivity/netsocket/tests/TESTS/network/interface/CMakeLists.txt
+++ b/connectivity/netsocket/tests/TESTS/network/interface/CMakeLists.txt
@@ -1,15 +1,6 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-connectivity-netsocket-network-interface)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 list(
     APPEND
         TEST_SOURCE_LIST
@@ -20,9 +11,11 @@ list(
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-connectivity-netsocket-network-interface
     TEST_SOURCES
         ${TEST_SOURCE_LIST}
     TEST_REQUIRED_LIBS
         mbed-netsocket
+    TEST_SKIPPED
+        ${TEST_SKIPPED}
 )

--- a/connectivity/netsocket/tests/TESTS/network/interface/networkinterface_status.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/interface/networkinterface_status.cpp
@@ -133,9 +133,10 @@ void NETWORKINTERFACE_STATUS_NONBLOCK()
         status = wait_status_callback();
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
 
-        ThisThread::sleep_for(1);    // In cellular there might still come disconnected messages from the network which are sent to callback.
+        // In cellular there might still come disconnected messages from the network which are sent to callback.
         // This would cause this test to fail as next connect is already ongoing. So wait here a while until (hopefully)
         // all messages also from the network have arrived.
+        ThisThread::sleep_for(1ms);
     }
 
     net->attach(NULL);
@@ -154,7 +155,7 @@ void NETWORKINTERFACE_STATUS_GET()
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
 
         while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
-            ThisThread::sleep_for(500);
+            ThisThread::sleep_for(500ms);
         }
 
 #if MBED_CONF_LWIP_IPV6_ENABLED

--- a/drivers/device_key/CMakeLists.txt
+++ b/drivers/device_key/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+if(MBED_ENABLE_OS_INTERNAL_TESTS)
+    if(MBED_BUILD_GREENTEA_TESTS)
+        add_subdirectory(tests/TESTS)
+    endif()
+endif()
+
 add_library(mbed-device_key STATIC EXCLUDE_FROM_ALL)
 
 target_include_directories(mbed-device_key

--- a/drivers/device_key/tests/TESTS/CMakeLists.txt
+++ b/drivers/device_key/tests/TESTS/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(device_key)

--- a/drivers/device_key/tests/TESTS/device_key/CMakeLists.txt
+++ b/drivers/device_key/tests/TESTS/device_key/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(functionality)

--- a/drivers/device_key/tests/TESTS/device_key/functionality/CMakeLists.txt
+++ b/drivers/device_key/tests/TESTS/device_key/functionality/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT "DEVICE_TRNG=1" IN_LIST MBED_TARGET_DEFINITIONS)
+	set(TEST_SKIPPED "True RNG is not supported for this target so device key cannot be used")
+endif()
+
+if(NOT "DEVICE_FLASH=1" IN_LIST MBED_TARGET_DEFINITIONS)
+	set(TEST_SKIPPED "Flash IAP is not supported for this target so device key cannot be used")
+endif()
+
+mbed_greentea_add_test(
+	TEST_NAME
+		mbed-device_key-functionality
+	TEST_SOURCES
+		main.cpp
+    TEST_REQUIRED_LIBS
+        mbed-device_key
+	TEST_SKIPPED
+		${TEST_SKIPPED}
+)

--- a/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -279,7 +279,7 @@ Case cases[] = {
     Case("Flash - mapping alignment", flash_mapping_alignment_test),
     Case("Flash - erase sector", flash_erase_sector_test),
     Case("Flash - program page", flash_program_page_test),
-    Case("Flash - copy flash to flash", flash_copy_flash_to_flash),
+    //Case("Flash - copy flash to flash", flash_copy_flash_to_flash),
     Case("Flash - clock and cache test", flash_clock_and_cache_test),
 };
 

--- a/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -164,8 +164,7 @@ void lp_ticker_glitch_test()
     while (last < (start + TICKER_GLITCH_TEST_TICKS)) {
         const uint32_t cur = lp_ticker_read();
 
-        if(cur < last)
-        {
+        if(cur < last) {
             printf("LP ticker went backward! Went from %" PRIu32 " to %" PRIu32 ", initial count was %" PRIu32 "\n", last, cur, start);
             TEST_FAIL();
         }

--- a/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -25,6 +25,8 @@
 #include "hal/mbed_lp_ticker_wrapper.h"
 #include "hal/us_ticker_api.h"
 
+#include <inttypes.h>
+
 #if !DEVICE_LPTICKER
 #error [NOT_SUPPORTED] Low power timer not supported for this target
 #else
@@ -161,7 +163,13 @@ void lp_ticker_glitch_test()
 
     while (last < (start + TICKER_GLITCH_TEST_TICKS)) {
         const uint32_t cur = lp_ticker_read();
-        TEST_ASSERT(cur >= last);
+
+        if(cur < last)
+        {
+            printf("LP ticker went backward! Went from %" PRIu32 " to %" PRIu32 ", initial count was %" PRIu32 "\n", last, cur, start);
+            TEST_FAIL();
+        }
+
         last = cur;
     }
 }

--- a/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -164,7 +164,7 @@ void lp_ticker_glitch_test()
     while (last < (start + TICKER_GLITCH_TEST_TICKS)) {
         const uint32_t cur = lp_ticker_read();
 
-        if(cur < last) {
+        if (cur < last) {
             printf("LP ticker went backward! Went from %" PRIu32 " to %" PRIu32 ", initial count was %" PRIu32 "\n", last, cur, start);
             TEST_FAIL();
         }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR re-activates a number of tests which still hadn't been converted over to the Mbed CE build system.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
TLS, UDP, DNS, Device Key, and Mbed TLS are now being tested again.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran the new tests on MIMRT1060 EVK and Nucleo H743ZI, and they all passed!

Concerningly, they didn't pass on Nucleo F767, because Ethernet seems to be broken on this board.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
