### PR TITLE
Update NUCLEO_H743ZI2.cmake

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
+++ b/targets/upload_method_cfg/NUCLEO_H743ZI2.cmake
@@ -44,7 +44,7 @@ set(OPENOCD_CHIP_CONFIG_COMMANDS
 
 set(STM32CUBE_UPLOAD_ENABLED TRUE)
 set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
-set(STM32CUBE_GDBSERVER_ARGS --swd)
+set(STM32CUBE_GDBSERVER_ARGS --swd --initialize-reset)
 
 # Config options for stlink
 # -------------------------------------------------------------


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 

    
-->

    Add "Initializes the device while under reset condition" --initialize-reset option to STM32CUBE_GDBSERVER_ARGS

    stlink-gdb-server fails to connect most of the time to the NUCLEO_H743ZI2 target

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
-->
    None. 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
 Issue:
```
 *  Executing task: C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_2.1.300.202403291623/tools/bin/ST-LINK_gdbserver.exe --swd -cp C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_2.1.201.202404072231/tools/bin -p 23331 --halt 



STMicroelectronics ST-LINK GDB server. Version 7.7.0
Copyright (c) 2024, STMicroelectronics. All rights reserved.

Starting server with the following options:
        Persistent Mode            : Disabled
        Logging Level              : 31
        Listen Port Number         : 23331
        Status Refresh Delay       : 15s
        Verbose Mode               : Disabled
        SWD Debug                  : Enabled

COM frequency = 24000 kHz
Target connection mode: Default
Target not halted after reset. Force halt
Failed to halt target
Target not halted

Error in initializing ST-LINK device.
Reason: Target not halted.

 *  The terminal process "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Command C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_2.1.300.202403291623/tools/bin/ST-LINK_gdbserver.exe --swd -cp C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_2.1.201.202404072231/tools/bin -p 23331 --halt" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 

```
After adding the --initialize-reset option
```
 *  Executing task: C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.stlink-gdb-server.win32_2.1.300.202403291623/tools/bin/ST-LINK_gdbserver.exe --swd --initialize-reset -cp C:/ST/STM32CubeIDE_1.15.1/STM32CubeIDE/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.win32_2.1.201.202404072231/tools/bin -p 23331 --halt 



STMicroelectronics ST-LINK GDB server. Version 7.7.0
Copyright (c) 2024, STMicroelectronics. All rights reserved.

Starting server with the following options:
        Persistent Mode            : Disabled
        Logging Level              : 31
        Listen Port Number         : 23331
        Status Refresh Delay       : 15s
        Verbose Mode               : Disabled
        SWD Debug                  : Enabled
        InitWhile                  : Enabled

COM frequency = 24000 kHz
Target connection mode: Under reset
Reading ROM table for AP 0 @0xe00fefd0
Hardware watchpoint supported by the target
ST-LINK Firmware version : V3J15M6
Device ID: 0x450
PC: 0x80003a0
ST-LINK device status: HALT_MODE
ST-LINK detects target voltage = 3.28 V
ST-LINK device status: HALT_MODE
ST-LINK device initialization OK
Stm32Device, pollAndNotify running...
SwvSrv state change: 0 -> 1
Waiting for connection on port 23332...
Waiting for debugger connection...
Waiting for connection on port 23331...
Accepted connection on port 23331...
Debugger connected
Waiting for debugger connection...
Waiting for connection on port 23331...
GDB session thread running
GdbSessionManager, session started: 1
Enter STM32_SystemReset() function 
Enter STM32_InitAfterReset() function 
NVIC_DFSR_REG = 0x0000000B
NVIC_CFGFSR_REG = 0x00000000
Stm32Device, closeDevice() entry
GDB session, device event: 5
Stm32Device, pollAndNotify stopped
Stm32Device, closeDevice() exit
 ------ Switching to STM32CubeProgrammer -----
      -------------------------------------------------------------------
                       STM32CubeProgrammer v2.16.0
      -------------------------------------------------------------------



Log output file:   C:\Users\tim\AppData\Local\Temp\STM32CubeProgrammer_a29456.log
ST-LINK SN  : 001D00393137511739383538
ST-LINK FW  : V3J15M6
Board       : NUCLEO-H743ZI
Voltage     : 3.27V
SWD freq    : 8000 KHz
Connect mode: Under Reset
Reset mode  : Hardware reset
Device ID   : 0x450
Revision ID : Rev V
Device name : STM32H7xx
Flash size  : 2 MBytes
Start Address : 8000000
Device type : MCU
Device CPU  : Cortex-M7
BL Version  : 0x90



Memory Programming ...
Opening and parsing file: ST-LINK_GDB_server_a29456.srec
  File          : ST-LINK_GDB_server_a29456.srec
  Size          : 60.44 KB
  Address       : 0x08000000


Erasing memory corresponding to segment 0:
Erasing internal memory sector 0
Download in Progress:


File download complete
Time elapsed during download operation: 00:00:01.078
 ------ Switching context -----
COM frequency = 24000 kHz
Target connection mode: Under reset
Reading ROM table for AP 0 @0xe00fefd0
Hardware watchpoint supported by the target
ST-LINK Firmware version : V3J15M6
Device ID: 0x450
PC: 0x80003a0
ST-LINK detects target voltage = 3.27 V
ST-LINK device status: HALT_MODE
GDB session, device event: 6
Stm32Device, pollAndNotify running...
Enter STM32_SystemReset() function
Enter STM32_InitAfterReset() function
NVIC_DFSR_REG = 0x0000000B
NVIC_CFGFSR_REG = 0x00000000
GDB session, device event: 3
GDB session, device event: 1
GDB session, device event: 0
NVIC_DFSR_REG = 0x00000003

```
   
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
