### PR TITLE
Add Arduino Nicla Sense ME support

### DIFF
--- a/drivers/source/PwmOut.cpp
+++ b/drivers/source/PwmOut.cpp
@@ -142,8 +142,8 @@ void PwmOut::resume()
     core_util_critical_section_enter();
     if (!_initialized) {
         PwmOut::init();
-        PwmOut::write(_duty_cycle);
         PwmOut::period_us(_period_us);
+        PwmOut::write(_duty_cycle);
     }
     core_util_critical_section_exit();
 }

--- a/storage/blockdevice/COMPONENT_SD/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_SD/mbed_lib.json
@@ -133,12 +133,6 @@
           "SPI_MOSI": "SPI_MOSI",
           "SPI_MISO": "SPI_MISO",
           "SPI_CLK": "SPI_SCK"
-        },
-      "ARDUINO_NICLA_SENSE_ME": {
-          "SPI_MOSI": "P0_13",
-          "SPI_MISO": "P0_14",
-          "SPI_CLK":  "P0_12",
-          "SPI_CS":   "P0_16"
-      }
+        }
     }
 }

--- a/storage/blockdevice/COMPONENT_SD/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_SD/mbed_lib.json
@@ -133,6 +133,12 @@
           "SPI_MOSI": "SPI_MOSI",
           "SPI_MISO": "SPI_MISO",
           "SPI_CLK": "SPI_SCK"
-        }
+        },
+      "ARDUINO_NICLA_SENSE_ME": {
+          "SPI_MOSI": "P0_13",
+          "SPI_MISO": "P0_14",
+          "SPI_CLK":  "P0_12",
+          "SPI_CS":   "P0_16"
+      }
     }
 }

--- a/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
@@ -67,6 +67,9 @@
            "SPI_MISO": "SPI3_MISO",
            "SPI_CLK":  "SPI3_SCK",
            "SPI_CS":   "SPI_CS1"
-       }
+       },
+      "ARDUINO_NICLA_SENSE_ME": {
+          "SPI_CS":   "CS_FLASH"
+      }
     }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_library(mbed-nrf52-dk INTERFACE)
 add_library(mbed-sdt52832b INTERFACE)
