### PR TITLE
lfsv2 missing from cmake storage: platform and kv-config

### DIFF
--- a/storage/kvstore/kv_config/CMakeLists.txt
+++ b/storage/kvstore/kv_config/CMakeLists.txt
@@ -23,5 +23,6 @@ target_link_libraries(mbed-storage-kv-config
         mbed-storage-filesystemstore
         mbed-storage-securestore
         mbed-storage-littlefs
+        mbed-storage-littlefs-v2
         mbed-storage-fat
 )

--- a/storage/platform/CMakeLists.txt
+++ b/storage/platform/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND mbed-storage-libs
     mbed-storage-filesystem
     mbed-storage-fat
     mbed-storage-littlefs
+    mbed-storage-littlefs-v2
 )
 
 if("DATAFLASH" IN_LIST MBED_TARGET_LABELS)


### PR DESCRIPTION
lfsv2 missing from cmake storage-platform and storage-kv-config
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
add "mbed-storage-littlefs-v2" to cmake mbed-storage-libs list
add "mbed-storage-littlefs-v2" to cmake mbed-storage-kv-config link libraries

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
