### PR TITLE
Fix PwmOut::resume() for static pinmap usage

### DIFF
--- a/drivers/include/drivers/PwmOut.h
+++ b/drivers/include/drivers/PwmOut.h
@@ -200,13 +200,13 @@ protected:
     /** Unlock deep sleep in case it is locked */
     void unlock_deep_sleep();
 
-    // Functions which call the underlying HAL init function.  The direct one calls the static 
+    // Functions which call the underlying HAL init function.  The direct one calls the static
     // pinmap version (pwmout_init_direct()) and the normal one calls the PinName-accepting one (pwmout_init()).
     // A pointer to one of these two functions is stored in the _init_func member.
     // It's done this way so that references to pwmout_init(), and therefore to the pinmap tables,
     // can be removed by the linker if only the static pinmap version is used.
-    static void _call_pwmout_init_direct(PwmOut * thisPtr);
-    static void _call_pwmout_init(PwmOut * thisPtr);
+    static void _call_pwmout_init_direct(PwmOut *thisPtr);
+    static void _call_pwmout_init(PwmOut *thisPtr);
 
     /** Initialize this instance */
     void init();
@@ -215,9 +215,9 @@ protected:
     void deinit();
 
     pwmout_t _pwm;
-    
+
     const PinName _pin; // Pin, NC if using static pinmap
-    PinMap const * const _pinmap; // Static pinmap, nullptr if not used
+    PinMap const *const _pinmap;  // Static pinmap, nullptr if not used
 
     /* Pointer to HAL init function */
     void (*_init_func)(PwmOut *);

--- a/drivers/include/drivers/PwmOut.h
+++ b/drivers/include/drivers/PwmOut.h
@@ -200,6 +200,14 @@ protected:
     /** Unlock deep sleep in case it is locked */
     void unlock_deep_sleep();
 
+    // Functions which call the underlying HAL init function.  The direct one calls the static 
+    // pinmap version (pwmout_init_direct()) and the normal one calls the PinName-accepting one (pwmout_init()).
+    // A pointer to one of these two functions is stored in the _init_func member.
+    // It's done this way so that references to pwmout_init(), and therefore to the pinmap tables,
+    // can be removed by the linker if only the static pinmap version is used.
+    static void _call_pwmout_init_direct(PwmOut * thisPtr);
+    static void _call_pwmout_init(PwmOut * thisPtr);
+
     /** Initialize this instance */
     void init();
 
@@ -210,6 +218,9 @@ protected:
     
     const PinName _pin; // Pin, NC if using static pinmap
     PinMap const * const _pinmap; // Static pinmap, nullptr if not used
+
+    /* Pointer to HAL init function */
+    void (*_init_func)(PwmOut *);
 
     bool _deep_sleep_locked;
     bool _initialized;

--- a/drivers/include/drivers/PwmOut.h
+++ b/drivers/include/drivers/PwmOut.h
@@ -63,7 +63,8 @@ public:
 
     /** Create a PwmOut connected to the specified pin
      *
-     *  @param pinmap reference to structure which holds static pinmap.
+     * @param pinmap reference to structure which holds static pinmap.
+     *   This reference is stored in the PwmOut, so the pinmap needs to live as long as this object does.
      */
     PwmOut(const PinMap &pinmap);
     PwmOut(const PinMap &&) = delete; // prevent passing of temporary objects
@@ -206,7 +207,10 @@ protected:
     void deinit();
 
     pwmout_t _pwm;
-    PinName _pin;
+    
+    const PinName _pin; // Pin, NC if using static pinmap
+    PinMap const * const _pinmap; // Static pinmap, nullptr if not used
+
     bool _deep_sleep_locked;
     bool _initialized;
     float _duty_cycle;

--- a/drivers/source/PwmOut.cpp
+++ b/drivers/source/PwmOut.cpp
@@ -28,6 +28,7 @@ namespace mbed {
 
 PwmOut::PwmOut(PinName pin) :
     _pin(pin),
+    _pinmap(nullptr),
     _deep_sleep_locked(false),
     _initialized(false),
     _duty_cycle(0),
@@ -36,11 +37,15 @@ PwmOut::PwmOut(PinName pin) :
     PwmOut::init();
 }
 
-PwmOut::PwmOut(const PinMap &pinmap) : _deep_sleep_locked(false)
+PwmOut::PwmOut(const PinMap &pinmap) : 
+    _pin(NC),
+    _pinmap(&pinmap),
+    _deep_sleep_locked(false),
+    _initialized(false),
+    _duty_cycle(0),
+    _period_us(0)
 {
-    core_util_critical_section_enter();
-    pwmout_init_direct(&_pwm, &pinmap);
-    core_util_critical_section_exit();
+    PwmOut::init();
 }
 
 PwmOut::~PwmOut()
