### PR TITLE
Fix issues with new async SPI changes that broke compiling for B_U585I_IOT2A

### DIFF
--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080B_SPI.cpp
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080B_SPI.cpp
@@ -195,12 +195,12 @@ void EMW3080B_SPI::spi_handler(int event)
 }
 
 
-int32_t EMW3080B_SPI::TransmitReceive(uint8_t *txdata, uint8_t *rxdata, uint32_t datalen,
+int32_t EMW3080B_SPI::TransmitReceive(uint8_t *txdata, CacheAlignedBuffer<uint8_t> & rxdata, uint32_t datalen,
                                       uint32_t timeout)
 {
     int32_t ret = 0;
     debug_if(_debug_level >= DEBUG_LOG, "EMW3080B_SPI : Spi Tx Rx %" PRIu32 "\n", datalen);
-    SPI::transfer((const uint8_t *) txdata, (int) datalen, rxdata, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
+    SPI::transfer( txdata, (int) datalen, rxdata, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
     if (SEM_WAIT(spi_transfer_done_sem, timeout, NULL) != SEM_OK) {
         debug_if(_debug_level >= DEBUG_WARNING, "EMW3080B_SPI : Timeout on TransmitReceive %d\n", spi_handler_count);
         ret = -1;
@@ -210,11 +210,11 @@ int32_t EMW3080B_SPI::TransmitReceive(uint8_t *txdata, uint8_t *rxdata, uint32_t
 }
 
 
-int32_t EMW3080B_SPI::Transmit(uint8_t *txdata, uint32_t datalen, uint32_t timeout)
+int32_t EMW3080B_SPI::Transmit(uint8_t * const txdata, uint32_t datalen, uint32_t timeout)
 {
     int32_t ret = 0;
     debug_if(_debug_level >= DEBUG_LOG, "EMW3080B_SPI : Spi Tx %" PRIu32 "\n", datalen);
-    SPI::transfer((const uint8_t *) txdata, (int) datalen, (uint8_t *)NULL, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
+    SPI::transfer(txdata, (int) datalen, nullptr, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
     if (SEM_WAIT(spi_transfer_done_sem, timeout, NULL) != SEM_OK) {
         debug_if(_debug_level >= DEBUG_WARNING, "EMW3080B_SPI : Timeout on Transmit\n");
         ret = -1;
@@ -222,11 +222,11 @@ int32_t EMW3080B_SPI::Transmit(uint8_t *txdata, uint32_t datalen, uint32_t timeo
     return ret;
 }
 
-int32_t EMW3080B_SPI::Receive(uint8_t *rxdata, uint32_t datalen, uint32_t timeout)
+int32_t EMW3080B_SPI::Receive(CacheAlignedBuffer<uint8_t> & rxdata, uint32_t datalen, uint32_t timeout)
 {
     int32_t ret = 0;
     debug_if(_debug_level >= DEBUG_LOG, "EMW3080B_SPI : Spi Rx %" PRIu32 "\n", datalen);
-    SPI::transfer((const uint8_t *) NULL, (int) datalen, rxdata, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
+    SPI::transfer(nullptr, (int) datalen, rxdata, (int) datalen, callback(this, &EMW3080B_SPI::spi_handler), SPI_EVENT_COMPLETE);
     if (SEM_WAIT(spi_transfer_done_sem, timeout, NULL) != SEM_OK) {
         debug_if(_debug_level >= DEBUG_WARNING, "EMW3080B_SPI : Timeout on Receive\n");
         ret = -1;
@@ -291,10 +291,13 @@ void EMW3080B_SPI::process_txrx_poll(uint32_t timeout)
         sheader.type = 0;
         sheader.len = 0;
 
-        if (TransmitReceive((uint8_t *)&mheader, (uint8_t *)&sheader, sizeof(mheader), SPI_MAX_TRANSMIT_DURATION)) {
+        StaticCacheAlignedBuffer<uint8_t, sizeof(mheader)> rxBuffer;
+        if (TransmitReceive((uint8_t *)&mheader, rxBuffer, sizeof(mheader), SPI_MAX_TRANSMIT_DURATION)) {
             MX_WIFI_SPI_CS_HIGH();
             debug_if(_debug_level >= DEBUG_WARNING, "EMW3080B_SPI : Send mheader error\r\n");
         }
+        memcpy(&sheader, rxBuffer.data(), sizeof(mheader));
+
         if (sheader.type != SPI_READ) {
             MX_WIFI_SPI_CS_HIGH();
             debug_if(_debug_level >= DEBUG_WARNING, "EMW3080B_SPI : Invalid SPI type %02x\r\n", sheader.type);
@@ -342,12 +345,12 @@ void EMW3080B_SPI::process_txrx_poll(uint32_t timeout)
             spi_tx_data = NULL;
             spi_tx_len = 0;
             if (NULL != p) {
-                ret = TransmitReceive(txdata, p, datalen, SPI_MAX_TRANSMIT_DURATION);
+                ret = TransmitReceive(txdata, netb->buffer, datalen, SPI_MAX_TRANSMIT_DURATION);
             } else {
                 ret = Transmit(txdata, datalen, SPI_MAX_TRANSMIT_DURATION);
             }
         } else {
-            ret = Receive(p, datalen, SPI_MAX_TRANSMIT_DURATION);
+            ret = Receive(netb->buffer, datalen, SPI_MAX_TRANSMIT_DURATION);
         }
 
         if (ret) {

--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080B_SPI.h
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080B_SPI.h
@@ -61,9 +61,9 @@ private:
     uint8_t *spi_tx_data = NULL;
     uint16_t spi_tx_len  = 0;
 
-    int32_t TransmitReceive(uint8_t *txdata, uint8_t *rxdata, uint32_t datalen, uint32_t timeout);
+    int32_t TransmitReceive(uint8_t *txdata, CacheAlignedBuffer<uint8_t> & rxdata, uint32_t datalen, uint32_t timeout);
     int32_t Transmit(uint8_t *txdata, uint32_t datalen, uint32_t timeout);
-    int32_t Receive(uint8_t *rxdata, uint32_t datalen, uint32_t timeout);
+    int32_t Receive(CacheAlignedBuffer<uint8_t> & rxdata, uint32_t datalen, uint32_t timeout);
     void    spi_handler(int event);
 
     int8_t mx_wifi_spi_txrx_start(void);

--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/mx_wifi_mbed_os.cpp
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/mx_wifi_mbed_os.cpp
@@ -20,7 +20,43 @@
 extern "C"
 {
 
-#if BASIC_MALLOC == 0
+#if BASIC_MALLOC
+
+
+// CacheAlignedBuffer-based implementation
+
+mx_buf_t *mx_buf_alloc(uint32_t len)
+{
+    return new mx_buf_t(len);
+}
+
+void mx_buf_free(mx_buf_t *p)
+{
+    delete p;
+}
+
+void mx_buf_hide_header(mx_buf_t *p, int32_t n)
+{
+    p->header_len += n;
+}
+
+uint8_t *mx_buf_payload(mx_buf_t *p)
+{
+    return p->buffer.data() + p->header_len;
+}
+
+uint32_t mx_buf_get_size(mx_buf_t *p)
+{
+    return p->len;
+}
+
+void mx_buf_set_size(mx_buf_t *p, int32_t n)
+{
+    p->len = n;
+}
+
+#else
+    // Memory manager implementation
 
     mx_buf_t   *mx_buf_alloc(uint32_t len)
     {

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -487,14 +487,14 @@ public:
     // Overloads of the above to support passing nullptr
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const std::nullptr_t tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
         MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
-        return transfer_internal(tx_buffer, tx_length, rx_buffer, rx_length, callback, event);
+        return transfer_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, callback, event);
     }
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer(const WordT *tx_buffer, int tx_length, std::nullptr_t *rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
+    transfer(const WordT *tx_buffer, int tx_length, std::nullptr_t rx_buffer, int rx_length, const event_callback_t &callback, int event = SPI_EVENT_COMPLETE)
     {
         return transfer_internal(tx_buffer, tx_length, rx_buffer, rx_length, callback, event);
     }
@@ -535,14 +535,14 @@ public:
     // Overloads of the above to support passing nullptr
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const std::nullptr_t *tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const std::nullptr_t tx_buffer, int tx_length, CacheAlignedBuffer<WordT> &rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
         MBED_ASSERT(rx_length <= static_cast<int>(rx_buffer.capacity()));
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer.data(), rx_length, timeout);
     }
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    transfer_and_wait(const WordT *tx_buffer, int tx_length, std::nullptr_t *rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
+    transfer_and_wait(const WordT *tx_buffer, int tx_length, std::nullptr_t rx_buffer, int rx_length, rtos::Kernel::Clock::duration_u32 timeout = rtos::Kernel::wait_for_u32_forever)
     {
         return transfer_and_wait_internal(tx_buffer, tx_length, rx_buffer, rx_length, timeout);
     }

--- a/drivers/include/drivers/SPI.h
+++ b/drivers/include/drivers/SPI.h
@@ -390,16 +390,16 @@ public:
     // Overloads of the above to support passing nullptr
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    write(const std::nullptr_t *tx_buffer, int tx_length, WordT *rx_buffer, int rx_length)
+    write(const std::nullptr_t tx_buffer, int tx_length, WordT *rx_buffer, int rx_length)
     {
-        return write_internal(reinterpret_cast<char const *>(tx_buffer), tx_length, reinterpret_cast<char *>(rx_buffer), rx_length);
+        return write_internal(tx_buffer, tx_length, reinterpret_cast<char *>(rx_buffer), rx_length);
     }
 
     template<typename WordT>
     typename std::enable_if<std::is_integral<WordT>::value, int>::type
-    write(const WordT *tx_buffer, int tx_length, std::nullptr_t *rx_buffer, int rx_length)
+    write(const WordT *tx_buffer, int tx_length, std::nullptr_t rx_buffer, int rx_length)
     {
-        return write_internal(reinterpret_cast<char const *>(tx_buffer), tx_length, reinterpret_cast<char *>(rx_buffer), rx_length);
+        return write_internal(reinterpret_cast<char const *>(tx_buffer), tx_length, rx_buffer, rx_length);
     }
 
     /**


### PR DESCRIPTION
### Summary of changes <!-- Required -->

In #199, I made a breaking change to the async SPI interface to require use of cache-aligned buffers.  These are required for correct functionality when DMA SPI is being used, but unfortunately required heavy, breaking changes to the SPI API.

Turns out that when I did that, I broke stuff badly for B_U585I_IOT2A and its EMW3080B wifi module.  Had to make two fixes:
- Some typos in SPI.h were causing the SPI::transfer(nullptr, 0, rx_buffer, len) overload to not work correctly.  I fixed those and now it works as intended -- turns out you are supposed to accept `std::nullptr_t` and not `std::nullptr_t *`
- The EMW3080B driver has extensive infrastructure built on top of Mbed SPI, including its own network memory manager.  I had to rewrite this part of the driver to use DynamicCacheAlignedBuffer objects to allocate the buffers instead of just creating them with malloc.

#### Impact of changes <!-- Optional -->
B_U585I_IOT2A compiles again after #199!

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
