### PR TITLE
Reactivate block device tests

### DIFF
--- a/storage/blockdevice/CMakeLists.txt
+++ b/storage/blockdevice/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if(MBED_ENABLE_OS_INTERNAL_TESTS)
     if(MBED_BUILD_GREENTEA_TESTS)
-        # add greentea test
+        add_subdirectory(tests/TESTS)
     else()
         add_subdirectory(COMPONENT_QSPIF)
         add_subdirectory(tests/UNITTESTS)

--- a/storage/blockdevice/tests/TESTS/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(blockdevice)

--- a/storage/blockdevice/tests/TESTS/blockdevice/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(buffered_block_device)
+add_subdirectory(flashsim_block_device)
+add_subdirectory(general_block_device)
+add_subdirectory(heap_block_device)
+add_subdirectory(mbr_block_device)
+add_subdirectory(util_block_device)

--- a/storage/blockdevice/tests/TESTS/blockdevice/buffered_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/buffered_block_device/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-buffered_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-buffered_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/storage/blockdevice/tests/TESTS/blockdevice/flashsim_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/flashsim_block_device/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-flashsim_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-flashsim_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/CMakeLists.txt
@@ -1,46 +1,37 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-general_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
-if("DATAFLASH" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_DATAFLASH=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-dataflash)
 endif()
 
-if("FLASHIAP" IN_LIST MBED_TARGET_LABELS)
+if("DEVICE_FLASH=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-flashiap)
 endif()
 
-if("I2CEE" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_I2CEE=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-i2cee)
 endif()
 
-if("OSPIF" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_OSPIF=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-ospif)
 endif()
 
-if("QSPIF" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_QSPIF=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-qspif)
 endif()
 
-if("SD" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_SD=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-sd)
 endif()
 
-if("SPIF" IN_LIST MBED_TARGET_LABELS)
+if("COMPONENT_SPIF=1" IN_LIST MBED_TARGET_DEFINITIONS)
     list(APPEND mbed_blockdevice_libs mbed-storage-spif)
 endif()
 
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-general_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -49,7 +49,7 @@
 #include "SDBlockDevice.h"
 #endif
 
-#if COMPONENT_FLASHIAP
+#if DEVICE_FLASH
 #include "FlashIAPBlockDevice.h"
 #endif
 
@@ -108,7 +108,7 @@ static SingletonPtr<rtos::Mutex> _mutex;
 
 BlockDevice *block_device = NULL;
 
-#if COMPONENT_FLASHIAP
+#if DEVICE_FLASH
 static inline uint32_t align_up(uint32_t val, uint32_t size)
 {
     return (((val - 1) / size) + 1) * size;
@@ -210,7 +210,7 @@ static BlockDevice *get_bd_instance(uint8_t bd_type)
             break;
         }
         case flashiap: {
-#if COMPONENT_FLASHIAP
+#if DEVICE_FLASH
 #if (MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE == 0) && (MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS == 0xFFFFFFFF)
 
             size_t flash_size;
@@ -907,7 +907,7 @@ void test_get_type_functionality()
     TEST_ASSERT_EQUAL(0, strcmp(bd_type, "DATAFLASH"));
 #elif COMPONENT_SD
     TEST_ASSERT_EQUAL(0, strcmp(bd_type, "SD"));
-#elif COMPONENT_FLASHIAP
+#elif DEVICE_FLASH
     TEST_ASSERT_EQUAL(0, strcmp(bd_type, "FLASHIAP"));
 #elif COMPONENT_SPINAND
     TEST_ASSERT_EQUAL(0, strcmp(bd_type, "SPINAND"));
@@ -966,7 +966,7 @@ int get_bd_count()
 #if COMPONENT_SD
     bd_arr[count++] = sd;             //3
 #endif
-#if COMPONENT_FLASHIAP
+#if DEVICE_FLASH
     bd_arr[count++] = flashiap;       //4
 #endif
 #if COMPONENT_OSPIF

--- a/storage/blockdevice/tests/TESTS/blockdevice/heap_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/heap_block_device/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-heap_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-heap_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/storage/blockdevice/tests/TESTS/blockdevice/mbr_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/mbr_block_device/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-mbr_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME   
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-mbr_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS

--- a/storage/blockdevice/tests/TESTS/blockdevice/util_block_device/CMakeLists.txt
+++ b/storage/blockdevice/tests/TESTS/blockdevice/util_block_device/CMakeLists.txt
@@ -1,18 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
-
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-storage-blockdevice-util_block_device)
-
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
 mbed_greentea_add_test(
     TEST_NAME
-        ${TEST_TARGET}
+        mbed-storage-blockdevice-util_block_device
     TEST_SOURCES
         main.cpp
     TEST_REQUIRED_LIBS


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR reactivates the tests of all the block devices under storage/blockdevices,  Looking at these tests initially I had thought that they were just for the "software" block devices like SlicingBlockDevice, but actually no: the "general" block device test actually tests all the hardware block device drivers if they exist on the current target.

I set up the build system for these tests so that they should now be able to run again.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

I ran the new tests on Arduino Giga (which has a QSPIF block device) and they all passed.
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