@@ -169,7 +174,13 @@ void PwmOut::init()
     core_util_critical_section_enter();
 
     if (!_initialized) {
-        pwmout_init(&_pwm, _pin);
+        if(_pinmap != nullptr) {
+            pwmout_init_direct(&_pwm, _pinmap);
+        }
+        else {
+            pwmout_init(&_pwm, _pin);
+        }
+        
         lock_deep_sleep();
         _initialized = true;
     }

--- a/drivers/source/PwmOut.cpp
+++ b/drivers/source/PwmOut.cpp
@@ -38,7 +38,7 @@ PwmOut::PwmOut(PinName pin) :
     PwmOut::init();
 }
 
-PwmOut::PwmOut(const PinMap &pinmap) : 
+PwmOut::PwmOut(const PinMap &pinmap) :
     _pin(NC),
     _pinmap(&pinmap),
     _init_func(_call_pwmout_init_direct),
@@ -171,12 +171,12 @@ void PwmOut::unlock_deep_sleep()
     }
 }
 
-void PwmOut::_call_pwmout_init_direct(PwmOut * thisPtr)
+void PwmOut::_call_pwmout_init_direct(PwmOut *thisPtr)
 {
     pwmout_init_direct(&thisPtr->_pwm, thisPtr->_pinmap);
 }
 
-void PwmOut::_call_pwmout_init(PwmOut * thisPtr)
+void PwmOut::_call_pwmout_init(PwmOut *thisPtr)
 {
     pwmout_init(&thisPtr->_pwm, thisPtr->_pin);
 }
@@ -189,7 +189,7 @@ void PwmOut::init()
 
         // Call either pwmout_init() or pwmout_init_direct(), depending on whether we have a PinName or a static pinmap
         _init_func(this);
-        
+
         lock_deep_sleep();
         _initialized = true;
     }

--- a/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
@@ -30,7 +30,7 @@
 // bitfield for this pin.
 // See section 8.5 in the LPC1768 user manual for the source of these pinmappings.
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
     {P0_0,  UART_3, 2},
     {P0_2,  UART_0, 1},
     {P0_10, UART_2, 1},
