### PR TITLE
LPC1768: Fix I2C pins not being open drain, fix destroying and recreating I2C making transactions fail

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -22,6 +22,14 @@
 #include "cmsis.h"
 #include "pinmap.h"
 
+// Change to 1 to enable debug prints.
+#define LPC1768_I2C_DEBUG 0
+
+#if LPC1768_I2C_DEBUG
+#include <stdio.h>
+#include <inttypes.h>
+#endif
+
 static const PinMap PinMap_I2C_SDA[] = {
     {P0_0 , I2C_1, 3},
     {P0_10, I2C_2, 2},
@@ -83,6 +91,10 @@ static int i2c_wait_SI(i2c_t *obj) {
     return 0;
 }
 
+static inline void i2c_interface_disable(i2c_t *obj) {
+    I2C_CONCLR(obj) = 0x40;
+}
+
 static inline void i2c_interface_enable(i2c_t *obj) {
     I2C_CONSET(obj) = 0x40;
 }
@@ -107,16 +119,29 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     
     // set default frequency at 100k
     i2c_frequency(obj, 100000);
+
+    // Reset the I2C bus by clearing all flags, including I2EN.
+    // This does a software reset of sorts, which is important because the I2C::recover()
+    // function, which is called before initializing the bus, seems to put the I2C 
+    // peripheral in a weird state where the next transaction will fail.
+    i2c_interface_disable(obj);
     i2c_conclr(obj, 1, 1, 1, 1);
+
     i2c_interface_enable(obj);
     
     pinmap_pinout(sda, PinMap_I2C_SDA);
+    pin_mode(sda, OpenDrain);
     pinmap_pinout(scl, PinMap_I2C_SCL);
+    pin_mode(scl, OpenDrain);
 }
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
     int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_start(): status was originally 0x%x\n", i2c_status(obj));
+#endif
 
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
@@ -134,6 +159,10 @@ inline int i2c_start(i2c_t *obj) {
 
     i2c_wait_SI(obj);
     status = i2c_status(obj);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_start(): status is now 0x%x\n", status);
+#endif
 
     // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
@@ -303,6 +332,10 @@ int i2c_byte_read(i2c_t *obj, int last) {
 int i2c_byte_write(i2c_t *obj, int data) {
     int ack;
     int status = i2c_do_write(obj, (data & 0xFF), 0);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_do_write(0x%hhx) returned 0x%x\n", data & 0xFF, status);
+#endif
     
     switch(status) {
         case 0x18: case 0x28:       // Master transmit ACKs

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -120,7 +120,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     // set default frequency at 100k
     i2c_frequency(obj, 100000);
 
-    // Reset the I2C bus by clearing all flags, including I2EN.
+    // Reset the I2C peripheral by clearing all flags, including I2EN.
     // This does a software reset of sorts, which is important because the I2C::recover()
     // function, which is called before initializing the bus, seems to put the I2C 
     // peripheral in a weird state where the next transaction will fail.


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Testing with my CI test shield, I noticed an I2C issue with LPC1768.  At first, it manifested as some of the test cases which constructed I2CEEBlockDevice objects failing on their first write command.  After a bit more debugging (left the debug macros in in case we ever need to dig into this again), I realized it was actually just the act of destroying and recreating the I2C object that was causing the issue.  When an I2C instance is recreated after being initialized previously, the very first transaction you do will always fail.

Why was this happening?  It seems to be due to a bad interaction with the [I2C::recover()](https://github.com/mbed-ce/mbed-os/blob/master/drivers/source/I2C.cpp#L172) function.  This function remaps the I2C pins as digital IOs and performs a specific sequence to unstick any slave devices on the bus.  The issue is, if this sequence occurs after the I2C peripheral has been enabled, it puts it in some sort of bad state that fouls up the next transaction.  I'm not sure exactly why, as the I2C alternate functions aren't active on the pins during this sequence -- maybe it's because the I2C peripheral is still receiving inputs from the pins even when not configured to output to them?

Regardless of why, the fix is thankfully fairly easy.  All one has to do is disable the peripheral before enabling it to reset its internal state.  This fixes whatever was getting screwed up and allows I2C to work reliably again.  If I2C had an `i2c_free()` function, that would be the place to do it, but the HAL currently doesn't have this function for some weird reason.

In the process of debugging this issue, I noticed another one as well: the I2C pins were never being configured for open drain.  I'm not totally clear if this actually causes the pins to output push-pull or not (I definitely can remember using Mbed 2 on LPC1768 and seeing the I2C pins correctly working in open drain mode), but the manual does say to set this register setting, so definitely seems worth doing.

#### Impact of changes <!-- Optional -->
- Deleting and recreating I2C object on LPC1768 no longer causes spurious transaction failure

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
