### PR TITLE
Increase RPi Pico PWM range and resolution to the max supported by HW

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -159,7 +159,7 @@
         },
         "minimal-printf-enable-floating-point": {
             "help": "Enable floating point printing when using minimal printf library",
-            "value": false
+            "value": true
         },
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed when using minimal printf library",

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -159,7 +159,7 @@
         },
         "minimal-printf-enable-floating-point": {
             "help": "Enable floating point printing when using minimal printf library",
-            "value": true
+            "value": false
         },
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed when using minimal printf library",

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/analogin_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/analogin_api.c
@@ -22,9 +22,8 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 
-static float    const ADC_VREF_VOLTAGE     = 3.3f; /* 3.3V */
 static uint16_t const ADC_RESOLUTION_BITS   = 12;
-static float    const ADC_CONVERSION_FACTOR = ADC_VREF_VOLTAGE / (1 << 16);
+static float    const ADC_CONVERSION_FACTOR = 1.0f / (1 << 16);
 
 void analogin_init(analogin_t *obj, PinName pin)
 {

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/objects.h
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/objects.h
@@ -114,12 +114,31 @@ struct spi_s {
     spi_inst_t * dev;
 };
 
-struct pwmout_s {
+struct pwmout_s
+{
+    /// Pin that the PWM is being sent out on
     PinName pin;
+
+    /// Slice number of this PWM (0-7).  Each slice contains two channels.
+    /// Each slice must have the same period but can have an independent duty cycle.
     uint8_t slice;
+
+    /// Channel of this PWM output on the slice (0 or 1)
     uint8_t channel;
-    uint16_t period;
+
+    /// Value after which this PWM channel will reset to 0.  This plus the clock divider controls the PWM period.
+    uint16_t top_count;
+
+    /// Current clock divider value that the channel is set to (hardware accepts 1-255.9375)
+    float clock_divider;
+
+    /// Current duty cycle percent
     float percent;
+
+    /// Current period setting in floating point seconds
+    float period;
+
+    /// Pico HAL config structure
     pwm_config cfg;
 };
 

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/pwmout_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/pwmout_api.c
@@ -45,7 +45,63 @@
 #include "hardware/clocks.h"
 #include "mbed_assert.h"
 
-const uint count_top = 1000;
+#include <math.h>
+
+/// Largest top count value supported by hardware.  Using this value will provide the highest duty cycle resolution,
+/// but will limit the period to a maximum of (1 / (125 MHz / 65534) =) 524 us
+const uint16_t MAX_TOP_COUNT = 65534;
+
+/// Value for PWM_CHn_DIV register that produces a division of 1
+const uint16_t PWM_CHn_DIV_1 = 0x010;
+
+/// Calculate the effective PWM period (in floating point seconds) based on a divider and top_count value
+static float calc_effective_pwm_period(float divider, uint16_t top_count)
+{
+    return 1.0f / (clock_get_hz(clk_sys) / divider / top_count);
+}
+
+/// Calculate the best possible top_count value (rounding up) for a divider and a desired pwm period
+static uint16_t calc_top_count_for_period(float divider, float desired_pwm_period)
+{
+    // Derivation:
+    // desired_pwm_period = 1.0f / ((clock_get_hz(clk_sys) / divider) / top_count)
+    // desired_pwm_period = top_count / (clock_get_hz(clk_sys) / divider)
+    // desired_pwm_period * (clock_get_hz(clk_sys) / divider) = top_count
+
+    return ceilf(desired_pwm_period * (clock_get_hz(clk_sys) / divider));
+}
+
+/// Calculate the best possible floating point divider value for a desired pwm period.
+/// This function assumes that top_count is set to MAX_TOP_COUNT.
+static uint16_t calc_divider_for_period(float desired_pwm_period)
+{
+    // Derivation:
+    // (desired_pwm_period * clock_get_hz(clk_sys)) / divider = top_count
+    // divider = (desired_pwm_period * clock_get_hz(clk_sys)) / top_count
+
+    return (desired_pwm_period * clock_get_hz(clk_sys)) / MAX_TOP_COUNT;
+}
+
+/// Convert PWM divider from floating point to a fixed point number (rounding up).
+/// The divider is returned as an 8.4 bit fixed point number, which is what the Pico registers use.
+static uint16_t pwm_divider_float_to_fixed(float divider_float)
+{
+    // To convert to a fixed point number, multiply by 16 and then round up
+    uint16_t divider_exact = ceil(divider_float * 16);
+
+    // Largest supported divider is 255 and 15/16
+    if(divider_exact > 0xFFF)
+    {
+        divider_exact = 0xFFF;
+    }
+    return divider_exact;
+}
+
+/// Convert PWM divider from the fixed point hardware value (8.4 bits) to a float.
+static float pwm_divider_fixed_to_float(uint16_t divider_fixed)
+{
+    return divider_fixed / 16.0f;
+}
 
 /** Initialize the pwm out peripheral and configure the pin
  *
@@ -60,11 +116,10 @@ void pwmout_init(pwmout_t *obj, PinName pin)
     obj->slice = pwm_gpio_to_slice_num(pin);
     obj->channel = pwm_gpio_to_channel(pin);
     obj->pin = pin;
-    obj->period = 0;
+    obj->top_count = MAX_TOP_COUNT;
     obj->percent = 0.5f;
-
     obj->cfg = pwm_get_default_config();
-    pwm_config_set_wrap(&(obj->cfg), count_top);
+    pwm_config_set_wrap(&(obj->cfg), obj->top_count);
 
     pwm_init(obj->slice, &(obj->cfg), false);
     gpio_set_function(pin, GPIO_FUNC_PWM);
@@ -89,7 +144,21 @@ void pwmout_free(pwmout_t *obj)
 void pwmout_write(pwmout_t *obj, float percent)
 {
     obj->percent = percent;
-    pwm_set_gpio_level(obj->pin, percent * (count_top + 1));
+
+    // Per datasheet section 4.5.2.2, a period value of top_count + 1 produces 100% duty cycle
+    int32_t reset_count = lroundf((obj->top_count + 1) * percent);
+
+    // Clamp to valid values
+    if(reset_count > obj->top_count + 1)
+    {
+        reset_count = obj->top_count + 1;
+    }
+    else if(reset_count < 0)
+    {
+        reset_count = 0;
+    }
+
+    pwm_set_chan_level(obj->slice, obj->channel, reset_count);
     pwm_set_enabled(obj->slice, true);
 }
 
@@ -114,8 +183,46 @@ float pwmout_read(pwmout_t *obj)
  */
 void pwmout_period(pwmout_t *obj, float period)
 {
-    /* Set new period. */
-    pwmout_period_us(obj, period * 1000000);
+    // Two possibilities here:
+    // - If the period is relatively short (< about 524 us), we want to keep the clock divider at 1
+    //    and reduce top_count to match the period
+    // - If the period is larger than what we can achieve with a clock divider of 1, we need to
+    //    use a higher clock divider, then recalculate the top_count to match
+
+    // Note: For math this complex, I wasn't able to avoid using floating point values.
+    // This function won't be too efficient, but for now I just want something that works and
+    // can access the full PWM range.
+
+    if(period <= calc_effective_pwm_period(1, MAX_TOP_COUNT))
+    {
+        // Short period.  Leave divider at 1 and reduce top_count to match the expected period
+        obj->clock_divider = 1.0f;
+        obj->cfg.div = PWM_CHn_DIV_1;
+        obj->top_count = calc_top_count_for_period(obj->clock_divider, period);
+    }
+    else
+    {
+        // Long period, need to use divider.
+
+        // Step 1: Calculate exact desired divider such that top_count would equal MAX_TOP_COUNT
+        float desired_divider = calc_divider_for_period(period);
+
+        // Step 2: Round desired divider upwards to the next value the hardware can do.
+        // We go upwards so that the top_count value can be trimmed downwards for the best period accuracy.
+        uint16_t divider_fixed_point = pwm_divider_float_to_fixed(desired_divider);
+        obj->cfg.div = divider_fixed_point;
+
+        // Step 3: Get the divider we'll actually be using as a float
+        obj->clock_divider = pwm_divider_fixed_to_float(divider_fixed_point);
+
+        // Step 4: For best accuracy, recalculate the top_count value using the divider.
+        obj->top_count = calc_top_count_for_period(obj->clock_divider, period);
+    }
+
+    // Save period for later
+    obj->period = period;
+
+    pwm_init(obj->slice, &(obj->cfg), false);
 }
 
 /** Set the PWM period specified in miliseconds, keeping the duty cycle the same
@@ -126,7 +233,7 @@ void pwmout_period(pwmout_t *obj, float period)
 void pwmout_period_ms(pwmout_t *obj, int period)
 {
     /* Set new period. */
-    pwmout_period_us(obj, period * 1000);
+    pwmout_period(obj, period / 1000.0f);
 }
 
 /** Set the PWM period specified in microseconds, keeping the duty cycle the same
@@ -136,18 +243,18 @@ void pwmout_period_ms(pwmout_t *obj, int period)
  */
 void pwmout_period_us(pwmout_t *obj, int period)
 {
-    obj->period = period;
-
-    // min_period should be 8us
-    uint32_t min_period = 1000000 * count_top / clock_get_hz(clk_sys);
-
-    pwm_config_set_clkdiv(&(obj->cfg), (float)period / (float)min_period);
-    pwm_init(obj->slice, &(obj->cfg), false);
+    /* Set new period. */
+    pwmout_period(obj, period / 1000000.0f);
 }
 
+/** Read the PWM period specified in microseconds
+ *
+ * @param obj The pwmout object
+ * @return A int output period
+ */
 int pwmout_read_period_us(pwmout_t *obj)
 {
-    return obj->period;
+    return lroundf(1000000 * calc_effective_pwm_period(obj->clock_divider, obj->top_count));
 }
 
 /** Set the PWM pulsewidth specified in seconds, keeping the period the same.
@@ -157,7 +264,7 @@ int pwmout_read_period_us(pwmout_t *obj)
  */
 void pwmout_pulsewidth(pwmout_t *obj, float pulse)
 {
-    pwmout_pulsewidth_us(obj, pulse * 1000000);
+    pwmout_write(obj, pulse / obj->period);
 }
 
 /** Set the PWM pulsewidth specified in miliseconds, keeping the period the same.
@@ -167,7 +274,7 @@ void pwmout_pulsewidth(pwmout_t *obj, float pulse)
  */
 void pwmout_pulsewidth_ms(pwmout_t *obj, int pulse)
 {
-    pwmout_pulsewidth_us(obj, pulse * 1000);
+    pwmout_write(obj, (pulse * .001f) / obj->period);
 }
 
 /** Set the PWM pulsewidth specified in microseconds, keeping the period the same.
@@ -177,19 +284,11 @@ void pwmout_pulsewidth_ms(pwmout_t *obj, int pulse)
  */
 void pwmout_pulsewidth_us(pwmout_t *obj, int pulse)
 {
-    /* Cap pulsewidth to period. */
-    if (pulse > obj->period) {
-        pulse = obj->period;
-    }
-
-    obj->percent = (float) pulse / (float) obj->period;
-
-    /* Restart instance with new values. */
-    pwmout_write(obj, obj->percent);
+    pwmout_write(obj, (pulse * .000001f) / obj->period);
 }
 
 int pwmout_read_pulsewidth_us(pwmout_t *obj) {
-    return (obj->period) * (obj->percent);
+    return lroundf(obj->period * obj->percent * 1000000);
 }
 
 const PinMap *pwmout_pinmap()

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/pwmout_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/pwmout_api.c
@@ -1,40 +1,20 @@
-/*
- * Copyright (c) 2018 Nordic Semiconductor ASA
- * All rights reserved.
+/* mbed Microcontroller Library
+ * Copyright (c) 2024, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   1. Redistributions of source code must retain the above copyright notice, this list
- *      of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
- *      integrated circuit in a product or a software update for such product, must reproduce
- *      the above copyright notice, this list of conditions and the following disclaimer in
- *      the documentation and/or other materials provided with the distribution.
- *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
- *      used to endorse or promote products derived from this software without specific prior
- *      written permission.
- *
- *   4. This software, with or without modification, must only be used with a
- *      Nordic Semiconductor ASA integrated circuit.
- *
- *   5. Any software provided in binary or object form under this license must not be reverse
- *      engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 
 #if DEVICE_PWMOUT
 

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -4876,7 +4876,12 @@
         "device_name": "STM32U575ZITx",
         "detect_code": [
             "886"
-        ]
+        ],
+        "overrides": {
+            // As shipped, this nucleo board connects VREFP to VDD_MCU, and connects VDD_MCU to 3.3V.
+            // Jumper JP4 can be used to switch VDD_MCU to 1.8V in which case you should override this setting to 1.8.
+            "default-adc-vref": 3.3
+        }
     },
 	"MCU_STM32U585xI": {
         "inherits": [
@@ -9758,7 +9763,7 @@
             "RTC"
         ]
     },
-    "RASPBERRY_PI_PICO_SWD": {
+    "RASPBERRY_PI_PICO": {
         "inherits": ["RP2040"],
         "macros_add": [
             "PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1",
@@ -9766,13 +9771,24 @@
             "PICO_TIME_DEFAULT_ALARM_POOL_DISABLED",
             "PICO_ON_DEVICE=1",
             "PICO_UART_ENABLE_CRLF_SUPPORT=0"
-        ]
-    },
-    "RASPBERRY_PI_PICO": {
-        "inherits": ["RASPBERRY_PI_PICO_SWD"],
+        ],
         "overrides": {
             "console-usb": true,
-            "console-uart": false
+            "console-uart": false,
+
+            // ADC_VDD sets the ADC reference voltage on this chip.
+            // Most RP2040 boards set this pin to 3.3V.
+            // Note that if the I/O voltage is set to less than the ADC reference voltage,
+            // voltages higher than the I/O voltage are illegal for the analog pins
+            // (so the ADC can never read 100%).
+            "default-adc-vref": 3.3
+        }
+    },
+    "RASPBERRY_PI_PICO_SWD": {
+        "inherits": ["RASPBERRY_PI_PICO"],
+        "overrides": {
+            "console-usb": false,
+            "console-uart": true
         }
     }
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

@Olivier_Corrio on the Mbed forums reported an [issue](https://forums.mbed.com/t/pwm-period-is-not-good-on-mbed-with-raspberry-pico/22151) with the PWM functionality on RPi Pico.  After some investigation, I confirmed the issue: The initial implementation of PWM always uses a top_count of 1000 and only varies the divider to set the PWM period.  I think they did it this way to avoid floating point math, but it is sub-optimalfor three reasons:
- Low duty cycle resolution of the PWM -- only 1/1000 increments when it could be 1/65536 increments
- High minimum PWM period -- with a divider of 1 and a top_count of 1000, the minimum PWM period is 8us, even though the hardware supports sub 1us periods (with top_count lower than 1000)
- Low maximum PWM period -- with a divider of 256 and a top_count of 1000, the maximum PWM period is 2.05ms, even though the hardware supports up to 134ms periods (with top_count = 65535)

This PR redesigns the math that sets the PWM period so that both the divider and the top_count are calculated dynamically in order to match the requested period as closely as possible.  It does mean that setting the PWM period will be a tad more performance intensive, but this isn't an operation done commonly at runtime, and the benefits to range and accuracy are significant, so I think we should be OK!

Bonus: I also fixed a bug where the RPi Pico HAL was returning values in the range [0, 3.3] instead of [0, 1] from the ADC.  This means that AnalogIn::read() now matches the spec behavior.

#### Impact of changes <!-- Optional -->
Improved range and accuracy of PWM for RPi Pico

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

I ran my new (create just for this!) [PWM and ADC test shield test](https://github.com/multiplemonomials/Mbed-CI-Test-Shield/blob/ci-shield-v2/Software/PWMAndADCTest.cpp) on the new implementation, and it passed!


```
8: Executing: C:/Program Files/Python311/python.exe -m mbed_host_tests.mbedhtrun --skip-flashing -p COM10 --skip-reset -e C:/Users/jamie/Documents/RPL/Mbed-CI-Test-Shield/Software/host_tests -m RASPBERRY_PI_PICO_SWD --baud-rate=115200
8: [1705309102.38][HTST][INF] host test executor ver. 0.0.16
8: [1705309102.38][HTST][INF] copy image onto target... SKIPPED!
8: [1705309102.40][HTST][INF] starting host test process...
8: [1705309103.71][CONN][INF] starting connection process...
8: [1705309103.71][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
8: [1705309103.71][CONN][INF] initializing serial port listener...
8: [1705309103.71][SERI][INF] using specified port 'COM10'
8: [1705309103.71][HTST][INF] setting timeout to: 60 sec
8: [1705309103.71][SERI][INF] serial(port=COM10, baudrate=115200, read_timeout=0.01, write_timeout=5)
8: [1705309103.71][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
8: [1705309103.71][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
8: [1705309103.71][CONN][INF] sending preamble 'd0210a0a-3a70-45e6-8ba2-68ecaad3325d'
8: [1705309103.71][SERI][TXD] {{__sync;d0210a0a-3a70-45e6-8ba2-68ecaad3325d}}
8: [1705309103.74][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed
8: [1705309103.74][CONN][INF] found SYNC in stream: {{__sync;d0210a0a-3a70-45e6-8ba2-68ecaad3325d}} it is #0 sent, queued...
8: [1705309103.74][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
8: [1705309103.74][CONN][INF] found KV pair in stream: {{__timeout;60}}, queued...
8: [1705309103.74][HTST][INF] sync KV found, uuid=d0210a0a-3a70-45e6-8ba2-68ecaad3325d, timestamp=1705309103.742140
8: [1705309103.74][HTST][INF] DUT greentea-client version: 1.3.0
8: [1705309103.74][HTST][INF] setting timeout to: 60 sec
8: [1705309103.75][CONN][RXD] >>> Running 7 test cases...
8: [1705309103.75][CONN][INF] found KV pair in stream: {{__host_test_name;signal_analyzer_test}}, queued...
8: [1705309103.75][CONN][INF] found KV pair in stream: {{__testcase_name;Test reading digital values with the ADC}}, queued...
8: [1705309103.76][HTST][INF] host test class: '<class 'signal_analyzer_test.SignalAnalyzerHostTest'>'
8: [1705309103.76][TEST][INF] Signal Analyzer Test host test setup complete.
8: [1705309103.76][HTST][INF] host test setup() call...
8: [1705309103.76][HTST][INF] CALLBACKs updated
8: [1705309103.76][HTST][INF] host test detected: signal_analyzer_test
8: [1705309103.77][CONN][INF] found KV pair in stream: {{__testcase_name;Test reading analog values with the ADC}}, queued...
8: [1705309103.77][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 50 Hz)}}, queued...
8: [1705309103.78][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 1 kHz)}}, queued...
8: [1705309103.78][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 10 kHz)}}, queued...
8: [1705309103.79][CONN][RXD] 
8: [1705309103.79][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 100 kHz)}}, queued...
8: [1705309103.79][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 1 MHz)}}, queued...
8: [1705309103.80][CONN][RXD] >>> Running case #1: 'Test reading digital values with the ADC'...
8: [1705309103.80][CONN][INF] found KV pair in stream: {{__testcase_start;Test reading digital values with the ADC}}, queued...
8: [1705309103.83][CONN][RXD] With the PWM at full off, the ADC reads 0.4% of reference voltage.
8: [1705309103.89][CONN][RXD] With the PWM at full on, the ADC reads 100.0% of reference voltage.
8: [1705309103.89][CONN][INF] found KV pair in stream: {{__testcase_finish;Test reading digital values with the ADC;1;0}}, queued...
8: [1705309103.90][CONN][RXD] >>> 'Test reading digital values with the ADC': 1 passed, 0 failed
8: [1705309103.90][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309103.91][CONN][RXD] Based on target.default-adc-vref of 3.30V, the digital IO voltage of this target is 3.30V.
8: [1705309103.91][CONN][RXD] >>> Running case #2: 'Test reading analog values with the ADC'...
8: [1705309103.92][CONN][INF] found KV pair in stream: {{__testcase_start;Test reading analog values with the ADC}}, queued...
8: [1705309103.96][CONN][RXD] PWM duty cycle of 0.0% produced an ADC reading of 0.6% (expected 0.0%)
8: [1705309104.01][CONN][RXD] PWM duty cycle of 10.0% produced an ADC reading of 10.6% (expected 10.0%)
8: [1705309104.05][CONN][RXD] PWM duty cycle of 20.0% produced an ADC reading of 20.8% (expected 20.0%)
8: [1705309104.11][CONN][RXD] PWM duty cycle of 30.0% produced an ADC reading of 31.2% (expected 30.0%)
8: [1705309104.16][CONN][RXD] PWM duty cycle of 40.0% produced an ADC reading of 40.8% (expected 40.0%)
8: [1705309104.20][CONN][RXD] PWM duty cycle of 50.0% produced an ADC reading of 50.7% (expected 50.0%)
8: [1705309104.26][CONN][RXD] PWM duty cycle of 60.0% produced an ADC reading of 60.6% (expected 60.0%)
8: [1705309104.30][CONN][RXD] PWM duty cycle of 70.0% produced an ADC reading of 70.5% (expected 70.0%)
8: [1705309104.36][CONN][RXD] PWM duty cycle of 80.0% produced an ADC reading of 80.5% (expected 80.0%)
8: [1705309104.41][CONN][RXD] PWM duty cycle of 90.0% produced an ADC reading of 90.6% (expected 90.0%)
8: [1705309104.41][CONN][INF] found KV pair in stream: {{__testcase_finish;Test reading analog values with the ADC;1;0}}, queued...
8: [1705309104.42][CONN][RXD] >>> 'Test reading analog values with the ADC': 1 passed, 0 failed
8: [1705309104.42][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309104.42][CONN][RXD]
8: [1705309104.43][CONN][RXD] >>> Running case #3: 'Test PWM frequency and duty cycle (freq = 50 Hz)'...
8: [1705309104.43][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 50 Hz)}}, queued...
8: [1705309104.43][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309105.58][SERI][TXD] {{frequency;50.0}}
8: [1705309105.59][SERI][TXD] {{duty_cycle;0.05318486703783241}}
8: [1705309105.61][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 5.32% (+-0.10%), host measured frequency 50 Hz and duty cycle 5.32%
8: [1705309105.61][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309106.75][SERI][TXD] {{frequency;50.0}}
8: [1705309106.76][SERI][TXD] {{duty_cycle;0.1601120997197507}}
8: [1705309106.78][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 16.01% (+-0.10%), host measured frequency 50 Hz and duty cycle 16.01%
8: [1705309106.78][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309107.93][SERI][TXD] {{frequency;50.0}}
8: [1705309107.94][SERI][TXD] {{duty_cycle;0.6614133464666339}}
8: [1705309107.96][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 66.14% (+-0.10%), host measured frequency 50 Hz and duty cycle 66.14%
8: [1705309107.96][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309109.09][SERI][TXD] {{frequency;50.0}}
8: [1705309109.10][SERI][TXD] {{duty_cycle;0.8503653740865648}}
8: [1705309109.13][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 85.04% (+-0.10%), host measured frequency 50 Hz and duty cycle 85.04%
8: [1705309109.13][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309110.26][SERI][TXD] {{frequency;50.0}}
8: [1705309110.27][SERI][TXD] {{duty_cycle;0.6394659013352466}}
8: [1705309110.29][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 63.95% (+-0.10%), host measured frequency 50 Hz and duty cycle 63.95%
8: [1705309110.30][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 50 Hz)': 1 passed, 0 failed
8: [1705309110.30][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 50 Hz);1;0}}, queued...
8: [1705309110.31][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309110.31][CONN][RXD]
8: [1705309110.31][CONN][RXD] >>> Running case #4: 'Test PWM frequency and duty cycle (freq = 1 kHz)'...
8: [1705309110.32][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 1 kHz)}}, queued...
8: [1705309110.32][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309111.47][SERI][TXD] {{frequency;1000.0}}
8: [1705309111.48][SERI][TXD] {{duty_cycle;0.6189334526663683}}
8: [1705309111.50][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 61.89% (+-0.10%), host measured frequency 1000 Hz and duty cycle 61.89%
8: [1705309111.50][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309112.63][SERI][TXD] {{frequency;1000.0}}
8: [1705309112.64][SERI][TXD] {{duty_cycle;0.4149539626150935}}
8: [1705309112.67][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 41.49% (+-0.10%), host measured frequency 1000 Hz and duty cycle 41.50%
8: [1705309112.67][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309113.81][SERI][TXD] {{frequency;1000.0}}
8: [1705309113.82][SERI][TXD] {{duty_cycle;0.7679805800485499}}
8: [1705309113.84][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 76.80% (+-0.10%), host measured frequency 1000 Hz and duty cycle 76.80%
8: [1705309113.84][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309114.99][SERI][TXD] {{frequency;1000.0}}
8: [1705309115.00][SERI][TXD] {{duty_cycle;0.9825100437248907}}
8: [1705309115.02][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 98.25% (+-0.10%), host measured frequency 1000 Hz and duty cycle 98.25%
8: [1705309115.02][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309116.15][SERI][TXD] {{frequency;1000.0}}
8: [1705309116.16][SERI][TXD] {{duty_cycle;0.4871312821717946}}
8: [1705309116.18][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 48.71% (+-0.10%), host measured frequency 1000 Hz and duty cycle 48.71%
8: [1705309116.19][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 1 kHz)': 1 passed, 0 failed
8: [1705309116.19][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 1 kHz);1;0}}, queued...
8: [1705309116.20][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309116.20][CONN][RXD]
8: [1705309116.20][CONN][RXD] >>> Running case #5: 'Test PWM frequency and duty cycle (freq = 10 kHz)'...
8: [1705309116.22][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 10 kHz)}}, queued...
8: [1705309116.22][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309117.36][SERI][TXD] {{frequency;10000.0}}
8: [1705309117.37][SERI][TXD] {{duty_cycle;0.7961130097174757}}
8: [1705309117.39][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 79.60% (+-0.10%), host measured frequency 10000 Hz and duty cycle 79.61%
8: [1705309117.39][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309118.54][SERI][TXD] {{frequency;10000.0}}
8: [1705309118.55][SERI][TXD] {{duty_cycle;0.9695325761685596}}
8: [1705309118.57][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 96.95% (+-0.10%), host measured frequency 10000 Hz and duty cycle 96.95%
8: [1705309118.57][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309119.71][SERI][TXD] {{frequency;10000.0}}
8: [1705309119.72][SERI][TXD] {{duty_cycle;0.24595438511403722}}
8: [1705309119.75][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 24.59% (+-0.10%), host measured frequency 10000 Hz and duty cycle 24.60%
8: [1705309119.75][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309120.87][SERI][TXD] {{frequency;10000.0}}
8: [1705309120.88][SERI][TXD] {{duty_cycle;0.8313079217301956}}
8: [1705309120.90][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 83.13% (+-0.10%), host measured frequency 10000 Hz and duty cycle 83.13%
8: [1705309120.90][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309122.05][SERI][TXD] {{frequency;10000.0}}
8: [1705309122.06][SERI][TXD] {{duty_cycle;0.2927892680268299}}
8: [1705309122.08][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 29.28% (+-0.10%), host measured frequency 10000 Hz and duty cycle 29.28%
8: [1705309122.10][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 10 kHz)': 1 passed, 0 failed
8: [1705309122.10][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 10 kHz);1;0}}, queued...
8: [1705309122.11][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309122.11][CONN][RXD]
8: [1705309122.11][CONN][RXD] >>> Running case #6: 'Test PWM frequency and duty cycle (freq = 100 kHz)'...
8: [1705309122.12][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 100 kHz)}}, queued...
8: [1705309122.12][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309123.26][SERI][TXD] {{frequency;100000.0}}
8: [1705309123.27][SERI][TXD] {{duty_cycle;0.34882412793968015}}
8: [1705309123.29][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 34.90% (+-1.00%), host measured frequency 100000 Hz and duty cycle 34.88%
8: [1705309123.29][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309124.43][SERI][TXD] {{frequency;100000.0}}
8: [1705309124.44][SERI][TXD] {{duty_cycle;0.2216819457951355}}
8: [1705309124.46][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 22.19% (+-1.00%), host measured frequency 100000 Hz and duty cycle 22.17%
8: [1705309124.46][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309125.59][SERI][TXD] {{frequency;100000.0}}
8: [1705309125.61][SERI][TXD] {{duty_cycle;0.6310709223226942}}
8: [1705309125.63][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 63.09% (+-1.00%), host measured frequency 100000 Hz and duty cycle 63.11%
8: [1705309125.63][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309126.76][SERI][TXD] {{frequency;100000.0}}
8: [1705309126.77][SERI][TXD] {{duty_cycle;0.8138579653550866}}
8: [1705309126.79][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 81.33% (+-1.00%), host measured frequency 100000 Hz and duty cycle 81.39%
8: [1705309126.79][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309127.94][SERI][TXD] {{frequency;100000.0}}
8: [1705309127.95][SERI][TXD] {{duty_cycle;0.49530376174059565}}
8: [1705309127.97][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 49.56% (+-1.00%), host measured frequency 100000 Hz and duty cycle 49.53%
8: [1705309127.98][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 100 kHz)': 1 passed, 0 failed
8: [1705309127.98][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 100 kHz);1;0}}, queued...
8: [1705309127.99][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309127.99][CONN][RXD]
8: [1705309127.99][CONN][RXD] >>> Running case #7: 'Test PWM frequency and duty cycle (freq = 1 MHz)'...
8: [1705309128.00][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 1 MHz)}}, queued...
8: [1705309128.00][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309129.15][SERI][TXD] {{frequency;1000000.0}}
8: [1705309129.16][SERI][TXD] {{duty_cycle;0.3157117107207232}}
8: [1705309129.18][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 30.80% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 31.57%
8: [1705309129.18][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309130.31][SERI][TXD] {{frequency;1000000.0}}
8: [1705309130.32][SERI][TXD] {{duty_cycle;0.4726613183467041}}
8: [1705309130.34][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 46.96% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 47.27%
8: [1705309130.34][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309131.50][SERI][TXD] {{frequency;1000000.0}}
8: [1705309131.51][SERI][TXD] {{duty_cycle;0.3469966325084187}}
8: [1705309131.53][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 34.13% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 34.70%
8: [1705309131.53][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309132.66][SERI][TXD] {{frequency;1000000.0}}
8: [1705309132.68][SERI][TXD] {{duty_cycle;0.35482411293971766}}
8: [1705309132.70][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 35.34% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 35.48%
8: [1705309132.70][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
8: [1705309133.83][SERI][TXD] {{frequency;1000010.0}}
8: [1705309133.84][SERI][TXD] {{duty_cycle;0.4447688880777798}}
8: [1705309133.86][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 44.74% (+-10.00%), host measured frequency 1000010 Hz and duty cycle 44.48%
8: [1705309133.87][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 1 MHz)': 1 passed, 0 failed
8: [1705309133.87][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 1 MHz);1;0}}, queued...
8: [1705309133.89][CONN][RXD] <greentea test suite>:0::PASS
8: [1705309133.89][CONN][RXD]
8: [1705309133.89][CONN][RXD] >>> Test cases: 7 passed, 0 failed
8: [1705309133.89][CONN][RXD]
8: [1705309133.89][CONN][RXD] -----------------------
8: [1705309133.89][CONN][RXD] 0 Tests 0 Failures 0 Ignored
8: [1705309133.89][CONN][RXD] OK
8: [1705309133.89][CONN][INF] found KV pair in stream: {{__testcase_summary;7;0}}, queued...
8: [1705309133.89][CONN][INF] found KV pair in stream: {{end;success}}, queued...
8: [1705309133.89][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
8: [1705309133.89][HTST][INF] __exit(0)
8: [1705309133.89][HTST][INF] __notify_complete(True)
8: [1705309133.89][HTST][INF] __exit_event_queue received
8: [1705309133.89][HTST][INF] test suite run finished after 30.15 sec...
8: [1705309133.91][CONN][INF] received special event '__host_test_finished' value='True', finishing
8: [1705309134.02][HTST][INF] CONN exited with code: 0
8: [1705309134.03][HTST][INF] Some events in queue
8: [1705309134.03][HTST][INF] stopped consuming events
8: [1705309134.03][HTST][INF] host test result() call skipped, received: True
8: [1705309134.03][HTST][INF] calling blocking teardown()
8: [1705309134.03][HTST][INF] teardown() finished
8: [1705309134.03][HTST][INF] {{result;success}}
1/1 Test #8: test-testshield-pwm-and-adc ......   Passed   48.30 sec

The following tests passed:
        test-testshield-pwm-and-adc

100% tests passed, 0 tests failed out of 1

```
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
