### PR TITLE
Use a virtual environment for Python packages by default

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -216,7 +216,8 @@ jobs:
 
       - name: Install python3-venv
         run: |
-          sudo apt-get install -y python3-venv
+          apt-get update
+          apt-get install -y python3-venv
 
       -
         name: cmake build

--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -214,11 +214,6 @@ jobs:
         name: Checkout repo
         uses: actions/checkout@v3
 
-
-      - name: Install Python packages
-        run: |
-          python3 -m pip install -r tools/requirements.txt
-
       -
         name: cmake build
         run: |

--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -214,6 +214,10 @@ jobs:
         name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Install python3-venv
+        run: |
+          sudo apt-get install -y python3-venv
+
       -
         name: cmake build
         run: |

--- a/.github/workflows/greentea_cmake.yml
+++ b/.github/workflows/greentea_cmake.yml
@@ -10,10 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Python packages
-        run: |
-            python3 -m pip install -r tools/requirements.txt
-
       - name: Build NUCLEO_G031K8 with baremetal profile
         run: |
             rm -rf __build

--- a/.github/workflows/greentea_cmake.yml
+++ b/.github/workflows/greentea_cmake.yml
@@ -10,6 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install python3-venv
+        run: |
+          sudo apt-get install -y python3-venv
+
       - name: Build NUCLEO_G031K8 with baremetal profile
         run: |
             rm -rf __build

--- a/.github/workflows/greentea_cmake.yml
+++ b/.github/workflows/greentea_cmake.yml
@@ -12,7 +12,8 @@ jobs:
 
       - name: Install python3-venv
         run: |
-          sudo apt-get install -y python3-venv
+          apt-get update
+          apt-get install -y python3-venv
 
       - name: Build NUCLEO_G031K8 with baremetal profile
         run: |

--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -9,10 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
-      - name: Install Python packages
-        run: |
-            python3 -m pip install -r tools/requirements.txt
 
       - name: Build the multiple_executables example
         run: |

--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -10,12 +10,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install Python packages
+        run: |
+          python3 -m pip install -r tools/requirements.txt
+
+      # Note: For this CI job we use MBED_CREATE_PYTHON_VENV=FALSE so that we can make sure
+      # this mode works.
       - name: Build the multiple_executables example
         run: |
             cd tools/cmake/tests/multiple_executables/
             mkdir cmake_build
             cd cmake_build
-            cmake -DMBED_TARGET=ARM_MUSCA_S1 ..
+            cmake -DMBED_TARGET=ARM_MUSCA_S1 -DMBED_CREATE_PYTHON_VENV=FALSE ..
             cmake --build .
 
       - name: Verify the post-build command has run successfully on each image

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -11,28 +11,7 @@ if(CCACHE)
 endif()
 
 # Find Python (needed to generate configurations)
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-include(CheckPythonPackage)
-
-# Check python packages
-set(PYTHON_PACKAGES_TO_CHECK intelhex prettytable future jinja2)
-foreach(PACKAGE_NAME ${PYTHON_PACKAGES_TO_CHECK})
-    string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UCASE) # Ucase name needed for CMake variable
-    string(TOLOWER ${PACKAGE_NAME} PACKAGE_NAME_LCASE) # Lcase name needed for import statement
-
-    check_python_package(${PACKAGE_NAME_LCASE} HAVE_PYTHON_${PACKAGE_NAME_UCASE})
-    if(NOT HAVE_PYTHON_${PACKAGE_NAME_UCASE})
-        message(WARNING "Missing Python dependency ${PACKAGE_NAME}")
-    endif()
-endforeach()
-
-# Check deps for memap
-if(Python3_FOUND AND HAVE_PYTHON_INTELHEX AND HAVE_PYTHON_PRETTYTABLE)
-    set(HAVE_MEMAP_DEPS TRUE)
-else()
-    set(HAVE_MEMAP_DEPS FALSE)
-    message(STATUS "Missing Python dependencies (at least one of: python3, intelhex, prettytable) so the memory map cannot be printed")
-endif()
+include(mbed_python_interpreter)
 
 include(mbed_generate_config_header)
 include(mbed_target_functions)

