### PR TITLE
[draft] Don't reset the RTC time from gettimeofday(), plus other RTC cleanups

### DIFF
--- a/platform/source/mbed_rtc_time.cpp
+++ b/platform/source/mbed_rtc_time.cpp
@@ -97,7 +97,7 @@ int gettimeofday(struct timeval *tv, MBED_UNUSED void *tz)
     _mutex->lock();
     if (_rtc_isenabled != NULL) {
         if (!(_rtc_isenabled())) {
-            set_time(0);
+            _rtc_init();
         }
     }
 

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -287,37 +287,6 @@ void mbed_sdk_init()
     SystemCoreClockUpdate();
 #endif /* DUAL_CORE */
 
-    /* Start LSI clock for RTC */
-#if DEVICE_RTC
-#if (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_HSE)
-    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-#if defined(RCC_RTCCLKSOURCE_HSE_DIVX)
-    PeriphClkInitStruct.RTCClockSelection = (RCC_RTCCLKSOURCE_HSE_DIVX | RTC_HSE_DIV << 16);
-#else
-    PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV128;
-#endif
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
-        error("PeriphClkInitStruct RTC failed with HSE\n");
-    }
-#elif ((MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSE_OR_LSI) && !MBED_CONF_TARGET_LSE_AVAILABLE) || (MBED_CONF_TARGET_RTC_CLOCK_SOURCE == USE_RTC_CLK_LSI)
-    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-
-    if (__HAL_RCC_GET_RTC_SOURCE() != RCC_RTCCLKSOURCE_NO_CLK) {
-#if TARGET_STM32WB
-        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
-#else
-        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
-#endif
-        RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
-        RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
-        if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
-            error("Init : cannot initialize LSI\n");
-        }
-    }
-#endif /* ! MBED_CONF_TARGET_LSE_AVAILABLE */
-#endif /* DEVICE_RTC */
-
 #ifndef MBED_DEBUG
 #if MBED_CONF_TARGET_GPIO_RESET_AT_INIT
     /* Reset all GPIO */

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3806,7 +3806,7 @@
         ],
         "config": {
             "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             },
@@ -3815,7 +3815,7 @@
                 "value": 1
             },
             "lse_drive_load_level": {
-                "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH.  May require power cycle to board for changes to this setting to take effect!",
+                "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
                 "value": "RCC_LSEDRIVE_LOW"
             },
             "i2c_timing_value_algo": {
@@ -9772,13 +9772,24 @@
             "PICO_TIME_DEFAULT_ALARM_POOL_DISABLED",
             "PICO_ON_DEVICE=1",
             "PICO_UART_ENABLE_CRLF_SUPPORT=0"
-        ]
-    },
-    "RASPBERRY_PI_PICO": {
-        "inherits": ["RASPBERRY_PI_PICO_SWD"],
+        ],
         "overrides": {
             "console-usb": true,
-            "console-uart": false
+            "console-uart": false,
+
+            // ADC_VDD sets the ADC reference voltage on this chip.
+            // Most RP2040 boards set this pin to 3.3V.
+            // Note that if the I/O voltage is set to less than the ADC reference voltage,
+            // voltages higher than the I/O voltage are illegal for the analog pins
+            // (so the ADC can never read 100%).
+            "default-adc-vref": 3.3
+        }
+    },
+    "RASPBERRY_PI_PICO_SWD": {
+        "inherits": ["RASPBERRY_PI_PICO"],
+        "overrides": {
+            "console-usb": false,
+            "console-uart": true
         }
     }
 }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -1219,6 +1219,10 @@
                 "help": "Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used",
                 "value": "1"
             },
+            "lse_bypass": {
+                "help": "Change to 1 to use a logic level oscillator (not a crystal) on 32k LSE",
+                "value": "0"
+            },
             "rtc_clock_source": {
                 "help": "Define the RTC clock source. USE_RTC_CLK_LSE_OR_LSI, USE_RTC_CLK_LSI, USE_RTC_CLK_HSE. LPTICKER is not available for HSE and should be removed from the target configuration.",
                 "value": "USE_RTC_CLK_LSE_OR_LSI"
@@ -3626,10 +3630,6 @@
                 "value": "25000000",
                 "macro_name": "HSE_VALUE"
             },
