### PR TITLE
Update STM32_gen_PeripheralPins.py for #212

### DIFF
--- a/targets/TARGET_STM/tools/STM32_gen_PeripheralPins.py
+++ b/targets/TARGET_STM/tools/STM32_gen_PeripheralPins.py
@@ -27,6 +27,8 @@ from xml.dom.minidom import parse, Node
 from argparse import RawTextHelpFormatter
 import subprocess
 
+if sys.version_info[0] < 3: raise Exception("Python 3+ is required (recommended latest one)")
+    
 GENPINMAP_VERSION = "1.20.5"
 
 ADD_DEVICE_IF = 0


### PR DESCRIPTION
In this PR I did small update of STM32_gen_PeripheralPins.py for protection against using python version older than python3+ and should be solution for #212 

Before this PR:
```
D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools>STM32_gen_PeripheralPins.py -m "STM32U575RGTx.xml"

Script version 1.20.5

Checking STM32_open_pin_data repo...
*** git clone https://github.com/STMicroelectronics/STM32_open_pin_data.git ***
*** git clone done

STM32_open_pin_data DB version STM32CubeMX-DB.6.0.90

 * Output directory: D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools\TARGET_CUSTOM\TARGET_STM\TARGET_STM32U5\TARGET_STM32U575xG\TARGET_STM32U575RGT
 * Generating PeripheralPins.c and PinNames.h with 'STM32_open_pin_data\mcu\STM32U575RGTx.xml'
 * GPIO file: STM32_open_pin_data\mcu\IP\GPIO-STM32U5x_gpio_v1_0_Modes.xml
Traceback (most recent call last):
  File "D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools\STM32_gen_PeripheralPins.py", line 1934, in <module>
    parse_pins()
  File "D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools\STM32_gen_PeripheralPins.py", line 1400, in parse_pins
    if "Variant" in s.attributes:
  File "C:\Python27\lib\xml\dom\minidom.py", line 523, in __getitem__
    return self._attrs[attname_or_tuple]
KeyError: 0
```
After this PR
```
D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools>STM32_gen_PeripheralPins.py -m "STM32U575RGTx.xml"
Traceback (most recent call last):
  File "D:\Mbed\MbedCE\MbedCE_test\mbed-os\targets\TARGET_STM\tools\STM32_gen_PeripheralPins.py", line 30, in <module>
    if sys.version_info[0] < 3: raise Exception("Python 3+ is required (recommended latest one).")
Exception: Python 3+ is required (recommended latest one).
```

I did real test with Python 2.7

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
N/A

### Documentation <!-- Required -->
N/A
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@multiplemonomials
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