--- a/tools/cmake/mbed_generate_configuration.cmake
+++ b/tools/cmake/mbed_generate_configuration.cmake
@@ -32,6 +32,12 @@ set(MBED_INTERNAL_LAST_MBED_TARGET "${MBED_TARGET}" CACHE INTERNAL "Previous mbe
 get_filename_component(MBED_APP_JSON_PATH "${MBED_APP_JSON_PATH}" ABSOLUTE BASE_DIR ${CMAKE_SOURCE_DIR})
 get_filename_component(CUSTOM_TARGETS_JSON_PATH "${CUSTOM_TARGETS_JSON_PATH}" ABSOLUTE BASE_DIR ${CMAKE_SOURCE_DIR})
 
+# Make it so that if mbed_app.json or custom_targets.json are modified, CMake is rerun.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${MBED_APP_JSON_PATH})
+if(EXISTS "${CUSTOM_TARGETS_JSON_PATH}" AND (NOT IS_DIRECTORY "${CUSTOM_TARGETS_JSON_PATH}"))
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CUSTOM_TARGETS_JSON_PATH})
+endif()
+
 # Check if mbed_app.json was modified
 # Note: if the path is an empty string, get_filename_component(ABSOLUTE) will convert it to a directory,
 # so we have to verify that the path we have is a file, not a dir.