-            "lse_bypass": {
-                "help": "1 to use an oscillator (not a crystal) on 32k LSE",
-                "value": "1"
-            },
             "usb_speed": {
                 "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
                 "value": "USE_USB_OTG_HS"
@@ -3662,6 +3662,7 @@
             "system_power_supply": "PWR_SMPS_1V8_SUPPLIES_LDO",
             "clock_source": "USE_PLL_HSE_EXTC",
             "lse_available": 1,
+            "lse_bypass": 1,
             "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET",
             "i2c_timing_value_algo": true
@@ -3805,7 +3806,7 @@
         ],
         "config": {
             "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             },
@@ -3814,7 +3815,7 @@
                 "value": 1
             },
             "lse_drive_load_level": {
-                "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH",
+                "help": "HSE drive load level  RCC_LSEDRIVE_LOW | RCC_LSEDRIVE_MEDIUMLOW | RCC_LSEDRIVE_MEDIUMHIGH | RCC_LSEDRIVE_HIGH.  May require power cycle to board for changes to this setting to take effect!",
                 "value": "RCC_LSEDRIVE_LOW"
             },
             "i2c_timing_value_algo": {
@@ -9763,7 +9764,7 @@
             "RTC"
         ]
     },
-    "RASPBERRY_PI_PICO": {
+    "RASPBERRY_PI_PICO_SWD": {
         "inherits": ["RP2040"],
         "macros_add": [
             "PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1",
@@ -9771,24 +9772,13 @@
             "PICO_TIME_DEFAULT_ALARM_POOL_DISABLED",
             "PICO_ON_DEVICE=1",
             "PICO_UART_ENABLE_CRLF_SUPPORT=0"
-        ],
+        ]
+    },
+    "RASPBERRY_PI_PICO": {
+        "inherits": ["RASPBERRY_PI_PICO_SWD"],
         "overrides": {
             "console-usb": true,
-            "console-uart": false,
-
-            // ADC_VDD sets the ADC reference voltage on this chip.
-            // Most RP2040 boards set this pin to 3.3V.
-            // Note that if the I/O voltage is set to less than the ADC reference voltage,
-            // voltages higher than the I/O voltage are illegal for the analog pins
-            // (so the ADC can never read 100%).
-            "default-adc-vref": 3.3
-        }
-    },
-    "RASPBERRY_PI_PICO_SWD": {
-        "inherits": ["RASPBERRY_PI_PICO"],
-        "overrides": {
-            "console-usb": false,
-            "console-uart": true
+            "console-uart": false
         }
     }
 }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -9764,7 +9764,7 @@
             "RTC"
         ]
     },
-    "RASPBERRY_PI_PICO_SWD": {
+    "RASPBERRY_PI_PICO": {
         "inherits": ["RP2040"],
         "macros_add": [
             "PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This is a fix for the RTC issues that [@sunnydaywest](https://forums.mbed.com/t/time-null-of-rtc-example-not-synchronizing-with-rtc-when-using-battery/22248) reported on the forums, and also as ARMmbed/mbed-os#15487.

As I explained in the thread, the easiest way to fix the issue is to update gettimeofday() to not reset the RTC time.  It's not intuitive for _getting_ the time to _reset_ the time, just because you didn't call rtc_init() first. 

While I was in the RTC code, I also took the opportunity to:
- Remove code from mbed_overrides.c which is also in rtc_api.c.  As far as we could tell, the code in rtc_api.c is the correct version, and it's what gets executed second so it makes sense for it to be the correct one.
- Move `target.lse_bypass` option to be for all STM32 targets, as this is a useful option which should work on all STM32 targets and might be wanted on custom boards
- Update docs for `target.clock_source` and `target.lse_drive_load_level` options

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
Calling time() or gettimeofday() without calling rtc_init() first will no longer cause the RTC time to be reset to 0.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
