### PR TITLE
LPC1768: Rewrite I2CSlave HAL to match datasheet way of doing it

### DIFF
--- a/drivers/include/drivers/I2CSlave.h
+++ b/drivers/include/drivers/I2CSlave.h
@@ -165,8 +165,10 @@ public:
      */
     int receive(void);
 
-    /** 
+    /**
      * @brief Read bytes transmitted to this MCU from an I2C master.
+     *
+     * Call this function only once \c receive() returns WriteAddressed or WriteGeneral.
      *
      *  @param data   Pointer to the buffer to read data into.
      *  @param length Maximum number of bytes to read.
@@ -181,9 +183,9 @@ public:
      */
     int read(void);
 
-    /** 
+    /**
      * @brief Write to an I2C master which is addressing this slave device.
-     * 
+     *
      * Call this function only once \c receive() returns ReadAddressed.
      * This will send the given data bytes to the master and then send a NACK to end the read transaction.
      *

--- a/drivers/include/drivers/I2CSlave.h
+++ b/drivers/include/drivers/I2CSlave.h
@@ -165,7 +165,8 @@ public:
      */
     int receive(void);
 
-    /** Read bytes transmitted to this MCU from an I2C master.
+    /** 
+     * @brief Read bytes transmitted to this MCU from an I2C master.
      *
      *  @param data   Pointer to the buffer to read data into.
      *  @param length Maximum number of bytes to read.
@@ -180,7 +181,11 @@ public:
      */
     int read(void);
 
-    /** Write to an I2C master.
+    /** 
+     * @brief Write to an I2C master which is addressing this slave device.
+     * 
+     * Call this function only once \c receive() returns ReadAddressed.
+     * This will send the given data bytes to the master and then send a NACK to end the read transaction.
      *
      *  @param data   Pointer to the buffer containing the data to be sent.
      *  @param length Number of bytes to send.
@@ -204,7 +209,7 @@ public:
 
     /** Set the I2C slave address.
      *
-     *  @param address The address to set for the slave (least significant bit is ignored).
+     *  @param address The 8-bit address to set for the slave (least significant bit is ignored).
      *
      *  @note If address is set to 0, the slave will only respond to the
      *  general call address.

--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -331,7 +331,7 @@ int  i2c_slave_read(i2c_t *obj, char *data, int length);
  *  @param obj The I2C object
  *  @param data    The buffer for sending
  *  @param length  Number of bytes to write
- *  @return non-zero if a value is available
+ *  @return number of bytes actually written to the master, or negative value on error.
  */
 int  i2c_slave_write(i2c_t *obj, const char *data, int length);
 

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -399,7 +399,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
     i2c_conset(obj, 0, 0, 0, length > 0); // Set AA flag to acknowledge write as long as we have buffer space to store a byte in
     i2c_clear_SI(obj);
 
