### PR TITLE
Bugfix: Only link mbed-wifi if it exists for this target

### DIFF
--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -79,7 +79,14 @@ target_link_libraries(mbed-netsocket
 
 target_link_libraries(mbed-netsocket
     INTERFACE
-        mbed-wifi
         mbed-cellular
         mbed-nanostack-libservice
 )
+
+# Link in mbed-wifi if we have any wifi drivers
+if(TARGET mbed-wifi)
+    target_link_libraries(mbed-netsocket
+        INTERFACE
+            mbed-wifi
+    )
+endif()

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8893,8 +8893,6 @@
         "TFM_OUTPUT_EXT": "hex"
     },
     // Also known as CYSBSYSKIT-DEV-01 Rapid IoT Connect Developer Kit
-    // Note: It appears that Infineon is also maintaining this as a custom target here:
-    // https://github.com/Infineon/TARGET_CYSBSYSKIT-DEV-01
     // However, as of 2024, I cannot find this board anywhere for sale, so it may be a candidate for removal.
     "CYSBSYSKIT_01": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes a build error that was happening after #247 for targets that did not have any wifi drivers when you linked mbed-netsocket.  The issue is that if you pass a non-existant library to a target_link_libraries() call, CMake thinks it's a system library and tries to link it with -l (legacy behavior), causing a linker error rather than a CMake error as it should.  Thanks to @JojoS62 for diagnosing the issue!

#### Impact of changes <!-- Optional -->
mbed-netsocket should be usable again... oops

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Ideally this should be covered by one of the new CI builds once they're added...
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
