### PR TITLE
Add target hse u575xg

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32U5/TARGET_STM32U575xG/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/TARGET_STM32U575xG/cmsis_nvic.h
@@ -22,7 +22,7 @@
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-#define MBED_ROM_SIZE  0x0  // 0 B
+#define MBED_ROM_SIZE  0x100000 // 1MB
 #endif
 
 #if !defined(MBED_RAM_START)
@@ -30,7 +30,7 @@
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-#define MBED_RAM_SIZE  0x0  // 0 B
+#define MBED_RAM_SIZE  0xc0000 // 786K
 #endif
 
 #define NVIC_NUM_VECTORS        142

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -4884,6 +4884,18 @@
             "default-adc-vref": 3.3
         }
     },
+    "MCU_STM32U575xG": {
+        "inherits": [
+            "MCU_STM32U5"
+        ],
+        "public": false,
+        "extra_labels_add": [
+            "STM32U575xG"
+        ],
+        "macros_add": [
+            "STM32U575xx"
+        ]
+    },
 	"MCU_STM32U585xI": {
         "inherits": [
             "MCU_STM32U5"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

MCU family MCU_STM32U575xG:
- ROM and RAM size
- Added support for HSE and LSE MSI auto calibration
- Added USB clock config


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Has been discussed in mbed ce tickets.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Tests with USB and HSI not done.
Tests are done with HSE and LSE.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
