### PR TITLE
Add public getters for CircularBuffer sizes on BufferedSerial

### DIFF
--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -37,6 +37,9 @@
 #define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE  256
 #endif
 
+static_assert(MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE <= (2**16), "Serial RX Buffer size too big");
+static_assert(MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE <= (2**16), "Serial TX Buffer size too big");
+
 namespace mbed {
 /**
  * \defgroup drivers_BufferedSerial BufferedSerial class

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -37,8 +37,8 @@
 #define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE  256
 #endif
 
-static_assert(MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE <= (2**16), "Serial RX Buffer size too big");
-static_assert(MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE <= (2**16), "Serial TX Buffer size too big");
+static_assert(MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE <= (1<<16), "Serial RX Buffer size too big");
+static_assert(MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE <= (1<<16), "Serial TX Buffer size too big");
 
 namespace mbed {
 /**

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -267,6 +267,18 @@ public:
         int bits = 8, Parity parity = BufferedSerial::None, int stop_bits = 1
     );
 
+    /** Get the current used size of the tx buffer
+     *
+     *  @return The number of elements in the tx buffer
+     */
+    size_t txbuf_size() const;
+
+    /** Get the current used size of the rx buffer
+     *
+     *  @return The number of elements in the rx buffer
+     */
+    size_t rxbuf_size() const;
+
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -339,8 +339,8 @@ private:
      *  By default buffer size is 256 for TX and 256 for RX. Configurable
      *  through mbed_app.json
      */
-    CircularBuffer<char, MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE> _rxbuf;
-    CircularBuffer<char, MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE> _txbuf;
+    CircularBuffer<uint16_t, MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE> _rxbuf;
+    CircularBuffer<uint16_t, MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE> _txbuf;
 
     rtos::Mutex _mutex;
 

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -271,13 +271,13 @@ public:
      *
      *  @return The number of elements in the tx buffer
      */
-    size_t txbuf_size() const;
+    uint16_t txbuf_size() const;
 
     /** Get the current used size of the rx buffer
      *
      *  @return The number of elements in the rx buffer
      */
-    size_t rxbuf_size() const;
+    uint16_t rxbuf_size() const;
 
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -72,12 +72,12 @@ void BufferedSerial::set_format(int bits, Parity parity, int stop_bits)
     api_unlock();
 }
 
-size_t BufferedSerial::txbuf_size()
+size_t BufferedSerial::txbuf_size() const
 {
     return _txbuf.size();
 }
 
-size_t BufferedSerial::rxbuf_size()
+size_t BufferedSerial::rxbuf_size() const
 {
     return _rxbuf.size();
 }

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -72,6 +72,16 @@ void BufferedSerial::set_format(int bits, Parity parity, int stop_bits)
     api_unlock();
 }
 
+size_t BufferedSerial::txbuf_size()
+{
+    return _txbuf.size();
+}
+
+size_t BufferedSerial::rxbuf_size()
+{
+    return _rxbuf.size();
+}
+
 #if DEVICE_SERIAL_FC
 void BufferedSerial::set_flow_control(Flow type, PinName flow1, PinName flow2)
 {

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -72,12 +72,12 @@ void BufferedSerial::set_format(int bits, Parity parity, int stop_bits)
     api_unlock();
 }
 
-size_t BufferedSerial::txbuf_size() const
+uint16_t BufferedSerial::txbuf_size() const
 {
     return _txbuf.size();
 }
 
-size_t BufferedSerial::rxbuf_size() const
+uint16_t BufferedSerial::rxbuf_size() const
 {
     return _rxbuf.size();
 }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Adds `size_t txbuf_size() const;` and `size_t rxbuf_size() const;` to expose the current usage of each buffer

Changed counter type to 16 bits to allow larger buffer sizes

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