@@ -92,6 +98,7 @@ if(MBED_NEED_TO_RECONFIGURE)
 
     set(MBEDTOOLS_CONFIGURE_COMMAND ${Python3_EXECUTABLE}
         -c "import mbed_tools.cli.main\; exit(mbed_tools.cli.main.cli())" # This is used instead of invoking mbed_tools as a script, because it might not be on the user's PATH.
+        -v # without -v, warnings (e.g. "you have tried to override a nonexistent parameter") do not get printed
         configure
         -t GCC_ARM # GCC_ARM is currently the only supported toolchain
         -m "${MBED_TARGET}"

--- a/tools/cmake/mbed_python_interpreter.cmake
+++ b/tools/cmake/mbed_python_interpreter.cmake
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CMake script to find the Python interpreter and either install or find
+# Mbed's dependencies.
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+include(CheckPythonPackage)
+
+option(MBED_CREATE_PYTHON_VENV "If true, Mbed OS will create its own virtual environment (venv) and install its Python packages there.  This removes the need to manually install Python packages." TRUE)
+
+if(MBED_CREATE_PYTHON_VENV)
+    # Create venv.
+    # Note: venv is stored in the source directory as it can be shared between all the build directories
+    # (not target specific)
+    set(MBED_VENV_LOCATION ${CMAKE_SOURCE_DIR}/mbed-os/venv)
+    set(VENV_STAMP_FILE ${MBED_VENV_LOCATION}/mbed-venv.stamp)
+    set(MBED_REQUIREMENTS_TXT_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../requirements.txt")
+
+    set(NEED_TO_CREATE_VENV FALSE)
+    set(NEED_TO_INSTALL_PACKAGES FALSE)
+    if(NOT EXISTS "${VENV_STAMP_FILE}")
+        set(NEED_TO_CREATE_VENV TRUE)
+        set(NEED_TO_INSTALL_PACKAGES TRUE)
+    elseif("${MBED_REQUIREMENTS_TXT_LOCATION}" IS_NEWER_THAN "${VENV_STAMP_FILE}")
+        set(NEED_TO_INSTALL_PACKAGES TRUE)
+    endif()
+
+    if(NEED_TO_CREATE_VENV)
+        check_python_package(venv HAVE_PYTHON_VENV)
+        if(NOT HAVE_PYTHON_VENV)
+            message(FATAL_ERROR "Need the venv python package installed in interpreter at ${Python3_EXECUTABLE} to create a venv.
+To disable venv creation, set MBED_CREATE_PYTHON_VENV to false.")
+        endif()
+
+        # Using approach from here: https://discourse.cmake.org/t/possible-to-create-a-python-virtual-env-from-cmake-and-then-find-it-with-findpython3/1132/2
+        message(STATUS "Mbed: Creating virtual environment with Python interpreter ${Python3_EXECUTABLE}")
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -m venv ${MBED_VENV_LOCATION}
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+
+        ## update the environment with VIRTUAL_ENV variable (mimic the activate script)
+        set (ENV{VIRTUAL_ENV} ${MBED_VENV_LOCATION})
+        ## change the context of the search
+        set (Python3_FIND_VIRTUALENV ONLY)
+        ## Reset FindPython3 cache variables so it will run again
+        unset(Python3_EXECUTABLE)
+        unset(_Python3_EXECUTABLE CACHE)
+        unset(_Python3_INTERPRETER_PROPERTIES CACHE)
+        unset(_Python3_INTERPRETER_SIGNATURE CACHE)
+        ## Launch a new search for Python3
+        find_package (Python3 REQUIRED COMPONENTS Interpreter)
+    endif()
+
+    if(NEED_TO_INSTALL_PACKAGES)
+        message(STATUS "Mbed: Installing Python requirements for Mbed into venv")
+        # Upgrade pip first in case it needs an upgrade, to prevent a warning being printed
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade pip
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -m pip install -r ${MBED_REQUIREMENTS_TXT_LOCATION}
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+
+        message("Mbed: venv created successfully")
+        file(TOUCH ${VENV_STAMP_FILE})
+    endif()
+
+    # We always have the memap deps with the venv
+    set(HAVE_MEMAP_DEPS TRUE)
+
+else()
+
+    # Check python packages
+    set(PYTHON_PACKAGES_TO_CHECK intelhex prettytable future jinja2)
+    foreach(PACKAGE_NAME ${PYTHON_PACKAGES_TO_CHECK})
+        string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UCASE) # Ucase name needed for CMake variable
+        string(TOLOWER ${PACKAGE_NAME} PACKAGE_NAME_LCASE) # Lcase name needed for import statement
+
+        check_python_package(${PACKAGE_NAME_LCASE} HAVE_PYTHON_${PACKAGE_NAME_UCASE})
+        if(NOT HAVE_PYTHON_${PACKAGE_NAME_UCASE})
+            message(WARNING "Missing Python dependency ${PACKAGE_NAME}")
+        endif()
+    endforeach()
+
+    # Check deps for memap
+    if(Python3_FOUND AND HAVE_PYTHON_INTELHEX AND HAVE_PYTHON_PRETTYTABLE)
+        set(HAVE_MEMAP_DEPS TRUE)
+    else()
+        set(HAVE_MEMAP_DEPS FALSE)
+        message(STATUS "Missing Python dependencies (at least one of: python3, intelhex, prettytable) so the memory map cannot be printed")
+    endif()
+
+endif()

--- a/tools/cmake/mbed_python_interpreter.cmake
+++ b/tools/cmake/mbed_python_interpreter.cmake
@@ -59,7 +59,7 @@ if(MBED_CREATE_PYTHON_VENV)
             COMMAND_ERROR_IS_FATAL ANY
         )
 
-        message("Mbed: venv created successfully")
+        message(STATUS "Mbed: venv created successfully")
         file(TOUCH ${VENV_STAMP_FILE})
     endif()
 

--- a/tools/cmake/mbed_python_interpreter.cmake
+++ b/tools/cmake/mbed_python_interpreter.cmake
@@ -27,12 +27,6 @@ if(MBED_CREATE_PYTHON_VENV)
     endif()
 
     if(NEED_TO_CREATE_VENV)
-        check_python_package(venv HAVE_PYTHON_VENV)
-        if(NOT HAVE_PYTHON_VENV)
-            message(FATAL_ERROR "Need the venv python package installed in interpreter at ${Python3_EXECUTABLE} to create a venv.
-To disable venv creation, set MBED_CREATE_PYTHON_VENV to false.")
-        endif()
-
         # Using approach from here: https://discourse.cmake.org/t/possible-to-create-a-python-virtual-env-from-cmake-and-then-find-it-with-findpython3/1132/2
         message(STATUS "Mbed: Creating virtual environment with Python interpreter ${Python3_EXECUTABLE}")
         execute_process(


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Using Mbed lately, and watching others use it, I have been feeling like the need to install Python packages, and to reinstall them if Mbed adds a new requirement, causes annoyance for people a lot of the time.  Traditionally I've been a bit of a critic of venvs but as I have gotten more into Python development I have understood their value more.  It's simply too common to have broken system packages, or a system with a too old version of a package, or a dependency conflict with something else you have installed.

While it's still nice to have the option to use system packages if needed, making the default to create a new venv with all the correct stuff seems like it will make Mbed more user friendly, and therefore, is worth doing.  The venv uses about 60MB per instance on my machine, which is not nothing, but still pretty manageable, especially compared to the size of Mbed itself.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
By default, Mbed's CMake scripts will now create a virtual environment under the mbed-os source dir when run for the first time.  The venv is located in the source dir to de-duplicate it, as it is not specific to a given build directory. 

The option `-DMBED_CREATE_PYTHON_VENV=FALSE` can be passed to CMake in order to disable this and switch to the old behavior of using the system interpreter.

Also, I fixed two other annoying issues in this PR:
- Up until now, modifying mbed_app.json or custom_targets.json and then running ninja did not cause the configuration to be regenerated because CMake was not rerun.  This has been fixed; CMake will now be rerun.
- Setting a nonexistant property in your target_overrides section did not cause any error or warning to be printed.  Now, a visible warning will be printed to the console.  (turned out we were missing the -v option to mbed-tools)
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

Once this PR is approved I will update all of the wiki pages to remove instructions to install the Python packages.  It should be a bit simpler!

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