@@ -42,7 +42,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
     {NC   , NC    , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
     {P0_1 , UART_3, 2},
     {P0_3 , UART_0, 1},
     {P0_11, UART_2, 1},
@@ -55,19 +55,19 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
 };
 
 // Only UART1 has hardware flow control on LPC176x
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RTS[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RTS[] = {
     {P0_22, UART_1, 1},
     {P2_7,  UART_1, 2},
     {NC,    NC,     0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_CTS[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_CTS[] = {
     {P0_17, UART_1, 1},
     {P2_2,  UART_1, 2},
     {NC,    NC,     0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
     {P0_7 , SPI_1, 2},
     {P0_15, SPI_0, 2},
     {P1_20, SPI_0, 3},
@@ -75,7 +75,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
     {P0_9 , SPI_1, 2},
     {P0_13, SPI_1, 2},
     {P0_18, SPI_0, 2},
@@ -83,7 +83,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
     {P0_8 , SPI_1, 2},
     {P0_12, SPI_1, 2},
     {P0_17, SPI_0, 2},
@@ -91,7 +91,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
     {P0_6 , SPI_1, 2},
     {P0_11, SPI_1, 2},
     {P0_16, SPI_0, 2},
@@ -99,7 +99,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
     {P0_23, ADC0_0, 1},
     {P0_24, ADC0_1, 1},
     {P0_25, ADC0_2, 1},
@@ -111,13 +111,13 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
     {NC,    NC,     0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_DAC[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_DAC[] = {
     {P0_26, DAC_0, 2},
     {NC   , NC   , 0}
 };
 
 // NOTE: For I2C, only the P0_27/P0_28 pinmapping is fully electrically compliant to the I2C standard.
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
     {P0_27, I2C_0, 1},
     {P0_0 , I2C_1, 3},
     {P0_19, I2C_1, 3},
@@ -125,7 +125,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
     {P0_28, I2C_0, 1},
     {P0_1 , I2C_1, 3},
     {P0_20, I2C_1, 3},
@@ -133,7 +133,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
     {NC   , NC,    0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
     {P1_18, PWM_1, 2},
     {P1_20, PWM_2, 2},
     {P1_21, PWM_3, 2},
@@ -151,7 +151,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
     {NC, NC, 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
     {P0_0 , CAN_1, 1},
     {P0_4 , CAN_2, 2},
     {P0_21, CAN_1, 3},
@@ -159,7 +159,7 @@ MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
     {NC   , NC   , 0}
 };
 
-MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_TD[] = {
+static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_TD[] = {
     {P0_1 , CAN_1, 1},
     {P0_5 , CAN_2, 2},
     {P0_22, CAN_1, 3},

--- a/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/PeripheralPinMaps.h
@@ -30,7 +30,7 @@
 // bitfield for this pin.
 // See section 8.5 in the LPC1768 user manual for the source of these pinmappings.
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
     {P0_0,  UART_3, 2},
     {P0_2,  UART_0, 1},
     {P0_10, UART_2, 1},
@@ -42,7 +42,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_TX[] = {
     {NC   , NC    , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
     {P0_1 , UART_3, 2},
     {P0_3 , UART_0, 1},
     {P0_11, UART_2, 1},
@@ -55,19 +55,19 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RX[] = {
 };
 
 // Only UART1 has hardware flow control on LPC176x
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RTS[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_RTS[] = {
     {P0_22, UART_1, 1},
     {P2_7,  UART_1, 2},
     {NC,    NC,     0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_CTS[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_UART_CTS[] = {
     {P0_17, UART_1, 1},
     {P2_2,  UART_1, 2},
     {NC,    NC,     0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
     {P0_7 , SPI_1, 2},
     {P0_15, SPI_0, 2},
     {P1_20, SPI_0, 3},
@@ -75,7 +75,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SCLK[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
     {P0_9 , SPI_1, 2},
     {P0_13, SPI_1, 2},
     {P0_18, SPI_0, 2},
@@ -83,7 +83,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MOSI[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
     {P0_8 , SPI_1, 2},
     {P0_12, SPI_1, 2},
     {P0_17, SPI_0, 2},
@@ -91,7 +91,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_MISO[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
     {P0_6 , SPI_1, 2},
     {P0_11, SPI_1, 2},
     {P0_16, SPI_0, 2},
@@ -99,7 +99,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_SPI_SSEL[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
     {P0_23, ADC0_0, 1},
     {P0_24, ADC0_1, 1},
     {P0_25, ADC0_2, 1},
@@ -111,13 +111,13 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
     {NC,    NC,     0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_DAC[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_DAC[] = {
     {P0_26, DAC_0, 2},
     {NC   , NC   , 0}
 };
 
 // NOTE: For I2C, only the P0_27/P0_28 pinmapping is fully electrically compliant to the I2C standard.
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
     {P0_27, I2C_0, 1},
     {P0_0 , I2C_1, 3},
     {P0_19, I2C_1, 3},
@@ -125,7 +125,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SDA[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
     {P0_28, I2C_0, 1},
     {P0_1 , I2C_1, 3},
     {P0_20, I2C_1, 3},
@@ -133,7 +133,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_I2C_SCL[] = {
     {NC   , NC,    0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
     {P1_18, PWM_1, 2},
     {P1_20, PWM_2, 2},
     {P1_21, PWM_3, 2},
@@ -151,7 +151,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_PWM[] = {
     {NC, NC, 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
     {P0_0 , CAN_1, 1},
     {P0_4 , CAN_2, 2},
     {P0_21, CAN_1, 3},
@@ -159,7 +159,7 @@ static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_RD[] = {
     {NC   , NC   , 0}
 };
 
-static MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_TD[] = {
+MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_CAN_TD[] = {
     {P0_1 , CAN_1, 1},
     {P0_5 , CAN_2, 2},
     {P0_22, CAN_1, 3},


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When running CI shield tests against master, I noticed that switching the LPC1768 to static pinmaps broke the PWM test.  And it was a weird error, too -- an assertion failure with "pinmap not found for peripheral".  As it turns out, [this PR](https://github.com/ARMmbed/mbed-os/pull/11892) which added static pinmaps to PwmOut made a big mistake -- they didn't notice that PwmOut::resume() calls init() a second time, and this version of init() is hardcoded to use a regular PinName, not a static pinmap.  If you had constructed PwmOut with a static pinmap, the _pin member variable never gets initialized, so it tries to map an undefined pin for PWM output.  Bam, (likely) assertion failure.

This PR fixes the issue by storing the pinmap and the init function to use as member variables, and then using the correct one later on.  I tried to copy how this is done in the SPI class, where they have the same sort of issue.

#### Impact of changes <!-- Optional -->
PwmOut::resume() no longer causes assertion failure when using a static pinmap.  Also, PwmOut now locks the deep sleep correctly when using a static pinmap (this was missed in the original code)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Now passes CI shield PWM test!

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
