### PR TITLE
Fix STM32 I2C v2 async transfer not doing a repeated start

### DIFF
--- a/drivers/include/drivers/I2C.h
+++ b/drivers/include/drivers/I2C.h
@@ -377,7 +377,8 @@ public:
      *
      * The %I2C peripheral will begin a transmit and/or receive operation in the background.  If only a transmit
      * or receive buffer is specified, only a transmit or receive will be done.  If both buffers are specified,
-     * first the transmission is done to the given slave address, then the specified number of bytes are received.
+     * first the transmission is done to the given slave address, then the MCU performs a repeated start
+     * and the specified number of bytes are received.
      *
      * If you wish to find out when the transfer is done, pass a callback function to the callback argument
      * and set the event argument to the events you wish to receive.
@@ -400,7 +401,7 @@ public:
      *        of the flags I2C_EVENT_ERROR, I2C_EVENT_ERROR_NO_SLAVE, I2C_EVENT_TRANSFER_COMPLETE, or I2C_EVENT_TRANSFER_EARLY_NACK
      * @param callback  The event callback function
      * @param repeated Set up for a repeated start.  If true, the Mbed processor does not relinquish the bus after
-     *       this write operation.  You may then call write(), read(), or start() again to start another operation.
+     *       this operation.  You may then call write(), read(), start(), or transfer() again to start another operation.
      *
      * @returns Zero if the transfer has started, or -1 if I2C peripheral is busy
      */
@@ -415,7 +416,8 @@ public:
      *
      * The %I2C peripheral will begin a transmit and/or receive operation in the background.  If only a transmit
      * or receive buffer is specified, only a transmit or receive will be done.  If both buffers are specified,
-     * first the transmission is done to the given slave address, then the specified number of bytes are received.
+     * first the transmission is done to the given slave address, then the MCU performs a repeated start
+     * and the specified number of bytes are received.
      *
      * Internally, the chip vendor may implement this function using either DMA or interrupts.
      *
@@ -428,7 +430,7 @@ public:
      * @param rx_length The length of RX buffer in bytes  If 0, no reception is done.
      * @param timeout timeout value.  Use #rtos::Kernel::wait_for_u32_forever to wait forever (the default).
      * @param repeated Set up for a repeated start.  If true, the Mbed processor does not relinquish the bus after
-     *       this operation.  You may then call write(), read(), or start() again to start another operation.
+     *       this operation.  You may then call write(), read(), start(), or transfer() again to start another operation.
      *
      * @returns Result code describing whether the transfer succeeded or not.
      */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Found a minor I2C issue when doing testing with the CI shield v2.  When you do an I2C async transfer that is both a write and a read, it should do the write first, then a repeated start, then the read.  This is worth doing for 3 reasons:
1. It's slightly more efficient in terms of data rate on the bus
2. In multi-master applications, it ensures that nothing else can use the bus between the write and the read
3. A small percentage of chips (e.g. the U-Blox MAX-8) require repeated starts and won't work without them.

However, the stm32 I2C HAL was not doing repeated starts, and instead was generating something like
```
Start Wr[0xa0] Ack 0x00 Ack 0x01 Ack Stop Start Rd[0xa1] Ack 0x02 Nack Stop
```
Now, with this patch, a single transfer call always does a repeated start:
```
Start Wr[0xa0] Ack 0x00 Ack 0x01 Ack RepeatedStart Rd[0xa1] Ack 0x02 Nack Stop
```
(this is using the Sigrok logic analyzer on the new CI shield to decode and evaluate I2C data).

#### Impact of changes <!-- Optional -->
Async transfers containing a write and a read now do repeated starts on STM32 I2C v2 hardware.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

Docs have been slightly updated to clarify that this transfer() does a repeated start.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