+add_library(mbed-arduino-nicla-sense-me INTERFACE)
 
 target_include_directories(mbed-nrf52-dk
     INTERFACE
@@ -13,6 +14,12 @@ target_include_directories(mbed-sdt52832b
     INTERFACE
         TARGET_SDT52832B
 )
+
+target_include_directories(mbed-arduino-nicla-sense-me
+    INTERFACE
+        TARGET_ARDUINO_NICLA_SENSE_ME
+)
+
 
 if(${MBED_TOOLCHAIN} STREQUAL "ARM")
     set(LINKER_FILE device/TOOLCHAIN_ARM_STD/nRF52832.sct)
@@ -46,3 +53,4 @@ mbed_set_linker_script(mbed-mcu-nrf52832 ${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_FI
 target_link_libraries(mbed-mcu-nrf52832 INTERFACE mbed-nrf52 mbed-sdk-15-0)
 target_link_libraries(mbed-nrf52-dk INTERFACE mbed-mcu-nrf52832)
 target_link_libraries(mbed-sdt52832b INTERFACE mbed-mcu-nrf52832)
+target_link_libraries(mbed-arduino-nicla-sense-me INTERFACE mbed-mcu-nrf52832)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list
+ *      of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
+ *      integrated circuit in a product or a software update for such product, must reproduce
+ *      the above copyright notice, this list of conditions and the following disclaimer in
+ *      the documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without specific prior
+ *      written permission.
+ *
+ *   4. This software, with or without modification, must only be used with a
+ *      Nordic Semiconductor ASA integrated circuit.
+ *
+ *   5. Any software provided in binary or object form under this license must not be reverse
+ *      engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* MBED TARGET LIST: ARDUINO_NICLA_SENSE_ME */
+
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+    p31 = 31,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,
+    P0_31 = p31,
+
+    //INT_BQ = p18,
+    INT_BHI260 = p14,
+    BQ_CDN = p25,
+    INT_ESLOV = p19,
+    //BHI_HOSTBOOT = p25,
+    RESET_BHI260 = p18,
+
+    GPIO0 = p24,
+    GPIO1 = p20,
+    GPIO2 = p9,
+    GPIO3 = p10,
+
+    RX_PIN_NUMBER  = p9,
+    TX_PIN_NUMBER  = p20,
+    CTS_PIN_NUMBER = NC,
+    RTS_PIN_NUMBER = NC,
+
+    CONSOLE_TX = TX_PIN_NUMBER,
+    CONSOLE_RX = RX_PIN_NUMBER,
+
+    // Mbed interface chip pins
+    STDIO_UART_TX = TX_PIN_NUMBER,
+    STDIO_UART_RX = RX_PIN_NUMBER,
+    STDIO_UART_CTS = CTS_PIN_NUMBER,
+    STDIO_UART_RTS = RTS_PIN_NUMBER,
+} PinName;
+
+// Alternate names for pins
+#define SPI_PSELSCK0   p3,
+#define SPI_PSELMISO0  p5,
+#define SPI_PSELMOSI0  p4,
+#define SPI_PSELSS0    p31,
+#define CS_FLASH       p26,
+
+#define SPI_PSELSS1    p29,
+#define SPI_PSELMISO1  p28,
+#define SPI_PSELMOSI1  p27,
+#define SPI_PSELSCK1   p11,
+
+#define SPI_MOSI       SPI_PSELMOSI0,
+#define SPI_MISO       SPI_PSELMISO0,
+#define SPI_CLK        SPI_PSELSCK0,
+#define SPI_CS         SPI_PSELSS0,
+
+#define SPI_COPI       SPI_PSELMOSI0,
+#define SPI_CIPO       SPI_PSELMISO0,
+
+#define I2C_SDA0  p15,
+#define I2C_SCL0  p16,
+
+#define I2C_SDA1  p22,
+#define I2C_SCL1  p23,
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
@@ -153,30 +153,33 @@ typedef enum {
 } PinName;
 
 // Alternate names for pins
-#define SPI_PSELSCK0   p3,
-#define SPI_PSELMISO0  p5,
-#define SPI_PSELMOSI0  p4,
-#define SPI_PSELSS0    p31,
-#define CS_FLASH       p26,
+#define SPI_PSELSCK0   p3
+#define SPI_PSELMISO0  p5
+#define SPI_PSELMOSI0  p4
+#define SPI_PSELSS0    p31
+#define CS_FLASH       p26
 
-#define SPI_PSELSS1    p29,
-#define SPI_PSELMISO1  p28,
-#define SPI_PSELMOSI1  p27,
-#define SPI_PSELSCK1   p11,
+#define SPI_PSELSS1    p29
+#define SPI_PSELMISO1  p28
+#define SPI_PSELMOSI1  p27
+#define SPI_PSELSCK1   p11
 
-#define SPI_MOSI       SPI_PSELMOSI0,
-#define SPI_MISO       SPI_PSELMISO0,
-#define SPI_CLK        SPI_PSELSCK0,
-#define SPI_CS         SPI_PSELSS0,
+#define SPI_MOSI       SPI_PSELMOSI0
+#define SPI_MISO       SPI_PSELMISO0
+#define SPI_SCK        SPI_PSELSCK0
+#define SPI_CS         SPI_PSELSS0
 
-#define SPI_COPI       SPI_PSELMOSI0,
-#define SPI_CIPO       SPI_PSELMISO0,
+#define SPI_COPI       SPI_PSELMOSI0
+#define SPI_CIPO       SPI_PSELMISO0
 
-#define I2C_SDA0  p15,
-#define I2C_SCL0  p16,
+#define I2C_SDA0  p15
+#define I2C_SCL0  p16
 
-#define I2C_SDA1  p22,
-#define I2C_SCL1  p23,
+#define I2C_SDA1  p22
+#define I2C_SCL1  p23
+
+// LEDs & buttons
+#define BUTTON1 p21
 
 typedef enum {
     PullNone = 0,

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/PinNames.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Nordic Semiconductor ASA
  * All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -172,11 +173,15 @@ typedef enum {
 #define SPI_COPI       SPI_PSELMOSI0
 #define SPI_CIPO       SPI_PSELMISO0
 
-#define I2C_SDA0  p15
-#define I2C_SCL0  p16
+// Note: Arduino convention is for I2C1 to be the "internal" I2C and for I2C0
+// to be the "external" I2C available on the pins.  Unfortunately this is backward to
+// how they are named in the schematic...
 
-#define I2C_SDA1  p22
-#define I2C_SCL1  p23
+#define I2C_SDA0  p22
+#define I2C_SCL0  p23
+
+#define I2C_SDA1  p15
+#define I2C_SCL1  p16
 
 // LEDs & buttons
 #define BUTTON1 p21

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_ARDUINO_NICLA_SENSE_ME/device.h
@@ -1,0 +1,22 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#include "objects.h"
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -16,28 +16,12 @@
 
 /* Linker script to configure memory regions. */
 
-/* Default to no softdevice */
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x0
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x80000
-#endif
-
-#if !defined(MBED_RAM_START)
-  #define MBED_RAM_START 0x20000000
-  #define MBED_RAM_SIZE 0x10000
-#endif
+#include "../nrf52832_memory_regions.h"
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
     #define MBED_CONF_TARGET_BOOT_STACK_SIZE 0x800
 #endif
 
-#define MBED_RAM0_START MBED_RAM_START
-#define MBED_RAM0_SIZE  0xE0
-#define MBED_RAM1_START (MBED_RAM_START + MBED_RAM0_SIZE)
-#define MBED_RAM1_SIZE  (MBED_RAM_SIZE - MBED_RAM0_SIZE)
 
 MEMORY
 {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/cmsis_nvic.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/cmsis_nvic.h
@@ -36,7 +36,7 @@
 
 #include "nrf52.h"
 #include "cmsis.h"
-
+#include "nrf52832_memory_regions.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/cmsis_nvic.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/cmsis_nvic.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/nrf52832_memory_regions.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/nrf52832_memory_regions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NRF52832_MEMORY_REGIONS_H
+#define NRF52832_MEMORY_REGIONS_H
+
+/* Default to no softdevice */
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
+#if !defined(MBED_RAM_START)
+  #define MBED_RAM_START 0x20000000
+  #define MBED_RAM_SIZE 0x10000
+#endif
+
+#define MBED_RAM0_START MBED_RAM_START
+#define MBED_RAM0_SIZE  0xE0
+#define MBED_RAM1_START (MBED_RAM_START + MBED_RAM0_SIZE)
+#define MBED_RAM1_SIZE  (MBED_RAM_SIZE - MBED_RAM0_SIZE)
+
+#endif //NRF52832_MEMORY_REGIONS_H

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/nrf52832_memory_regions.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/nrf52832_memory_regions.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2024 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/targets/drivers.json5
+++ b/targets/drivers.json5
@@ -134,15 +134,15 @@
 
 // LoRa modules ---------------------------------------------------------------------
 		"COMPONENT_SX126x": {
-            "description": "LoRa Connect™ 150-960MHz Transcievers",
-            "friendly_name": "Semtech SX1272"
+            "description": "LoRa Connect™ 150-960MHz Transceivers",
+            "friendly_name": "Semtech SX126x"
         },
 		"COMPONENT_SX1272": {
-            "description": "LoRa Connect™ 860-1000MHz Transciever",
+            "description": "LoRa Connect™ 860-1000MHz Transceiver",
             "friendly_name": "Semtech SX1272"
         },
 		"COMPONENT_SX1276": {
-            "description": "LoRa Connect™ 137-1020MHz Transciever",
+            "description": "LoRa Connect™ 137-1020MHz Transceiver",
             "friendly_name": "Semtech SX1276"
         },
 

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -6926,7 +6926,6 @@
                 "value": 32
             }
         },
-        "OUTPUT_EXT": "hex",
         "is_disk_virtual": true,
         "supported_toolchains": [
             "GCC_ARM"
@@ -6947,7 +6946,8 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "is_mcu_family_target": true
     },
     "NRF52_DK": {
         "supported_form_factors": [
@@ -6996,6 +6996,33 @@
             "3104"
         ],
         "device_name": "nRF52832_xxAA"
+    },
+    "ARDUINO_NICLA_SENSE_ME": {
+        "inherits": ["MCU_NRF52832"],
+        "components_add": [
+            "FLASHIAP",
+            "SPIF"
+        ],
+        "device_name": "nRF52832_xxAA",
+        "macros_add": [
+            "CONFIG_GPIO_AS_PINRESET",
+            "CONFIG_NFCT_PINS_AS_GPIOS",
+            "NRF52_PAN_12",
+            "NRF52_PAN_15",
+            "NRF52_PAN_20",
+            "NRF52_PAN_30",
+            "NRF52_PAN_31",
+            "NRF52_PAN_36",
+            "NRF52_PAN_51",
+            "NRF52_PAN_53",
+            "NRF52_PAN_54",
+            "NRF52_PAN_55",
+            "NRF52_PAN_58",
+            "NRF52_PAN_62",
+            "NRF52_PAN_63",
+            "NRF52_PAN_64"
+        ],
+        "image_url": "https://store-usa.arduino.cc/cdn/shop/products/ABX00050_03.front_1000x750.jpg?v=1631089821"
     },
     "MCU_NRF52840": {
         "inherits": [

--- a/targets/upload_method_cfg/ARDUINO_NICLA_SENSE_ME.cmake
+++ b/targets/upload_method_cfg/ARDUINO_NICLA_SENSE_ME.cmake
@@ -1,0 +1,27 @@
+# Mbed OS upload method configuration file for target ARDUINO_NANO33BLE_SWD.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include app.cmake and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using pyocd with this device requires installing a pack: `pyocd pack install nrf52`.
+
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT OPENOCD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME nrf52832)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/interface/cmsis-dap.cfg
+	-c "transport select swd"
+	-f ${OpenOCD_SCRIPT_DIR}/target/nrf52.cfg)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->


This PR adds support for Arduino Nicla Sense ME.  Arduino sent me a free test unit a while back so figured I may as well give it a shot.  This one ended up actually being pretty easy to work with because, unlike most Arduinos, it has a standard Mbed CMSIS-DAP interface chip on it, no weird bootloader hijinks needed.  Basically just had to add the PinNames.h, the CMake file, and the targets.json definition.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

https://github.com/mbed-ce/mbed-os/wiki/MCU-Info-Page:-Arduino-Nicla-Sense-ME

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran the full set of Greentea tests on the nicla and they all passed except for test-mbed-hal-trng.  This one is failing because they didn't connect the MCU reset line to the CMSIS DAP interface, so it can't reset the CPU when it tries to.  Not sure what the best way to fix this is at this point...

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