-    // This is implemented as a state machine according to section 19.10.8 in the datasheet.
+    // This is implemented as a state machine according to section 19.10.8 in the reference manual.
     while(true) {
 
         // Wait until the I2C peripheral has an event for us
@@ -469,7 +469,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
     i2c_conset(obj, 0, 0, 0, 1); // Set AA flag to acknowledge read as long as we have something to transmit
     i2c_clear_SI(obj);
 
-    // This is implemented as a state machine according to section 19.10.9 in the datasheet.
+    // This is implemented as a state machine according to section 19.10.9 in the reference manual.
     while(true) {
 
         // Wait until the I2C peripheral has an event for us

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -382,56 +382,127 @@ int i2c_slave_receive(i2c_t *obj) {
 }
 
 int i2c_slave_read(i2c_t *obj, char *data, int length) {
+
     int count = 0;
-    int status;
-    
-    do {
-        i2c_clear_SI(obj);
-        i2c_wait_SI(obj);
-        status = i2c_status(obj);
-        if((status == 0x80) || (status == 0x90)) {
-            data[count] = I2C_DAT(obj) & 0xFF;
-        }
-        count++;
-    } while (((status == 0x80) || (status == 0x90) ||
-            (status == 0x060) || (status == 0x70)) && (count < length));
- 
-    // Clear old status and wait for Serial Interrupt. 
-    i2c_clear_SI(obj);
-    i2c_wait_SI(obj);
- 
-    // Obtain new status.
-    status = i2c_status(obj);
- 
-    if(status != 0xA0) {
-        i2c_stop(obj);
+
+    if(i2c_status(obj) != 0x60 && i2c_status(obj) != 0x70) {
+        return -1; // I2C peripheral not in setup-write-to-slave mode
     }
- 
+
+    if(i2c_status(obj) == 0x70) {
+        // When addressed with the general call address, per the manual we can only receive a max of 1 byte.
+        if(length > 1) {
+            length = 1;
+        }
+    }
+
+    i2c_conset(obj, 0, 0, 0, length > 0); // Set AA flag to acknowledge write as long as we have buffer space to store a byte in
     i2c_clear_SI(obj);
-    
-    return count;
+
+    // This is implemented as a state machine according to section 19.10.8 in the datasheet.
+    while(true) {
+
+        // Wait until the I2C peripheral has an event for us
+        i2c_wait_SI(obj);
+
+#if LPC1768_I2C_DEBUG
+        printf("i2c_slave_read(): in state 0x%hhx\n", i2c_status(obj));
+#endif
+
+        switch(i2c_status(obj)) {
+        case 0x68:
+        case 0x78:
+            // Arbitration Lost event.  I'm a bit confused about how this can happen as a slave device but the manual says it can...
+            i2c_conclr(obj, 1, 0, 0, 1); // Clear start and ack
+            i2c_clear_SI(obj);
+            
+            // Reset the I2C state machine. This doesn't actually send a STOP condition in slave mode.
+            i2c_stop(obj);
+            return -2; // Arbitration lost
+
+        case 0x80:
+        case 0x90:
+            // Received another data byte from master.  ACK has been returned.
+            data[count++] = I2C_DAT(obj) & 0xFF;
+            
+            if(count >= length) {
+                // Out of buffer space, NACK the next byte
+                i2c_conclr(obj, 0, 0, 0, 1);
+                i2c_clear_SI(obj);
+            }
+            else {
+                // Ack the next byte
+                i2c_conset(obj, 0, 0, 0, 1);
+                i2c_clear_SI(obj);
+            }
+            break;
+
+        case 0x88:
+        case 0x98:
+            // Master wrote us a byte and we NACKed it.  Slave receive mode has been exited.
+            i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
+            i2c_clear_SI(obj);
+            return count;
+
+        case 0xA0:
+            // Stop condition received.  Slave receive mode has been exited.
+            i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
+            i2c_clear_SI(obj);
+            return count;
+        }
+    }
 }
 
 int i2c_slave_write(i2c_t *obj, const char *data, int length) {
-    int count = 0;
-    int status;
-    
-    if(length <= 0) {
-        return(0);
+
+    int next_byte_idx = 0;
+
+    if(i2c_status(obj) != 0xA8) {
+        return -1; // I2C peripheral not in setup-read-from-slave mode
     }
     
-    do {
-        status = i2c_do_write(obj, data[count], 0);
-        count++;
-    } while ((count < length) && (status == 0xB8));
-    
-    if ((status != 0xC0) && (status != 0xC8)) {
-        i2c_stop(obj);
-    }
-    
+    // Write first data byte.  Note that there's no way for the slave to NACK a read-from-slave event, so if we run out of bytes,
+    // just send zeroes.
+    I2C_DAT(obj) = (next_byte_idx < length) ? data[next_byte_idx] : 0;
+    ++next_byte_idx;
+
+    i2c_conset(obj, 0, 0, 0, 1); // Set AA flag to acknowledge read as long as we have something to transmit
     i2c_clear_SI(obj);
-    
-    return(count);
+
+    // This is implemented as a state machine according to section 19.10.9 in the datasheet.
+    while(true) {
+
+        // Wait until the I2C peripheral has an event for us
+        i2c_wait_SI(obj);
+
+        switch(i2c_status(obj)) {
+        case 0xB0:
+            // Arbitration Lost event.  I'm a bit confused about how this can happen as a slave device but the manual says it can...
+            i2c_conclr(obj, 1, 0, 0, 1); // Clear start and ack
+            i2c_clear_SI(obj);
+            
+            // Reset the I2C state machine. This doesn't actually send a STOP condition in slave mode.
+            i2c_stop(obj);
+            return -2; // Arbitration lost
+
+        case 0xB8:
+            // Prev data byte has been transmitted.  ACK has been received.  Write the next data byte.
+            I2C_DAT(obj) = (next_byte_idx < length) ? data[next_byte_idx] : 0;
+            ++next_byte_idx;
+
+            i2c_conset(obj, 0, 0, 0, 1); // Set AA flag to acknowledge read as long as we have something to transmit
+            i2c_clear_SI(obj);
+            break;
+
+        case 0xC0:
+        case 0xC8:
+            // Last data byte transmitted (ended either by us not setting AA, or by the master NACKing)
+            i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
+            i2c_clear_SI(obj);
+
+            return next_byte_idx;
+        }
+    }
 }
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I developed this PR in combination with my new [I2C Slave CI shield test suite](https://github.com/mbed-ce/mbed-ce-test-tools/blob/master/CI-Shield-Tests/I2CSlaveCommsTest.cpp).  In developing the tests, I noticed that there were a few issues with LPC1768's implementation of the I2C slave HAL.  The apparent issue was that i2c_slave_read returned an incorrect number of bytes read (and seems to have been doing so for the last decade).  However, the broader issue I noticed was that the functions were not implemented in a way that matched the LPC1768 reference manual.  NXP was nice enough to provide an example state machine that implements I2CSlave, and we just ignored it!

This PR redoes both the slave read and the slave write function to actually conform to the datasheet method of doing things.

#### Impact of changes <!-- Optional -->
- Fixed bug where LPC1768 I2CSlave::read() would return one more byte than actually read
- Minor doc cleanups to I2CSlave API

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

```
5: [1716480796.38][SERI][INF] serial(port=/dev/ttyLPC1768, baudrate=115200, read_timeout=0.01, write_timeout=5)
5: [1716480796.38][HTST][INF] setting timeout to: 60 sec
5: [1716480796.39][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
5: [1716480796.39][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
5: [1716480796.39][CONN][INF] sending preamble '896cc0b1-848c-4cca-866d-2191e531dd78'
5: [1716480796.39][SERI][TXD] {{__sync;896cc0b1-848c-4cca-866d-2191e531dd78}}
5: [1716480796.40][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed
5: [1716480796.41][CONN][RXD] >>> Running 9 test cases...
5: [1716480796.42][CONN][INF] found SYNC in stream: {{__sync;896cc0b1-848c-4cca-866d-2191e531dd78}} it is #0 sent, queued...
5: [1716480796.42][HTST][INF] sync KV found, uuid=896cc0b1-848c-4cca-866d-2191e531dd78, timestamp=1716480796.416077
5: [1716480796.42][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
5: [1716480796.42][CONN][INF] found KV pair in stream: {{__timeout;30}}, queued...
5: [1716480796.42][HTST][INF] DUT greentea-client version: 1.3.0
5: [1716480796.42][HTST][INF] setting timeout to: 30 sec
5: [1716480796.42][CONN][INF] found KV pair in stream: {{__host_test_name;i2c_slave_comms}}, queued...
5: [1716480796.42][HTST][INF] host test class: '<class 'i2c_slave_comms.I2CSlaveCommsTest'>'
5: [1716480796.43][CONN][INF] found KV pair in stream: {{__testcase_name;Write one byte to slave}}, queued...
5: [1716480796.44][CONN][INF] found KV pair in stream: {{__testcase_name;Does not acknowledge other slave address}}, queued...
5: [1716480796.44][CONN][INF] found KV pair in stream: {{__testcase_name;Destroy & recreate I2C object}}, queued...
5: [1716480796.44][CONN][INF] found KV pair in stream: {{__testcase_name;Write multiple bytes to slave}}, queued...
5: [1716480796.44][cy_serial_bridge]Discovered USB endpoints successfully
5: [1716480796.45][CONN][INF] found KV pair in stream: {{__testcase_name;Write less bytes than expected to slave}}, queued...
5: [1716480796.45][CONN][INF] found KV pair in stream: {{__testcase_name;Read one byte from slave}}, queued...
5: [1716480796.45][CONN][INF] found KV pair in stream: {{__testcase_name;Destroy & recreate I2C object}}, queued...
5: [1716480796.45][CONN][INF] found KV pair in stream: {{__testcase_name;Read multiple bytes from slave}}, queued...
5: [1716480796.46][CONN][RXD] 
5: [1716480796.46][CONN][RXD] >>> Running case #1: 'Write one byte to slave'...
5: [1716480796.46][CONN][INF] found KV pair in stream: {{__testcase_name;Read less bytes than expected from slave}}, queued...
5: [1716480796.46][CONN][INF] found KV pair in stream: {{__testcase_start;Write one byte to slave}}, queued...
5: [1716480796.48][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480796.53][cy_serial_bridge]Device signature: b'CYUS'
5: Connected to I2C interface of CY7C652xx device, firmware version 2.0.3 build 112
5: [1716480796.54][TEST][INF] I2C Record-Only Test host test setup complete.
5: [1716480796.54][HTST][INF] host test setup() call...
5: [1716480796.54][HTST][INF] CALLBACKs updated
5: [1716480796.54][HTST][INF] host test detected: i2c_slave_comms
5: [1716480797.55][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480797.56][CONN][INF] found KV pair in stream: {{write_bytes_to_slave;addr 0xE4 data 0x1}}, queued...
5: [1716480797.70][TEST][INF] Saw on the I2C bus:
5: Start Wr[0xe4] Ack 0x01 Ack Stop
5: 
5: [1716480797.70][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480797.71][SERI][TXD] {{write_bytes_to_slave;complete}}
5: [1716480797.72][CONN][INF] found KV pair in stream: {{__testcase_finish;Write one byte to slave;1;0}}, queued...
5: [1716480797.73][CONN][RXD] >>> 'Write one byte to slave': 1 passed, 0 failed
5: [1716480797.73][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480797.73][CONN][RXD] 
5: [1716480797.73][CONN][RXD] >>> Running case #2: 'Does not acknowledge other slave address'...
5: [1716480797.75][CONN][INF] found KV pair in stream: {{__testcase_start;Does not acknowledge other slave address}}, queued...
5: [1716480797.75][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480798.76][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480798.77][CONN][INF] found KV pair in stream: {{try_write_to_wrong_address;0xE6}}, queued...
5: [1716480798.91][TEST][INF] Saw on the I2C bus:
5: Start Wr[0xe6] Nack Stop
5: 
5: [1716480798.91][SERI][TXD] {{try_write_to_wrong_address;complete}}
5: [1716480799.03][CONN][RXD] >>> 'Does not acknowledge other slave address': 1 passed, 0 failed
5: [1716480799.03][CONN][INF] found KV pair in stream: {{__testcase_finish;Does not acknowledge other slave address;1;0}}, queued...
5: [1716480799.04][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480799.04][CONN][RXD] 
5: [1716480799.04][CONN][RXD] >>> Running case #3: 'Destroy & recreate I2C object'...
5: [1716480799.04][CONN][INF] found KV pair in stream: {{__testcase_start;Destroy & recreate I2C object}}, queued...
5: [1716480799.05][CONN][INF] found KV pair in stream: {{reinit_i2c_bridge;please}}, queued...
5: [1716480799.06][cy_serial_bridge]Discovered USB endpoints successfully
5: [1716480799.16][cy_serial_bridge]Device signature: b'CYUS'
5: [1716480799.16][SERI][TXD] {{reinit_i2c_bridge;complete}}
5: [1716480799.17][CONN][INF] found KV pair in stream: {{__testcase_finish;Destroy & recreate I2C object;1;0}}, queued...
5: [1716480799.19][CONN][RXD] >>> 'Destroy & recreate I2C object': 1 passed, 0 failed
5: [1716480799.19][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480799.19][CONN][RXD] 
5: [1716480799.19][CONN][RXD] >>> Running case #4: 'Write multiple bytes to slave'...
5: [1716480799.20][CONN][INF] found KV pair in stream: {{__testcase_start;Write multiple bytes to slave}}, queued...
5: [1716480799.20][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480800.21][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480800.22][CONN][INF] found KV pair in stream: {{write_bytes_to_slave;addr 0xE4 data 0x4 0x5 0x6 0x7}}, queued...
5: Connected to I2C interface of CY7C652xx device, firmware version 2.0.3 build 112
5: [1716480800.36][TEST][INF] Saw on the I2C bus:
5: Start Wr[0xe4] Ack 0x04 Ack 0x05 Ack 0x06 Ack 0x07 Ack Stop
5: 
5: [1716480800.36][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480800.37][SERI][TXD] {{write_bytes_to_slave;complete}}
5: [1716480800.38][CONN][INF] found KV pair in stream: {{__testcase_finish;Write multiple bytes to slave;1;0}}, queued...
5: [1716480800.39][CONN][RXD] >>> 'Write multiple bytes to slave': 1 passed, 0 failed
5: [1716480800.39][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480800.39][CONN][RXD] 
5: [1716480800.40][CONN][RXD] >>> Running case #5: 'Write less bytes than expected to slave'...
5: [1716480800.41][CONN][INF] found KV pair in stream: {{__testcase_start;Write less bytes than expected to slave}}, queued...
5: [1716480800.41][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480801.42][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480801.43][CONN][INF] found KV pair in stream: {{write_bytes_to_slave;addr 0xE4 data 0x8 0x9}}, queued...
5: [1716480801.60][TEST][INF] Saw on the I2C bus:
5: Start Wr[0xe4] Ack 0x08 Ack 0x09 Ack Stop
5: 
5: [1716480801.61][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480801.62][SERI][TXD] {{write_bytes_to_slave;complete}}
5: [1716480801.63][CONN][INF] found KV pair in stream: {{__testcase_finish;Write less bytes than expected to slave;1;0}}, queued...
5: [1716480801.65][CONN][RXD] >>> 'Write less bytes than expected to slave': 1 passed, 0 failed
5: [1716480801.65][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480801.65][CONN][RXD] 
5: [1716480801.66][CONN][RXD] >>> Running case #6: 'Read one byte from slave'...
5: [1716480801.66][CONN][INF] found KV pair in stream: {{__testcase_start;Read one byte from slave}}, queued...
5: [1716480801.66][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480802.67][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480802.69][CONN][INF] found KV pair in stream: {{read_bytes_from_slave;addr 0xE4 expected-data 0x10}}, queued...
5: [1716480802.82][TEST][INF] Saw on the I2C bus:
5: Start Rd[0xe5] Ack 0x10 Nack Stop
5: 
5: [1716480802.82][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480802.83][CONN][INF] found KV pair in stream: {{__testcase_finish;Read one byte from slave;1;0}}, queued...
5: [1716480802.85][CONN][RXD] >>> 'Read one byte from slave': 1 passed, 0 failed
5: [1716480802.85][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480802.85][CONN][RXD] 
5: [1716480802.85][CONN][RXD] >>> Running case #7: 'Destroy & recreate I2C object'...
5: [1716480802.86][CONN][INF] found KV pair in stream: {{__testcase_start;Destroy & recreate I2C object}}, queued...
5: [1716480802.86][CONN][INF] found KV pair in stream: {{reinit_i2c_bridge;please}}, queued...
5: [1716480802.86][cy_serial_bridge]Discovered USB endpoints successfully
5: [1716480802.93][cy_serial_bridge]Device signature: b'CYUS'
5: [1716480802.94][SERI][TXD] {{reinit_i2c_bridge;complete}}
5: [1716480802.95][CONN][INF] found KV pair in stream: {{__testcase_finish;Destroy & recreate I2C object;1;0}}, queued...
5: [1716480802.96][CONN][RXD] >>> 'Destroy & recreate I2C object': 1 passed, 0 failed
5: [1716480802.96][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480802.97][CONN][RXD] 
5: [1716480802.97][CONN][RXD] >>> Running case #8: 'Read multiple bytes from slave'...
5: [1716480802.98][CONN][INF] found KV pair in stream: {{__testcase_start;Read multiple bytes from slave}}, queued...
5: [1716480802.98][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480803.99][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480804.00][CONN][INF] found KV pair in stream: {{read_bytes_from_slave;addr 0xE4 expected-data 0x11 0x12 0x13 0x14}}, queued...
5: Connected to I2C interface of CY7C652xx device, firmware version 2.0.3 build 112
5: [1716480804.13][TEST][INF] Saw on the I2C bus:
5: Start Rd[0xe5] Ack 0x11 Ack 0x12 Ack 0x13 Ack 0x14 Nack Stop
5: 
5: [1716480804.13][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480804.15][CONN][INF] found KV pair in stream: {{__testcase_finish;Read multiple bytes from slave;1;0}}, queued...
5: [1716480804.16][CONN][RXD] >>> 'Read multiple bytes from slave': 1 passed, 0 failed
5: [1716480804.16][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480804.16][CONN][RXD] 
5: [1716480804.17][CONN][RXD] >>> Running case #9: 'Read less bytes than expected from slave'...
5: [1716480804.17][CONN][INF] found KV pair in stream: {{__testcase_start;Read less bytes than expected from slave}}, queued...
5: [1716480804.17][CONN][INF] found KV pair in stream: {{start_recording_i2c;please}}, queued...
5: [1716480805.18][SERI][TXD] {{start_recording_i2c;complete}}
5: [1716480805.19][CONN][INF] found KV pair in stream: {{read_bytes_from_slave;addr 0xE4 expected-data 0x15 0x16}}, queued...
5: [1716480805.32][TEST][INF] Saw on the I2C bus:
5: Start Rd[0xe5] Ack 0x15 Ack 0x16 Nack Stop
5: 
5: [1716480805.33][SERI][TXD] {{read_bytes_from_slave;complete}}
5: [1716480805.34][CONN][INF] found KV pair in stream: {{__testcase_finish;Read less bytes than expected from slave;1;0}}, queued...
5: [1716480805.35][CONN][RXD] >>> 'Read less bytes than expected from slave': 1 passed, 0 failed
5: [1716480805.35][CONN][RXD] <greentea test suite>:0::PASS
5: [1716480805.35][CONN][RXD] 
5: [1716480805.36][CONN][RXD] >>> Test cases: 9 passed, 0 failed
5: [1716480805.36][CONN][RXD] 
5: [1716480805.36][CONN][RXD] -----------------------
5: [1716480805.36][CONN][RXD] 0 Tests 0 Failures 0 Ignored 
5: [1716480805.36][CONN][RXD] OK
5: [1716480805.36][CONN][INF] found KV pair in stream: {{__testcase_summary;9;0}}, queued...
5: [1716480805.36][CONN][INF] found KV pair in stream: {{end;success}}, queued...
5: [1716480805.36][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
5: [1716480805.37][HTST][INF] __exit(0)
5: [1716480805.37][HTST][INF] __notify_complete(True)
5: [1716480805.37][HTST][INF] __exit_event_queue received
5: [1716480805.37][HTST][INF] test suite run finished after 8.95 sec...
5: [1716480805.37][CONN][INF] received special event '__host_test_finished' value='True', finishing
5: [1716480805.38][HTST][INF] CONN exited with code: 0
5: [1716480805.38][HTST][INF] Some events in queue
5: [1716480805.38][HTST][INF] stopped consuming events
5: [1716480805.38][HTST][INF] host test result() call skipped, received: True
5: [1716480805.38][HTST][INF] calling blocking teardown()
5: [1716480805.38][HTST][INF] teardown() finished
5: [1716480805.38][HTST][INF] {{result;success}}
1/1 Test #5: test-testshield-i2c-slave-comms ...   Passed   16.66 sec

The following tests passed:
        test-testshield-i2c-slave-comms

100% tests passed, 0 tests failed out of 1
```
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
