### PR TITLE
STMicro: Improve PWM resolution

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/objects.h
@@ -34,16 +34,6 @@
 extern "C" {
 #endif
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/objects.h
@@ -60,16 +60,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -125,16 +125,6 @@ struct i2c_s {
 #endif
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 #if DEVICE_CAN
 struct can_s {
     CAN_HandleTypeDef CanHandle;

--- a/targets/TARGET_STM/TARGET_STM32F3/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/objects.h
@@ -47,16 +47,6 @@
 extern "C" {
 #endif
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -50,9 +50,16 @@ struct port_s {
 struct pwmout_s {
     PWMName pwm;
     PinName pin;
-    uint32_t prescaler;
     uint32_t period;
-    uint32_t pulse;
+
+    // Current compare value.  Once the PWM counter becomes >= this value,
+    // the PWM turns off.
+    uint32_t compare_value;
+    
+    // How many counts the PWM timer makes before it resets.
+    // Example: if counts = 3, the timer will count 0, 1, 2, 0, 1, 2, etc.
+    uint16_t counts;
+
     uint8_t channel;
     uint8_t inverted;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/objects.h
@@ -47,23 +47,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t period;
-
-    // Current compare value.  Once the PWM counter becomes >= this value,
-    // the PWM turns off.
-    uint32_t compare_value;
-    
-    // How many counts the PWM timer makes before it resets.
-    // Example: if counts = 3, the timer will count 0, 1, 2, 0, 1, 2, etc.
-    uint16_t counts;
-
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/objects.h
@@ -65,16 +65,6 @@ struct trng_s {
     RNG_HandleTypeDef handle;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32G0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G0/objects.h
@@ -45,17 +45,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32G4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32G4/objects.h
@@ -45,16 +45,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -54,16 +54,6 @@ struct trng_s {
     RNG_HandleTypeDef handle;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L0/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/objects.h
@@ -47,17 +47,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/objects.h
@@ -46,17 +46,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/objects.h
@@ -44,16 +44,6 @@ struct dac_s {
 };
 #endif
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32L5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L5/objects.h
@@ -54,16 +54,6 @@ struct trng_s {
     RNG_HandleTypeDef handle;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32U5/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32U5/objects.h
@@ -54,16 +54,6 @@ struct trng_s {
     RNG_HandleTypeDef handle;
 };
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32WB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/objects.h
@@ -37,16 +37,6 @@
 extern "C" {
 #endif
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/TARGET_STM32WL/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WL/objects.h
@@ -40,16 +40,6 @@ struct dac_s {
 };
 #endif
 
-struct pwmout_s {
-    PWMName pwm;
-    PinName pin;
-    uint32_t prescaler;
-    uint32_t period;
-    uint32_t pulse;
-    uint8_t channel;
-    uint8_t inverted;
-};
-
 struct serial_s {
     UARTName uart;
     int index; // Used by irq

--- a/targets/TARGET_STM/device.h
+++ b/targets/TARGET_STM/device.h
@@ -38,6 +38,7 @@
 #include "objects.h"
 #include "stm_i2c_api.h"
 #include "stm_spi_api.h"
+#include "stm_pwmout_api.h"
 
 #if DEVICE_USTICKER
 #include "us_ticker_defines.h"

--- a/targets/TARGET_STM/pwmout_api.c
+++ b/targets/TARGET_STM/pwmout_api.c
@@ -37,7 +37,25 @@
 #include "PeripheralPins.h"
 #include "pwmout_device.h"
 
+#include <math.h>
+
 static TIM_HandleTypeDef TimHandle;
+
+// Maximum counts per timer cycle.
+// Note: Hardware can do 65536, but I don't believe you can have 100% duty cycle with 65536 counts/cycle.
+#define MAX_COUNTS_PER_CYCLE 65535
+
+// Maximum prescaler division possible
+#define MAX_PRESCALER 65536 
+
+// Change to 1 to enable debug prints of what's being calculated.
+// Must comment out the critical section calls in PwmOut to use.
+#define STM_PWMOUT_DEBUG 0
+
+#if STM_PWMOUT_DEBUG
+#include <stdio.h>
+#include <inttypes.h>
+#endif
 
 /* Convert STM32 Cube HAL channel to LL channel */
 uint32_t TIM_ChannelConvert_HAL2LL(uint32_t channel, pwmout_t *obj)
@@ -200,8 +218,8 @@ static void _pwmout_init_direct(pwmout_t *obj, const PinMap *pinmap)
 
     obj->pin = pinmap->pin;
     obj->period = 0;
-    obj->pulse = 0;
-    obj->prescaler = 1;
+    obj->compare_value = 0;
+    obj->counts = 1;
 
     pwmout_period_us(obj, 20000); // 20 ms per default
 }
@@ -219,7 +237,7 @@ void pwmout_init(pwmout_t *obj, PinName pin)
 void pwmout_free(pwmout_t *obj)
 {
     // Configure GPIO back to reset value
-    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0));
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 }
 
 void pwmout_write(pwmout_t *obj, float value)
@@ -235,11 +253,22 @@ void pwmout_write(pwmout_t *obj, float value)
         value = 1.0;
     }
 
-    obj->pulse = (uint32_t)((float)obj->period * value + 0.5);
+    // Calculate the correct compare value.  The PWM output changes to 0 once the counter becomes
+    // >= the compare value.
+    // Examples:
+    // - if value is .999 and counts is 3, we want to write 3 so the PWM is on all the time
+    // - if value is .33 and counts is 3, we want to write 1 so that we turn off after the counter becomes 1.
+    // - if value is .1 and counts is 3, that rounds to 0 so we want to write 0 so that the PWM is off all the time
+
+    obj->compare_value = lroundf((float)obj->counts * value);
+
+#if STM_PWMOUT_DEBUG
+    printf("Setting compare value to %" PRIu32 "\n", obj->compare_value);
+#endif
 
     // Configure channels
     sConfig.OCMode       = TIM_OCMODE_PWM1;
-    sConfig.Pulse        = obj->pulse / obj->prescaler;
+    sConfig.Pulse        = obj->compare_value;
     sConfig.OCPolarity   = TIM_OCPOLARITY_HIGH;
     sConfig.OCFastMode   = TIM_OCFAST_DISABLE;
 #if defined(TIM_OCIDLESTATE_RESET)
@@ -292,7 +321,7 @@ float pwmout_read(pwmout_t *obj)
 {
     float value = 0;
     if (obj->period > 0) {
-        value = (float)(obj->pulse) / (float)(obj->period);
+        value = (float)(obj->compare_value) / (float)(obj->counts);
     }
     return ((value > (float)1.0) ? (float)(1.0) : (value));
 }
@@ -341,35 +370,41 @@ void pwmout_period_us(pwmout_t *obj, int us)
 #endif
     }
 
-
-    /* By default use, 1us as SW pre-scaler */
-    obj->prescaler = 1;
     // TIMxCLK = PCLKx when the APB prescaler = 1 else TIMxCLK = 2 * PCLKx
+    uint32_t timxClk;
     if (APBxCLKDivider == RCC_HCLK_DIV1) {
-        TimHandle.Init.Prescaler = (((PclkFreq) / 1000000)) - 1; // 1 us tick
+        timxClk = PclkFreq;
     } else {
-        TimHandle.Init.Prescaler = (((PclkFreq * 2) / 1000000)) - 1; // 1 us tick
-    }
-    TimHandle.Init.Period = (us - 1);
-
-    /*  In case period or pre-scalers are out of range, loop-in to get valid values */
-    while ((TimHandle.Init.Period > 0xFFFF) || (TimHandle.Init.Prescaler > 0xFFFF)) {
-        obj->prescaler = obj->prescaler * 2;
-        if (APBxCLKDivider == RCC_HCLK_DIV1) {
-            TimHandle.Init.Prescaler = (((PclkFreq) / 1000000) * obj->prescaler) - 1;
-        } else {
-            TimHandle.Init.Prescaler = (((PclkFreq * 2) / 1000000) * obj->prescaler) - 1;
-        }
-        TimHandle.Init.Period = (us - 1) / obj->prescaler;
-        /*  Period decreases and prescaler increases over loops, so check for
-         *  possible out of range cases */
-        if ((TimHandle.Init.Period < 0xFFFF) && (TimHandle.Init.Prescaler > 0xFFFF)) {
-            error("Cannot initialize PWM\n");
-            break;
-        }
+        timxClk = PclkFreq * 2;
     }
 
-    TimHandle.Init.ClockDivision = 0;
+    // To generate the desired frequency, we have 2 knobs to play with: the reload value and the
+    // duty cycle.  We generally want to have the reload value as high as possible since that will
+    // give the best duty cycle resolution at high frequencies.
+
+    // Step 1: Calculate the smallest prescaler that will allow the desired period to be achieved by
+    // tuning the reload value.
+    // (prescaler * reloadValue) / (timxClk) = period
+    // prescaler = (period * timxClk) / reloadValue
+    // minimum needed prescaler (floating point) = (period * timxClk) / 65536
+
+    const float periodSeconds = us * 1e-6f;
+    const uint32_t prescaler = ceilf(periodSeconds * timxClk / MAX_COUNTS_PER_CYCLE);
+    MBED_ASSERT(prescaler <= MAX_PRESCALER);
+
+    // Step 2: Calculate top count based on determined prescaler
+    // reloadValue = period * timxClk / prescaler
+    uint32_t topCount = lroundf(periodSeconds * timxClk / prescaler);
+    MBED_ASSERT(topCount <= MAX_COUNTS_PER_CYCLE);
+
+#if STM_PWMOUT_DEBUG
+    printf("Setting prescaler to %" PRIu32 " and top count to %" PRIu32 "\n", prescaler, topCount);
+#endif
+
+    TimHandle.Init.Prescaler = prescaler - 1; // value of 0 means divide by 1
+    TimHandle.Init.Period = topCount - 1; // value of 0 means count once
+
+    TimHandle.Init.ClockDivision = 0; // Dead time generators and digital filters use CK_INT directly
     TimHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
 
     if (HAL_TIM_PWM_Init(&TimHandle) != HAL_OK) {
@@ -378,6 +413,7 @@ void pwmout_period_us(pwmout_t *obj, int us)
 
     // Save for future use
     obj->period = us;
+    obj->counts = topCount;
 
     // Set duty cycle again
     pwmout_write(obj, dc);
@@ -409,7 +445,7 @@ void pwmout_pulsewidth_us(pwmout_t *obj, int us)
 int pwmout_read_pulsewidth_us(pwmout_t *obj)
 {
     float pwm_duty_cycle = pwmout_read(obj);
-    return (int)(pwm_duty_cycle * (float)obj->period);
+    return lroundf(pwm_duty_cycle * (float)obj->period);
 }
 
 const PinMap *pwmout_pinmap()

--- a/targets/TARGET_STM/pwmout_api.c
+++ b/targets/TARGET_STM/pwmout_api.c
@@ -219,7 +219,7 @@ static void _pwmout_init_direct(pwmout_t *obj, const PinMap *pinmap)
     obj->pin = pinmap->pin;
     obj->period = 0;
     obj->compare_value = 0;
-    obj->counts = 1;
+    obj->top_count = 1;
 
     pwmout_period_us(obj, 20000); // 20 ms per default
 }
@@ -260,7 +260,7 @@ void pwmout_write(pwmout_t *obj, float value)
     // - if value is .33 and counts is 3, we want to write 1 so that we turn off after the counter becomes 1.
     // - if value is .1 and counts is 3, that rounds to 0 so we want to write 0 so that the PWM is off all the time
 
-    obj->compare_value = lroundf((float)obj->counts * value);
+    obj->compare_value = lroundf((float)obj->top_count * value);
 
 #if STM_PWMOUT_DEBUG
     printf("Setting compare value to %" PRIu32 "\n", obj->compare_value);
@@ -321,7 +321,7 @@ float pwmout_read(pwmout_t *obj)
 {
     float value = 0;
     if (obj->period > 0) {
-        value = (float)(obj->compare_value) / (float)(obj->counts);
+        value = (float)(obj->compare_value) / (float)(obj->top_count);
     }
     return ((value > (float)1.0) ? (float)(1.0) : (value));
 }
@@ -413,7 +413,7 @@ void pwmout_period_us(pwmout_t *obj, int us)
 
     // Save for future use
     obj->period = us;
-    obj->counts = topCount;
+    obj->top_count = topCount;
 
     // Set duty cycle again
     pwmout_write(obj, dc);

--- a/targets/TARGET_STM/pwmout_api.c
+++ b/targets/TARGET_STM/pwmout_api.c
@@ -237,7 +237,7 @@ void pwmout_init(pwmout_t *obj, PinName pin)
 void pwmout_free(pwmout_t *obj)
 {
     // Configure GPIO back to reset value
-    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0));
 }
 
 void pwmout_write(pwmout_t *obj, float value)

--- a/targets/TARGET_STM/stm_pwmout_api.h
+++ b/targets/TARGET_STM/stm_pwmout_api.h
@@ -1,0 +1,50 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2024 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_OS_STM_PWMOUT_API_H
+#define MBED_OS_STM_PWMOUT_API_H
+
+#include "PeripheralNames.h"
+#include "PinNames.h"
+
+struct pwmout_s {
+
+    // PWM (timer) peripheral that this pwmout is created with
+    PWMName pwm;
+
+    // Pin that this pwmout is using.  This is used to reset the pin function in pwmout_free()
+    PinName pin;
+
+    // Current period of the pwmout, in microseconds
+    uint32_t period;
+
+    // Current compare value.  Once the PWM counter becomes >= this value,
+    // the PWM turns off.
+    uint32_t compare_value;
+    
+    // How many counts the PWM timer makes before it resets.
+    // Example: if top_count = 3, the timer will count 0, 1, 2, 0, 1, 2, etc.
+    uint16_t top_count;
+
+    // Channel number on the timer that this pin is connected to
+    uint8_t channel;
+
+    // Whether this hardware channel is an inverted output (1) or not (0)
+    uint8_t inverted;
+};
+
+#endif //MBED_OS_STM_PWMOUT_API_H


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Running my new PWM test suite, I noticed that STMicro boards (STM32F429 and STM32U575) were failing a lot of cases in the PWM test.  Things were mostly OK with the frequency <=10kHz, but at 100kHz the duty cycle had excessive error, and at 1MHz the PWM signal would not even run properly -- it was stuck high or low.

To understand what was going on, I dug into the STMicro PWM HAL.  As it turns out, their procedure for selecting a PWM prescaler is... kinda sub-optimal.  Their code starts by selecting a prescaler such that one PWM count is equal to one microsecond of duty cycle -- e.g. if you ask for a period of 150us, it will try and find a prescaler such that the PWM top count is 150.  Then, if that prescaler would exceed the limit of 2^16, the code iteratively makes the top count bigger until it isn't.

However, this method turns out to have bad impacts on the duty cycle resolution -- at 100kHz frequency, there are only 10 steps available between 0 duty cycle and full duty cycle!  And, this is a totally artificial limit, because the STMicro timers are quite powerful and have a full 16 bit prescaler (not just a power of 2!) and a 16 bit counter.  By using a lower prescaler value at high frequencies, it's possible to keep close to the full 16 bit resolution.

The new code in this PR solves this issue by using a different strategy.  When you set the PWM period, it first calculates the smallest integer prescaler such that top_count <= 65535.  Then, it sets top_count to hit the desired period exactly.  This gives you the largest top_count possible for your frequency -- at 1MHz, on the F429ZI, you still have a duty cycle resolution of over 6 bits, more than enough to pass the PWM test shield test.

In this PR, I also fixed a few other bugs, such as suspend mode not working and a rounding error in the read duty cycle function.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- PwmOut::suspend()/resume() works now on STM32 targets
- PWM duty cycle resolution should now be the maximum available on STM32 targets
- Rounding error fixed in PwmOut::read_pulsewidth_us() for STM32 targets

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None (except code comments)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
 Test shield PWM test:
```
9: [1717607654.02][SERI][TXD] {{__sync;2c005572-129c-4443-9b86-3115a25b477d}}
9: [1717607654.03][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed
9: [1717607654.03][CONN][INF] found SYNC in stream: {{__sync;2c005572-129c-4443-9b86-3115a25b477d}} it is #0 sent, queued...
9: [1717607654.03][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
9: [1717607654.03][HTST][INF] sync KV found, uuid=2c005572-129c-4443-9b86-3115a25b477d, timestamp=1717607654.027773
9: [1717607654.03][HTST][INF] DUT greentea-client version: 1.3.0
9: [1717607654.04][CONN][RXD] >>> Running 9 test cases...
9: [1717607654.04][CONN][INF] found KV pair in stream: {{__timeout;75}}, queued...
9: [1717607654.04][CONN][INF] found KV pair in stream: {{__host_test_name;signal_analyzer_test}}, queued...
9: [1717607654.04][HTST][INF] setting timeout to: 75 sec
9: [1717607654.04][CONN][INF] found KV pair in stream: {{__testcase_name;Test reading digital values with the ADC}}, queued...
9: [1717607654.04][HTST][INF] host test class: '<class 'signal_analyzer_test.SignalAnalyzerHostTest'>'
9: [1717607654.04][TEST][INF] Signal Analyzer Test host test setup complete.
9: [1717607654.04][HTST][INF] host test setup() call...
9: [1717607654.04][HTST][INF] CALLBACKs updated
9: [1717607654.04][HTST][INF] host test detected: signal_analyzer_test
9: [1717607654.05][CONN][INF] found KV pair in stream: {{__testcase_name;Test reading analog values with the ADC}}, queued...
9: [1717607654.05][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 50 Hz)}}, queued...
9: [1717607654.07][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 1 kHz)}}, queued...
9: [1717607654.07][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 10 kHz)}}, queued...
9: [1717607654.08][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 100 kHz)}}, queued...
9: [1717607654.08][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM frequency and duty cycle (freq = 1 MHz)}}, queued...
9: [1717607654.09][CONN][RXD] 
9: [1717607654.09][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM Suspend/Resume (freq = 1kHz)}}, queued...
9: [1717607654.09][CONN][INF] found KV pair in stream: {{__testcase_name;Test PWM Maintains Duty Cycle (freq = 1kHz)}}, queued...
9: [1717607654.10][CONN][RXD] >>> Running case #1: 'Test reading digital values with the ADC'...
9: [1717607654.10][CONN][INF] found KV pair in stream: {{__testcase_start;Test reading digital values with the ADC}}, queued...
9: [1717607654.13][CONN][RXD] With the PWM at full off, the ADC reads 0.2% of reference voltage.
9: [1717607654.19][CONN][RXD] With the PWM at full on, the ADC reads 100.0% of reference voltage.
9: [1717607654.19][CONN][INF] found KV pair in stream: {{__testcase_finish;Test reading digital values with the ADC;1;0}}, queued...
9: [1717607654.20][CONN][RXD] >>> 'Test reading digital values with the ADC': 1 passed, 0 failed
9: [1717607654.20][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607654.21][CONN][RXD] Cannot convert to volts, target.default-adc-vref is not set for this target
9: [1717607654.21][CONN][RXD] >>> Running case #2: 'Test reading analog values with the ADC'...
9: [1717607654.22][CONN][INF] found KV pair in stream: {{__testcase_start;Test reading analog values with the ADC}}, queued...
9: [1717607654.26][CONN][RXD] PWM duty cycle of 0.0% produced an ADC reading of 0.1% (expected 0.0%)
9: [1717607654.30][CONN][RXD] PWM duty cycle of 10.0% produced an ADC reading of 10.0% (expected 10.0%)
9: [1717607654.35][CONN][RXD] PWM duty cycle of 20.0% produced an ADC reading of 20.0% (expected 20.0%)
9: [1717607654.41][CONN][RXD] PWM duty cycle of 30.0% produced an ADC reading of 30.2% (expected 30.0%)
9: [1717607654.46][CONN][RXD] PWM duty cycle of 40.0% produced an ADC reading of 40.3% (expected 40.0%)
9: [1717607654.50][CONN][RXD] PWM duty cycle of 50.0% produced an ADC reading of 50.7% (expected 50.0%)
9: [1717607654.56][CONN][RXD] PWM duty cycle of 60.0% produced an ADC reading of 60.7% (expected 60.0%)
9: [1717607654.61][CONN][RXD] PWM duty cycle of 70.0% produced an ADC reading of 70.7% (expected 70.0%)
9: [1717607654.65][CONN][RXD] PWM duty cycle of 80.0% produced an ADC reading of 80.4% (expected 80.0%)
9: [1717607654.70][CONN][RXD] PWM duty cycle of 90.0% produced an ADC reading of 90.2% (expected 90.0%)
9: [1717607654.71][CONN][INF] found KV pair in stream: {{__testcase_finish;Test reading analog values with the ADC;1;0}}, queued...
9: [1717607654.72][CONN][RXD] >>> 'Test reading analog values with the ADC': 1 passed, 0 failed
9: [1717607654.72][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607654.72][CONN][RXD] 
9: [1717607654.73][CONN][RXD] >>> Running case #3: 'Test PWM frequency and duty cycle (freq = 50 Hz)'...
9: [1717607654.73][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 50 Hz)}}, queued...
9: [1717607654.73][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607656.96][SERI][TXD] {{frequency;50.0}}
9: [1717607656.98][SERI][TXD] {{duty_cycle;0.05319368350789561}}
9: [1717607657.00][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 5.32% (+-0.10%), host measured frequency 50 Hz and duty cycle 5.32%
9: [1717607657.00][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607659.20][SERI][TXD] {{frequency;50.0}}
9: [1717607659.22][SERI][TXD] {{duty_cycle;0.16010729986587516}}
9: [1717607659.24][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 16.01% (+-0.10%), host measured frequency 50 Hz and duty cycle 16.01%
9: [1717607659.24][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607661.46][SERI][TXD] {{frequency;50.0}}
9: [1717607661.47][SERI][TXD] {{duty_cycle;0.6614116732354085}}
9: [1717607661.50][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 66.14% (+-0.10%), host measured frequency 50 Hz and duty cycle 66.14%
9: [1717607661.50][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607663.73][SERI][TXD] {{frequency;50.0}}
9: [1717607663.74][SERI][TXD] {{duty_cycle;0.8503851870185162}}
9: [1717607663.77][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 85.04% (+-0.10%), host measured frequency 50 Hz and duty cycle 85.04%
9: [1717607663.77][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607665.99][SERI][TXD] {{frequency;50.0}}
9: [1717607666.01][SERI][TXD] {{duty_cycle;0.6394817006478742}}
9: [1717607666.03][CONN][RXD] Expected PWM frequency was 50 Hz (+- 20 Hz) and duty cycle was 63.95% (+-0.10%), host measured frequency 50 Hz and duty cycle 63.95%
9: [1717607666.03][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 50 Hz);1;0}}, queued...
9: [1717607666.04][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 50 Hz)': 1 passed, 0 failed
9: [1717607666.04][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607666.04][CONN][RXD] 
9: [1717607666.05][CONN][RXD] >>> Running case #4: 'Test PWM frequency and duty cycle (freq = 1 kHz)'...
9: [1717607666.05][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 1 kHz)}}, queued...
9: [1717607666.05][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607668.28][SERI][TXD] {{frequency;1000.0}}
9: [1717607668.30][SERI][TXD] {{duty_cycle;0.6189367263290921}}
9: [1717607668.32][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 61.89% (+-0.10%), host measured frequency 1000 Hz and duty cycle 61.89%
9: [1717607668.32][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607670.54][SERI][TXD] {{frequency;1000.0}}
9: [1717607670.56][SERI][TXD] {{duty_cycle;0.4149407313240858}}
9: [1717607670.58][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 41.49% (+-0.10%), host measured frequency 1000 Hz and duty cycle 41.49%
9: [1717607670.58][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607672.82][SERI][TXD] {{frequency;1000.0}}
9: [1717607672.84][SERI][TXD] {{duty_cycle;0.7679765400293249}}
9: [1717607672.86][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 76.80% (+-0.10%), host measured frequency 1000 Hz and duty cycle 76.80%
9: [1717607672.86][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607675.10][SERI][TXD] {{frequency;1000.0}}
9: [1717607675.11][SERI][TXD] {{duty_cycle;0.9825187718515351}}
9: [1717607675.14][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 98.25% (+-0.10%), host measured frequency 1000 Hz and duty cycle 98.25%
9: [1717607675.14][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607677.36][SERI][TXD] {{frequency;1000.0}}
9: [1717607677.37][SERI][TXD] {{duty_cycle;0.48714689106638615}}
9: [1717607677.39][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 48.71% (+-0.10%), host measured frequency 1000 Hz and duty cycle 48.71%
9: [1717607677.39][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 1 kHz);1;0}}, queued...
9: [1717607677.40][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 1 kHz)': 1 passed, 0 failed
9: [1717607677.40][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607677.41][CONN][RXD] 
9: [1717607677.42][CONN][RXD] >>> Running case #5: 'Test PWM frequency and duty cycle (freq = 10 kHz)'...
9: [1717607677.42][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 10 kHz)}}, queued...
9: [1717607677.42][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607679.64][SERI][TXD] {{frequency;10000.0}}
9: [1717607679.66][SERI][TXD] {{duty_cycle;0.7959727550340562}}
9: [1717607679.68][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 79.60% (+-0.10%), host measured frequency 10000 Hz and duty cycle 79.60%
9: [1717607679.68][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607681.90][SERI][TXD] {{frequency;10000.0}}
9: [1717607681.92][SERI][TXD] {{duty_cycle;0.9694537881827647}}
9: [1717607681.94][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 96.95% (+-0.10%), host measured frequency 10000 Hz and duty cycle 96.95%
9: [1717607681.94][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607684.13][SERI][TXD] {{frequency;10000.0}}
9: [1717607684.15][SERI][TXD] {{duty_cycle;0.24590844261444672}}
9: [1717607684.17][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 24.59% (+-0.10%), host measured frequency 10000 Hz and duty cycle 24.59%
9: [1717607684.17][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607686.38][SERI][TXD] {{frequency;10000.0}}
9: [1717607686.40][SERI][TXD] {{duty_cycle;0.8312464609419238}}
9: [1717607686.42][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 83.13% (+-0.10%), host measured frequency 10000 Hz and duty cycle 83.12%
9: [1717607686.42][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607688.62][SERI][TXD] {{frequency;10000.0}}
9: [1717607688.63][SERI][TXD] {{duty_cycle;0.29265963417545726}}
9: [1717607688.66][CONN][RXD] Expected PWM frequency was 10000 Hz (+- 20 Hz) and duty cycle was 29.28% (+-0.10%), host measured frequency 10000 Hz and duty cycle 29.27%
9: [1717607688.66][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 10 kHz);1;0}}, queued...
9: [1717607688.67][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 10 kHz)': 1 passed, 0 failed
9: [1717607688.67][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607688.67][CONN][RXD] 
9: [1717607688.68][CONN][RXD] >>> Running case #6: 'Test PWM frequency and duty cycle (freq = 100 kHz)'...
9: [1717607688.68][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 100 kHz)}}, queued...
9: [1717607688.69][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607690.89][SERI][TXD] {{frequency;100000.0}}
9: [1717607690.91][SERI][TXD] {{duty_cycle;0.3485583143021071}}
9: [1717607690.93][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 34.90% (+-1.00%), host measured frequency 100000 Hz and duty cycle 34.86%
9: [1717607690.93][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607693.12][SERI][TXD] {{frequency;100000.0}}
9: [1717607693.13][SERI][TXD] {{duty_cycle;0.2237947202565997}}
9: [1717607693.16][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 22.19% (+-1.00%), host measured frequency 100000 Hz and duty cycle 22.38%
9: [1717607693.16][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607695.37][SERI][TXD] {{frequency;100000.0}}
9: [1717607695.38][SERI][TXD] {{duty_cycle;0.6308867113916108}}
9: [1717607695.40][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 63.09% (+-1.00%), host measured frequency 100000 Hz and duty cycle 63.09%
9: [1717607695.40][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607697.62][SERI][TXD] {{frequency;100000.0}}
9: [1717607697.63][SERI][TXD] {{duty_cycle;0.8131777335278331}}
9: [1717607697.65][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 81.33% (+-1.00%), host measured frequency 100000 Hz and duty cycle 81.32%
9: [1717607697.65][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607699.85][SERI][TXD] {{frequency;100000.0}}
9: [1717607699.87][SERI][TXD] {{duty_cycle;0.4951506310617112}}
9: [1717607699.89][CONN][RXD] Expected PWM frequency was 100000 Hz (+- 20 Hz) and duty cycle was 49.56% (+-1.00%), host measured frequency 100000 Hz and duty cycle 49.52%
9: [1717607699.89][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 100 kHz);1;0}}, queued...
9: [1717607699.90][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 100 kHz)': 1 passed, 0 failed
9: [1717607699.90][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607699.90][CONN][RXD] 
9: [1717607699.91][CONN][RXD] >>> Running case #7: 'Test PWM frequency and duty cycle (freq = 1 MHz)'...
9: [1717607699.91][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM frequency and duty cycle (freq = 1 MHz)}}, queued...
9: [1717607699.92][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607702.15][SERI][TXD] {{frequency;1000000.0}}
9: [1717607702.16][SERI][TXD] {{duty_cycle;0.3176571029286213}}
9: [1717607702.18][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 30.80% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 31.77%
9: [1717607702.18][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607704.40][SERI][TXD] {{frequency;1000000.0}}
9: [1717607704.41][SERI][TXD] {{duty_cycle;0.4658544176819779}}
9: [1717607704.43][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 46.96% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 46.59%
9: [1717607704.43][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607706.66][SERI][TXD] {{frequency;1000000.0}}
9: [1717607706.67][SERI][TXD] {{duty_cycle;0.33934457581928024}}
9: [1717607706.69][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 34.13% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 33.93%
9: [1717607706.69][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607708.91][SERI][TXD] {{frequency;999990.0}}
9: [1717607708.93][SERI][TXD] {{duty_cycle;0.36189704762869046}}
9: [1717607708.95][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 35.34% (+-10.00%), host measured frequency 999990 Hz and duty cycle 36.19%
9: [1717607708.95][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607711.18][SERI][TXD] {{frequency;1000000.0}}
9: [1717607711.19][SERI][TXD] {{duty_cycle;0.4375744530319337}}
9: [1717607711.21][CONN][RXD] Expected PWM frequency was 1000000 Hz (+- 20 Hz) and duty cycle was 44.74% (+-10.00%), host measured frequency 1000000 Hz and duty cycle 43.76%
9: [1717607711.21][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM frequency and duty cycle (freq = 1 MHz);1;0}}, queued...
9: [1717607711.22][CONN][RXD] >>> 'Test PWM frequency and duty cycle (freq = 1 MHz)': 1 passed, 0 failed
9: [1717607711.22][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607711.22][CONN][RXD] 
9: [1717607711.23][CONN][RXD] >>> Running case #8: 'Test PWM Suspend/Resume (freq = 1kHz)'...
9: [1717607711.23][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM Suspend/Resume (freq = 1kHz)}}, queued...
9: [1717607711.23][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607713.44][SERI][TXD] {{frequency;1000.0}}
9: [1717607713.46][SERI][TXD] {{duty_cycle;0.7500003124996094}}
9: [1717607713.48][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 75.00% (+-0.10%), host measured frequency 1000 Hz and duty cycle 75.00%
9: [1717607713.48][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607715.70][SERI][TXD] {{frequency;0.0}}
9: [1717607715.71][SERI][TXD] {{duty_cycle;0.9999987500015625}}
9: [1717607715.73][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607717.94][SERI][TXD] {{frequency;1000.0}}
9: [1717607717.95][SERI][TXD] {{duty_cycle;0.7500028124964844}}
9: [1717607717.97][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 75.00% (+-0.10%), host measured frequency 1000 Hz and duty cycle 75.00%
9: [1717607717.97][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM Suspend/Resume (freq = 1kHz);1;0}}, queued...
9: [1717607717.98][CONN][RXD] >>> 'Test PWM Suspend/Resume (freq = 1kHz)': 1 passed, 0 failed
9: [1717607717.98][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607717.98][CONN][RXD] 
9: [1717607718.00][CONN][RXD] >>> Running case #9: 'Test PWM Maintains Duty Cycle (freq = 1kHz)'...
9: [1717607718.00][CONN][INF] found KV pair in stream: {{__testcase_start;Test PWM Maintains Duty Cycle (freq = 1kHz)}}, queued...
9: [1717607718.00][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607720.21][SERI][TXD] {{frequency;1000.0}}
9: [1717607720.22][SERI][TXD] {{duty_cycle;0.7499953125058594}}
9: [1717607720.24][CONN][RXD] Expected PWM frequency was 1000 Hz (+- 20 Hz) and duty cycle was 75.00% (+-0.10%), host measured frequency 1000 Hz and duty cycle 75.00%
9: [1717607720.24][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607722.46][SERI][TXD] {{frequency;40000.0}}
9: [1717607722.47][SERI][TXD] {{duty_cycle;0.7499828125214844}}
9: [1717607722.49][CONN][RXD] Expected PWM frequency was 40000 Hz (+- 20 Hz) and duty cycle was 75.00% (+-0.40%), host measured frequency 40000 Hz and duty cycle 75.00%
9: [1717607722.49][CONN][INF] found KV pair in stream: {{analyze_signal;please}}, queued...
9: [1717607724.70][SERI][TXD] {{frequency;200.0}}
9: [1717607724.72][SERI][TXD] {{duty_cycle;0.7499953125058594}}
9: [1717607724.74][CONN][RXD] Expected PWM frequency was 200 Hz (+- 20 Hz) and duty cycle was 75.00% (+-0.10%), host measured frequency 200 Hz and duty cycle 75.00%
9: [1717607724.74][CONN][INF] found KV pair in stream: {{__testcase_finish;Test PWM Maintains Duty Cycle (freq = 1kHz);1;0}}, queued...
9: [1717607724.75][CONN][RXD] >>> 'Test PWM Maintains Duty Cycle (freq = 1kHz)': 1 passed, 0 failed
9: [1717607724.75][CONN][RXD] <greentea test suite>:0::PASS
9: [1717607724.75][CONN][RXD] 
9: [1717607724.75][CONN][RXD] >>> Test cases: 9 passed, 0 failed
9: [1717607724.75][CONN][RXD] 
9: [1717607724.75][CONN][RXD] -----------------------
9: [1717607724.76][CONN][RXD] 0 Tests 0 Failures 0 Ignored 
9: [1717607724.76][CONN][RXD] OK
9: [1717607724.76][CONN][INF] found KV pair in stream: {{__testcase_summary;9;0}}, queued...
9: [1717607724.76][CONN][INF] found KV pair in stream: {{end;success}}, queued...
9: [1717607724.76][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
9: [1717607724.77][HTST][INF] __exit(0)
9: [1717607724.77][HTST][INF] __notify_complete(True)
9: [1717607724.77][HTST][INF] __exit_event_queue received
9: [1717607724.77][HTST][INF] test suite run finished after 70.73 sec...
9: [1717607724.78][CONN][INF] received special event '__host_test_finished' value='True', finishing
9: [1717607724.78][HTST][INF] CONN exited with code: 0
9: [1717607724.78][HTST][INF] Some events in queue
9: [1717607724.79][HTST][INF] stopped consuming events
9: [1717607724.79][HTST][INF] host test result() call skipped, received: True
9: [1717607724.79][HTST][INF] calling blocking teardown()
9: [1717607724.79][HTST][INF] teardown() finished
9: [1717607724.79][HTST][INF] {{result;success}}
1/1 Test #9: test-testshield-pwm-and-adc ......   Passed   94.85 sec

The following tests passed:
        test-testshield-pwm-and-adc

100% tests passed, 0 tests failed out of 1
```

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
