### PR TITLE
Make DMA SPI driver aware of CPU cache, fix data corruption and other SPI issues on STM32H7

### DIFF
--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -478,7 +478,7 @@ public:
      */
     template<typename WordT, size_t RxBufferLen>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> & rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
         return transfer_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, callback, event);
     }
@@ -486,7 +486,7 @@ public:
     // Overloads of the above to support passing nullptr
     template<typename WordT, size_t RxBufferLen>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> & rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
         return transfer_internal(tx_buffer, tx_length, rx_buffer, rx_length, callback, event);
     }
@@ -524,7 +524,7 @@ public:
      */
     template<typename WordT, size_t RxBufferLen>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> & rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, timeout);
     }
@@ -532,7 +532,7 @@ public:
     // Overloads of the above to support passing nullptr
     template<typename WordT, size_t RxBufferLen>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> & rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, timeout);
     }
@@ -741,7 +741,7 @@ protected:
 #if __DCACHE_PRESENT
     // These variables store the location and length in bytes of the Rx buffer if an async transfer
     // is in progress.  They are used for invalidating the cache after the transfer completes.
-    void * _transfer_in_progress_rx_buffer;
+    void *_transfer_in_progress_rx_buffer;
     size_t _transfer_in_progress_rx_len;
 #endif
 

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -195,6 +195,11 @@ const use_gpio_ssel_t use_gpio_ssel;
  * the transfer but others can execute).  Here's a sample of how to send the same data as above
  * using the blocking async API:</p>
  *
+ * <p>Note that when using the asynchronous API, you must use the CacheAlignedBuffer class when declaring the
+ * receive buffer.  This is because some processors' async SPI implementations require the received buffer to
+ * be at an address which is aligned to the processor cache line size.  CacheAlignedBuffer takes care of this
+ * for you and provides functions (data(), begin(), end()) to access the underlying data in the buffer.</p>
+ *
  * @code
  * #include "mbed.h"
  *
@@ -204,8 +209,8 @@ const use_gpio_ssel_t use_gpio_ssel;
  *     device.format(8, 0);
  *
  *     uint8_t command[2] = {0x0A, 0x0B};
- *     uint8_t response[2];
- *     int result = device.transfer_and_wait(command, sizeof(command), response, sizeof(response));
+ *     CacheAlignedBuffer<uint8_t, 2> response;
+ *     int result = device.transfer_and_wait(command, sizeof(command), response, sizeof(command));
  * }
  * @endcode
  *

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -476,18 +476,20 @@ public:
      * @retval 0 If the transfer has started.
      * @retval -1 if the transfer could not be enqueued (increase drivers.spi_transaction_queue_len option)
      */
-    template<typename WordT, size_t RxBufferLen>
+    template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
+        MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
         return transfer_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, callback, event);
     }
 
     // Overloads of the above to support passing nullptr
-    template<typename WordT, size_t RxBufferLen>
+    template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
+        MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
         return transfer_internal(tx_buffer, tx_length, rx_buffer, rx_length, callback, event);
     }
     template<typename WordT>
@@ -522,18 +524,20 @@ public:
      * @retval 2 on other error
      * @retval 0 on success
      */
-    template<typename WordT, size_t RxBufferLen>
+    template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const WordT *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
+        MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, timeout);
     }
 
     // Overloads of the above to support passing nullptr
-    template<typename WordT, size_t RxBufferLen>
+    template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT, RxBufferLen> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
+        MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, timeout);
     }
     template<typename WordT>

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -396,6 +396,17 @@ void SPI::abort_transfer()
             _set_ssel(1);
         }
 
+#if __DCACHE_PRESENT
+        if(_transfer_in_progress_uses_dma)
+        {
+            // If the cache is present, invalidate the Rx data so it's loaded from main RAM.
+            // We only want to do this if DMA actually got used for the transfer because, if interrupts
+            // were used instead, the cache might have the correct data and NOT the main memory.
+            SCB_InvalidateDCache_by_Addr(_transfer_in_progress_rx_buffer, _transfer_in_progress_rx_len);
+        }
+#endif
+        _transfer_in_progress = false;
+
 #if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
         dequeue_transaction();
 #endif
@@ -466,8 +477,33 @@ void SPI::start_transfer(const void *tx_buffer, int tx_length, void *rx_buffer, 
 
     _callback = callback;
     _irq.callback(&SPI::irq_handler_asynch);
+
+#if __DCACHE_PRESENT
+    // On devices with a cache, we need to carefully manage the Tx and Rx buffer cache invalidation.
+    // We can assume that asynchronous SPI implementations might rely on DMA, and that DMA will
+    // not interoperate with the CPU cache.  So, manual flushing/invalidation will be required.
+    // This page is very useful for how to do this correctly:
+    // https://community.st.com/t5/stm32-mcus-products/maintaining-cpu-data-cache-coherence-for-dma-buffers/td-p/95746
+    if(tx_length > 0)
+    {
+        // For chips with a cache, we need to evict the Tx data from cache to main memory.
+        // This ensures that the DMA controller can see the most up-to-date copy of the data.
+        SCB_CleanDCache_by_Addr(const_cast<void*>(tx_buffer), tx_length);
+    }
+
+    // Additionally, we have to make sure that there aren't any pending changes which could be written back
+    // to the Rx buffer memory by the cache at a later date, corrupting the DMA results
+    if(rx_length > 0)
+    {
+        SCB_CleanInvalidateDCache_by_Addr(rx_buffer, rx_length);
+    }
+    _transfer_in_progress_rx_buffer = rx_buffer;
+    _transfer_in_progress_rx_len = rx_length;
+#endif
+
     _transfer_in_progress = true;
-    spi_master_transfer(&_peripheral->spi, tx_buffer, tx_length, rx_buffer, rx_length, bit_width, _irq.entry(), event, _usage);
+
+    _transfer_in_progress_uses_dma = spi_master_transfer(&_peripheral->spi, tx_buffer, tx_length, rx_buffer, rx_length, bit_width, _irq.entry(), event, _usage);
 }
 
 void SPI::lock_deep_sleep()
