### PR TITLE
Fix STM32H7 LPUART clock source being incorrect for higher baudrates

### DIFF
--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3187,6 +3187,7 @@
         ],
         "overrides": {
             "lpticker_delay_ticks": 0,
+            // Mbed's clock code does not initialize PLL2, so we have to disable USE_LPUART_CLK_PCLK1 here.
             "lpuart_clock_source": "USE_LPUART_CLK_LSE|USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "device_has_add": [

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -1203,8 +1203,8 @@
                 "value": "USE_RTC_CLK_LSE_OR_LSI"
             },
             "lpuart_clock_source": {
-                "help": "Define the LPUART clock source. Mask values: USE_LPUART_CLK_LSE, USE_LPUART_CLK_PCLK1, USE_LPUART_CLK_HSI",
-                "value": "USE_LPUART_CLK_LSE|USE_LPUART_CLK_PCLK1|USE_LPUART_CLK_PCLK3"
+                "help": "Define the LPUART clock source. LSE clock source will only be used when baudrate is slow (<= LSE freq / 3).  Mask values: USE_LPUART_CLK_LSE, USE_LPUART_CLK_PCLK1, USE_LPUART_CLK_PCLK3, USE_LPUART_CLK_HSI, USE_LPUART_CLK_SYSCLK.",
+                "value": "USE_LPUART_CLK_LSE|USE_LPUART_CLK_PCLK1|USE_LPUART_CLK_PCLK3|USE_LPUART_CLK_SYSCLK"
             },
             "stdio_uart_tx": {
                 "help": "default TX STDIO pins is defined in PinNames.h file, but it can be overridden"
@@ -3186,7 +3186,8 @@
             "MBED_TICKLESS"
         ],
         "overrides": {
-            "lpticker_delay_ticks": 0
+            "lpticker_delay_ticks": 0,
+            "lpuart_clock_source": "USE_LPUART_CLK_LSE|USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "device_has_add": [
             "ANALOGOUT",
@@ -4264,7 +4265,7 @@
             "STM32L475xG"
         ],
         "overrides": {
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "macros_add": [
             "STM32L475xx",
@@ -4308,7 +4309,7 @@
             "STM32L476xG"
         ],
         "overrides": {
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "macros_add": [
             "STM32L476xx",
@@ -4370,7 +4371,7 @@
             "STM32L486xG"
         ],
         "overrides": {
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "macros_add": [
             "STM32L486xx",
@@ -4420,7 +4421,7 @@
             "STM32L496xG"
         ],
         "overrides": {
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "macros_add": [
             "STM32L496xx"
@@ -4781,7 +4782,7 @@
         },
         "overrides": {
             "lpticker_delay_ticks": 0,
-            "lpuart_clock_source": "USE_LPUART_CLK_HSI"
+            "lpuart_clock_source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK"
         },
         "device_has_add": [
             "ANALOGOUT",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

USC RPL noticed another bug: on STM32H7, if you set the LPUART to run at higher than 9600 baud, data is not transmitted (& presumably received) correctly.  @qwertyquerty noticed that when he set 115200 baud, he was actually getting 960 baud!  I suspect that noone noticed this before because LPUART is more commonly used at lower baudrates, but it's actually better than the regular UART peripherals (it has a FIFO though Mbed currently does not enable the FIFO), so no reason not to use it at higher baudrates too.

Digging into it a bit, it looks like what happens is, the serial_api.c code checks the baudrate, and if it's too low to run off the LSE oscillator, it falls back to the next configured clock source.  By default, on STM32H7, that is PLL2.  However, we don't actually use PLL2 in code, so I don't even think it was getting enabled (frankly I'm not sure how data was getting transmitted at all, at any baud).

This PR fixes it so that on STM32H7, only LSE, HSI, and SYSCLK are selected as clock sources for LPUART as these are the clock sources that actually work!  It also cleans up and documents the way that this option works.

#### Impact of changes <!-- Optional -->
- STM32H7 processors can now use LPUART at baudrates above 9600
- Undocumented SYSCLK fallback for LPUART clock source is now documented
- Improved documentation for `target.lpuart_clock_source` option
- LPUART clock code does not try to use LSE oscillator if LSE oscillator does not exist

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Updated docs in targets.json5

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
