### PR TITLE
LPC1768: Support static pinmaps

### DIFF
--- a/hal/include/hal/serial_api.h
+++ b/hal/include/hal/serial_api.h
@@ -324,12 +324,12 @@ void serial_pinout_tx(PinName tx);
 
 #if DEVICE_SERIAL_FC
 /** Configure the serial for the flow control. It sets flow control in the hardware
- *  if a serial peripheral supports it, otherwise software emulation is used.
+ *  if a serial peripheral supports it, otherwise software emulation shall be used.
  *
  * @param obj    The serial object
  * @param type   The type of the flow control. Look at the available FlowControl types.
- * @param rxflow The TX pin name
- * @param txflow The RX pin name
+ * @param rxflow The TX (RTS) pin name
+ * @param txflow The RX (CTS) pin name
  */
 void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow);
 

--- a/hal/include/hal/static_pinmap.h
+++ b/hal/include/hal/static_pinmap.h
@@ -165,7 +165,7 @@ MSTD_CONSTEXPR_FN_14 serial_fc_pinmap_t get_uart_fc_pinmap(const PinName rxflow,
 #endif // DEVICE_SERIAL
 
 #if defined(DEVICE_SPI) && defined(PINMAP_SPI_MOSI) && defined(PINMAP_SPI_MISO) && defined(PINMAP_SPI_SCLK) && defined(PINMAP_SPI_SSEL)
-MSTD_CONSTEXPR_FN_14 spi_pinmap_t get_spi_pinmap(const PinName mosi, const PinName miso, const PinName sclk, const PinName ssel)
+MSTD_CONSTEXPR_FN_14 spi_pinmap_t get_spi_pinmap(const PinName mosi, const PinName miso, const PinName sclk, const PinName ssel = NC)
 {
     const PinMap *mosi_map = nullptr;
     for (const PinMap &pinmap : PINMAP_SPI_MOSI) {

--- a/targets/TARGET_NXP/TARGET_LPC176X/PeripheralNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/PeripheralNames.h
@@ -46,6 +46,8 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
+// Note: We only use the two SSP peripherals in Mbed, not SPI0.  This is because
+// SPI0 is a legacy version of the SSP peripheral and cannot be used at the same time as SSP0.
 typedef enum {
     SPI_0 = (int)LPC_SSP0_BASE,
     SPI_1 = (int)LPC_SSP1_BASE

--- a/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
@@ -1,0 +1,186 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2024 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PERIPHERAL_PINMAPS_H
+#define PERIPHERAL_PINMAPS_H
+
+#include <mstd_cstddef>
+
+#include "pinmap.h"
+
+#include "PeripheralNames.h"
+
+// For LPC1768, PinMap entries are in the form
+// (pin name, peripheral name, function number)
+// where the function number is the 2-bit value that will be written into the PINSELn
+// bitfield for this pin.
+// See section 8.5 in the LPC1768 user manual for the source of these pinmappings.
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
+    {P0_0,  UART_3, 2},
+    {P0_2,  UART_0, 1},
+    {P0_10, UART_2, 1},
+    {P0_15, UART_1, 1},
+    {P0_25, UART_3, 3},
+    {P2_0 , UART_1, 2},
+    {P2_8 , UART_2, 2},
+    {P4_28, UART_3, 3},
+    {NC   , NC    , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
+    {P0_1 , UART_3, 2},
+    {P0_3 , UART_0, 1},
+    {P0_11, UART_2, 1},
+    {P0_16, UART_1, 1},
+    {P0_26, UART_3, 3},
+    {P2_1 , UART_1, 2},
+    {P2_9 , UART_2, 2},
+    {P4_29, UART_3, 3},
+    {NC   , NC    , 0}
+};
+
+// Only UART1 has hardware flow control on LPC176x
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RTS[] = {
+    {P0_22, UART_1, 1},
+    {P2_7,  UART_1, 2},
+    {NC,    NC,     0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_CTS[] = {
+    {P0_17, UART_1, 1},
+    {P2_2,  UART_1, 2},
+    {NC,    NC,     0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
+    {P0_7 , SPI_1, 2},
+    {P0_15, SPI_0, 2},
+    {P1_20, SPI_0, 3},
+    {P1_31, SPI_1, 2},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
+    {P0_9 , SPI_1, 2},
+    {P0_13, SPI_1, 2},
+    {P0_18, SPI_0, 2},
+    {P1_24, SPI_0, 3},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
+    {P0_8 , SPI_1, 2},
+    {P0_12, SPI_1, 2},
+    {P0_17, SPI_0, 2},
+    {P1_23, SPI_0, 3},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
+    {P0_6 , SPI_1, 2},
+    {P0_11, SPI_1, 2},
+    {P0_16, SPI_0, 2},
+    {P1_21, SPI_0, 3},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
+    {P0_23, ADC0_0, 1},
+    {P0_24, ADC0_1, 1},
+    {P0_25, ADC0_2, 1},
+    {P0_26, ADC0_3, 1},
+    {P1_30, ADC0_4, 3},
+    {P1_31, ADC0_5, 3},
+    {P0_2,  ADC0_7, 2},
+    {P0_3,  ADC0_6, 2},
+    {NC,    NC,     0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_DAC[] = {
+    {P0_26, DAC_0, 2},
+    {NC   , NC   , 0}
+};
+
+// NOTE: For I2C, only the P0_27/P0_28 pinmapping is fully electrically compliant to the I2C standard.
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
+    {P0_27, I2C_0, 1},
+    {P0_0 , I2C_1, 3},
+    {P0_19, I2C_1, 3},
+    {P0_10, I2C_2, 2},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
+    {P0_28, I2C_0, 1},
+    {P0_1 , I2C_1, 3},
+    {P0_20, I2C_1, 3},
+    {P0_11, I2C_2, 2},
+    {NC   , NC,    0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
+    {P1_18, PWM_1, 2},
+    {P1_20, PWM_2, 2},
+    {P1_21, PWM_3, 2},
+    {P1_23, PWM_4, 2},
+    {P1_24, PWM_5, 2},
+    {P1_26, PWM_6, 2},
+    {P2_0, PWM_1, 1},
+    {P2_1, PWM_2, 1},
+    {P2_2, PWM_3, 1},
+    {P2_3, PWM_4, 1},
+    {P2_4, PWM_5, 1},
+    {P2_5, PWM_6, 1},
+    {P3_25, PWM_2, 3},
+    {P3_26, PWM_3, 3},
+    {NC, NC, 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
+    {P0_0 , CAN_1, 1},
+    {P0_4 , CAN_2, 2},
+    {P0_21, CAN_1, 3},
+    {P2_7 , CAN_2, 1},
+    {NC   , NC   , 0}
+};
+
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_TD[] = {
+    {P0_1 , CAN_1, 1},
+    {P0_5 , CAN_2, 2},
+    {P0_22, CAN_1, 3},
+    {P2_8 , CAN_2, 1},
+    {NC   , NC   , 0}
+};
+
+// Pinmap name macros
+#define PINMAP_UART_TX PinMap_UART_TX
+#define PINMAP_UART_RX PinMap_UART_RX
+#define PINMAP_UART_RTS PinMap_UART_RTS
+#define PINMAP_UART_CTS PinMap_UART_CTS
+#define PINMAP_SPI_SCLK PinMap_SPI_SCLK
+#define PINMAP_SPI_MOSI PinMap_SPI_MOSI
+#define PINMAP_SPI_MISO PinMap_SPI_MISO
+#define PINMAP_SPI_SSEL PinMap_SPI_SSEL
+#define PINMAP_ANALOGIN PinMap_ADC
+#define PINMAP_ANALOGOUT PinMap_DAC
+#define PINMAP_I2C_SDA PinMap_I2C_SDA
+#define PINMAP_I2C_SCL PinMap_I2C_SCL
+#define PINMAP_PWM PinMap_PWM
+#define PINMAP_CAN_RD PinMap_CAN_RD
+#define PINMAP_CAN_TD PinMap_CAN_TD
+#endif

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
@@ -31,6 +31,9 @@ typedef enum {
     PIN_OUTPUT
 } PinDirection;
 
+/* If this macro is defined, you can use constexpr utility functions for pin map search. */
+#define STATIC_PINMAP_READY 1
+
 #define PORT_SHIFT  5
 
 typedef enum {

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
@@ -73,18 +73,6 @@ typedef enum {
     p29 = P0_5,
     p30 = P0_4,
 
-    // Other mbed Pin Names
-#ifdef MCB1700
-    LED1 = P1_28,
-    LED2 = P1_29,
-    LED3 = P1_31,
-    LED4 = P2_2,
-#else
-    LED1 = P1_18,
-    LED2 = P1_20,
-    LED3 = P1_21,
-    LED4 = P1_23,
-#endif
     CONSOLE_TX = P0_2,
     CONSOLE_RX = P0_3,
 
@@ -113,18 +101,24 @@ typedef enum {
     A4 = P1_30,
     A5 = P1_31,
 
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-
-    //SPI Pins configuration
-    SPI_MOSI = P0_9,
-    SPI_MISO = P0_8,
-    SPI_SCK  = P0_7,
-    SPI_CS   = P0_6,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;
+
+// Standard buttons and LEDs
+#define LED1 P1_18
+#define LED2 P1_20
+#define LED3 P1_21
+#define LED4 P1_23
+
+// I2C and SPI pin names
+#define I2C_SCL D15
+#define I2C_SDA D14
+
+#define SPI_MOSI P0_9
+#define SPI_MISO P0_8
+#define SPI_SCK  P0_7
+#define SPI_CS   P0_6
 
 typedef enum {
     PullUp = 0,

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
@@ -31,6 +31,9 @@ typedef enum {
     PIN_OUTPUT
 } PinDirection;
 
+/* If this macro is defined, you can use constexpr utility functions for pin map search. */
+#define STATIC_PINMAP_READY 1
+
 #define PORT_SHIFT  5
 
 typedef enum {

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -22,6 +22,14 @@
 #include "cmsis.h"
 #include "pinmap.h"
 
+// Change to 1 to enable debug prints.
+#define LPC1768_I2C_DEBUG 0
+
+#if LPC1768_I2C_DEBUG
+#include <stdio.h>
+#include <inttypes.h>
+#endif
+
 static const PinMap PinMap_I2C_SDA[] = {
     {P0_0 , I2C_1, 3},
     {P0_10, I2C_2, 2},
@@ -83,6 +91,10 @@ static int i2c_wait_SI(i2c_t *obj) {
     return 0;
 }
 
+static inline void i2c_interface_disable(i2c_t *obj) {
+    I2C_CONCLR(obj) = 0x40;
+}
+
 static inline void i2c_interface_enable(i2c_t *obj) {
     I2C_CONSET(obj) = 0x40;
 }
@@ -107,16 +119,29 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     
     // set default frequency at 100k
     i2c_frequency(obj, 100000);
+
+    // Reset the I2C bus by clearing all flags, including I2EN.
+    // This does a software reset of sorts, which is important because the I2C::recover()
+    // function, which is called before initializing the bus, seems to put the I2C 
+    // peripheral in a weird state where the next transaction will fail.
+    i2c_interface_disable(obj);
     i2c_conclr(obj, 1, 1, 1, 1);
+
     i2c_interface_enable(obj);
     
     pinmap_pinout(sda, PinMap_I2C_SDA);
+    pin_mode(sda, OpenDrain);
     pinmap_pinout(scl, PinMap_I2C_SCL);
+    pin_mode(scl, OpenDrain);
 }
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
     int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_start(): status was originally 0x%x\n", i2c_status(obj));
+#endif
 
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
@@ -134,6 +159,10 @@ inline int i2c_start(i2c_t *obj) {
 
     i2c_wait_SI(obj);
     status = i2c_status(obj);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_start(): status is now 0x%x\n", status);
+#endif
 
     // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
@@ -303,6 +332,10 @@ int i2c_byte_read(i2c_t *obj, int last) {
 int i2c_byte_write(i2c_t *obj, int data) {
     int ack;
     int status = i2c_do_write(obj, (data & 0xFF), 0);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_do_write(0x%hhx) returned 0x%x\n", data & 0xFF, status);
+#endif
     
     switch(status) {
         case 0x18: case 0x28:       // Master transmit ACKs

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -120,7 +120,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     // set default frequency at 100k
     i2c_frequency(obj, 100000);
 
-    // Reset the I2C bus by clearing all flags, including I2EN.
+    // Reset the I2C peripheral by clearing all flags, including I2EN.
     // This does a software reset of sorts, which is important because the I2C::recover()
     // function, which is called before initializing the bus, seems to put the I2C 
     // peripheral in a weird state where the next transaction will fail.

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -22,6 +22,8 @@
 #include "cmsis.h"
 #include "pinmap.h"
 
+#include "PeripheralPinMaps.h"
+
 // Change to 1 to enable debug prints.
 #define LPC1768_I2C_DEBUG 0
 
@@ -29,22 +31,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #endif
-
-static const PinMap PinMap_I2C_SDA[] = {
-    {P0_0 , I2C_1, 3},
-    {P0_10, I2C_2, 2},
-    {P0_19, I2C_1, 3},
-    {P0_27, I2C_0, 1},
-    {NC   , NC   , 0}
-};
-
-static const PinMap PinMap_I2C_SCL[] = {
-    {P0_1 , I2C_1, 3},
-    {P0_11, I2C_2, 2},
-    {P0_20, I2C_1, 3},
-    {P0_28, I2C_0, 1},
-    {NC   , NC,    0}
-};
 
 #define I2C_CONSET(x)       (x->i2c->I2CONSET)
 #define I2C_CONCLR(x)       (x->i2c->I2CONCLR)
@@ -107,13 +93,10 @@ static inline void i2c_power_enable(i2c_t *obj) {
     }
 }
 
-void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
-    // determine the SPI to use
-    I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
-    I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
-    obj->i2c = (LPC_I2C_TypeDef *)pinmap_merge(i2c_sda, i2c_scl);
-    MBED_ASSERT((int)obj->i2c != NC);
-    
+void i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
+{
+    obj->i2c = (LPC_I2C_TypeDef *)pinmap->peripheral;
+
     // enable power
     i2c_power_enable(obj);
     
@@ -129,11 +112,32 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
     i2c_interface_enable(obj);
     
-    pinmap_pinout(sda, PinMap_I2C_SDA);
-    pin_mode(sda, OpenDrain);
-    pinmap_pinout(scl, PinMap_I2C_SCL);
-    pin_mode(scl, OpenDrain);
+    // Map pins
+    pin_function(pinmap->sda_pin, pinmap->sda_function);
+    pin_mode(pinmap->sda_pin, OpenDrain);
+    pin_function(pinmap->scl_pin, pinmap->scl_function);
+    pin_mode(pinmap->scl_pin, OpenDrain);
 }
+
+void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
+
+    i2c_pinmap_t pinmap;
+    pinmap.sda_pin = sda;
+    pinmap.scl_pin = scl;
+
+    // Determine peripheral associated with these pins
+    I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
+    I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
+    pinmap.peripheral = pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT((int)pinmap.peripheral != NC);
+
+    // Get pin functions
+    pinmap.sda_function = pinmap_find_function(sda, PinMap_I2C_SDA);
+    pinmap.scl_function = pinmap_find_function(scl, PinMap_I2C_SCL);
+
+    i2c_init_direct(obj, &pinmap);
+}
+
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -19,54 +19,14 @@
 
 #include "spi_api.h"
 #include "cmsis.h"
-#include "pinmap.h"
+#include "PeripheralPinMaps.h"
 #include "mbed_error.h"
-
-static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_7 , SPI_1, 2},
-    {P0_15, SPI_0, 2},
-    {P1_20, SPI_0, 3},
-    {P1_31, SPI_1, 2},
-    {NC   , NC   , 0}
-};
-
-static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_1, 2},
-    {P0_13, SPI_1, 2},
-    {P0_18, SPI_0, 2},
-    {P1_24, SPI_0, 3},
-    {NC   , NC   , 0}
-};
-
-static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_1, 2},
-    {P0_12, SPI_1, 2},
-    {P0_17, SPI_0, 2},
-    {P1_23, SPI_0, 3},
-    {NC   , NC   , 0}
-};
-
-static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_6 , SPI_1, 2},
-    {P0_11, SPI_1, 2},
-    {P0_16, SPI_0, 2},
-    {P1_21, SPI_0, 3},
-    {NC   , NC   , 0}
-};
 
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (LPC_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->spi != NC);
+void spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap) {
+    obj->spi = (LPC_SSP_TypeDef*)pinmap->peripheral;
     
     // enable power and clocking
     switch ((int)obj->spi) {
@@ -75,12 +35,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(pinmap->mosi_pin, pinmap->mosi_function);
+    pin_mode(pinmap->mosi_pin, PullNone);
+    pin_function(pinmap->miso_pin, pinmap->miso_function);
+    pin_mode(pinmap->miso_pin, PullNone);
+    pin_function(pinmap->sclk_pin, pinmap->sclk_function);
+    pin_mode(pinmap->sclk_pin, PullNone);
+
+    if (pinmap->ssel_pin != NC) {
+        pin_function(pinmap->ssel_pin, pinmap->ssel_function);
+        pin_mode(pinmap->ssel_pin, PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
+    spi_pinmap_t pinmap;
+    pinmap.mosi_pin = mosi;
+    pinmap.miso_pin = miso;
+    pinmap.sclk_pin = sclk;
+    pinmap.ssel_pin = ssel;
+
+    // determine the SPI to use
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
+    pinmap.peripheral = pinmap_merge(spi_data, spi_cntl);
+    MBED_ASSERT((int)obj->spi != NC);
+
+    // Get pin functions
+    pinmap.mosi_function = pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    pinmap.miso_function = pinmap_find_function(miso, PinMap_SPI_MISO);
+    pinmap.sclk_function = pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    pinmap.ssel_function = pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    spi_init_direct(obj, &pinmap);
 }
 
 void spi_free(spi_t *obj) {}

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -346,7 +346,7 @@
         },
         "overrides": {
             "network-default-interface-type": "ETHERNET",
-            "semihosting-enabled": true // needed for LOCALFILESYSTEM
+            "target.default-adc-vref": 3.3 // Per "mbed-005.1" schematic, Vref is 3.3V
         },
         "supported_c_libs": {
             "arm": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR updates LPC1768 to support static pinmaps.  This means that pins can be mapped at compile time instead of at runtime, like:
```
    constexpr auto spiPinmap = get_spi_pinmap(PIN_SPI_MOSI, PIN_SPI_MISO, PIN_SPI_SCLK);
    spi = new SPI(spiPinmap);
```
To be honest, a lot of the reason I made this PR is I wanted to learn about the static pinmap system, since I had not used it before.  And I figured, may as well do something useful while I'm learning it!  Plus, this way LPC1768 users can save some ROM space and execution time by taking advantage of the static pinmap support.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- Static pinmaps now supported on LPC1768

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I ran the CI shield ADC, I2C, PWM, and SPI tests.  The first three all passed, and the SPI test has no new failures at least.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