@@ -508,7 +544,18 @@ void SPI::dequeue_transaction()
 void SPI::irq_handler_asynch(void)
 {
     int event = spi_irq_handler_asynch(&_peripheral->spi);
-    if (_callback && (event & SPI_EVENT_ALL)) {
+    if ((event & SPI_EVENT_ALL)) {
+
+#if __DCACHE_PRESENT
+        if(_transfer_in_progress_uses_dma)
+        {
+            // If the cache is present, invalidate the Rx data so it's loaded from main RAM.
+            // We only want to do this if DMA actually got used for the transfer because, if interrupts
+            // were used instead, the cache might have the correct data and NOT the main memory.
+            SCB_InvalidateDCache_by_Addr(_transfer_in_progress_rx_buffer, _transfer_in_progress_rx_len);
+        }
+#endif
+
         // If using GPIO CS mode, unless we were asked to keep the peripheral selected, deselect it.
         // If there's another transfer queued, we *do* want to deselect the peripheral now.
         // It will be reselected in start_transfer() which is called by dequeue_transaction() below.
@@ -518,7 +565,11 @@ void SPI::irq_handler_asynch(void)
         _transfer_in_progress = false;
 
         unlock_deep_sleep();
-        _callback.call(event & SPI_EVENT_ALL);
+
+        if(_callback)
+        {
+            _callback.call(event & SPI_EVENT_ALL);
+        }
     }
 #if MBED_CONF_DRIVERS_SPI_TRANSACTION_QUEUE_LEN
     if (event & (SPI_EVENT_ALL | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE)) {

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -397,8 +397,7 @@ void SPI::abort_transfer()
         }
 
 #if __DCACHE_PRESENT
-        if(_transfer_in_progress_uses_dma && _transfer_in_progress_rx_len > 0)
-        {
+        if (_transfer_in_progress_uses_dma && _transfer_in_progress_rx_len > 0) {
             // If the cache is present, invalidate the Rx data so it's loaded from main RAM.
             // We only want to do this if DMA actually got used for the transfer because, if interrupts
             // were used instead, the cache might have the correct data and NOT the main memory.
@@ -484,17 +483,15 @@ void SPI::start_transfer(const void *tx_buffer, int tx_length, void *rx_buffer, 
     // not interoperate with the CPU cache.  So, manual flushing/invalidation will be required.
     // This page is very useful for how to do this correctly:
     // https://community.st.com/t5/stm32-mcus-products/maintaining-cpu-data-cache-coherence-for-dma-buffers/td-p/95746
-    if(tx_length > 0)
-    {
+    if (tx_length > 0) {
         // For chips with a cache, we need to evict the Tx data from cache to main memory.
         // This ensures that the DMA controller can see the most up-to-date copy of the data.
-        SCB_CleanDCache_by_Addr(const_cast<void*>(tx_buffer), tx_length);
+        SCB_CleanDCache_by_Addr(const_cast<void *>(tx_buffer), tx_length);
     }
 
     // Additionally, we have to make sure that there aren't any pending changes which could be written back
     // to the Rx buffer memory by the cache at a later date, corrupting the DMA results.
-    if(rx_length > 0)
-    {
+    if (rx_length > 0) {
         SCB_InvalidateDCache_by_Addr(rx_buffer, rx_length);
     }
     _transfer_in_progress_rx_buffer = rx_buffer;
@@ -547,8 +544,7 @@ void SPI::irq_handler_asynch(void)
     if ((event & SPI_EVENT_ALL)) {
 
 #if __DCACHE_PRESENT
-        if(_transfer_in_progress_uses_dma && _transfer_in_progress_rx_len > 0)
-        {
+        if (_transfer_in_progress_uses_dma && _transfer_in_progress_rx_len > 0) {
             // If the cache is present, invalidate the Rx data so it's loaded from main RAM.
             // We only want to do this if DMA actually got used for the transfer because, if interrupts
             // were used instead, the cache might have the correct data and NOT the main memory.
@@ -566,8 +562,7 @@ void SPI::irq_handler_asynch(void)
 
         unlock_deep_sleep();
 
-        if(_callback)
-        {
+        if (_callback) {
             _callback.call(event & SPI_EVENT_ALL);
         }
     }

--- a/platform/include/platform/CacheAlignedBuffer.h
+++ b/platform/include/platform/CacheAlignedBuffer.h
@@ -57,7 +57,7 @@ private:
     constexpr static size_t requiredSizeRoundedUp =  (BufferSize * sizeof(DataT) + __SCB_DCACHE_LINE_SIZE - 1) & ~((__SCB_DCACHE_LINE_SIZE) - 1);
     constexpr static size_t backingBufferSizeBytes = requiredSizeRoundedUp + __SCB_DCACHE_LINE_SIZE - 1;
 #else
-    constexpr static size_t backingBufferSize = BufferSize * sizeof(DataT);
+    constexpr static size_t backingBufferSizeBytes = BufferSize * sizeof(DataT);
 #endif
 
     uint8_t _backingBuffer[backingBufferSizeBytes];

--- a/platform/include/platform/CacheAlignedBuffer.h
+++ b/platform/include/platform/CacheAlignedBuffer.h
@@ -28,8 +28,11 @@ namespace mbed {
 /**
  * @brief CacheAlignedBuffer is used by Mbed in locations where we need a cache-aligned buffer.
  *
- * Cache alignment is desirable in several different situations in embedded programming; often
- * when working with DMA or other peripherals which write their results back to main memory.
+ * Cache alignment is desirable in several different situations in embedded programming -- one common
+ * use is when working with DMA or other peripherals which write their results back to main memory.
+ * After these peripherals do their work, the data will be correct in main memory, but the CPU cache
+ * might also contain a value cached from that memory which is now incorrect.
+ *
  * In order to read those results from memory without risk of getting old data from the
  * CPU cache, one needs to align the buffer so it takes up an integer number of cache lines,
  * then invalidate the cache lines so that the data gets reread from RAM.
@@ -43,7 +46,7 @@ namespace mbed {
  */
 template<typename DataT, size_t BufferSize>
 struct
-CacheAlignedBuffer {
+    CacheAlignedBuffer {
 private:
 #if __DCACHE_PRESENT
     // Allocate enough extra space that we can shift the start of the buffer forward to be on a cache line.
@@ -54,14 +57,14 @@ private:
     // So, we need to round up the backing buffer size to the nearest multiple of the cache line size.
     // The math for rounding up can be found here:
     // https://community.st.com/t5/stm32-mcus-products/maintaining-cpu-data-cache-coherence-for-dma-buffers/td-p/95746
-    constexpr static size_t requiredSizeRoundedUp =  (BufferSize * sizeof(DataT) + __SCB_DCACHE_LINE_SIZE - 1) & ~((__SCB_DCACHE_LINE_SIZE) - 1);
+    constexpr static size_t requiredSizeRoundedUp = (BufferSize *sizeof(DataT) + __SCB_DCACHE_LINE_SIZE - 1) & ~((__SCB_DCACHE_LINE_SIZE) - 1);
     constexpr static size_t backingBufferSizeBytes = requiredSizeRoundedUp + __SCB_DCACHE_LINE_SIZE - 1;
 #else
     constexpr static size_t backingBufferSizeBytes = BufferSize * sizeof(DataT);
 #endif
 
     uint8_t _backingBuffer[backingBufferSizeBytes];
-    DataT * _alignedArrayPtr;
+    DataT *_alignedArrayPtr;
 
     /**
      * Find and return the first location in the given buffer that starts on a cache line.
@@ -71,7 +74,7 @@ private:
      *
      * @return Pointer to first data item, aligned at the start of a cache line.
      */
-    inline DataT * findCacheLineStart(uint8_t * buffer)
+    inline DataT *findCacheLineStart(uint8_t *buffer)
     {
 #if __DCACHE_PRESENT
         // Use integer division to divide the address down to the cache line size, which
@@ -90,22 +93,22 @@ private:
 public:
 
     // Iterator types
-    typedef DataT * iterator;
-    typedef DataT const * const_iterator;
+    typedef DataT *iterator;
+    typedef DataT const *const_iterator;
 
     /**
      * @brief Construct new cache-aligned buffer.  Buffer will be zero-initialized.
      */
     CacheAlignedBuffer():
-    _backingBuffer{},
-    _alignedArrayPtr(findCacheLineStart(_backingBuffer))
+        _backingBuffer{},
+        _alignedArrayPtr(findCacheLineStart(_backingBuffer))
     {}
 
     /**
      * @brief Copy from other cache-aligned buffer.  Buffer memory will be copied.
      */
-    CacheAlignedBuffer(CacheAlignedBuffer const & other):
-    _alignedArrayPtr(findCacheLineStart(_backingBuffer))
+    CacheAlignedBuffer(CacheAlignedBuffer const &other):
+        _alignedArrayPtr(findCacheLineStart(_backingBuffer))
     {
         memcpy(this->_alignedArrayPtr, other._alignedArrayPtr, BufferSize * sizeof(DataT));
     }
@@ -113,7 +116,7 @@ public:
     /**
      * @brief Assign from other cache-aligned buffer.  Buffer memory will be assigned.
      */
-    CacheAlignedBuffer & operator=(CacheAlignedBuffer const & other)
+    CacheAlignedBuffer &operator=(CacheAlignedBuffer const &other)
     {
         memcpy(this->_alignedArrayPtr, other._alignedArrayPtr, BufferSize * sizeof(DataT));
     }
@@ -121,47 +124,74 @@ public:
     /**
      * @brief Get a pointer to the aligned data array inside the buffer
      */
-    DataT * data() { return _alignedArrayPtr; }
+    DataT *data()
+    {
+        return _alignedArrayPtr;
+    }
 
     /**
      * @brief Get a pointer to the aligned data array inside the buffer (const version)
      */
-    DataT const * data() const { return _alignedArrayPtr; }
+    DataT const *data() const
+    {
+        return _alignedArrayPtr;
+    }
 
     /**
      * @brief Element access
      */
-    DataT & operator[](size_t index) { return _alignedArrayPtr[index]; }
+    DataT &operator[](size_t index)
+    {
+        return _alignedArrayPtr[index];
+    }
 
     /**
      * @brief Element access (const)
      */
-    DataT operator[](size_t index) const { return _alignedArrayPtr[index]; }
+    DataT operator[](size_t index) const
+    {
+        return _alignedArrayPtr[index];
+    }
 
     /**
      * @brief Get iterator for start of buffer
      */
-    iterator begin() { return _alignedArrayPtr; }
+    iterator begin()
+    {
+        return _alignedArrayPtr;
+    }
 
     /**
      * @brief Get iterator for start of buffer
      */
-    const_iterator begin() const { return _alignedArrayPtr; }
+    const_iterator begin() const
+    {
+        return _alignedArrayPtr;
+    }
 
     /**
      * @brief Get iterator for end of buffer
      */
-    iterator end() { return _alignedArrayPtr + BufferSize; }
+    iterator end()
+    {
+        return _alignedArrayPtr + BufferSize;
+    }
 
     /**
      * @brief Get iterator for end of buffer
      */
-    const_iterator end() const { return _alignedArrayPtr + BufferSize; }
+    const_iterator end() const
+    {
+        return _alignedArrayPtr + BufferSize;
+    }
 
     /**
      * @return The maximum amount of DataT elements that this buffer can hold
      */
-    constexpr size_t capacity() { return BufferSize; }
+    constexpr size_t capacity()
+    {
+        return BufferSize;
+    }
 
     /**
      * @brief If this MCU has a data cache, this function _invalidates_ the buffer in the data cache.

--- a/platform/include/platform/CacheAlignedBuffer.h
+++ b/platform/include/platform/CacheAlignedBuffer.h
@@ -79,27 +79,27 @@ constexpr inline size_t getNeededBackingBufferSize(size_t neededCapacity, size_t
  *
  * <h2> Converting Code to use CacheAlignedBuffer </h2>
  * For code using static arrays, like this:
- * \code{.cpp}
+ * @code
  * uint8_t rxBuffer[16];
  * spi.transfer_and_wait(nullptr, 0, rxBuffer, 16);
- * \endcode
+ * @endcode
  * Use a StaticCacheAlignedBuffer:
- * \code{.cpp}
+ * @code
  * StaticCacheAlignedBuffer<uint8_t, 16> rxBuffer;
  * spi.transfer_and_wait(nullptr, 0, rxBuffer, 16);
- * \endcode
+ * @endcode
  * For code using dynamic allocation to handle unknown buffer sizes, like:
- * \code{.cpp}
+ * @code
  * uint16_t * rxBuffer = new uint16_t[bufferSize];
  * spi.transfer_and_wait(nullptr, 0, rxBuffer, bufferSize);
  * ...
  * delete[] rxBuffer;
- * \endcode
+ * @endcode
  * use a DynamicCacheAlignedBuffer:
- * \code{.cpp}
+ * @code
  * DynamicCacheAlignedBuffer<uint16_t> rxBuffer(bufferSize);
  * spi.transfer_and_wait(nullptr, 0, rxBuffer, bufferSize);
- * \endcode
+ * @endcode
  *
  * @tparam DataT Type of the data to store in the buffer.  Note: %CacheAlignedBuffer is not designed for
  *    using class types as DataT, and will not call constructors.

--- a/platform/include/platform/CacheAlignedBuffer.h
+++ b/platform/include/platform/CacheAlignedBuffer.h
@@ -1,0 +1,183 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2023 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_CACHEALIGNEDBUFFER_H
+#define MBED_CACHEALIGNEDBUFFER_H
+
+#include <cstdlib>
+
+#include "device.h"
+
+namespace mbed {
+
+
+/**
+ * @brief CacheAlignedBuffer is used by Mbed in locations where we need a cache-aligned buffer.
+ *
+ * Cache alignment is desirable in several different situations in embedded programming; often
+ * when working with DMA or other peripherals which write their results back to main memory.
+ * In order to read those results from memory without risk of getting old data from the
+ * CPU cache, one needs to align the buffer so it takes up an integer number of cache lines,
+ * then invalidate the cache lines so that the data gets reread from RAM.
+ *
+ * CacheAlignedBuffer provides an easy way to allocate the correct amount of space so that
+ * a buffer of any size can be made cache-aligned.
+ *
+ * @tparam DataT Type of the data to store in the buffer.  Note: %CacheAlignedBuffer is not designed for
+ *    using class types as DataT, and will not call constructors.
+ * @tparam BufferSize Buffer size (number of elements) needed by the application for the buffer.
+ */
+template<typename DataT, size_t BufferSize>
+struct
+CacheAlignedBuffer {
+private:
+#if __DCACHE_PRESENT
+    // Allocate enough extra space that we can shift the start of the buffer forward to be on a cache line.
+    // The worst case for this is when the first byte is allocated 1 byte past the start of a cache line, so we
+    // will need an additional (cache line size - 1) bytes.
+    // Additionally, since we are going to be invalidating this buffer, we can't allow any other variables to be
+    // in the same cache lines, or they might get corrupted.
+    // So, we need to round up the backing buffer size to the nearest multiple of the cache line size.
+    // The math for rounding up can be found here:
+    // https://community.st.com/t5/stm32-mcus-products/maintaining-cpu-data-cache-coherence-for-dma-buffers/td-p/95746
+    constexpr static size_t requiredSizeRoundedUp =  (BufferSize * sizeof(DataT) + __SCB_DCACHE_LINE_SIZE - 1) & ~((__SCB_DCACHE_LINE_SIZE) - 1);
+    constexpr static size_t backingBufferSizeBytes = requiredSizeRoundedUp + __SCB_DCACHE_LINE_SIZE - 1;
+#else
+    constexpr static size_t backingBufferSize = BufferSize * sizeof(DataT);
+#endif
+
+    uint8_t _backingBuffer[backingBufferSizeBytes];
+    DataT * _alignedArrayPtr;
+
+    /**
+     * Find and return the first location in the given buffer that starts on a cache line.
+     * If this MCU does not use a cache, this function is a no-op.
+     *
+     * @param buffer Pointer to buffer
+     *
+     * @return Pointer to first data item, aligned at the start of a cache line.
+     */
+    inline DataT * findCacheLineStart(uint8_t * buffer)
+    {
+#if __DCACHE_PRESENT
+        // Use integer division to divide the address down to the cache line size, which
+        // rounds to the cache line before the given address.
+        // So that we always go one cache line back even if the given address is on a cache line,
+        // subtract 1.
+        ptrdiff_t prevCacheLine = ((ptrdiff_t)(buffer - 1)) / __SCB_DCACHE_LINE_SIZE;
+
+        // Now we just have to multiply up again to get an address (adding 1 to go forward by 1 cache line)
+        return reinterpret_cast<DataT *>((prevCacheLine + 1) * __SCB_DCACHE_LINE_SIZE);
+#else
+        return reinterpret_cast<DataT *>(buffer);
+#endif
+    }
+
+public:
+
+    // Iterator types
+    typedef DataT * iterator;
+    typedef DataT const * const_iterator;
+
+    /**
+     * @brief Construct new cache-aligned buffer.  Buffer will be zero-initialized.
+     */
+    CacheAlignedBuffer():
+    _backingBuffer{},
+    _alignedArrayPtr(findCacheLineStart(_backingBuffer))
+    {}
+
+    /**
+     * @brief Copy from other cache-aligned buffer.  Buffer memory will be copied.
+     */
+    CacheAlignedBuffer(CacheAlignedBuffer const & other):
+    _alignedArrayPtr(findCacheLineStart(_backingBuffer))
+    {
+        memcpy(this->_alignedArrayPtr, other._alignedArrayPtr, BufferSize * sizeof(DataT));
+    }
+
+    /**
+     * @brief Assign from other cache-aligned buffer.  Buffer memory will be assigned.
+     */
+    CacheAlignedBuffer & operator=(CacheAlignedBuffer const & other)
+    {
+        memcpy(this->_alignedArrayPtr, other._alignedArrayPtr, BufferSize * sizeof(DataT));
+    }
+
+    /**
+     * @brief Get a pointer to the aligned data array inside the buffer
+     */
+    DataT * data() { return _alignedArrayPtr; }
+
+    /**
+     * @brief Get a pointer to the aligned data array inside the buffer (const version)
+     */
+    DataT const * data() const { return _alignedArrayPtr; }
+
+    /**
+     * @brief Element access
+     */
+    DataT & operator[](size_t index) { return _alignedArrayPtr[index]; }
+
+    /**
+     * @brief Element access (const)
+     */
+    DataT operator[](size_t index) const { return _alignedArrayPtr[index]; }
+
+    /**
+     * @brief Get iterator for start of buffer
+     */
+    iterator begin() { return _alignedArrayPtr; }
+
+    /**
+     * @brief Get iterator for start of buffer
+     */
+    const_iterator begin() const { return _alignedArrayPtr; }
+
+    /**
+     * @brief Get iterator for end of buffer
+     */
+    iterator end() { return _alignedArrayPtr + BufferSize; }
+
+    /**
+     * @brief Get iterator for end of buffer
+     */
+    const_iterator end() const { return _alignedArrayPtr + BufferSize; }
+
+    /**
+     * @return The maximum amount of DataT elements that this buffer can hold
+     */
+    constexpr size_t capacity() { return BufferSize; }
+
+    /**
+     * @brief If this MCU has a data cache, this function _invalidates_ the buffer in the data cache.
+     *
+     * Invalidation means that the next time code access the buffer data, it is guaranteed to be fetched from
+     * main memory rather than from the CPU cache.  If there are changes made to the data which have not been
+     * flushed back to main memory, those changes will be lost!
+     */
+    void invalidate()
+    {
+#if __DCACHE_PRESENT
+        SCB_InvalidateDCache_by_Addr(_alignedArrayPtr, BufferSize * sizeof(DataT));
+#endif
+    }
+};
+
+}
+
+#endif //MBED_CACHEALIGNEDBUFFER_H

--- a/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
@@ -57,6 +57,10 @@
  * Access an SD Card using SPI bus
  */
 class SDBlockDevice : public mbed::BlockDevice {
+
+    // Only HC block size is supported. Making this a static constant reduces code size.
+    static constexpr uint32_t _block_size = 512; /*!< Block size supported for SDHC card is 512 bytes  */
+
 public:
     /** Creates an SDBlockDevice on a SPI bus specified by pins (using dynamic pin-map)
      *
@@ -302,7 +306,6 @@ private:
     }
 
     rtos::Mutex _mutex;
-    static const uint32_t _block_size;
     uint32_t _erase_size;
     bool _is_initialized;
     bool _dbg;
@@ -314,6 +317,7 @@ private:
 
 #if DEVICE_SPI_ASYNCH
     bool _async_spi_enabled = false;
+    mbed::CacheAlignedBuffer<uint8_t, _block_size> _async_data_buffer;
 #endif
 };
 

--- a/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
@@ -317,7 +317,7 @@ private:
 
 #if DEVICE_SPI_ASYNCH
     bool _async_spi_enabled = false;
-    mbed::CacheAlignedBuffer<uint8_t, _block_size> _async_data_buffer;
+    mbed::StaticCacheAlignedBuffer<uint8_t, _block_size> _async_data_buffer;
 #endif
 };
 

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -1078,7 +1078,7 @@ bd_size_t SDBlockDevice::_sd_sectors()
         return 0;
     }
 #ifdef DEVICE_SPI_ASYNCH
-    CacheAlignedBuffer<uint8_t, 16> csd_buffer;
+    StaticCacheAlignedBuffer<uint8_t, 16> csd_buffer;
     uint8_t *csd = csd_buffer.data();
 #else
     uint8_t csd[16];

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -921,8 +921,7 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
     // read data
 #if DEVICE_SPI_ASYNCH
     if (_async_spi_enabled) {
-        if(length > _async_data_buffer.capacity())
-        {
+        if (length > _async_data_buffer.capacity()) {
             return SD_BLOCK_DEVICE_ERROR_PARAMETER;
         }
 
@@ -973,8 +972,7 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
     // read data
 #if DEVICE_SPI_ASYNCH
     if (_async_spi_enabled) {
-        if(length > _async_data_buffer.capacity())
-        {
+        if (length > _async_data_buffer.capacity()) {
             return SD_BLOCK_DEVICE_ERROR_PARAMETER;
         }
 
@@ -1081,7 +1079,7 @@ bd_size_t SDBlockDevice::_sd_sectors()
     }
 #ifdef DEVICE_SPI_ASYNCH
     CacheAlignedBuffer<uint8_t, 16> csd_buffer;
-    uint8_t * csd = csd_buffer.data();
+    uint8_t *csd = csd_buffer.data();
 #else
     uint8_t csd[16];
 #endif

--- a/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_SD/source/SDBlockDevice.cpp
@@ -181,7 +181,6 @@ using namespace std::chrono;
 #define SD_BLOCK_DEVICE_ERROR_ERASE              -5010  /*!< Erase error: reset/sequence */
 #define SD_BLOCK_DEVICE_ERROR_WRITE              -5011  /*!< SPI Write error: !SPI_DATA_ACCEPTED */
 
-#define BLOCK_SIZE_HC                            512    /*!< Block size supported for SD card is 512 bytes  */
 #define WRITE_BL_PARTIAL                         0      /*!< Partial block write - Not supported */
 #define SPI_CMD(x) (0x40 | (x & 0x3f))
 
@@ -248,9 +247,6 @@ using namespace std::chrono;
 #define SPI_READ_ERROR_ECC_C     (0x1 << 2)  /*!< Card ECC failed */
 #define SPI_READ_ERROR_OFR       (0x1 << 3)  /*!< Out of Range */
 
-// Only HC block size is supported. Making this a static constant reduces code size.
-const uint32_t SDBlockDevice::_block_size = BLOCK_SIZE_HC;
-
 #if MBED_CONF_SD_CRC_ENABLED
 SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(mosi, miso, sclk, cs, use_gpio_ssel), _is_initialized(0),
@@ -269,7 +265,7 @@ SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName c
     _init_sck = MBED_CONF_SD_INIT_FREQUENCY;
     _transfer_sck = hz;
 
-    _erase_size = BLOCK_SIZE_HC;
+    _erase_size = _block_size;
 }
 
 #if MBED_CONF_SD_CRC_ENABLED
@@ -290,7 +286,7 @@ SDBlockDevice::SDBlockDevice(const spi_pinmap_t &spi_pinmap, PinName cs, uint64_
     _init_sck = MBED_CONF_SD_INIT_FREQUENCY;
     _transfer_sck = hz;
 
-    _erase_size = BLOCK_SIZE_HC;
+    _erase_size = _block_size;
 }
 
 SDBlockDevice::~SDBlockDevice()
@@ -925,7 +921,16 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
     // read data
 #if DEVICE_SPI_ASYNCH
     if (_async_spi_enabled) {
-        _spi.transfer_and_wait(nullptr, 0, buffer, length);
+        if(length > _async_data_buffer.capacity())
+        {
+            return SD_BLOCK_DEVICE_ERROR_PARAMETER;
+        }
+
+        // Do read into cache aligned buffer, then copy data into application buffer
+        if (_spi.transfer_and_wait(nullptr, 0, _async_data_buffer, length) != 0) {
+            return SD_BLOCK_DEVICE_ERROR_WRITE;
+        }
+        memcpy(buffer, _async_data_buffer.data(), length);
     } else
 #endif
     {
@@ -968,9 +973,16 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
     // read data
 #if DEVICE_SPI_ASYNCH
     if (_async_spi_enabled) {
-        if (_spi.transfer_and_wait(nullptr, 0, buffer, length) != 0) {
+        if(length > _async_data_buffer.capacity())
+        {
+            return SD_BLOCK_DEVICE_ERROR_PARAMETER;
+        }
+
+        // Do read into cache aligned buffer, then copy data into application buffer
+        if (_spi.transfer_and_wait(nullptr, 0, _async_data_buffer, length) != 0) {
             return SD_BLOCK_DEVICE_ERROR_WRITE;
         }
+        memcpy(buffer, _async_data_buffer.data(), length);
     } else
 #endif
     {
@@ -1067,7 +1079,13 @@ bd_size_t SDBlockDevice::_sd_sectors()
         debug_if(SD_DBG, "Didn't get a response from the disk\n");
         return 0;
     }
+#ifdef DEVICE_SPI_ASYNCH
+    CacheAlignedBuffer<uint8_t, 16> csd_buffer;
+    uint8_t * csd = csd_buffer.data();
+#else
     uint8_t csd[16];
+#endif
+
     if (_read_bytes(csd, 16) != 0) {
         debug_if(SD_DBG, "Couldn't read csd response from disk\n");
         return 0;
@@ -1091,10 +1109,10 @@ bd_size_t SDBlockDevice::_sd_sectors()
 
             // ERASE_BLK_EN = 1: Erase in multiple of 512 bytes supported
             if (ext_bits(csd, 46, 46)) {
-                _erase_size = BLOCK_SIZE_HC;
+                _erase_size = _block_size;
             } else {
                 // ERASE_BLK_EN = 1: Erase in multiple of SECTOR_SIZE supported
-                _erase_size = BLOCK_SIZE_HC * (ext_bits(csd, 45, 39) + 1);
+                _erase_size = _block_size * (ext_bits(csd, 45, 39) + 1);
             }
             break;
 
@@ -1105,7 +1123,7 @@ bd_size_t SDBlockDevice::_sd_sectors()
             debug_if(SD_DBG, "Sectors: 0x%" PRIx64 "x : %" PRIu64 "\n", blocks, blocks);
             debug_if(SD_DBG, "Capacity: %" PRIu64 " MB\n", (blocks / (2048U)));
             // ERASE_BLK_EN is fixed to 1, which means host can erase one or multiple of 512 bytes.
-            _erase_size = BLOCK_SIZE_HC;
+            _erase_size = _block_size;
             break;
 
         default:

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
@@ -234,7 +234,7 @@ const PinMap *spi_slave_cs_pinmap(void)
 
 #if DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, MBED_UNUSED uint8_t bit_width, uint32_t handler, uint32_t event, MBED_UNUSED DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, MBED_UNUSED uint8_t bit_width, uint32_t handler, uint32_t event, MBED_UNUSED DMAUsage hint)
 {
     struct spi_s *spi = cy_get_spi(obj);
     spi->async_handler = (void (*)(void))handler;
@@ -248,6 +248,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_spi_transfer_async");
     }
     spi->async_in_progress = true;
+
+    return false; // Currently we always use interrupts, not DMA
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -358,7 +358,7 @@ static void spi_buffer_set(spi_t *obj, const void *tx, uint32_t tx_length, void 
     obj->rx_buff.width = bit_width;
 }
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     if (spi_active(obj)) {
         return;
@@ -400,6 +400,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         // Can't enter deep sleep as long as SPI transfer is active
         sleep_manager_lock_deep_sleep();
     }
+
+    return hint != DMA_USAGE_NEVER; // DMA will be used as long as the hint is not NEVER
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -882,8 +882,10 @@ static void nordic_nrf5_spi_event_handler(nrfx_spi_evt_t const *p_event, void *p
  * Parameter  event     The logical OR of events to be registered
  * Parameter  handler   SPI interrupt handler
  * Parameter  hint      A suggestion for how to use DMA with this transfer
+ *
+ * Returns    bool      True if DMA was used for the transfer, false otherwise
  */
-void spi_master_transfer(spi_t *obj,
+bool spi_master_transfer(spi_t *obj,
                          const void *tx,
                          size_t tx_length,
                          void *rx,
@@ -949,6 +951,12 @@ void spi_master_transfer(spi_t *obj,
         /* Signal callback handler. */
         callback();
     }
+
+#if NRFX_CHECK(NRFX_SPIM_ENABLED)
+    return true; // We always use DMA when the SPIM preripheral is available
+#else
+    return false; // We always use interrupts when the SPI peripheral is available
+#endif
 }
 
 /** The asynchronous IRQ handler

--- a/targets/TARGET_NUVOTON/TARGET_M2354/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/spi_api.c
@@ -445,7 +445,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -573,6 +573,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/spi_api.c
@@ -369,7 +369,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -497,6 +497,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/spi_api.c
@@ -390,7 +390,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -518,6 +518,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -1,5 +1,6 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2015-2016 Nuvoton
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -383,7 +383,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -501,6 +501,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M460/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M460/spi_api.c
@@ -488,7 +488,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -616,6 +616,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
@@ -439,7 +439,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -567,6 +567,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
@@ -1,5 +1,6 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2015-2017 Nuvoton
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
@@ -434,7 +434,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -549,6 +549,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         PDMA_Trigger(obj->spi.dma_chn_id_rx);
         PDMA_Trigger(obj->spi.dma_chn_id_tx);
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -1,5 +1,6 @@
 /* mbed Microcontroller Library
  * Copyright (c) 2015-2016 Nuvoton
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -389,7 +389,7 @@ void spi_slave_write(spi_t *obj, int value)
 #endif
 
 #if DEVICE_SPI_ASYNCH
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
     SPI_SET_DATA_WIDTH(spi_base, bit_width);
@@ -503,6 +503,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
         /* Don't enable SPI TX/RX threshold interrupts as commented above */
     }
+
+    return obj->spi.dma_usage != DMA_USAGE_NEVER;
 }
 
 /**

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
@@ -518,7 +518,7 @@ static void spi_async_read(spi_t *obj)
  * ASYNCHRONOUS HAL
  ******************************************************************************/
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     int i;
     MBED_ASSERT(obj);
@@ -556,6 +556,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_irqs_set(obj, 1);
     
     spi_async_write(obj);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A2XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A2XX/spi_api.c
@@ -526,7 +526,7 @@ static void spi_async_read(spi_t *obj)
  * ASYNCHRONOUS HAL
  ******************************************************************************/
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     int i;
     MBED_ASSERT(obj);
@@ -564,6 +564,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_irqs_set(obj, 1);
 
     spi_async_write(obj);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32H7/STM32Cube_FW/STM32H7xx_HAL_Driver/stm32h7xx_hal_dma_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/STM32Cube_FW/STM32H7xx_HAL_Driver/stm32h7xx_hal_dma_ex.c
@@ -290,7 +290,18 @@ HAL_StatusTypeDef HAL_DMAEx_MultiBufferStart_IT(DMA_HandleTypeDef *hdma, uint32_
     {
       /* Enable Common interrupts*/
       MODIFY_REG(((DMA_Stream_TypeDef   *)hdma->Instance)->CR, (DMA_IT_TC | DMA_IT_TE | DMA_IT_DME | DMA_IT_HT), (DMA_IT_TC | DMA_IT_TE | DMA_IT_DME));
-      ((DMA_Stream_TypeDef   *)hdma->Instance)->FCR |= DMA_IT_FE;
+
+      /* Mbed CE mod: Only enable the FIFO Error interrupt if the FIFO is actually enabled.
+       * If it's not enabled, then this interrupt can trigger spuriously from memory bus
+       * stalls that the DMA engine encounters, and this creates random DMA failures.
+       * Reference forum thread here:
+       * https://community.st.com/t5/stm32-mcus-products/spi-dma-fifo-error-issue-feifx/td-p/537074
+       * also: https://community.st.com/t5/stm32-mcus-touch-gfx-and-gui/spi-dma-error-is-occurred-when-the-other-dma-memory-to-memory-is/td-p/191590
+       */
+      if(((DMA_Stream_TypeDef *)hdma->Instance)->FCR & DMA_SxFCR_DMDIS)
+      {
+        ((DMA_Stream_TypeDef *)hdma->Instance)->FCR |= DMA_IT_FE;
+      }
 
       if((hdma->XferHalfCpltCallback != NULL) || (hdma->XferM1HalfCpltCallback != NULL))
       {

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -1410,13 +1410,15 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     if (handle->Init.Direction == SPI_DIRECTION_2LINES) {
+        const int word_size = 0x01 << bitshift;
+
         int write_fill_frame = write_fill;
         /* extend fill symbols for 16/32 bit modes */
-        for (int i = 0; i < bitshift; i++) {
+        for (int i = 0; i < word_size; i++) {
             write_fill_frame = (write_fill_frame << 8) | write_fill;
         }
 
-        const int word_size = 0x01 << bitshift;
+
         for (int i = 0; i < total; i += word_size) {
             int out = (i < tx_length) ? spi_get_word_from_buffer(tx_buffer + i, bitshift) : write_fill_frame;
             int in = spi_master_write(obj, out);
@@ -1534,8 +1536,8 @@ typedef enum {
 } transfer_type_t;
 
 
-/// @returns the number of bytes transferred, or `0` if nothing transferred
-static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer_type, const void *tx, void *rx, size_t length, DMAUsage hint)
+/// @returns True if DMA was used, false otherwise
+static bool spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer_type, const void *tx, void *rx, size_t length, DMAUsage hint)
 {
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
@@ -1547,7 +1549,6 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
     size_t words;
 
     obj->spi.transfer_type = transfer_type;
-
     words = length >> bitshift;
 
     bool useDMA = false;
@@ -1579,6 +1580,8 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
 
         useDMA = true;
     }
+
+    obj->spi.curr_transfer_uses_dma = useDMA;
 #endif
 
     DEBUG_PRINTF("SPI inst=0x%8X Start: type=%u, length=%u, DMA=%d\r\n", (int) handle->Instance, transfer_type, length, !!useDMA);
@@ -1589,15 +1592,6 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
     NVIC_EnableIRQ(irq_n);
-
-#if defined(STM32_SPI_CAPABILITY_DMA) && defined(__DCACHE_PRESENT)
-    if (useDMA && transfer_type != SPI_TRANSFER_TYPE_RX)
-    {
-        // For chips with a cache (e.g. Cortex-M7), we need to evict the Tx data from cache to main memory.
-        // This ensures that the DMA controller can see the most up-to-date copy of the data.
-        SCB_CleanDCache_by_Addr((volatile void*)tx, length);
-    }
-#endif
 
     // flush FIFO
 #if defined(SPI_FLAG_FRLVL)
@@ -1635,7 +1629,7 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
 
             if (useDMA) {
 #if defined(STM32_SPI_CAPABILITY_DMA) && defined(__DCACHE_PRESENT)
-                // For chips with a cache (e.g. Cortex-M7), we need to evict the Tx data from cache to main memory.
+                // For chips with a cache (e.g. Cortex-M7), we need to evict the Tx fill data from cache to main memory.
                 // This ensures that the DMA controller can see the most up-to-date copy of the data.
                 SCB_CleanDCache_by_Addr(rx, length);
 #endif
@@ -1650,15 +1644,6 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
             length = 0;
     }
 
-#if defined(STM32_SPI_CAPABILITY_DMA) && defined(__DCACHE_PRESENT)
-    if (useDMA && transfer_type != SPI_TRANSFER_TYPE_TX)
-    {
-        // For chips with a cache (e.g. Cortex-M7), we need to invalidate the Rx data in cache.
-        // This ensures that the CPU will fetch the data from SRAM instead of using its cache.
-        SCB_InvalidateDCache_by_Addr(rx, length);
-    }
-#endif
-
     if (rc) {
 #if defined(SPI_IP_VERSION_V2)
         // enable SPI back in case of error
@@ -1667,14 +1652,13 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
         }
 #endif
         DEBUG_PRINTF("SPI: RC=%u\n", rc);
-        length = 0;
     }
 
-    return length;
+    return useDMA;
 }
 
 // asynchronous API
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
@@ -1687,7 +1671,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
     // don't do anything, if the buffers aren't valid
     if (!use_tx && !use_rx) {
-        return;
+        return false;
     }
 
     // copy the buffers to the SPI object
@@ -1717,11 +1701,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
             obj->tx_buff.length = size;
             obj->rx_buff.length = size;
         }
-        spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_TXRX, tx, rx, size, hint);
+        return spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_TXRX, tx, rx, size, hint);
     } else if (use_tx) {
-        spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_TX, tx, NULL, tx_length, hint);
+        return spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_TX, tx, NULL, tx_length, hint);
     } else if (use_rx) {
-        spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_RX, NULL, rx, rx_length, hint);
+        return spi_master_start_asynch_transfer(obj, SPI_TRANSFER_TYPE_RX, NULL, rx, rx_length, hint);
+    }
+    else {
+        return false;
     }
 }
 
@@ -1830,21 +1817,10 @@ void spi_abort_asynch(spi_t *obj)
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
 
-#ifdef STM32_SPI_CAPABILITY_DMA
-    // Abort DMA transfers if DMA channels have been allocated
-    if(spiobj->txDMAInitialized) {
-        HAL_DMA_Abort_IT(spiobj->handle.hdmatx);
-    }
-    if(spiobj->rxDMAInitialized) {
-        HAL_DMA_Abort_IT(spiobj->handle.hdmarx);
-    }
-#endif
-
-    // clean-up
-    LL_SPI_Disable(SPI_INST(obj));
-    HAL_SPI_DeInit(handle);
-
-    init_spi(obj);
+    // Use HAL abort function.
+    // Conveniently, this is smart enough to automatically abort the DMA transfer
+    // if DMA was used.
+    HAL_SPI_Abort_IT(handle);
 }
 
 #endif //DEVICE_SPI_ASYNCH

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -2,6 +2,7 @@
  *******************************************************************************
  * Copyright (c) 2015, STMicroelectronics
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/stm_spi_api.h
+++ b/targets/TARGET_STM/stm_spi_api.h
@@ -36,6 +36,7 @@ struct spi_s {
 #if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
+    bool curr_transfer_uses_dma;
 
     // Callback function for when we get an interrupt on an async transfer.
     // This will point, through a bit of indirection, to SPI::irq_handler_asynch()

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -1168,7 +1168,7 @@ void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
  * @param[in] handler   SPI interrupt handler
  * @param[in] hint      A suggestion for how to use DMA with this transfer
  */
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     if( spi_active(obj) ) return;
 

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -1116,8 +1116,10 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
 *       * ALWAYS: use DMA if channels are available, and hold on to the channels after the transfer.
 *                 If the previous transfer has kept the channel, that channel will continue to get used.
 *
+*  Returns true if DMA was used, false otherwise.
+*
 ********************************************************************/
-void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int tx_length, int rx_length, void* cb, DMAUsage hint)
+bool spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int tx_length, int rx_length, void* cb, DMAUsage hint)
 {
     /* Init DMA here to include it in the power figure */
     dma_init();
@@ -1128,11 +1130,13 @@ void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
     if (hint != DMA_USAGE_NEVER && obj->spi.dmaOptionsTX.dmaUsageState == DMA_USAGE_ALLOCATED) {
         /* setup has already been done, so just activate the transfer */
         spi_activate_dma(obj, rxdata, txdata, tx_length, rx_length);
+        return true;
     } else if (hint == DMA_USAGE_NEVER) {
         /* use IRQ */
         obj->spi.spi->IFC = 0xFFFFFFFF;
         spi_master_write_asynch(obj);
         spi_enable_interrupt(obj, (uint32_t)cb, true);
+        return false;
     } else {
         /* try to acquire channels */
         dma_init();
@@ -1147,11 +1151,13 @@ void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
             spi_master_dma_channel_setup(obj, cb);
             /* and activate the transfer */
             spi_activate_dma(obj, rxdata, txdata, tx_length, rx_length);
+            return true;
         } else {
             /* DMA is unavailable, so fall back to IRQ */
             obj->spi.spi->IFC = 0xFFFFFFFF;
             spi_master_write_asynch(obj);
             spi_enable_interrupt(obj, (uint32_t)cb, true);
+            return false;
         }
     }
 }
@@ -1167,6 +1173,9 @@ void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
  * @param[in] event     The logical OR of events to be registered
  * @param[in] handler   SPI interrupt handler
  * @param[in] hint      A suggestion for how to use DMA with this transfer
+ *
+ * @return True if DMA was actually used for the transfer, false otherwise (if interrupts or another CPU-based
+ * method is used to do the transfer).
  */
 bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
@@ -1190,7 +1199,7 @@ bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_enable_event(obj, event, true);
 
     /* And kick off the transfer */
-    spi_master_transfer_dma(obj, tx, rx, tx_length, rx_length, (void*)handler, hint);
+    return spi_master_transfer_dma(obj, tx, rx, tx_length, rx_length, (void*)handler, hint);
 }
 
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
@@ -2,6 +2,7 @@
  *******************************************************************************
  * (C)Copyright TOSHIBA ELECTRONIC DEVICES & STORAGE CORPORATION 2017 All rights reserved
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
@@ -409,7 +409,7 @@ const PinMap *spi_slave_cs_pinmap()
 
 #ifdef DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
                          uint32_t handler, uint32_t event, DMAUsage hint)
 {
     struct spi_s *obj_s = SPI_S(obj);
@@ -455,6 +455,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
     SSP_Enable(spi);
     NVIC_EnableIRQ(obj_s->irqn);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
@@ -484,7 +484,7 @@ const PinMap *spi_slave_cs_pinmap()
 
 #ifdef DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
     struct spi_s *obj_s = SPI_S(obj);
     tspi_t *p_obj = &(obj_s->p_obj);
@@ -535,6 +535,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         NVIC_EnableIRQ(obj_s->rxirqn);
     }
     NVIC_EnableIRQ(obj_s->errirqn);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/spi_api.c
@@ -517,7 +517,7 @@ const PinMap *spi_slave_cs_pinmap()
 
 #if DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
                          uint32_t handler, uint32_t event, DMAUsage hint)
 {
     struct spi_s *spiobj = SPI_S(obj);
@@ -574,6 +574,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     NVIC_EnableIRQ(p_irqn->Error);
     NVIC_EnableIRQ(p_irqn->Tx);
     NVIC_EnableIRQ(p_irqn->Rx);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 uint32_t spi_irq_handler_asynch(spi_t *obj)
 {

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4NR/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4NR/spi_api.c
@@ -398,7 +398,7 @@ const PinMap *spi_slave_cs_pinmap()
 
 #if DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
+bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width,
                          uint32_t handler, uint32_t event, DMAUsage hint)
 {
     struct spi_s *spiobj = SPI_S(obj);
@@ -455,6 +455,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     NVIC_EnableIRQ(p_irqn->Error);
     NVIC_EnableIRQ(p_irqn->Tx);
     NVIC_EnableIRQ(p_irqn->Rx);
+
+    return false; // Currently we always use interrupts, not DMA
 }
 uint32_t spi_irq_handler_asynch(spi_t *obj)
 {

--- a/tools/python/run_python_tests.sh
+++ b/tools/python/run_python_tests.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-PYTHON=python
+PYTHON=python3
 
 # Comma separated list of directories to exclude from coverage
 COVERAGE_EXCLUDES='--omit=python_tests/*'

--- a/tools/python/run_python_tests.sh
+++ b/tools/python/run_python_tests.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-PYTHON=python3
+PYTHON=python
 
 # Comma separated list of directories to exclude from coverage
 COVERAGE_EXCLUDES='--omit=python_tests/*'


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I started this effort to track down some DMA SPI issues that were showing up in the test cases for Nucleo H743ZI.  I thought there might just be some random bugs in the HAL driver, and I did in fact find two such issues.  However, I also found a more serious problem: the DMA SPI code did not correctly manage the cache for Cortex-M7 devices which have a CPU cache.

For the initial DMA SPI implementation, I thought it would be enough to just invalidate the cache for the Rx buffer after the transfer is over.  And this *almost* works -- it does ensure that the correct Rx data gets read out at the end of the transfer.  However, if there are any other variables being stored in the same cache lines as the Rx data, these can actually be corrupted, because the variable could be up to date in the CPU cache but out of date in main memory, in which case the cache invalidation throws out the correct value.  I actually found the issue because of a test case which declared an Rx buffer on the stack and was seeing stack corruption (!).

At its core, the issue is kinda a design problem.  Mbed acts like you can just do a DMA SPI operation into any old memory buffer, but you really can't.  The destination buffer has to be cache aligned in order for things to work, because we need to be able to safely cache invalidate the buffer.

So, I had to fix the design problem with an API change.  I added a new `CacheAlignedBuffer<DataT, BufferSize>` template, and changed the SPI code to require that this structure be used when declaring rx buffers for asynchronous operations.  On devices without a CPU cache (according to CMSIS definitions), the CacheAlignedBuffer template works basically like std::array, and just allocates an array of the specified type.  On devices with a CPU cache, it allocates additional space (on the order of 64 bytes) to make sure that the buffer can be cache aligned. I thought about declaring CacheAlignedBuffer with `alignas(32)` instead of doing the alignment "manually", but believe that needs linker script support to work, and also I don't know if it would work with malloc() allocated structures.

I also had to make one more change, this time to the HAL API layer.  So that we know if we need to invalidate the cache, we need some way to know if DMA actually got used for a transfer.  The "DMA hint" is just that -- a hint.  The HAL layer is free to always use interrupts or always use DMA if that's all that's supported.  So, I updated the signature of `spi_master_transfer()` so that the HAL layer must return true if DMA actually got used for a transfer, and false otherwise.  I then went through every HAL implementation which supports async SPI (8 of them, not counting copy pasted files) and had it return the right value based on what it supports.

With these pieces in place, I could finally implement cache management in the SPI driver.  It follows the three step process outlined [here](https://community.st.com/t5/stm32-mcus-products/maintaining-cpu-data-cache-coherence-for-dma-buffers/td-p/95746), and does:
- Clean of the Tx buffer before the transfer
- Invalidate of the Rx buffer before the transfer
- Invalidate of the Rx buffer after the transfer
I wanted to do this at the driver level, since the implementation is common to all ARM processors with a CPU cache, and also it's easy to screw up so I didn't want it to be up to the HAL vendors to get right.  It does require some ifdefs and some new added variables for each SPI instance supporting async, but I think it's worth it so that we can get cache management right.

Finally, after all these fixes, my entire SPI test suite is passing on STM32H743!

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
The API for SPI::transfer() and SPI::transfer_and_wait() is changing -- a `CacheAlignedBuffer` structure must be passed instead of a raw pointer for the Rx buffer.  This is to support MCUs where the Rx buffer has to be cache aligned when receiving memory from a peripheral with DMA.

Due to the relative obscurity and poor documentation of these APIs until recently, I doubt that a large number of applications were using them.  However, applications that were using them will need updates.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
`CacheAlignedBuffer` structures will need to be declared and used for the rx_buffers when calling `SPI::transfer()` and `SPI::transfer_and_wait()`.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Included in this PR!

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
<details>
  <summary>Show test log</summary>

```
6: [1701677033.63][CONN][RXD] >>> Running 28 test cases...
6: [1701677033.63][CONN][INF] found SYNC in stream: {{__sync;eb4bc5cb-595a-45f5-99b8-4fdec301a3c6}} it is #0 sent, queued...
6: [1701677033.63][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
6: [1701677033.63][CONN][INF] found KV pair in stream: {{__timeout;45}}, queued...
6: [1701677033.63][CONN][INF] found KV pair in stream: {{__host_test_name;spi_basic_test}}, queued...
6: [1701677033.63][HTST][INF] sync KV found, uuid=eb4bc5cb-595a-45f5-99b8-4fdec301a3c6, timestamp=1701677033.630847
6: [1701677033.63][HTST][INF] DUT greentea-client version: 1.3.0
6: [1701677033.63][HTST][INF] setting timeout to: 45 sec
6: [1701677033.63][HTST][INF] host test class: '<class 'spi_basic_test.SpiBasicTestHostTest'>'
6: [1701677033.63][TEST][INF] SPI Basic Test host test setup complete.
6: [1701677033.63][HTST][INF] host test setup() call...
6: [1701677033.63][HTST][INF] CALLBACKs updated
6: [1701677033.63][HTST][INF] host test detected: spi_basic_test
6: [1701677033.64][CONN][INF] found KV pair in stream: {{__testcase_name;Send 8 Bit Data via Single Word API}}, queued...
6: [1701677033.64][CONN][INF] found KV pair in stream: {{__testcase_name;Send 16 Bit Data via Single Word API}}, queued...
6: [1701677033.65][CONN][INF] found KV pair in stream: {{__testcase_name;Send 32 Bit Data via Single Word API}}, queued...
6: [1701677033.65][CONN][INF] found KV pair in stream: {{__testcase_name;Send 8 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677033.66][CONN][INF] found KV pair in stream: {{__testcase_name;Send 16 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677033.66][CONN][INF] found KV pair in stream: {{__testcase_name;Send 32 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677033.68][CONN][INF] found KV pair in stream: {{__testcase_name;Read 8 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677033.68][CONN][INF] found KV pair in stream: {{__testcase_name;Read 16 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677033.69][CONN][INF] found KV pair in stream: {{__testcase_name;Read 32 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677033.69][CONN][INF] found KV pair in stream: {{__testcase_name;Transfer 8 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677033.70][CONN][INF] found KV pair in stream: {{__testcase_name;Transfer 16 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677033.71][CONN][INF] found KV pair in stream: {{__testcase_name;Transfer 32 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677033.71][CONN][INF] found KV pair in stream: {{__testcase_name;Use Multiple SPI Instances (synchronous API)}}, queued...
6: [1701677033.72][CONN][INF] found KV pair in stream: {{__testcase_name;Free and Reallocate SPI Instance (synchronous API)}}, queued...
6: [1701677033.72][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async Interrupt API (Tx only)}}, queued...
6: [1701677033.73][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async Interrupt API (Rx only)}}, queued...
6: [1701677033.73][CONN][INF] found KV pair in stream: {{__testcase_name;Free and Reallocate SPI Instance with Interrupts}}, queued...
6: [1701677033.74][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async Interrupt API (Tx/Rx)}}, queued...
6: [1701677033.74][CONN][INF] found KV pair in stream: {{__testcase_name;Benchmark Async SPI via Interrupts}}, queued...
6: [1701677033.75][CONN][INF] found KV pair in stream: {{__testcase_name;Queueing and Aborting Async SPI via Interrupts}}, queued...
6: [1701677033.75][CONN][INF] found KV pair in stream: {{__testcase_name;Use Multiple SPI Instances with Interrupts}}, queued...
6: [1701677033.77][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async DMA API (Tx only)}}, queued...
6: [1701677033.77][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async DMA API (Rx only)}}, queued...
6: [1701677033.78][CONN][INF] found KV pair in stream: {{__testcase_name;Free and Reallocate SPI Instance with DMA}}, queued...
6: [1701677033.78][CONN][INF] found KV pair in stream: {{__testcase_name;Send Data via Async DMA API (Tx/Rx)}}, queued...
6: [1701677033.78][CONN][INF] found KV pair in stream: {{__testcase_name;Benchmark Async SPI via DMA}}, queued...
6: [1701677033.79][CONN][RXD] 
6: [1701677033.79][CONN][INF] found KV pair in stream: {{__testcase_name;Queueing and Aborting Async SPI via DMA}}, queued...
6: [1701677033.79][CONN][INF] found KV pair in stream: {{__testcase_name;Use Multiple SPI Instances with DMA}}, queued...
6: [1701677033.80][CONN][RXD] >>> Running case #1: 'Send 8 Bit Data via Single Word API'...
6: [1701677033.80][CONN][INF] found KV pair in stream: {{__testcase_start;Send 8 Bit Data via Single Word API}}, queued...
6: [1701677033.81][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677034.83][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677034.84][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677034.95][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677034.95][TEST][INF] PASS
6: [1701677034.95][SERI][TXD] {{verify_sequence;complete}}
6: [1701677034.96][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 8 Bit Data via Single Word API;1;0}}, queued...
6: [1701677034.97][CONN][RXD] >>> 'Send 8 Bit Data via Single Word API': 1 passed, 0 failed
6: [1701677034.97][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677034.97][CONN][RXD]
6: [1701677034.98][CONN][RXD] >>> Running case #2: 'Send 16 Bit Data via Single Word API'...
6: [1701677034.98][CONN][INF] found KV pair in stream: {{__testcase_start;Send 16 Bit Data via Single Word API}}, queued...
6: [1701677034.98][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677035.99][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677036.00][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677036.11][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677036.11][TEST][INF] PASS
6: [1701677036.12][SERI][TXD] {{verify_sequence;complete}}
6: [1701677036.13][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 16 Bit Data via Single Word API;1;0}}, queued...
6: [1701677036.14][CONN][RXD] >>> 'Send 16 Bit Data via Single Word API': 1 passed, 0 failed
6: [1701677036.14][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677036.14][CONN][RXD]
6: [1701677036.15][CONN][RXD] >>> Running case #3: 'Send 32 Bit Data via Single Word API'...
6: [1701677036.15][CONN][INF] found KV pair in stream: {{__testcase_start;Send 32 Bit Data via Single Word API}}, queued...
6: [1701677036.15][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677037.16][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677037.17][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677037.27][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677037.27][TEST][INF] PASS
6: [1701677037.28][SERI][TXD] {{verify_sequence;complete}}
6: [1701677037.29][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 32 Bit Data via Single Word API;1;0}}, queued...
6: [1701677037.30][CONN][RXD] >>> 'Send 32 Bit Data via Single Word API': 1 passed, 0 failed
6: [1701677037.30][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677037.30][CONN][RXD]
6: [1701677037.31][CONN][RXD] >>> Running case #4: 'Send 8 Bit Data via Transactional API (Tx only)'...
6: [1701677037.31][CONN][INF] found KV pair in stream: {{__testcase_start;Send 8 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677037.31][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677038.32][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677038.33][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677038.43][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677038.43][TEST][INF] PASS
6: [1701677038.44][SERI][TXD] {{verify_sequence;complete}}
6: [1701677038.45][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 8 Bit Data via Transactional API (Tx only);1;0}}, queued...
6: [1701677038.46][CONN][RXD] >>> 'Send 8 Bit Data via Transactional API (Tx only)': 1 passed, 0 failed
6: [1701677038.46][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677038.46][CONN][RXD]
6: [1701677038.47][CONN][RXD] >>> Running case #5: 'Send 16 Bit Data via Transactional API (Tx only)'...
6: [1701677038.47][CONN][INF] found KV pair in stream: {{__testcase_start;Send 16 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677038.48][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677039.49][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677039.50][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677039.59][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677039.59][TEST][INF] PASS
6: [1701677039.60][SERI][TXD] {{verify_sequence;complete}}
6: [1701677039.61][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 16 Bit Data via Transactional API (Tx only);1;0}}, queued...
6: [1701677039.62][CONN][RXD] >>> 'Send 16 Bit Data via Transactional API (Tx only)': 1 passed, 0 failed
6: [1701677039.62][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677039.62][CONN][RXD]
6: [1701677039.63][CONN][RXD] >>> Running case #6: 'Send 32 Bit Data via Transactional API (Tx only)'...
6: [1701677039.63][CONN][INF] found KV pair in stream: {{__testcase_start;Send 32 Bit Data via Transactional API (Tx only)}}, queued...
6: [1701677039.64][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677040.65][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677040.66][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677040.76][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677040.76][TEST][INF] PASS
6: [1701677040.76][SERI][TXD] {{verify_sequence;complete}}
6: [1701677040.78][CONN][INF] found KV pair in stream: {{__testcase_finish;Send 32 Bit Data via Transactional API (Tx only);1;0}}, queued...
6: [1701677040.79][CONN][RXD] >>> 'Send 32 Bit Data via Transactional API (Tx only)': 1 passed, 0 failed
6: [1701677040.79][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677040.79][CONN][RXD]
6: [1701677040.80][CONN][RXD] >>> Running case #7: 'Read 8 Bit Data via Transactional API (Rx only)'...
6: [1701677040.80][CONN][INF] found KV pair in stream: {{__testcase_start;Read 8 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677040.81][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677041.82][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677041.83][CONN][INF] found KV pair in stream: {{print_spi_data;please}}, queued...
                                                                                                                                                         6: [1701677041.93][TEST][INF] Saw on the SPI bus: [mosi: b'afafafaf', miso: b'afafafaf']
6: [1701677041.93][SERI][TXD] {{print_spi_data;complete}}
6: [1701677041.95][CONN][INF] found KV pair in stream: {{__testcase_finish;Read 8 Bit Data via Transactional API (Rx only);1;0}}, queued...
6: [1701677041.96][CONN][RXD] >>> 'Read 8 Bit Data via Transactional API (Rx only)': 1 passed, 0 failed
6: [1701677041.96][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677041.96][CONN][RXD]
6: [1701677041.97][CONN][RXD] >>> Running case #8: 'Read 16 Bit Data via Transactional API (Rx only)'...
6: [1701677041.97][CONN][INF] found KV pair in stream: {{__testcase_start;Read 16 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677041.98][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677042.99][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677043.00][CONN][INF] found KV pair in stream: {{print_spi_data;please}}, queued...
                                                                                                                                                         6: [1701677043.10][TEST][INF] Saw on the SPI bus: [mosi: b'afafafaf', miso: b'afafafaf']
6: [1701677043.11][SERI][TXD] {{print_spi_data;complete}}
6: [1701677043.12][CONN][INF] found KV pair in stream: {{__testcase_finish;Read 16 Bit Data via Transactional API (Rx only);1;0}}, queued...
6: [1701677043.13][CONN][RXD] >>> 'Read 16 Bit Data via Transactional API (Rx only)': 1 passed, 0 failed
6: [1701677043.13][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677043.13][CONN][RXD]
6: [1701677043.14][CONN][RXD] >>> Running case #9: 'Read 32 Bit Data via Transactional API (Rx only)'...
6: [1701677043.14][CONN][INF] found KV pair in stream: {{__testcase_start;Read 32 Bit Data via Transactional API (Rx only)}}, queued...
6: [1701677043.15][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677044.16][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677044.17][CONN][INF] found KV pair in stream: {{print_spi_data;please}}, queued...
                                                                                                                                                         6: [1701677044.28][TEST][INF] Saw on the SPI bus: [mosi: b'afafafaf', miso: b'afafafaf']
6: [1701677044.28][SERI][TXD] {{print_spi_data;complete}}
6: [1701677044.29][CONN][INF] found KV pair in stream: {{__testcase_finish;Read 32 Bit Data via Transactional API (Rx only);1;0}}, queued...
6: [1701677044.30][CONN][RXD] >>> 'Read 32 Bit Data via Transactional API (Rx only)': 1 passed, 0 failed
6: [1701677044.30][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677044.30][CONN][RXD]
6: [1701677044.31][CONN][RXD] >>> Running case #10: 'Transfer 8 Bit Data via Transactional API (Tx/Rx)'...
6: [1701677044.31][CONN][INF] found KV pair in stream: {{__testcase_start;Transfer 8 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677044.32][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677045.35][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677045.36][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677045.45][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677045.45][TEST][INF] PASS
6: [1701677045.45][SERI][TXD] {{verify_sequence;complete}}
6: [1701677045.46][CONN][INF] found KV pair in stream: {{__testcase_finish;Transfer 8 Bit Data via Transactional API (Tx/Rx);1;0}}, queued...
6: [1701677045.47][CONN][RXD] >>> 'Transfer 8 Bit Data via Transactional API (Tx/Rx)': 1 passed, 0 failed
6: [1701677045.47][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677045.47][CONN][RXD]
6: [1701677045.48][CONN][RXD] >>> Running case #11: 'Transfer 16 Bit Data via Transactional API (Tx/Rx)'...
6: [1701677045.48][CONN][INF] found KV pair in stream: {{__testcase_start;Transfer 16 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677045.49][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677046.51][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677046.52][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677046.61][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677046.61][TEST][INF] PASS
6: [1701677046.62][SERI][TXD] {{verify_sequence;complete}}
6: [1701677046.63][CONN][INF] found KV pair in stream: {{__testcase_finish;Transfer 16 Bit Data via Transactional API (Tx/Rx);1;0}}, queued...
6: [1701677046.64][CONN][RXD] >>> 'Transfer 16 Bit Data via Transactional API (Tx/Rx)': 1 passed, 0 failed
6: [1701677046.64][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677046.64][CONN][RXD]
6: [1701677046.65][CONN][RXD] >>> Running case #12: 'Transfer 32 Bit Data via Transactional API (Tx/Rx)'...
6: [1701677046.67][CONN][INF] found KV pair in stream: {{__testcase_start;Transfer 32 Bit Data via Transactional API (Tx/Rx)}}, queued...
6: [1701677046.67][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677047.68][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677047.69][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677047.79][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677047.79][TEST][INF] PASS
6: [1701677047.80][SERI][TXD] {{verify_sequence;complete}}
6: [1701677047.81][CONN][INF] found KV pair in stream: {{__testcase_finish;Transfer 32 Bit Data via Transactional API (Tx/Rx);1;0}}, queued...
6: [1701677047.82][CONN][RXD] >>> 'Transfer 32 Bit Data via Transactional API (Tx/Rx)': 1 passed, 0 failed
6: [1701677047.82][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677047.82][CONN][RXD]
6: [1701677047.83][CONN][RXD] >>> Running case #13: 'Use Multiple SPI Instances (synchronous API)'...
6: [1701677047.83][CONN][INF] found KV pair in stream: {{__testcase_start;Use Multiple SPI Instances (synchronous API)}}, queued...
6: [1701677047.84][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677048.86][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677048.87][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677048.96][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677048.96][TEST][INF] PASS
6: [1701677048.97][SERI][TXD] {{verify_sequence;complete}}
6: [1701677048.98][CONN][INF] found KV pair in stream: {{__testcase_finish;Use Multiple SPI Instances (synchronous API);1;0}}, queued...
6: [1701677048.99][CONN][RXD] >>> 'Use Multiple SPI Instances (synchronous API)': 1 passed, 0 failed
6: [1701677048.99][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677048.99][CONN][RXD]
6: [1701677049.01][CONN][RXD] >>> Running case #14: 'Free and Reallocate SPI Instance (synchronous API)'...
6: [1701677049.01][CONN][INF] found KV pair in stream: {{__testcase_start;Free and Reallocate SPI Instance (synchronous API)}}, queued...
6: [1701677049.02][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677050.03][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677050.04][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677050.14][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677050.14][TEST][INF] PASS
6: [1701677050.15][SERI][TXD] {{verify_sequence;complete}}
6: [1701677050.16][CONN][INF] found KV pair in stream: {{__testcase_finish;Free and Reallocate SPI Instance (synchronous API);1;0}}, queued...
6: [1701677050.17][CONN][RXD] >>> 'Free and Reallocate SPI Instance (synchronous API)': 1 passed, 0 failed
6: [1701677050.17][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677050.17][CONN][RXD]
6: [1701677050.18][CONN][RXD] >>> Running case #15: 'Send Data via Async Interrupt API (Tx only)'...
6: [1701677050.18][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async Interrupt API (Tx only)}}, queued...
6: [1701677050.19][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677051.20][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677051.21][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677051.30][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677051.30][TEST][INF] PASS
6: [1701677051.30][SERI][TXD] {{verify_sequence;complete}}
6: [1701677051.31][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async Interrupt API (Tx only);1;0}}, queued...
6: [1701677051.33][CONN][RXD] >>> 'Send Data via Async Interrupt API (Tx only)': 1 passed, 0 failed
6: [1701677051.33][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677051.33][CONN][RXD]
6: [1701677051.34][CONN][RXD] >>> Running case #16: 'Send Data via Async Interrupt API (Rx only)'...
6: [1701677051.34][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async Interrupt API (Rx only)}}, queued...
6: [1701677051.35][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677052.36][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677052.37][CONN][RXD] Got: ff ff ff ff
                                                                                                            6: [1701677052.37][CONN][INF] found KV pair in stream: {{print_spi_data;please}}, queued...
    6: [1701677052.47][TEST][INF] Saw on the SPI bus: [mosi: b'ffffffff', miso: b'ffffffff']
6: [1701677052.47][SERI][TXD] {{print_spi_data;complete}}
6: [1701677052.48][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async Interrupt API (Rx only);1;0}}, queued...
6: [1701677052.49][CONN][RXD] >>> 'Send Data via Async Interrupt API (Rx only)': 1 passed, 0 failed
6: [1701677052.49][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677052.49][CONN][RXD]
6: [1701677052.51][CONN][RXD] >>> Running case #17: 'Free and Reallocate SPI Instance with Interrupts'...
6: [1701677052.51][CONN][INF] found KV pair in stream: {{__testcase_start;Free and Reallocate SPI Instance with Interrupts}}, queued...
6: [1701677052.52][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677053.53][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677053.54][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677053.65][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677053.65][TEST][INF] PASS
6: [1701677053.66][SERI][TXD] {{verify_sequence;complete}}
6: [1701677053.67][CONN][INF] found KV pair in stream: {{__testcase_finish;Free and Reallocate SPI Instance with Interrupts;1;0}}, queued...
6: [1701677053.68][CONN][RXD] >>> 'Free and Reallocate SPI Instance with Interrupts': 1 passed, 0 failed
6: [1701677053.68][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677053.68][CONN][RXD]
6: [1701677053.69][CONN][RXD] >>> Running case #18: 'Send Data via Async Interrupt API (Tx/Rx)'...
6: [1701677053.69][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async Interrupt API (Tx/Rx)}}, queued...
6: [1701677053.69][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677054.70][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677054.71][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677054.81][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677054.81][TEST][INF] PASS
6: [1701677054.81][SERI][TXD] {{verify_sequence;complete}}
6: [1701677054.82][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async Interrupt API (Tx/Rx);1;0}}, queued...
6: [1701677054.83][CONN][RXD] >>> 'Send Data via Async Interrupt API (Tx/Rx)': 1 passed, 0 failed
6: [1701677054.83][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677054.83][CONN][RXD]
6: [1701677054.84][CONN][RXD] >>> Running case #19: 'Benchmark Async SPI via Interrupts'...
6: [1701677054.84][CONN][INF] found KV pair in stream: {{__testcase_start;Benchmark Async SPI via Interrupts}}, queued...
6: [1701677054.85][CONN][RXD] Transferred 32 bytes @ 1000kHz in 428us, with 420us occurring in the background.
6: [1701677054.87][CONN][RXD] Note: Based on the byte count and frequency, the theoretical best time for this SPI transaction is 256us
6: [1701677054.87][CONN][RXD] Note: the above background time does not include overhead from interrupts, which may be significant.
6: [1701677054.88][CONN][RXD] >>> 'Benchmark Async SPI via Interrupts': 1 passed, 0 failed
6: [1701677054.88][CONN][INF] found KV pair in stream: {{__testcase_finish;Benchmark Async SPI via Interrupts;1;0}}, queued...
6: [1701677054.89][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677054.89][CONN][RXD]
6: [1701677054.89][CONN][RXD] >>> Running case #20: 'Queueing and Aborting Async SPI via Interrupts'...
6: [1701677054.90][CONN][INF] found KV pair in stream: {{__testcase_start;Queueing and Aborting Async SPI via Interrupts}}, queued...
6: [1701677054.90][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677055.91][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677055.95][CONN][INF] found KV pair in stream: {{verify_queue_and_abort_test;please}}, queued...
                                                                                                                                                                      6: [1701677056.02][TEST][INF]
 Saw on the SPI bus: [mosi: b'010200000000000000000000000000000000000000000102000000000000000000000000000000000000000000000000000000000000', miso: b'010200000000000000000000000000000000000000000102000000000000000000000000000000000000000000000000000000000000']
6: [1701677056.02][SERI][TXD] {{verify_queue_and_abort_test;pass}}
6: [1701677056.04][CONN][INF] found KV pair in stream: {{__testcase_finish;Queueing and Aborting Async SPI via Interrupts;1;0}}, queued...
6: [1701677056.05][CONN][RXD] >>> 'Queueing and Aborting Async SPI via Interrupts': 1 passed, 0 failed
6: [1701677056.05][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677056.05][CONN][RXD]
6: [1701677056.06][CONN][RXD] >>> Running case #21: 'Use Multiple SPI Instances with Interrupts'...
6: [1701677056.06][CONN][INF] found KV pair in stream: {{__testcase_start;Use Multiple SPI Instances with Interrupts}}, queued...
6: [1701677056.07][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677057.09][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677057.10][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: Correct number of messages
6: First message looks OK
6: Second message looks OK
6: [1701677057.20][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677057.20][TEST][INF] PASS
6: [1701677057.20][SERI][TXD] {{verify_sequence;complete}}
6: [1701677057.21][CONN][INF] found KV pair in stream: {{__testcase_finish;Use Multiple SPI Instances with Interrupts;1;0}}, queued...
6: [1701677057.22][CONN][RXD] >>> 'Use Multiple SPI Instances with Interrupts': 1 passed, 0 failed
6: [1701677057.22][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677057.22][CONN][RXD]
6: [1701677057.23][CONN][RXD] >>> Running case #22: 'Send Data via Async DMA API (Tx only)'...
6: [1701677057.23][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async DMA API (Tx only)}}, queued...
6: [1701677057.23][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677058.24][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677058.25][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677058.35][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677058.35][TEST][INF] PASS
6: [1701677058.36][SERI][TXD] {{verify_sequence;complete}}
6: [1701677058.37][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async DMA API (Tx only);1;0}}, queued...
6: [1701677058.38][CONN][RXD] >>> 'Send Data via Async DMA API (Tx only)': 1 passed, 0 failed
6: [1701677058.38][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677058.38][CONN][RXD]
6: [1701677058.39][CONN][RXD] >>> Running case #23: 'Send Data via Async DMA API (Rx only)'...
6: [1701677058.39][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async DMA API (Rx only)}}, queued...
6: [1701677058.39][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677059.40][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677059.41][CONN][RXD] Got: ff ff ff ff
                                                                                                            6: [1701677059.41][CONN][INF] found KV pair in stream: {{print_spi_data;please}}, queued...
    6: [1701677059.51][TEST][INF] Saw on the SPI bus: [mosi: b'ffffffff', miso: b'ffffffff']
6: [1701677059.51][SERI][TXD] {{print_spi_data;complete}}
6: [1701677059.52][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async DMA API (Rx only);1;0}}, queued...
6: [1701677059.53][CONN][RXD] >>> 'Send Data via Async DMA API (Rx only)': 1 passed, 0 failed
6: [1701677059.53][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677059.53][CONN][RXD]
6: [1701677059.54][CONN][RXD] >>> Running case #24: 'Free and Reallocate SPI Instance with DMA'...
6: [1701677059.54][CONN][INF] found KV pair in stream: {{__testcase_start;Free and Reallocate SPI Instance with DMA}}, queued...
6: [1701677059.54][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677060.55][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677060.56][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677060.66][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677060.66][TEST][INF] PASS
6: [1701677060.67][SERI][TXD] {{verify_sequence;complete}}
6: [1701677060.68][CONN][INF] found KV pair in stream: {{__testcase_finish;Free and Reallocate SPI Instance with DMA;1;0}}, queued...
6: [1701677060.69][CONN][RXD] >>> 'Free and Reallocate SPI Instance with DMA': 1 passed, 0 failed
6: [1701677060.69][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677060.69][CONN][RXD]
6: [1701677060.70][CONN][RXD] >>> Running case #25: 'Send Data via Async DMA API (Tx/Rx)'...
6: [1701677060.70][CONN][INF] found KV pair in stream: {{__testcase_start;Send Data via Async DMA API (Tx/Rx)}}, queued...
6: [1701677060.70][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677061.71][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677061.72][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: [1701677061.82][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677061.82][TEST][INF] PASS
6: [1701677061.83][SERI][TXD] {{verify_sequence;complete}}
6: [1701677061.84][CONN][INF] found KV pair in stream: {{__testcase_finish;Send Data via Async DMA API (Tx/Rx);1;0}}, queued...
6: [1701677061.85][CONN][RXD] >>> 'Send Data via Async DMA API (Tx/Rx)': 1 passed, 0 failed
6: [1701677061.85][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677061.85][CONN][RXD]
6: [1701677061.86][CONN][RXD] >>> Running case #26: 'Benchmark Async SPI via DMA'...
6: [1701677061.86][CONN][INF] found KV pair in stream: {{__testcase_start;Benchmark Async SPI via DMA}}, queued...
6: [1701677061.87][CONN][RXD] Transferred 32 bytes @ 1000kHz in 425us, with 419us occurring in the background.
6: [1701677061.87][CONN][RXD] Note: Based on the byte count and frequency, the theoretical best time for this SPI transaction is 256us
6: [1701677061.88][CONN][RXD] Note: the above background time does not include overhead from interrupts, which may be significant.
6: [1701677061.89][CONN][RXD] >>> 'Benchmark Async SPI via DMA': 1 passed, 0 failed
6: [1701677061.89][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677061.89][CONN][RXD]
6: [1701677061.89][CONN][INF] found KV pair in stream: {{__testcase_finish;Benchmark Async SPI via DMA;1;0}}, queued...
6: [1701677061.91][CONN][RXD] >>> Running case #27: 'Queueing and Aborting Async SPI via DMA'...
6: [1701677061.91][CONN][INF] found KV pair in stream: {{__testcase_start;Queueing and Aborting Async SPI via DMA}}, queued...
6: [1701677061.92][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677062.93][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677062.98][CONN][INF] found KV pair in stream: {{verify_queue_and_abort_test;please}}, queued...
                                                                                                                                                                      6: [1701677063.05][TEST][INF]
 Saw on the SPI bus: [mosi: b'010200000000000000000000000000000000000000000102000000000000000000000000000000000000000000000000000000000000', miso: b'010200000000000000000000000000000000000000000102000000000000000000000000000000000000000000000000000000000000']
6: [1701677063.05][SERI][TXD] {{verify_queue_and_abort_test;pass}}
6: [1701677063.06][CONN][INF] found KV pair in stream: {{__testcase_finish;Queueing and Aborting Async SPI via DMA;1;0}}, queued...
6: [1701677063.07][CONN][RXD] >>> 'Queueing and Aborting Async SPI via DMA': 1 passed, 0 failed
6: [1701677063.07][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677063.07][CONN][RXD]
6: [1701677063.08][CONN][RXD] >>> Running case #28: 'Use Multiple SPI Instances with DMA'...
6: [1701677063.08][CONN][INF] found KV pair in stream: {{__testcase_start;Use Multiple SPI Instances with DMA}}, queued...
6: [1701677063.08][CONN][INF] found KV pair in stream: {{start_recording_spi;please}}, queued...
6: [1701677064.09][SERI][TXD] {{start_recording_spi;complete}}
                                                              6: [1701677064.10][CONN][INF] found KV pair in stream: {{verify_sequence;standard_word}}, queued...
                                                                                                                                                                 6: Correct number of messages
6: First message looks OK
6: Second message looks OK
6: [1701677064.23][TEST][INF] Saw on the SPI bus: [mosi: b'01020408', miso: b'01020408']
6: [1701677064.23][TEST][INF] PASS
6: [1701677064.24][SERI][TXD] {{verify_sequence;complete}}
6: [1701677064.25][CONN][INF] found KV pair in stream: {{__testcase_finish;Use Multiple SPI Instances with DMA;1;0}}, queued...
6: [1701677064.26][CONN][RXD] >>> 'Use Multiple SPI Instances with DMA': 1 passed, 0 failed
6: [1701677064.26][CONN][RXD] <greentea test suite>:0::PASS
6: [1701677064.26][CONN][RXD]
6: [1701677064.26][CONN][RXD] >>> Test cases: 28 passed, 0 failed
6: [1701677064.26][CONN][RXD]
6: [1701677064.26][CONN][RXD] -----------------------
6: [1701677064.27][CONN][RXD] 0 Tests 0 Failures 0 Ignored
6: [1701677064.27][CONN][RXD] OK
6: [1701677064.27][CONN][INF] found KV pair in stream: {{__testcase_summary;28;0}}, queued...
6: [1701677064.27][CONN][INF] found KV pair in stream: {{end;success}}, queued...
6: [1701677064.27][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
6: [1701677064.27][HTST][INF] __exit(0)
6: [1701677064.28][HTST][INF] __notify_complete(True)
6: [1701677064.28][HTST][INF] __exit_event_queue received
6: [1701677064.28][HTST][INF] test suite run finished after 30.64 sec...
6: [1701677064.28][CONN][INF] received special event '__host_test_finished' value='True', finishing
6: [1701677064.43][HTST][INF] CONN exited with code: 0
6: [1701677064.43][HTST][INF] Some events in queue
6: [1701677064.43][HTST][INF] stopped consuming events
6: [1701677064.43][HTST][INF] host test result() call skipped, received: True
6: [1701677064.43][HTST][INF] calling blocking teardown()
6: [1701677064.43][HTST][INF] teardown() finished
6: [1701677064.44][HTST][INF] {{result;success}}
1/1 Test #6: test-testshield-spi-basic ........   Passed   43.11 sec

```
</details>
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
