### PR TITLE
Add feature for auto search of upload method config for custom targets

### DIFF
--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -75,10 +75,29 @@ endif()
 # Load upload method configuration defaults for this target.
 # Loading the settings here makes sure they are set at global scope, and also makes sure that
 # the user can override them by changing variable values after including app.cmake.
-set(EXPECTED_MBED_UPLOAD_CFG_FILE_PATH targets/upload_method_cfg/${MBED_TARGET}.cmake)
-if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/../../${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH})
-    message(STATUS "Mbed: Loading default upload method configuration from ${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH}")
-    include(${CMAKE_CURRENT_LIST_DIR}/../../${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH})
+#
+# default expected paths
+set(EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH ${CMAKE_SOURCE_DIR}/custom_targets/${MBED_TARGET}/${MBED_TARGET}.cmake)
+set(EXPECTED_MBED_UPLOAD_CFG_FILE_PATH ${CMAKE_SOURCE_DIR}/mbed-os/targets/upload_method_cfg/${MBED_TARGET}.cmake)
+
+# check if a custom upload config path is defined in top lvl cmake
+if((DEFINED CUSTOM_UPLOAD_CFG_PATH))
+    if(EXISTS ${CUSTOM_UPLOAD_CFG_PATH})
+        include(${CUSTOM_UPLOAD_CFG_PATH})
+        message(STATUS "Mbed: Custom upload config included from ${CUSTOM_UPLOAD_CFG_PATH}")
+    else()
+        message(FATAL_ERROR "Mbed: Custom upload config is defined but files was not found here - ${CUSTOM_UPLOAD_CFG_PATH}")
+    endif()
+	
+# check if a custom upload config is present in custom_targets/YOUR_TARGET folder
+elseif(EXISTS ${EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH})
+	include(${EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH})
+	message(STATUS "Mbed: Custom upload config included from ${EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH}")
+	
+# check for build in upload config
+elseif(EXISTS ${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH})
+	include(${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH})
+	message(STATUS "Mbed: Loading default upload method configuration from ${EXPECTED_MBED_UPLOAD_CFG_FILE_PATH}")
 else()
     message(STATUS "Mbed: Target does not have any upload method configuration.  'make flash-' commands will not be available unless configured by the upper-level project.")
     set(UPLOAD_METHOD_DEFAULT "NONE")

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -77,7 +77,7 @@ endif()
 # the user can override them by changing variable values after including app.cmake.
 #
 # default expected paths
-set(EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH ${CMAKE_SOURCE_DIR}/custom_targets/${MBED_TARGET}/${MBED_TARGET}.cmake)
+set(EXPECTED_CUSTOM_UPLOAD_CFG_FILE_PATH ${CMAKE_SOURCE_DIR}/custom_targets/upload_method_cfg/${MBED_TARGET}.cmake)
 set(EXPECTED_MBED_UPLOAD_CFG_FILE_PATH ${CMAKE_SOURCE_DIR}/mbed-os/targets/upload_method_cfg/${MBED_TARGET}.cmake)
 
 # check if a custom upload config path is defined in top lvl cmake


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR is in context of many discussions and I hope everyone will find its option.
* [#233](https://github.com/mbed-ce/mbed-os/pull/233)
* https://github.com/mbed-ce/mbed-os/discussions/112

In current state Mbed CE build system auto searches only for upload method config for regular targets. In case of custom targets is expected the config will be defined via top level cmakelist.

```
// this is example how look current structure of a project with a custom target
./Project_Name/
│
├── mbed-os/
├── Build/
├── Custom_targets/
│   ├── YOUR_TARGET/
│   │	└──  somefiles.xxx
│   ├── ANOTHER_TARGET/
│   │	└──  somefiles.xxx
│   └──	CMakeLists.txt
│
├── CMakeLists.txt
├── mabed_app.json
├── custom_targets.json
└── main.cpp
```
This PR brings the build system will also search for an upload method config in `custom_targets/upload_method_cfg/` folder (it mirrors same logic from `mbed-os/targets/upload_method_cfg/` folder) and also brings an option to change default expected path via top lvl cmakelist.

```
// this is example how will look new expected structure of a project with a custom target
./Project_Name/
│
├── mbed-os/
├── Build/
├── Custom_targets/
│   ├── YOUR_TARGET/
│   │   └──  somefiles.xxx
│   ├── ANOTHER_TARGET/
│   │   └──  somefiles.xxx
│   │
│   ├── upload_method_cfg/
│   │   ├──  YOUR_TARGET.cmake
│   │   └──  ANOTHER_TARGET.cmake
│   └──	CMakeLists.txt
│
├── CMakeLists.txt
├── custom_targets.json
├── mabed_app.json
└── main.cpp
```

We will have an official automated solution how to deal with upload method config file for custom targets. But also a solution for anyone who want to go its own way.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
N/A

### Documentation <!-- Required -->
How will this merged I can update [custom target example 
](https://github.com/mbed-ce/mbed-ce-custom-targets)  as soon as possible.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@multiplemonomials 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
