### PR TITLE
Reorganize targets.json5, add image URLs to all targets

### DIFF
--- a/targets/cmsis_mcu_descriptions.json5
+++ b/targets/cmsis_mcu_descriptions.json5
@@ -13689,5 +13689,104 @@
         ],
         "sub_family": null,
         "vendor": "Nordic Semiconductor:54"
+    },
+
+    // Manually added targets (not in CMSIS pack index)
+    "S1SBP6A": {
+        "memories": {
+            "IRAM1": {
+                "access": {
+                    "execute": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": true,
+                "size": 0x40000, // 256kiB
+                "start": 0x20000000,
+                "startup": false
+            },
+            "IROM1": {
+                "access": {
+                    "execute": true,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "size": 0x200000, // 2MiB
+                "start": 0,
+                "startup": true
+            }
+        },
+        "name": "S1SBP6A",
+        "processor": {
+            "Symmetric": {
+                "core": "CortexM4",
+                "fpu": "SinglePrecision",
+                "mpu": "Present",
+                "units": 1
+            }
+        },
+        "vendor": "Samsung:47"
+    },
+    "RP2040": {
+        "memories": {
+            "IRAM1": {
+                "access": {
+                    "execute": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": true,
+                "size": 0x40000, // 256kiB
+                "start": 0x20000000,
+                "startup": false
+            },
+
+
+            // Scratch banks are commonly used for critical data and functions accessed only by
+            // one core (when only one core is accessing the RAM bank, there is no opportunity for stalls).
+            "SCRATCH_X": {
+                "access": {
+                    "execute": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": false,
+                "size": 0x1000, // 4kiB
+                "start": 0x20040000,
+                "startup": false
+            },
+            "SCRATCH_Y": {
+                "access": {
+                    "execute": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": false,
+                "size": 0x1000, // 4kiB
+                "start": 0x20041000,
+                "startup": false
+            }
+        },
+        "name": "RP2040",
+        "processor": {
+            "Symmetric": {
+                "core": "CortexM0Plus",
+                "fpu": "None",
+                "mpu": "Present",
+                "units": 2
+            }
+        },
+        "vendor": "Raspberry Pi:x"
     }
 }

--- a/targets/cmsis_mcu_descriptions.json5
+++ b/targets/cmsis_mcu_descriptions.json5
@@ -1043,6 +1043,136 @@
         "sub_family": "PSoC 63 Dual-Core",
         "vendor": "Cypress:19"
     },
+    "CYB0644ABZI-S2D44": {
+        "algorithms": [
+            {
+                "default": true,
+                "file_name": "Flash/CYxx64xA.FLM",
+                "ram_size": 49152,
+                "ram_start": 135135232,
+                "size": 1900544,
+                "start": 268435456,
+                "style": "Keil"
+            },
+            {
+                "default": true,
+                "file_name": "Flash/CY8C6xxA_WFLASH.FLM",
+                "ram_size": 49152,
+                "ram_start": 135135232,
+                "size": 32768,
+                "start": 335544320,
+                "style": "Keil"
+            },
+            {
+                "default": false,
+                "file_name": "Flash/CY8C6xxA_SMIF_S25FL512S.FLM",
+                "ram_size": 49152,
+                "ram_start": 135135232,
+                "size": 134217728,
+                "start": 402653184,
+                "style": "Keil"
+            },
+            {
+                "default": true,
+                "file_name": "Flash/CYxx64xA.FLM",
+                "ram_size": 911360,
+                "ram_start": 134223872,
+                "size": 1900544,
+                "start": 268435456,
+                "style": "Keil"
+            },
+            {
+                "default": true,
+                "file_name": "Flash/CY8C6xxA_WFLASH.FLM",
+                "ram_size": 911360,
+                "ram_start": 134223872,
+                "size": 32768,
+                "start": 335544320,
+                "style": "Keil"
+            },
+            {
+                "default": false,
+                "file_name": "Flash/CY8C6xxA_SMIF_S25FL512S.FLM",
+                "ram_size": 911360,
+                "ram_start": 134223872,
+                "size": 134217728,
+                "start": 402653184,
+                "style": "Keil"
+            }
+        ],
+        "family": "PSoC 64",
+        "from_pack": {
+            "pack": "PSoC6_DFP",
+            "url": "https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PSoC6_DFP/",
+            "vendor": "Cypress",
+            "version": "1.2.0"
+        },
+        "memories": {
+            "IRAM1": {
+                "access": {
+                    "execute": true,
+                    "non_secure": false,
+                    "non_secure_callable": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": true,
+                "p_name": null,
+                "size": 1048576,
+                "start": 134217728,
+                "startup": false
+            },
+            "IROM1": {
+                "access": {
+                    "execute": true,
+                    "non_secure": false,
+                    "non_secure_callable": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "p_name": null,
+                "size": 1900544,
+                "start": 268435456,
+                "startup": true
+            }
+        },
+        "name": "CYB0644ABZI-S2D44",
+        "processors": [
+            {
+                "address": null,
+                "ap": 0,
+                "apid": null,
+                "core": "CortexM0Plus",
+                "default_reset_sequence": null,
+                "dp": 0,
+                "fpu": "None",
+                "mpu": "Present",
+                "name": "Cortex-M0p",
+                "svd": "SVD/psoc6_02.svd",
+                "unit": 0
+            },
+            {
+                "address": null,
+                "ap": 0,
+                "apid": null,
+                "core": "CortexM4",
+                "default_reset_sequence": null,
+                "dp": 0,
+                "fpu": "SinglePrecision",
+                "mpu": "Present",
+                "name": "Cortex-M4",
+                "svd": "SVD/psoc6_02.svd",
+                "unit": 0
+            }
+        ],
+        "sub_family": null,
+        "vendor": "Cypress:19"
+    },
     "EFM32GG11B820F2048GL192": {
         "algorithms": [
             {

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -221,6 +221,116 @@
             "9991"
         ]
     },
+
+// Analog Devices targets ----------------------------------------------------------------------------------------------
+    "EV_COG_AD4050LZ": {
+        "inherits": [
+            "Target"
+        ],
+        "core": "Cortex-M4F",
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "macros": [
+            "__ADUCM4050__",
+            "EV_COG_AD4050LZ"
+        ],
+        "extra_labels": [
+            "Analog_Devices",
+            "ADUCM4X50",
+            "ADUCM4050",
+            "EV_COG_AD4050LZ",
+            "FLASH_CMSIS_ALGO"
+        ],
+        "device_has": [
+            "FLASH",
+            "USTICKER",
+            "RTC",
+            "SERIAL",
+            "TRNG",
+            "SLEEP",
+            "INTERRUPTIN",
+            "SPI",
+            "I2C",
+            "ANALOGIN",
+            "MPU"
+        ],
+        "device_name": "ADuCM4050",
+        "detect_code": [
+            "0603"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "bootloader_supported": true,
+        "supported_application_profiles" : ["full", "bare-metal"],
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        },
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-images/images/ev-cog-ad4050lzangle-web.gif?rev=40854bbeb052442f8c1e3af0ed0cc9aa&sc_lang=en&h=500&thn=1&hash=1CC040DB3294C38F0A712BD1A3D1951D"
+    },
+    "EV_COG_AD3029LZ": {
+        "inherits": [
+            "Target"
+        ],
+        "core": "Cortex-M3",
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "macros": [
+            "__ADUCM3029__",
+            "EV_COG_AD3029LZ"
+        ],
+        "extra_labels": [
+            "Analog_Devices",
+            "ADUCM302X",
+            "ADUCM3029",
+            "EV_COG_AD3029LZ",
+            "FLASH_CMSIS_ALGO"
+        ],
+        "device_has": [
+            "FLASH",
+            "USTICKER",
+            "RTC",
+            "SERIAL",
+            "TRNG",
+            "SLEEP",
+            "INTERRUPTIN",
+            "SPI",
+            "I2C",
+            "ANALOGIN",
+            "MPU"
+        ],
+        "device_name": "ADuCM3029",
+        "detect_code": [
+            "0602"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "bootloader_supported": true,
+        "supported_application_profiles" : ["full", "bare-metal"],
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        },
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-images/images/ev-cog-ad3029lzangle-web.gif?rev=dcc918a6e9b64a60a3ce0fc397a9a88d&sc_lang=en&h=500&thn=1&hash=ED3986B5366C771376C5F062488FE056"
+    },
+
+// NXP LPC1xxx Targets  ------------------------------------------------------------------------------------------------
     "LPCTarget": {
         "inherits": [
             "Target"
@@ -285,7 +395,8 @@
         "device_name": "LPC1114FN28/102",
         "detect_code": [
             "1114"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/cache/platforms/LPC1114_1_hXXAnmW.jpg.250x250_q85.jpg"
     },
     "LPC1768": {
         "inherits": [
@@ -429,8 +540,11 @@
         },
         "detect_code": [
             "9004"
-        ]
+        ],
+        "image_url": "https://files.seeedstudio.com/wiki/Arch_Pro/img/Arch_pro.jpg"
     },
+
+    // Freescale (now NXP) Kinetis Targets -----------------------------------------------------------------------------
     "KL25Z": {
         "supported_form_factors": [
             "ARDUINO"
@@ -482,7 +596,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/uploads/chris/frd_small.jpg"
     },
     "KL46Z": {
         "supported_form_factors": [
@@ -538,7 +653,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/BOARD-FRDM-KL46Z-PRODUCT-SHOT.png"
     },
     "MCU_K22F512": {
         "core": "Cortex-M4F",
@@ -619,7 +735,8 @@
         ],
         "detect_code": [
             "0231"
-        ]
+        ],
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/FRDM-K22F-ANGLE.jpg"
     },
     "KL43Z": {
         "supported_form_factors": [
@@ -682,7 +799,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/FRDM-KL43Z-BLOCK-DIAGRAM.jpg"
     },
     "KW41Z": {
         "supported_form_factors": [
@@ -739,15 +857,10 @@
         "bootloader_supported": true,
         "overrides": {
             "network-default-interface-type": "MESH"
-        }
+        },
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/FRDM-KW41Z_OG.jpg"
     },
-    "K64F": {
-        "supported_form_factors": [
-            "ARDUINO_UNO"
-        ],
-        "components_add": [
-            "SD",
-        ],
+    "MCU_K64F": {
         "core": "Cortex-M4F",
         "supported_toolchains": [
             "GCC_ARM"
@@ -756,13 +869,10 @@
             "Freescale",
             "MCUXpresso_MCUS",
             "KSDK2_MCUS",
-            "FRDM",
             "KPSDK_MCUS",
             "KPSDK_CODE",
-            "MCU_K64F",
             "Freescale_EMAC"
         ],
-        "is_disk_virtual": true,
         "macros_add": [
             "CPU_MK64FN1M0VMD12",
             "FSL_RTOS_MBED",
@@ -771,9 +881,6 @@
         ],
         "inherits": [
             "PSA_V7_M"
-        ],
-        "detect_code": [
-            "0240"
         ],
         "device_has_add": [
             "USTICKER",
@@ -827,191 +934,51 @@
         "supported_application_profiles": [
             "full", "bare-metal"
         ],
-        "is_mcu_family_target": true
+        "is_mcu_family_target": true,
+        "public": false
+    },
+    "K64F": { // AKA FRDM-K64F
+        "supported_form_factors": [
+            "ARDUINO_UNO"
+        ],
+        "components_add": [
+            "SD",
+        ],
+        "extra_labels_add": [
+            "FRDM"
+        ],
+        "is_disk_virtual": true,
+        "inherits": [
+            "MCU_K64F"
+        ],
+        "detect_code": [
+            "0240"
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/407/MFG_FRDM-K64F.JPG"
     },
     "SDT64B": {
         "inherits": [
-            "K64F"
+            "MCU_K64F"
         ],
         "extra_labels_add": [
             "K64F"
         ],
-        "extra_labels_remove": [
-            "FRDM"
-        ],
-        "components_remove": [
-            "SD"
-        ],
         "supported_form_factors": [],
         "detect_code": [
             "3105"
-        ]
-    },
-    "EV_COG_AD4050LZ": {
-        "inherits": [
-            "Target"
         ],
-        "core": "Cortex-M4F",
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "macros": [
-            "__ADUCM4050__",
-            "EV_COG_AD4050LZ"
-        ],
-        "extra_labels": [
-            "Analog_Devices",
-            "ADUCM4X50",
-            "ADUCM4050",
-            "EV_COG_AD4050LZ",
-            "FLASH_CMSIS_ALGO"
-        ],
-        "device_has": [
-            "FLASH",
-            "USTICKER",
-            "RTC",
-            "SERIAL",
-            "TRNG",
-            "SLEEP",
-            "INTERRUPTIN",
-            "SPI",
-            "I2C",
-            "ANALOGIN",
-            "MPU"
-        ],
-        "device_name": "ADuCM4050",
-        "detect_code": [
-            "0603"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "bootloader_supported": true,
-        "supported_application_profiles" : ["full", "bare-metal"],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        }
-    },
-    "EV_COG_AD3029LZ": {
-        "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M3",
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "macros": [
-            "__ADUCM3029__",
-            "EV_COG_AD3029LZ"
-        ],
-        "extra_labels": [
-            "Analog_Devices",
-            "ADUCM302X",
-            "ADUCM3029",
-            "EV_COG_AD3029LZ",
-            "FLASH_CMSIS_ALGO"
-        ],
-        "device_has": [
-            "FLASH",
-            "USTICKER",
-            "RTC",
-            "SERIAL",
-            "TRNG",
-            "SLEEP",
-            "INTERRUPTIN",
-            "SPI",
-            "I2C",
-            "ANALOGIN",
-            "MPU"
-        ],
-        "device_name": "ADuCM3029",
-        "detect_code": [
-            "0602"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "bootloader_supported": true,
-        "supported_application_profiles" : ["full", "bare-metal"],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        }
+        "image_url": "https://os.mbed.com/media/cache/platforms/SDT64B_size.png.250x250_q85.png"
     },
     "HEXIWEAR": {
         "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels": [
-            "Freescale",
-            "MCUXpresso_MCUS",
-            "KSDK2_MCUS",
             "MCU_K64F"
         ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "supported_application_profiles": [
-            "full",
-            "bare-metal"
-        ],
-        "macros": [
-            "CPU_MK64FN1M0VMD12",
-            "FSL_RTOS_MBED",
-            "TARGET_K64F",
-            "MBED_TICKLESS"
-        ],
-        "is_disk_virtual": true,
-        "default_toolchain": "ARM",
         "detect_code": [
             "0214"
         ],
-        "device_has": [
-            "USTICKER",
-            "LPTICKER",
-            "RTC",
-            "ANALOGIN",
-            "ANALOGOUT",
-            "I2C",
-            "I2CSLAVE",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "RESET_REASON",
-            "SERIAL",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC",
-            "SLEEP",
-            "SPI",
-            "SPI_ASYNCH",
-            "SPISLAVE",
-            "TRNG",
-            "FLASH",
-            "WATCHDOG"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "MK64FN1M0xxx12",
-        "bootloader_supported": true
+        "image_url": "https://os.mbed.com/media/cache/platforms/Hexiwear_Platform_Image_19Ja2aX_pNSWsjb.png.250x250_q85.png",
     },
-    "K66F": {
+    "K66F": { // AKA FRDM-K66F
         "supported_form_factors": [
             "ARDUINO"
         ],
@@ -1088,9 +1055,10 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/FRDM-K66F-BD.jpg"
     },
-    "K82F": {
+    "K82F": { // AKA FRDM-K82F
         "supported_form_factors": [
             "ARDUINO"
         ],
@@ -1158,8 +1126,11 @@
         "supported_application_profiles": [
             "full", "bare-metal"
         ],
-        "is_mcu_family_target": true
+        "is_mcu_family_target": true,
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/117498-CS_FRDM-K82-Board-Top_Mbed.jpg"
     },
+
+    // STM32 Top-Level Target ------------------------------------------------------------------------------------------
     "MCU_STM32": {
         "inherits": [
             "Target"
@@ -1258,6 +1229,8 @@
             "RESET_REASON"
         ]
     },
+
+    // STM32F0 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F0": {
         "inherits": [
             "MCU_STM32"
@@ -1279,7 +1252,7 @@
                 "value": "RCC_LSEDRIVE_LOW"
             },
             "i2c_timing_value_algo": {
-                "help": "If value was set to true I2C timing algorithm is enabled. Enabling may leads to performance issue. Keeping this false and changing system clock will trigger assert.)",
+                "help": "If set to true, I2C timing algorithm is enabled. Enabling may lead to performance issues. Keeping this false and changing system clock will trigger assert.)",
                 "value": false
             }
         },
@@ -1337,7 +1310,8 @@
         "detect_code": [
             "0755"
         ],
-        "device_name": "STM32F070RBTx"
+        "device_name": "STM32F070RBTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF261500.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F072xB": {
         "inherits": [
@@ -1365,7 +1339,8 @@
         "detect_code": [
             "0730"
         ],
-        "device_name": "STM32F072RBTx"
+        "device_name": "STM32F072RBTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF261500.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F091xC": {
         "inherits": [
@@ -1393,7 +1368,8 @@
         "detect_code": [
             "0750"
         ],
-        "device_name": "STM32F091RCTx"
+        "device_name": "STM32F091RCTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF261500.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F1": {
         "inherits": [
@@ -2702,9 +2678,6 @@
             "MCU_STM32G0"
         ],
         "public": false,
-        "overrides": {
-            "boot-stack-size": "0x400"
-        },
         "supported_application_profiles": [
             "bare-metal"
         ],
@@ -2716,7 +2689,8 @@
         ],
         "overrides": {
             "lpticker_delay_ticks": 1,
-            "lpticker_lptim": "0"
+            "lpticker_lptim": "0",
+            "boot-stack-size": "0x400"
         }
     },
     "MCU_STM32G031x8": {
@@ -2769,9 +2743,6 @@
             "MCU_STM32G0"
         ],
         "public": false,
-        "overrides": {
-            "boot-stack-size": "0x400"
-        },
         "supported_application_profiles": [
             "bare-metal"
         ],
@@ -2783,7 +2754,8 @@
         ],
         "overrides": {
             "lpticker_delay_ticks": 1,
-            "lpticker_lptim": "0"
+            "lpticker_lptim": "0",
+            "boot-stack-size": "0x400"
         }
     },
     "MCU_STM32G051x8": {
@@ -5173,7 +5145,9 @@
         "mbed_ram_start": "0x20000000",
         "mbed_ram_size": "0x10000"
     },
-    // Note: "MIMXRT105X" target is for the MIMXRT1051, MIMXRT1061=2, MIMXRT1061, and MIMXRT1062
+    // NXP i.MX RT Targets ---------------------------------------------------------------------------------------------
+
+    // Note: "MIMXRT105X" target is for the MIMXRT1051, MIMXRT1052, MIMXRT1061, and MIMXRT1062
     // See here for details: https://github.com/mbed-ce/mbed-os/wiki/MCU-Info-Page:-MIMXRT105x-and-106x
     "MIMXRT105X": {
         "core": "Cortex-M7FD",
@@ -5268,7 +5242,8 @@
             "network-default-interface-type": "ETHERNET"
         },
         "bootloader_supported": true,
-        "device_name": "MIMXRT1052DVL6A"
+        "device_name": "MIMXRT1052DVL6A",
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/IMX_RT1050-EVKB_TOP-LR.jpg"
     },
     "MIMXRT1060_EVK": {
         "inherits": [
@@ -5292,7 +5267,8 @@
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         },
-        "device_name": "MIMXRT1062DVL6B"
+        "device_name": "MIMXRT1062DVL6B",
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/X-MIMXRT1060-EVK-BOARD-BOTTOM.jpg"
     },
     "TEENSY_40": {
         "inherits": [
@@ -5310,7 +5286,8 @@
         "device_has_remove": [
             "EMAC"
         ],
-        "device_name": "MIMXRT1062DVL6B"
+        "device_name": "MIMXRT1062DVL6B",
+        "image_url": "https://www.pjrc.com/store/teensy40_front.jpg"
     },
     "TEENSY_41": {
         "inherits": [
@@ -5326,7 +5303,8 @@
             "console-uart": false,
             "network-default-interface-type": "ETHERNET"
         },
-        "device_name": "MIMXRT1062DVL6B"
+        "device_name": "MIMXRT1062DVL6B",
+        "image_url": "https://www.pjrc.com/store/teensy41_4.jpg"
     },
     "MIMXRT1170_EVK": {
         "supported_form_factors": [
@@ -5390,9 +5368,12 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/MIMXRT1170-EVKB-TOP-IMG.jpg"
     },
-    "LPC54114": {
+
+    // NXP LPC5xxxx Targets --------------------------------------------------------------------------------------------
+    "LPC54114": { // AKA LPCXpresso54114
         "supported_form_factors": [
             "ARDUINO"
         ],
@@ -5457,7 +5438,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/691/OM13089UL.JPG"
     },
     "MCU_LPC546XX": {
         "core": "Cortex-M4F",
@@ -5519,9 +5501,10 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "is_mcu_family_target": true
     },
-    "LPC546XX": {
+    "LPC546XX": { // AKA LPCXpresso54608
         "supported_form_factors": [
             "ARDUINO"
         ],
@@ -5539,7 +5522,8 @@
         ],
         "components_add": [
             "QSPIF"
-        ]
+        ],
+        "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/LPCXpresso54608_back.png"
     },
     "FF_LPC546XX": {
         "inherits": [
@@ -5555,6 +5539,8 @@
             "5"
         ]
     },
+
+    // ARM MPS2 FPGA prototyping targets -------------------------------------------------------------------------------
     "ARM_MPS2_Target": {
         "inherits": [
             "Target"
@@ -5586,7 +5572,8 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "is_mcu_family_target": true
     },
     "ARM_MPS2_M0": {
         "inherits": [
@@ -5625,7 +5612,8 @@
             "5"
         ],
         "copy_method": "mps2",
-        "reset_method": "reboot.txt"
+        "reset_method": "reboot.txt",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_MPS2_M0P": {
         "inherits": [
@@ -5662,7 +5650,8 @@
             "5"
         ],
         "copy_method": "mps2",
-        "reset_method": "reboot.txt"
+        "reset_method": "reboot.txt",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_MPS2_M3": {
         "inherits": [
@@ -5700,7 +5689,8 @@
             "5"
         ],
         "copy_method": "mps2",
-        "reset_method": "reboot.txt"
+        "reset_method": "reboot.txt",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_MPS2_M4": {
         "inherits": [
@@ -5738,7 +5728,8 @@
             "5"
         ],
         "copy_method": "mps2",
-        "reset_method": "reboot.txt"
+        "reset_method": "reboot.txt",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_MPS2_M7": {
         "inherits": [
@@ -5776,7 +5767,8 @@
             "5"
         ],
         "copy_method": "mps2",
-        "reset_method": "reboot.txt"
+        "reset_method": "reboot.txt",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_IOTSS_Target": {
         "inherits": [
@@ -5799,7 +5791,7 @@
             "MPU"
         ]
     },
-    "ARM_CM3DS_MPS2": {
+    "ARM_CM3DS_MPS2": { // AKA Cortex-M3 Design Start (CM3DS) on MPS2 Board
         "inherits": [
             "ARM_IOTSS_Target"
         ],
@@ -5846,7 +5838,8 @@
         },
         "detect_code": [
             "5004"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2161/MFG_V2M-MPS2-0318C.jpg"
     },
     "ARM_MUSCA_B1": {
         "inherits": [
@@ -5901,7 +5894,8 @@
         "detect_code": [
             "5007"
         ],
-        "OUTPUT_EXT": "bin"
+        "OUTPUT_EXT": "bin",
+        "image_url": "https://www.psacertified.org/app/uploads/2019/01/musca-b1-600x0-c-default.jpg"
     },
     "ARM_MUSCA_S1": {
         "inherits": [
@@ -5959,8 +5953,11 @@
         "detect_code": [
             "5009"
         ],
-        "OUTPUT_EXT": "bin"
+        "OUTPUT_EXT": "bin",
+        "image_url": "https://os.mbed.com/media/cache/platforms/Musca-S1_Rev_B_Board-1_transpant.png.250x250_q85.png"
     },
+
+    // Renesas RZ Targets ----------------------------------------------------------------------------------------------
     "RZ_A1XX": {
         "inherits": [
             "Target"
@@ -6013,7 +6010,7 @@
         },
         "is_mcu_family_target": true
     },
-    "RZ_A1H": {
+    "RZ_A1H": { // AKA GR-PEACH
         "inherits": [
             "RZ_A1XX"
         ],
@@ -6049,7 +6046,8 @@
         ],
         "detect_code": [
             "5500"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/cache/platforms/GR-PEACH_C_trans.png.250x250_q85.png"
     },
     "GR_LYCHEE": {
         "inherits": [
@@ -6092,7 +6090,8 @@
         },
         "detect_code": [
             "5501"
-        ]
+        ],
+        "image_url": "https://www.cnx-software.com/wp-content/uploads/2017/06/GR-LYCHEE.jpg"
     },
     "RZ_A2XX": {
         "inherits": ["Target"],
@@ -6152,10 +6151,12 @@
         },
         "detect_code": [
             "5502"
-        ]
-
+        ],
+        "image_url": "https://www.renesas.com/sites/default/files/media/images/gr-mango-top.png"
     },
-    "MAX32620FTHR": {
+
+    // Maxim Targets ---------------------------------------------------------------------------------------------------
+    "MCU_MAX32620": {
         "inherits": [
             "Target"
         ],
@@ -6189,9 +6190,7 @@
             "SPI",
             "USTICKER"
         ],
-        "detect_code": [
-            "0418"
-        ],
+        "device_name": "MAX32620",
         "supported_application_profiles" : ["full", "bare-metal"],
         "supported_c_libs": {
             "arm": [
@@ -6205,59 +6204,27 @@
             "iar": [
                 "std"
             ]
-        }
+        },
+        "public": false,
+        "is_mcu_family_target": true
+    },
+    "MAX32620FTHR": {
+        "inherits": [
+            "MCU_MAX32620C"
+        ],
+        "detect_code": [
+            "0418"
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/895/MFG_MAX32620FTHR.jpg"
     },
     "SDT32620B": {
         "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M4F",
-        "macros": [
-            "__SYSTEM_HFX=96000000",
-            "TARGET=MAX32620",
-            "TARGET_REV=0x4332",
-            "OPEN_DRAIN_LEDS"
+            "MCU_MAX32620C"
         ],
         "detect_code": [
             "3101"
         ],
-        "extra_labels": [
-            "Maxim",
-            "MAX32620C"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "device_has": [
-            "ANALOGIN",
-            "FLASH",
-            "I2C",
-            "INTERRUPTIN",
-            "LPTICKER",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "SERIAL",
-            "SERIAL_FC",
-            "SLEEP",
-            "SPI",
-            "USTICKER"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "supported_application_profiles" : ["full", "bare-metal"],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        }
+        "image_url": "https://os.mbed.com/media/cache/platforms/SDT32620B_size.png.250x250_q85.png"
     },
     "MAX32625_BASE": {
         "inherits": [
@@ -6319,7 +6286,8 @@
         ],
         "detect_code": [
             "0415"
-        ]
+        ],
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-maxim-images/max32625mbed.png?rev=cce27b18ca564ddbb28163b4612b7592&h=500&hash=5F057314B14CBC46F7A8EEC655632DCE"
     },
     "SDT32625B": {
         "inherits": [

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -7067,12 +7067,11 @@
             "3104"
         ],
         "device_name": "nRF52832_xxAA",
-        "image_url": "https://www.devicemart.co.kr/data/collect_img/kind_0/goods/large/6500289.jpg"
+        "image_url": "https://os.mbed.com/media/cache/platforms/SDT52832B_size.png.250x250_q85.png"
     },
     "ARDUINO_NICLA_SENSE_ME": {
         "inherits": ["MCU_NRF52832"],
         "components_add": [
-            "FLASHIAP",
             "SPIF"
         ],
         "device_name": "nRF52832_xxAA",
@@ -7096,6 +7095,8 @@
         ],
         "image_url": "https://store-usa.arduino.cc/cdn/shop/products/ABX00050_03.front_1000x750.jpg?v=1631089821"
     },
+
+    // Nordic NRF52840 Targets------------------------------------------------------------------------------------------
     "MCU_NRF52840": {
         "inherits": [
             "Target"
@@ -7237,7 +7238,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF52-Series/nRF52840-DK/nRF52840-DK/nRF52840-DK-prod-page.png?h=750&iar=0&mw=350&w=350&hash=3DB140F6AE70CAE159FD911D8E6E9109"
     },
     "ARDUINO_NANO33BLE": {
         "inherits": [
@@ -7261,7 +7263,8 @@
             "console-usb": true,
             "console-uart": false
         },
-        "OUTPUT_EXT": "bin"
+        "OUTPUT_EXT": "bin",
+        "image_url": "https://m.media-amazon.com/images/I/61bGcUKwSzL.jpg"
     },
     "ARDUINO_NANO33BLE_SWD": {
         "inherits": [
@@ -7279,6 +7282,28 @@
             "MBED_APP_START=0x10000",
             "MBED_APP_SIZE=0xf0000"
         ]
+    },
+    "EP_AGORA": { // AKA Embedded Planet Agora (w/ dev kit for flashing and debugging) https://www.embeddedplanet.com/agora/
+        "inherits": [
+            "MCU_NRF52840"
+        ],
+        "supported_form_factors": [],
+        "macros_add": [
+            "CONFIG_GPIO_AS_PINRESET"
+        ],
+        "detect_code": [
+            "2600"
+        ],
+        "config": {
+            "enable-objects-extensions": {
+                "help": "Enable inclusion of objects_extensions.h",
+                "value": false
+            }
+        },
+        "components_add": [
+            "TELIT_ME910"
+        ],
+        "image_url": "https://www.embeddedplanet.com/wp-content/uploads/2019/02/EPM2M-AG-CELL-page.jpg"
     },
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",
@@ -9205,27 +9230,6 @@
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         }
-    },
-    "EP_AGORA": { // AKA Embedded Planet Agora (w/ dev kit for flashing and debugging) https://www.embeddedplanet.com/agora/
-        "inherits": [
-            "MCU_NRF52840"
-        ],
-        "supported_form_factors": [],
-        "macros_add": [
-            "CONFIG_GPIO_AS_PINRESET"
-        ],
-        "detect_code": [
-            "2600"
-        ],
-        "config": {
-            "enable-objects-extensions": {
-                "help": "Enable inclusion of objects_extensions.h",
-                "value": false
-            }
-        },
-        "components_add": [
-            "TELIT_ME910"
-        ]
     },
     "MCU_M261": {
         "core": "Cortex-M23",

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -1371,6 +1371,8 @@
         "device_name": "STM32F091RCTx",
         "image_url": "https://www.st.com/bin/ecommerce/api/image.PF261500.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
+
+    // STM32F1 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F1": {
         "inherits": [
             "MCU_STM32"
@@ -1395,7 +1397,8 @@
         ],
         "device_has_remove": [
             "LPTICKER"
-        ]
+        ],
+        "is_mcu_family_target": true
     },
     "MCU_STM32F103x8": {
         "inherits": [
@@ -1431,7 +1434,8 @@
         "detect_code": [
             "0700"
         ],
-        "device_name": "STM32F103RB"
+        "device_name": "STM32F103RB",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF259875.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F103xC": {
         "inherits": [
@@ -1493,6 +1497,7 @@
             "MPU"
         ]
     },
+    // STM32F2 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F2": {
         "inherits": [
             "MCU_STM32"
@@ -1561,8 +1566,11 @@
         "device_name": "STM32F207ZGTx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
+
+    // STM32F3 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F3": {
         "inherits": [
             "MCU_STM32"
@@ -1634,7 +1642,8 @@
         "detect_code": [
             "0775"
         ],
-        "device_name": "STM32F303K8Tx"
+        "device_name": "STM32F303K8Tx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262544.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F303xC": {
         "inherits": [
@@ -1679,7 +1688,8 @@
         "detect_code": [
             "0745"
         ],
-        "device_name": "STM32F303RETx"
+        "device_name": "STM32F303RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_F303ZE": {
         "inherits": [
@@ -1694,7 +1704,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32F303ZETx"
+        "device_name": "STM32F303ZETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F334x8": {
         "inherits": [
@@ -1709,6 +1720,8 @@
             "STM32F334x8"
         ]
     },
+
+    // STM32F4 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F4": {
         "inherits": [
             "MCU_STM32"
@@ -1757,7 +1770,8 @@
         "detect_code": [
             "0720"
         ],
-        "device_name": "STM32F401RETx"
+        "device_name": "STM32F401RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260000.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F407xE": {
         "inherits": [
@@ -1803,7 +1817,8 @@
         },
         "detect_code": [
             "9011"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/1881/MFG_102110014.jpg"
     },
     "MCU_STM32F411xE": {
         "inherits": [
@@ -1827,9 +1842,10 @@
         "detect_code": [
             "0740"
         ],
-        "device_name": "STM32F411RETx"
+        "device_name": "STM32F411RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
-    "MTS_DRAGONFLY_F411RE": {
+    "MTS_DRAGONFLY_F411RE": { // AKA MTQ-MNA1-B01/MTQ-MNA1-B02
         "inherits": [
             "MCU_STM32F411xE"
         ],
@@ -1852,7 +1868,8 @@
         ],
         "components_add": [
             "TELIT_HE910"
-        ]
+        ],
+        "image_url": "https://static-data2.manualslib.com/product-images/de1/2702201/multitech-multiconnect-dragonfly-mtq-mna1-b02.jpg"
     },
     "MTS_MDOT_F411RE": {
         "inherits": [
@@ -1871,7 +1888,8 @@
         "device_name": "STM32F411RETx",
         "detect_code": [
             "0320"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/1290/MTDOT-868-X1P-SMA-1.jpg"
     },
     "BLACKPILL_F411CE": {
         "inherits": [
@@ -1890,7 +1908,8 @@
         "detect_code": [
             "0740"
         ],
-        "device_name": "STM32F411CEYx"
+        "device_name": "STM32F411CEYx",
+        "image_url": "https://user-images.githubusercontent.com/1301112/69389644-eb5fb080-0ccc-11ea-8002-67d3db851250.png"
     },
     "MCU_STM32F412xE": {
         "inherits": [
@@ -1937,7 +1956,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32F412ZGTx"
+        "device_name": "STM32F412ZGTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     // Also known as MXChip EMW3166
     "WIO_EMW3166": {
@@ -1955,7 +1975,8 @@
         },
         "detect_code": [
             "0451"
-        ]
+        ],
+        "image_url": "https://cdn.mxchip.com/mxchip_official_website/img/EMW3166-P-%E7%99%BD-%E6%AD%A3.jpg"
     },
     "MCU_STM32F413xH": {
         "inherits": [
@@ -1984,6 +2005,11 @@
             "TRNG"
         ]
     },
+    // As of 2024, I am unable to find any device being sold by multitech that
+    // is called a dragonfly and has an STM32F413RHTx MCU.
+    // That would make this target a candidate for removal.
+    // It was originally added via a rather vague PR here:
+    // https://github.com/ARMmbed/mbed-os/pull/11573
     "MTS_DRAGONFLY_F413RH": {
         "inherits": [
             "MCU_STM32F413xH"
@@ -2012,7 +2038,8 @@
             "SPIF",
             "TELIT_HE910"
         ],
-        "device_name": "STM32F413RHTx"
+        "device_name": "STM32F413RHTx",
+        "image_url": "https://static-data2.manualslib.com/product-images/de1/2702201/multitech-multiconnect-dragonfly-mtq-mna1-b02.jpg"
     },
     "DISCO_F413ZH": {
         "inherits": [
@@ -2034,7 +2061,8 @@
             "QSPI",
             "USBDEVICE"
         ],
-        "device_name": "STM32F413ZHTx"
+        "device_name": "STM32F413ZHTx",
+        "image_url": "https://www.mouser.com/images/marketingid/2017/img/128173244_STMicroelectronics_32F413HDISCOVERYDiscoveryKit.png?v=070223.0256"
     },
     "NUCLEO_F413ZH": {
         "inherits": [
@@ -2049,7 +2077,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32F413ZHTx"
+        "device_name": "STM32F413ZHTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F429xI": {
         "inherits": [
@@ -2102,7 +2131,8 @@
         "device_name": "STM32F429ZITx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "DISCO_F429ZI": {
         "inherits": [
@@ -2123,7 +2153,8 @@
         "device_name": "STM32F429ZITx",
         "detect_code": [
             "0795"
-        ]
+        ],
+        "image_url": "https://m.media-amazon.com/images/I/71M-Bd6yaJL._AC_UF894,1000_QL80_.jpg"
     },
     "MCU_STM32F439xI": {
         "inherits": [
@@ -2166,7 +2197,8 @@
         "components_add": [
             "QUECTEL_UG96"
         ],
-        "device_name": "STM32F439VITx"
+        "device_name": "STM32F439VITx",
+        "image_url": "https://os.mbed.com/media/cache/platforms/Wio_3G.png.250x250_q85.png"
     },
 
     // Note: It seems like Seeed no longer sells any WIO boards with BG96 cellular modules.
@@ -2196,7 +2228,8 @@
         "components_add": [
             "SD",
             "QUECTEL_BG96"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/cache/platforms/Wio_3G-1.png.250x250_q85.png.250x250_q85.png"
     },
     "NUCLEO_F439ZI": {
         "inherits": [
@@ -2226,7 +2259,8 @@
         "device_name": "STM32F439ZITx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F446xE": {
         "inherits": [
@@ -2254,7 +2288,8 @@
         "detect_code": [
             "0777"
         ],
-        "device_name": "STM32F446RETx"
+        "device_name": "STM32F446RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_F446ZE": {
         "inherits": [
@@ -2275,7 +2310,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32F446ZETx"
+        "device_name": "STM32F446ZETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32F469xI": {
         "inherits": [
@@ -2317,7 +2353,8 @@
             "QSPI",
             "USBDEVICE"
         ],
-        "device_name": "STM32F469NIHx"
+        "device_name": "STM32F469NIHx",
+        "image_url": "https://static5.arrow.com/pdfs/2015/11/30/5/10/19/531/st_/manual/stm32f469i-disco_fig.1_1.jpg"
     },
     "SDP_K1": {
         "inherits": [
@@ -2351,8 +2388,11 @@
         "device_name": "STM32F469NIHx",
         "detect_code": [
             "0604"
-        ]
+        ],
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-images/images/eval-sdp-ck1ztop-web.gif?rev=2b0d46c94afe490cb3543819752a0471&sc_lang=en&h=270&thn=1&hash=C1A2567A6E5A569665B40C5DCFE1B8C3"
     },
+
+    // STM32F7 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32F7": {
         "inherits": [
             "MCU_STM32"
@@ -2419,7 +2459,8 @@
         "detect_code": [
             "0812"
         ],
-        "device_name": "STM32F722ZETx"
+        "device_name": "STM32F722ZETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "DISCO_F746NG": {
         "inherits": [
@@ -2457,7 +2498,8 @@
             "QSPI",
             "USBDEVICE"
         ],
-        "device_name": "STM32F746NGHx"
+        "device_name": "STM32F746NGHx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF261641.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_F746ZG": {
         "inherits": [
@@ -2490,7 +2532,8 @@
         "device_name": "STM32F746ZGTx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_F756ZG": {
         "inherits": [
@@ -2524,7 +2567,8 @@
         "device_name": "STM32F756ZGTx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "UHURU_RAVEN": {
         "inherits": [
@@ -2549,7 +2593,8 @@
         "device_has_remove": [
             "SERIAL_FC"
         ],
-        "device_name": "STM32F767VITx"
+        "device_name": "STM32F767VITx",
+        "image_url": "https://uhuru.co.jp/wp-content/uploads/2019/02/20190222_pr_raven_02.jpg"
     },
     "NUCLEO_F767ZI": {
         "inherits": [
@@ -2586,7 +2631,8 @@
         "device_name": "STM32F767ZITx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "DISCO_F769NI": {
         "inherits": [
@@ -2627,8 +2673,11 @@
         "device_name": "STM32F769NIHx",
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://www.mouser.com/images/marketingid/2016/img/167234246_STMicro_32F769IDISCOVERYDiscoveryKit.png?v=070223.0222"
     },
+
+    // STM32G0 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32G0": {
         "inherits": [
             "MCU_STM32"
@@ -2718,7 +2767,8 @@
         "detect_code": [
             "0852"
         ],
-        "device_name": "STM32G031K8Tx"
+        "device_name": "STM32G031K8Tx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267508.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32G041x8": {
         "inherits": [
@@ -2845,7 +2895,8 @@
         "detect_code": [
             "0221"
         ],
-        "device_name": "STM32G071RBTx"
+        "device_name": "STM32G071RBTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF265386.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32G081xB": {
         "inherits": [
@@ -2903,7 +2954,8 @@
         "detect_code": [
             "0872"
         ],
-        "device_name": "STM32G0B1RETx"
+        "device_name": "STM32G0B1RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF265386.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32G0C1xE": {
         "inherits": [
@@ -2920,6 +2972,8 @@
             "ANALOGOUT"
         ]
     },
+
+    // STM32G4 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32G4": {
         "inherits": [
             "MCU_STM32"
@@ -2996,7 +3050,8 @@
         "overrides": {
             "hse_value": 24000000
         },
-        "device_name": "STM32G431RBTx"
+        "device_name": "STM32G431RBTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267029.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_G431KB": {
         "inherits": [
@@ -3009,7 +3064,8 @@
       "detect_code": [
         "0851"
       ],
-      "device_name": "STM32G431KBTx"
+      "device_name": "STM32G431KBTx",
+      "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267030.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32G441xB": {
         "inherits": [
@@ -3072,7 +3128,8 @@
         "detect_code": [
             "0841"
         ],
-        "device_name": "STM32G474RETx"
+        "device_name": "STM32G474RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267029.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32G483xE": {
         "inherits": [
@@ -3122,6 +3179,8 @@
             "STM32G4A1xx"
         ]
     },
+
+    // STM32H7 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32H7": {
         "inherits": [
             "MCU_STM32"
@@ -3220,7 +3279,7 @@
             "system_power_supply": "PWR_LDO_SUPPLY"
         }
     },
-    "WIO_H725AE": {
+    "WIO_H725AE": { // AKA "Seeed Wio Lite AI"
         "inherits": [
             "MCU_STM32H725xE"
         ],
@@ -3240,7 +3299,8 @@
             "lse_drive_load_level": "RCC_LSEDRIVE_MEDIUMLOW",
             "enable-overdrive-mode": 0
         },
-        "device_name": "STM32H725AEIx"
+        "device_name": "STM32H725AEIx",
+        "image_url": "https://www.mouser.com/images/seeedstudios/hd/102110607_SPL.jpg"
     },
     "MCU_STM32H735xG": {
         "inherits": [
@@ -3304,7 +3364,8 @@
         "detect_code": [
             "0836"
         ],
-        "device_name": "STM32H743ZITx"
+        "device_name": "STM32H743ZITx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_H723ZG": {
         "inherits": [
@@ -3343,7 +3404,8 @@
         "detect_code": [
             "0836"
         ],
-        "device_name": "STM32H723ZGTx"
+        "device_name": "STM32H723ZGTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32H745xI": {
         "inherits": [
@@ -3422,7 +3484,8 @@
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         },
-        "device_name": "STM32H745ZITx"
+        "device_name": "STM32H745ZITx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_H745ZI_Q_CM4": {
         "inherits": [
@@ -3449,7 +3512,8 @@
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         },
-        "device_name": "STM32H745ZITx"
+        "device_name": "STM32H745ZITx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF262651.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_H745ZI_Q" : {
         "inherits" : [
@@ -3513,12 +3577,14 @@
         "detect_code": [
             "0814"
         ],
-        "device_name": "STM32H747XIHx"
+        "device_name": "STM32H747XIHx",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/310/MFG_STM32H747I-DISCO.jpg"
     },
     "DISCO_H747I": {
         "inherits": [
             "DISCO_H747I_CM7"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/310/MFG_STM32H747I-DISCO.jpg"
     },
     "MCU_STM32H747xI_CM4": {
         "inherits": [
@@ -3557,7 +3623,8 @@
             "STMOD",
             "PMOD"
         ],
-        "device_name": "STM32H747XIHx"
+        "device_name": "STM32H747XIHx",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/310/MFG_STM32H747I-DISCO.jpg"
     },
     "PORTENTA_H7": {
         "public": false,
@@ -3604,7 +3671,8 @@
             // the LDO power comes from the SMPS).
             "enable-overdrive-mode": 1
         },
-        "device_name": "STM32H747XIHx"
+        "device_name": "STM32H747XIHx",
+        "image_url": "https://store.arduino.cc/cdn/shop/products/ABX00042_00.iso_1200x900.jpg?v=1675840144"
     },
     "PORTENTA_H7_M7": {
         "inherits": ["PORTENTA_H7"],
@@ -3709,7 +3777,8 @@
         "device_name": "STM32H7A3ZITxQ",
         "detect_code": [
             "0860"
-        ]
+        ],
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267690.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32H7B3xIQ": {
         "inherits": [
@@ -3734,6 +3803,8 @@
             "enable-overdrive-mode": 0
         }
     },
+
+    // STM32L0 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32L0": {
         "inherits": [
             "MCU_STM32"
@@ -3844,7 +3915,7 @@
             "TRNG"
         ]
     },
-    "DISCO_L072CZ_LRWAN1": {
+    "DISCO_L072CZ_LRWAN1": { // AKA B-L072Z-LRWAN1
         "inherits": [
             "MCU_STM32L072xZ"
         ],
@@ -3857,7 +3928,8 @@
         "detect_code": [
             "0833"
         ],
-        "device_name": "STM32L072CZTx"
+        "device_name": "STM32L072CZTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF264368.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32L073xZ": {
         "inherits": [
@@ -3885,7 +3957,8 @@
         "detect_code": [
             "0760"
         ],
-        "device_name": "STM32L073RZTx"
+        "device_name": "STM32L073RZTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32L082xZ": {
         "inherits": [
@@ -3903,6 +3976,8 @@
             "TRNG"
         ]
     },
+
+    // STM32L1 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32L1": {
         "inherits": [
             "MCU_STM32"
@@ -3988,15 +4063,19 @@
         "device_name": "STM32L151CCTx",
         "detect_code": [
             "0350"
-        ]
+        ],
+        "image_url": "https://multitech.com/wp-content/uploads/elementor/thumbs/MT_xDot_Kit_MTMDK-NX-XDOT_clear_hp1000px-qiietlpii6czroara761mb7hrzdtvfj6350luxui2o.png"
     },
-    "FF1705_L151CC": {
+    // As of 2024, L-Tek no longer sells the FF1705 as far as I can tell from their webshop.
+    // It was delisted sometime after 2021.
+    "FF1705_L151CC": { // AKA L-Tek FF1705
         "inherits": [
             "XDOT_L151CC"
         ],
         "detect_code": [
             "8080"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/cache/platforms/LTEK-xdot.jpg.250x250_q85.jpg"
     },
     "MCU_STM32L152xC": {
         "inherits": [
@@ -4010,7 +4089,7 @@
             "STM32L152xC"
         ]
     },
-    "MOTE_L152RC": {
+    "MOTE_L152RC": { // AKA SX1272LM1CEP or NAMote72 or Semtech LoRaMote
         "inherits": [
             "MCU_STM32L152xC"
         ],
@@ -4026,7 +4105,8 @@
         "device_has_remove": [
             "SERIAL_FC"
         ],
-        "device_name": "STM32L152RCTx"
+        "device_name": "STM32L152RCTx",
+        "image_url": "https://www.newark.com/productimages/large/en_US/14AC8252-40.jpg"
     },
     "MCU_STM32L152xE": {
         "inherits": [
@@ -4050,8 +4130,11 @@
         "detect_code": [
             "0710"
         ],
-        "device_name": "STM32L152RETx"
+        "device_name": "STM32L152RETx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
+
+    // STM32L4 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32L4": {
         "inherits": [
             "MCU_STM32"
@@ -4135,7 +4218,8 @@
         "detect_code": [
             "0770"
         ],
-        "device_name": "STM32L432KCUx"
+        "device_name": "STM32L432KCUx",
+        "image_url": "https://eu.mouser.com/images/marketingid/2019/img/168228755.png?v=021424.0917"
     },
     "MCU_STM32L433xC": {
         "inherits": [
@@ -4159,7 +4243,8 @@
         "detect_code": [
             "0779"
         ],
-        "device_name": "STM32L433RCTx"
+        "device_name": "STM32L433RCTx",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2508/MFG_NUCLEO-L433RC-P.jpg"
     },
     "MCU_STM32L443xC": {
         "inherits": [
@@ -4175,6 +4260,7 @@
             "STM32L443xx"
         ]
     },
+    // Note: Advantech WISE-DK1510 required as external debugger
     "ADV_WISE_1510": {
         "inherits": [
             "MCU_STM32L443xC"
@@ -4189,7 +4275,8 @@
         "device_name": "STM32L443RCTx",
         "detect_code": [
             "0458"
-        ]
+        ],
+        "image_url": "https://www.mouser.com/images/advantechcorporation/lrg/WISE-1510WMB-SDA1E_DSL.jpg"
     },
     "MCU_STM32L452xE": {
         "inherits": [
@@ -4214,7 +4301,8 @@
         "detect_code": [
             "0829"
         ],
-        "device_name": "STM32L452RETx"
+        "device_name": "STM32L452RETx",
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2508/MFG_NUCLEO-L433RC-P.jpg"
     },
     "MCU_STM32L471xG": {
         "inherits": [
@@ -4242,7 +4330,8 @@
         "components_add": [
             "MULTITECH_DRAGONFLY_NANO_CELLULAR",
         ],
-        "device_name": "STM32L471QGIx"
+        "device_name": "STM32L471QGIx",
+        "image_url": "https://www.mouser.com/images/marketingid/2021/img/175572858.png?v=011524.1015"
     },
     "MCU_STM32L475xG": {
         "inherits": [
@@ -4286,7 +4375,8 @@
         "features": [
             "BLE"
         ],
-        "device_name": "STM32L475VGTx"
+        "device_name": "STM32L475VGTx",
+        "image_url": "https://www.mouser.com/images/stmicroelectronics/lrg/B_L475E_IOT01A1_SPL.jpg"
     },
     "MCU_STM32L476xG": {
         "inherits": [
@@ -4314,7 +4404,8 @@
         "detect_code": [
             "0765"
         ],
-        "device_name": "STM32L476RGTx"
+        "device_name": "STM32L476RGTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "DISCO_L476VG": {
         "inherits": [
@@ -4333,8 +4424,12 @@
             "QSPI",
             "USBDEVICE"
         ],
-        "device_name": "STM32L476VGTx"
+        "device_name": "STM32L476VGTx",
+        "image_url": "https://static5.arrow.com/pdfs/2015/11/2/7/58/36/906/st_/manual/stm32l476g-disco_fig.1.jpg"
     },
+    // As of 2024, rhomb.io seems to be effectively dead as a company -- their website is down, and
+    // their github and twitter have been inactive since 2021.
+    // So, this board seems to no longer exist and is a candidate for removal.
     "RHOMBIO_L476DMW1K": {
         "inherits": [
             "MCU_STM32L476xG"
@@ -4377,7 +4472,8 @@
         "detect_code": [
             "0827"
         ],
-        "device_name": "STM32L486RGTx"
+        "device_name": "STM32L486RGTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF260945.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     // AKA Advantech WISE-1570
     // This board is EOL from the manufacturer so it is a candidate for removal.
@@ -4398,7 +4494,8 @@
         "OUTPUT_EXT": "hex",
         "components_add": [
             "QUECTEL_BC95"
-        ]
+        ],
+        "image_url": "https://www.sphinxcomputer.de/produktdb/images/products/6821_25480.png"
     },
     "MCU_STM32L496xG": {
         "inherits": [
@@ -4437,7 +4534,8 @@
             "USBDEVICE",
             "QSPI"
         ],
-        "device_name": "STM32L496AGIx"
+        "device_name": "STM32L496AGIx",
+        "image_url": "https://www.mouser.com/images/marketingid/2017/img/121062128_STmicro_32L496GDISCOVERYDiscoveryBoard.png?v=070223.0249"
     },
     "NUCLEO_L496ZG": {
         "inherits": [
@@ -4452,7 +4550,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32L496ZGTx"
+        "device_name": "STM32L496ZGTx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267690.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_L496ZG_P": {
         "inherits": [
@@ -4528,7 +4627,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32L4R5ZITx"
+        "device_name": "STM32L4R5ZITx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF267690.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "NUCLEO_L4R5ZI_P": {
         "inherits": [
@@ -4576,7 +4676,8 @@
             "QSPI",
             "OSPI",
             "USBDEVICE"
-        ]
+        ],
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF264782.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
     "MCU_STM32L4S5xI": {
         "inherits": [
@@ -4621,7 +4722,8 @@
         "features": [
             "BLE"
         ],
-        "device_name": "STM32L4S5VITx"
+        "device_name": "STM32L4S5VITx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF270120.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
     "MCU_STM32L5": {
         "inherits": [

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -7305,6 +7305,32 @@
         ],
         "image_url": "https://www.embeddedplanet.com/wp-content/uploads/2019/02/EPM2M-AG-CELL-page.jpg"
     },
+    "EP_ATLAS": { // AKA Embedded Planet Atlas board. https://www.embeddedplanet.com/chronos/#atlas
+        "inherits": ["MCU_NRF52840"],
+        "device_name": "nRF52840_xxAA",
+        "supported_form_factors": [],
+        "config": {
+            "modem_is_on_board": {
+                "help": "Value: Tells the build system that the modem is on-board as oppose to a plug-in shield/module.",
+                "value": 1,
+                "macro_name": "MODEM_ON_BOARD"
+            },
+            "modem_data_connection_type": {
+                "help": "Value: Defines how an on-board modem is wired up to the MCU, e.g., data connection can be a UART or USB and so forth.",
+                "value": 1,
+                "macro_name": "MODEM_ON_BOARD_UART"
+            }
+        },
+        "components_add": ["SPIF", "TELIT_ME310"],
+        "components_remove": ["QSPIF"],
+        "release_versions": ["5"],
+        "macros_add": [
+            "CONFIG_GPIO_AS_PINRESET"
+        ],
+        "image_url": "https://www.embeddedplanet.com/wp-content/uploads/2021/04/Atlas_4-768x719.png"
+    },
+
+    // Nuvoton Targets -------------------------------------------------------------------------------------------------
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",
         "default_toolchain": "ARM",
@@ -7417,7 +7443,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/uploads/MACRUM/img_9240.jpg"
     },
     "NUMAKER_PFM_M453": {
         "core": "Cortex-M4F",
@@ -7537,7 +7564,8 @@
         },
         "detect_code": [
             "1303"
-        ]
+        ],
+        "image_url": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.6.0/zephyr/_images/pfm_m487.jpg"
     },
     "NUMAKER_PFM_NANO130": {
         "core": "Cortex-M0",
@@ -7650,7 +7678,8 @@
         },
         "detect_code": [
             "1306"
-        ]
+        ],
+        "image_url": "https://www.nuvoton.com/export/sites/nuvoton/images/Microcontrollers/NuMaker-PFM-M487KM.png_576589920.png"
     },
     "MCU_M460": {
         "core": "Cortex-M4F",
@@ -7837,7 +7866,8 @@
             "hbi-mfp-reg-list": "0x40000534, 0x4000057C, 0x40000590, 0x40000594",
             "hbi-mfp-reg-msk-list": "0xFFFFFF00, 0xFFFFFFFF, 0xFFFF0000, 0xFFFFFFFF",
             "hbi-mfp-reg-val-list": "0x10101000, 0x10101010, 0x10100000, 0x10101010"
-        }
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/NuMaker-IoT-M467_V1.1_F.png.250x250_q85.png"
     },
     "MCU_M480": {
         "core": "Cortex-M4F",
@@ -7999,7 +8029,8 @@
             "usb-uart-rx": "PB_12",
             "spim-ccm-enable": 1,
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/NuMaker-PFM-M487.png.250x250_q85.png"
     },
     "NUMAKER_IOT_M487": {
         "inherits": [
@@ -8020,181 +8051,8 @@
             "usb-uart-rx": "PB_12",
             "spim-ccm-enable": 1,
             "network-default-interface-type": "WIFI"
-        }
-    },
-    "TMPM46B": {
-        "inherits": [
-            "Target"
-        ],
-        "core": "Cortex-M4F",
-        "is_disk_virtual": true,
-        "extra_labels": [
-            "TOSHIBA"
-        ],
-        "macros": [
-            "__TMPM46B__"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "device_has": [
-            "USTICKER",
-            "ANALOGIN",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "RESET_REASON",
-            "RTC",
-            "SERIAL",
-            "SERIAL_FC",
-            "SPI",
-            "SPISLAVE",
-            "SPI_ASYNCH",
-            "I2C",
-            "I2CSLAVE",
-            "I2C_ASYNCH",
-            "TRNG",
-            "FLASH",
-            "SLEEP"
-        ],
-        "device_name": "TMPM46BF10FG",
-        "detect_code": [
-            "7013"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "bootloader_supported": true,
-        "supported_application_profiles" : ["full", "bare-metal"],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        }
-    },
-    "ARM_FM": {
-        "inherits": [
-            "Target"
-        ],
-        "public": false,
-        "extra_labels": [
-            "ARM_FM"
-        ]
-    },
-    "FVP_MPS2": {
-        "inherits": [
-            "ARM_FM"
-        ],
-        "features_add": [
-            "PSA"
-        ],
-        "extra_labels_add": [
-            "MBED_PSA_SRV"
-        ],
-        "public": false,
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "OUTPUT_EXT": "elf",
-        "device_has": [
-            "AACI",
-            "ANALOGIN",
-            "CLCD",
-            "EMAC",
-            "FLASH",
-            "I2C",
-            "INTERRUPTIN",
-            "LPTICKER",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "SERIAL",
-            "SLEEP",
-            "SPI",
-            "SPISLAVE",
-            "TSC",
-            "TRNG",
-            "USTICKER"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
         },
-        "supported_application_profiles" : ["full", "bare-metal"],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        },
-        "is_mcu_family_target": true
-    },
-    "FVP_MPS2_M0": {
-        "inherits": [
-            "FVP_MPS2"
-        ],
-        "core": "Cortex-M0",
-        "macros_add": [
-            "CMSDK_CM0"
-        ]
-    },
-    "FVP_MPS2_M0P": {
-        "inherits": [
-            "FVP_MPS2"
-        ],
-        "core": "Cortex-M0+",
-        "macros_add": [
-            "CMSDK_CM0plus"
-        ]
-    },
-    "FVP_MPS2_M3": {
-        "inherits": [
-            "FVP_MPS2"
-        ],
-        "core": "Cortex-M3",
-        "macros_add": [
-            "CMSDK_CM3"
-        ],
-        "device_has_add": [
-            "MPU"
-        ]
-    },
-    "FVP_MPS2_M4": {
-        "inherits": [
-            "FVP_MPS2"
-        ],
-        "core": "Cortex-M4F",
-        "macros_add": [
-            "CMSDK_CM4"
-        ],
-        "device_has_add": [
-            "MPU"
-        ]
-    },
-    "FVP_MPS2_M7": {
-        "inherits": [
-            "FVP_MPS2"
-        ],
-        "core": "Cortex-M7FD",
-        "macros_add": [
-            "CMSDK_CM7"
-        ],
-        "device_has_add": [
-            "MPU"
-        ]
+        "image_url": "https://direct.nuvoton.com/989/numaker-iot-m487.jpg"
     },
     "MCU_M2354": {
         "inherits": [
@@ -8310,7 +8168,7 @@
         "forced_reset_timeout": 5,
         "is_mcu_family_target": true
     },
-    "NU_M2354": {
+    "NU_M2354": { // AKA NUMAKER-M2354
         "inherits": [
             "MCU_M2354"
         ],
@@ -8342,7 +8200,8 @@
             "ARMCLANG",
             "GNUARM"
         ],
-        "tfm_delivery_dir": "TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW"
+        "tfm_delivery_dir": "TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW",
+        "image_url": "https://direct.nuvoton.com/1085-large_default/numaker-m2354.jpg"
     },
     "MCU_M251": {
         "core": "Cortex-M23",
@@ -8478,7 +8337,7 @@
         ],
         "is_mcu_family_target": true
     },
-    "NUMAKER_IOT_M252": {
+    "NUMAKER_IOT_M252": { // AKA NuMaker-LoRaD-M252
         "inherits": [
             "MCU_M251"
         ],
@@ -8494,54 +8353,65 @@
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
             "usb-uart-rx": "PB_12"
-        }
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/NuMaker-LoRaD-M252_V1.0_dAwfIUu.jpg.250x250_q85.jpg"
     },
-    "TMPM4G9": {
+
+    // ARM Fast Model (FM) Fixed Virtual Platforms (FVPs) --------------------------------------------------------------
+    // Unlike the MPS2 targets, which are real targets that can be run on an FPGA, Fast Models are entirely
+    // software based.  They simulate an ARM core, the associated peripherals, and hardware connected to the MCU.
+
+    "ARM_FM": {
         "inherits": [
             "Target"
         ],
-        "core": "Cortex-M4F",
-        "is_disk_virtual": true,
+        "public": false,
         "extra_labels": [
-            "TOSHIBA"
+            "ARM_FM"
         ],
-        "macros": [
-            "__TMPM4G9__"
+        "is_mcu_target_family": true
+    },
+    "FVP_MPS2": {
+        "inherits": [
+            "ARM_FM"
         ],
+        "features_add": [
+            "PSA"
+        ],
+        "extra_labels_add": [
+            "MBED_PSA_SRV"
+        ],
+        "public": false,
         "supported_toolchains": [
             "GCC_ARM"
         ],
+        "OUTPUT_EXT": "elf",
         "device_has": [
+            "AACI",
             "ANALOGIN",
-            "ANALOGOUT",
+            "CLCD",
+            "EMAC",
+            "FLASH",
+            "I2C",
             "INTERRUPTIN",
+            "LPTICKER",
             "PORTIN",
             "PORTINOUT",
             "PORTOUT",
-            "PWMOUT",
-            "RESET_REASON",
             "SERIAL",
-            "SERIAL_FC",
+            "SLEEP",
             "SPI",
             "SPISLAVE",
-            "SPI_ASYNCH",
-            "I2C",
-            "I2CSLAVE",
-            "I2C_ASYNCH",
-            "RTC",
-            "FLASH",
-            "SLEEP",
-            "USTICKER",
-            "MPU"
-        ],
-        "device_name": "TMPM4G9F15FG",
-        "detect_code": [
-            "7015"
+            "TSC",
+            "TRNG",
+            "USTICKER"
         ],
         "release_versions": [
             "5"
         ],
-        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        },
         "supported_application_profiles" : ["full", "bare-metal"],
         "supported_c_libs": {
             "arm": [
@@ -8552,8 +8422,65 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "is_mcu_family_target": true
     },
+    "FVP_MPS2_M0": {
+        "inherits": [
+            "FVP_MPS2"
+        ],
+        "core": "Cortex-M0",
+        "macros_add": [
+            "CMSDK_CM0"
+        ]
+    },
+    "FVP_MPS2_M0P": {
+        "inherits": [
+            "FVP_MPS2"
+        ],
+        "core": "Cortex-M0+",
+        "macros_add": [
+            "CMSDK_CM0plus"
+        ]
+    },
+    "FVP_MPS2_M3": {
+        "inherits": [
+            "FVP_MPS2"
+        ],
+        "core": "Cortex-M3",
+        "macros_add": [
+            "CMSDK_CM3"
+        ],
+        "device_has_add": [
+            "MPU"
+        ]
+    },
+    "FVP_MPS2_M4": {
+        "inherits": [
+            "FVP_MPS2"
+        ],
+        "core": "Cortex-M4F",
+        "macros_add": [
+            "CMSDK_CM4"
+        ],
+        "device_has_add": [
+            "MPU"
+        ]
+    },
+    "FVP_MPS2_M7": {
+        "inherits": [
+            "FVP_MPS2"
+        ],
+        "core": "Cortex-M7FD",
+        "macros_add": [
+            "CMSDK_CM7"
+        ],
+        "device_has_add": [
+            "MPU"
+        ]
+    },
+
+    // Cypress (now Infineon) PSOC6 Targets ----------------------------------------------------------------------------
     "MCU_PSOC6": {
         "inherits": [
             "Target"
@@ -8695,7 +8622,8 @@
         ],
         "overrides": {
             "network-default-interface-type": "WIFI"
-        }
+        },
+        "image_url": "https://www.mouser.com/images/cypresssemiconductor/lrg/CY8CPROTO-062-4343W_t.jpg"
     },
     "CY8CKIT_062S2_43012": {
         "inherits": [
@@ -8732,7 +8660,8 @@
         ],
         "overrides": {
             "network-default-interface-type": "WIFI"
-        }
+        },
+        "image_url": "https://iotexpert.com/wp-content/uploads/2021/02/Screen-Shot-2021-02-24-at-6.55.57-AM-1024x713.jpg"
     },
     "CY8CPROTO_062S3_4343W": {
         "inherits": [
@@ -8767,9 +8696,10 @@
         ],
         "overrides": {
             "network-default-interface-type": "WIFI"
-        }
+        },
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/4218/MFG_CY8CPROTO-062S3-4343W.jpg"
     },
-    "CY8CKIT_062_WIFI_BT": {
+    "CY8CKIT_062_WIFI_BT": { // AKA PSoC 6 WiFi-BT Pioneer Kit
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -8811,9 +8741,10 @@
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
-        "program_cycle_s": 10
+        "program_cycle_s": 10,
+        "image_url": "https://os.mbed.com/media/cache/platforms/P6_WiFi_Pionner_Kit.PNG.250x250_q85.png"
     },
-    "CY8CKIT_062_BLE": {
+    "CY8CKIT_062_BLE": { // AKA PSoC 6 BLE Pioneer Kit
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -8842,9 +8773,10 @@
                 512
             ]
         ],
-        "bootloader_supported": false
+        "bootloader_supported": false,
+        "image_url": "https://os.mbed.com/media/cache/platforms/SS2_3797_with_out_USB_cable.jpg.250x250_q85.jpg"
     },
-    "CYW9P62S1_43438EVB_01": {
+    "CYW9P62S1_43438EVB_01": { // AKA CYW9P62S1-43438EVB-01 PSoC 62S1 Wi-Fi BT Pioneer Kit
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -8886,9 +8818,12 @@
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
-        "program_cycle_s": 10
+        "program_cycle_s": 10,
+
+        // This is not a great picture but it's the best I could find...
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/424/MFG_CY8CKIT-062S2-43012.jpg"
     },
-    "CYW9P62S1_43012EVB_01": {
+    "CYW9P62S1_43012EVB_01": { // AKA CYW9P62S1-43012EVB-01 PSoC 62S1 Wi-Fi BT Pioneer Kit
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -8925,9 +8860,10 @@
         ],
         "overrides": {
             "network-default-interface-type": "WIFI"
-        }
+        },
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/4905/CYW9P62S1-43012EVB-01.jpg"
     },
-    "CY8CKIT064B0S2_4343W": {
+    "CY8CKIT064B0S2_4343W": { // AKA CY8CKIT-064B0S2-4343W PSoC 64 Secure Boot Wi-Fi BT Pioneer Kit
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -8977,9 +8913,11 @@
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
-        "program_cycle_s": 10
+        "program_cycle_s": 10,
+        "device_name": "CYB0644ABZI-S2D44",
+        "image_url": "https://os.mbed.com/media/cache/platforms/SSP_8683_Ywwh0ix.jpg.250x250_q85.jpg"
     },
-    "CYTFM_064B0S2_4343W": {
+    "CYTFM_064B0S2_4343W": { // Same as
         "inherits": [
             "MCU_PSOC6_M4"
         ],
@@ -9044,7 +8982,9 @@
             "GNUARM"
         ],
         "tfm_delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/COMPONENT_TFM_S_FW",
-        "TFM_OUTPUT_EXT": "hex"
+        "TFM_OUTPUT_EXT": "hex",
+        "device_name": "CYB0644ABZI-S2D44",
+        "image_url": "https://os.mbed.com/media/cache/platforms/SSP_8683_Ywwh0ix.jpg.250x250_q85.jpg"
     },
     // Also known as CYSBSYSKIT-DEV-01 Rapid IoT Connect Developer Kit
     // However, as of 2024, I cannot find this board anywhere for sale, so it may be a candidate for removal.
@@ -9105,7 +9045,8 @@
                 "help": "Value: Tells the np to connect to wifi with its network credentials or wait till cp provides network credentials to it",
                 "value": false
             }
-        }
+        },
+        "image_url": "https://manuals.plus/wp-content/uploads/2023/05/infineon-CYSBSYSKIT-DEV-01-Rapid-IoT-Connect-Developer-Kit-PRODUCT.png"
     },
     "GD32_Target": {
         "inherits": [
@@ -9411,30 +9352,6 @@
             "3701"
         ]
     },
-    "EP_ATLAS": { // AKA Embedded Planet Atlas board. https://www.embeddedplanet.com/chronos/#atlas
-        "inherits": ["MCU_NRF52840"],
-        "device_name": "nRF52840_xxAA",
-        "supported_form_factors": [],
-        "config": {
-            "modem_is_on_board": {
-                "help": "Value: Tells the build system that the modem is on-board as oppose to a plug-in shield/module.",
-                "value": 1,
-                "macro_name": "MODEM_ON_BOARD"
-            },
-            "modem_data_connection_type": {
-                "help": "Value: Defines how an on-board modem is wired up to the MCU, e.g., data connection can be a UART or USB and so forth.",
-                "value": 1,
-                "macro_name": "MODEM_ON_BOARD_UART"
-            }
-        },
-        "components_add": ["SPIF", "TELIT_ME310"],
-        "components_remove": ["QSPIF"],
-        "release_versions": ["5"],
-        "macros_add": [
-            "CONFIG_GPIO_AS_PINRESET"
-        ],
-        "image_url": "https://www.embeddedplanet.com/wp-content/uploads/2021/04/Atlas_4-768x719.png"
-    },
     "S1SBP6A": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
@@ -9552,9 +9469,122 @@
         "inherits": ["AMA3B1KK"],
         "components_add": ["lis2dh12", "hm01b0"]
     },
-    "__build_tools_metadata__": {
-        "version": "1",
-        "public": false
+    // Toshiba Targets -------------------------------------------------------------------------------------------------
+    "TMPM46B": { // AKA AdBun-M46B
+        "inherits": [
+            "Target"
+        ],
+        "core": "Cortex-M4F",
+        "is_disk_virtual": true,
+        "extra_labels": [
+            "TOSHIBA"
+        ],
+        "macros": [
+            "__TMPM46B__"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "device_has": [
+            "USTICKER",
+            "ANALOGIN",
+            "INTERRUPTIN",
+            "PORTIN",
+            "PORTINOUT",
+            "PORTOUT",
+            "PWMOUT",
+            "RESET_REASON",
+            "RTC",
+            "SERIAL",
+            "SERIAL_FC",
+            "SPI",
+            "SPISLAVE",
+            "SPI_ASYNCH",
+            "I2C",
+            "I2CSLAVE",
+            "I2C_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "SLEEP"
+        ],
+        "device_name": "TMPM46BF10FG",
+        "detect_code": [
+            "7013"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "bootloader_supported": true,
+        "supported_application_profiles" : ["full", "bare-metal"],
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        },
+        "image_url": "https://www.chip1stop.com/img/product/SSST/0109140533_5a544d9d16351.JPG"
+    },
+    "TMPM4G9": {
+        "inherits": [
+            "Target"
+        ],
+        "core": "Cortex-M4F",
+        "is_disk_virtual": true,
+        "extra_labels": [
+            "TOSHIBA"
+        ],
+        "macros": [
+            "__TMPM4G9__"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "device_has": [
+            "ANALOGIN",
+            "ANALOGOUT",
+            "INTERRUPTIN",
+            "PORTIN",
+            "PORTINOUT",
+            "PORTOUT",
+            "PWMOUT",
+            "RESET_REASON",
+            "SERIAL",
+            "SERIAL_FC",
+            "SPI",
+            "SPISLAVE",
+            "SPI_ASYNCH",
+            "I2C",
+            "I2CSLAVE",
+            "I2C_ASYNCH",
+            "RTC",
+            "FLASH",
+            "SLEEP",
+            "USTICKER",
+            "MPU"
+        ],
+        "device_name": "TMPM4G9F15FG",
+        "detect_code": [
+            "7015"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "bootloader_supported": true,
+        "supported_application_profiles" : ["full", "bare-metal"],
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        }
     },
     "TMPM4KN": {
         "inherits": ["Target"],

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -457,7 +457,7 @@
         },
         "overrides": {
             "network-default-interface-type": "ETHERNET",
-            "target.default-adc-vref": 3.3 // Per "mbed-005.1" schematic, Vref is 3.3V
+            "default-adc-vref": 3.3 // Per "mbed-005.1" schematic, Vref is 3.3V
         },
         "supported_c_libs": {
             "arm": [

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -6656,6 +6656,8 @@
         ],
         "image_url": "https://os.mbed.com/media/uploads/sadik_maxim/max32670evkit_daplink_fw_update.png"
     },
+
+    // SiLabs EFM32 Targets---------------------------------------------------------------------------------------------
     "EFM32": {
         "inherits": [
             "Target"
@@ -6671,52 +6673,12 @@
         ],
         "public": false
     },
-    "EFM32GG990F1024": {
+    "MCU_EFM32_GECKO": { // Family target for EFM32 Gecko MCUs
         "inherits": [
-            "EFM32"
+            "Target"
         ],
-        "extra_labels_add": [
-            "EFM32GG",
-            "1024K",
-            "SL_AES"
-        ],
-        "core": "Cortex-M3",
-        "macros_add": [
-            "EFM32GG990F1024"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "device_name": "EFM32GG990F1024",
-        "public": false,
-        "bootloader_supported": true,
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        },
-        "supported_application_profiles": [
-            "full", "bare-metal"
-        ]
-    },
-    "EFM32GG_STK3700": {
-        "inherits": [
-            "EFM32GG990F1024"
-        ],
-        "progen": {
-            "target": "efm32gg-stk"
-        },
         "device_has": [
             "ANALOGIN",
-            "ANALOGOUT",
             "I2C",
             "I2CSLAVE",
             "I2C_ASYNCH",
@@ -6735,12 +6697,11 @@
             "SPISLAVE",
             "SPI_ASYNCH",
             "USTICKER",
+            "TRNG",
             "FLASH",
-            "ITM",
             "MPU",
             "WATCHDOG"
         ],
-        "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
                 "help": "Value: HFXO for external crystal, HFRCO for internal RC oscillator",
@@ -6764,14 +6725,71 @@
             },
             "hfrco_clock_freq": {
                 "help": "Value: Frequency in hertz, must correspond to setting of hfrco_band_select",
-                "value": "21000000",
+                "value": "32000000",
                 "macro_name": "HFRCO_FREQUENCY"
-            },
+            }
+        },
+        "bootloader_supported": true,
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        },
+        "supported_application_profiles": [
+            "full", "bare-metal"
+        ],
+        "public": false,
+        "is_mcu_family_target": true
+    },
+    "EFM32GG990F1024": {
+        "inherits": [
+            "MCU_EFM32_GECKO"
+        ],
+        "extra_labels_add": [
+            "EFM32GG",
+            "1024K",
+            "SL_AES"
+        ],
+        "device_has_add": [
+            "ANALOGOUT"
+        ],
+        "config": {
             "hfrco_band_select": {
                 "help": "Value: One of _CMU_HFRCOCTRL_BAND_28MHZ, _CMU_HFRCOCTRL_BAND_21MHZ, _CMU_HFRCOCTRL_BAND_14MHZ, _CMU_HFRCOCTRL_BAND_11MHZ, _CMU_HFRCOCTRL_BAND_7MHZ, _CMU_HFRCOCTRL_BAND_1MHZ. Be sure to set hfrco_clock_freq accordingly!",
                 "value": "_CMU_HFRCOCTRL_BAND_21MHZ",
                 "macro_name": "HFRCO_FREQUENCY_ENUM"
-            },
+            }
+        },
+        "core": "Cortex-M3",
+        "macros_add": [
+            "EFM32GG990F1024"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "device_name": "EFM32GG990F1024",
+        "public": false,
+        "supported_application_profiles": [
+            "full", "bare-metal"
+        ]
+    },
+    "EFM32GG_STK3700": { // AKA EFM32 Giant Gecko
+        "inherits": [
+            "EFM32GG990F1024"
+        ],
+        "progen": {
+            "target": "efm32gg-stk"
+        },
+        "forced_reset_timeout": 2,
+        "config": {
             "board_controller_enable": {
                 "help": "Pin to pull high for enabling the USB serial port",
                 "value": "PF7",
@@ -6780,11 +6798,15 @@
         },
         "detect_code": [
             "2015"
-        ]
+        ],
+        "overrides": {
+            "hfrco_clock_freq": "21000000"
+        },
+        "image_url": "https://www.silabs.com/content/dam/siliconlabs/images/products/microcontrollers/32-bit_mcus/giant_gecko/giant-gecko-starter-kit.jpg"
     },
     "EFR32MG12P332F1024GL125": {
         "inherits": [
-            "EFM32"
+            "MCU_EFM32_GECKO"
         ],
         "extra_labels_add": [
             "EFR32MG12",
@@ -6793,6 +6815,17 @@
             "SL_RAIL",
             "SL_CRYPTO"
         ],
+        "device_has_add": [
+            "802_15_4_PHY",
+            "CRC"
+        ],
+        "config": {
+            "hfrco_band_select": {
+                "help": "Value: One of cmuHFRCOFreq_1M0Hz, cmuHFRCOFreq_2M0Hz, cmuHFRCOFreq_4M0Hz, cmuHFRCOFreq_7M0Hz, cmuHFRCOFreq_13M0Hz, cmuHFRCOFreq_16M0Hz, cmuHFRCOFreq_19M0Hz, cmuHFRCOFreq_26M0Hz, cmuHFRCOFreq_32M0Hz, cmuHFRCOFreq_38M0Hz. Be sure to set hfrco_clock_freq accordingly!",
+                "value": "cmuHFRCOFreq_32M0Hz",
+                "macro_name": "HFRCO_FREQUENCY_ENUM"
+            }
+        },
         "core": "Cortex-M4F",
         "macros_add": [
             "EFR32MG12P332F1024GL125"
@@ -6805,102 +6838,46 @@
         ],
         "device_name": "EFR32MG12P332F1024GL125",
         "public": false,
-        "bootloader_supported": true,
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        },
         "supported_application_profiles": [
             "full", "bare-metal"
         ]
     },
-    "TB_SENSE_12": {
+    "TB_SENSE_12": { // AKA Thunderboard Sense 2
         "inherits": [
             "EFR32MG12P332F1024GL125"
         ],
-        "device_name": "EFR32MG12P332F1024GL125",
-        "device_has": [
-            "802_15_4_PHY",
-            "ANALOGIN",
-            "CRC",
-            "I2C",
-            "I2CSLAVE",
-            "I2C_ASYNCH",
-            "INTERRUPTIN",
-            "LPTICKER",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "RESET_REASON",
-            "RTC",
-            "SERIAL",
-            "SERIAL_ASYNCH",
-            "SLEEP",
-            "SPI",
-            "SPISLAVE",
-            "SPI_ASYNCH",
-            "USTICKER",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "WATCHDOG"
-        ],
         "forced_reset_timeout": 5,
-        "config": {
-            "hf_clock_src": {
-                "help": "Value: HFXO for external crystal, HFRCO for internal RC oscillator",
-                "value": "HFXO",
-                "macro_name": "CORE_CLOCK_SOURCE"
-            },
-            "hfxo_clock_freq": {
-                "help": "Value: External crystal frequency in hertz",
-                "value": "38400000",
-                "macro_name": "HFXO_FREQUENCY"
-            },
-            "lf_clock_src": {
-                "help": "Value: LFXO for external crystal, LFRCO for internal RC oscillator, ULFRCO for internal 1KHz RC oscillator",
-                "value": "LFXO",
-                "macro_name": "LOW_ENERGY_CLOCK_SOURCE"
-            },
-            "lfxo_clock_freq": {
-                "help": "Value: External crystal frequency in hertz",
-                "value": "32768",
-                "macro_name": "LFXO_FREQUENCY"
-            },
-            "hfrco_clock_freq": {
-                "help": "Value: Frequency in hertz, must correspond to setting of hfrco_band_select",
-                "value": "32000000",
-                "macro_name": "HFRCO_FREQUENCY"
-            },
-            "hfrco_band_select": {
-                "help": "Value: One of cmuHFRCOFreq_1M0Hz, cmuHFRCOFreq_2M0Hz, cmuHFRCOFreq_4M0Hz, cmuHFRCOFreq_7M0Hz, cmuHFRCOFreq_13M0Hz, cmuHFRCOFreq_16M0Hz, cmuHFRCOFreq_19M0Hz, cmuHFRCOFreq_26M0Hz, cmuHFRCOFreq_32M0Hz, cmuHFRCOFreq_38M0Hz. Be sure to set hfrco_clock_freq accordingly!",
-                "value": "cmuHFRCOFreq_32M0Hz",
-                "macro_name": "HFRCO_FREQUENCY_ENUM"
-            }
-        },
         "overrides": {
-            "network-default-interface-type": "MESH"
+            "network-default-interface-type": "MESH",
+            "hfxo_clock_freq": "38400000",
         },
         "detect_code": [
             "2041"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2145/MFG_SLTB004A.jpg"
     },
     "EFM32GG11B820F2048GL192": {
         "inherits": [
-            "EFM32"
+            "MCU_EFM32_GECKO"
         ],
         "extra_labels_add": [
             "EFM32GG11",
             "2048K",
             "SL_CRYPTO"
         ],
+        "device_has_add": [
+            "CAN",
+            "CRC",
+            "EMAC",
+            "ITM"
+        ],
+        "config": {
+            "hfrco_band_select": {
+                "help": "Value: One of cmuHFRCOFreq_1M0Hz, cmuHFRCOFreq_2M0Hz, cmuHFRCOFreq_4M0Hz, cmuHFRCOFreq_7M0Hz, cmuHFRCOFreq_13M0Hz, cmuHFRCOFreq_16M0Hz, cmuHFRCOFreq_19M0Hz, cmuHFRCOFreq_26M0Hz, cmuHFRCOFreq_32M0Hz, cmuHFRCOFreq_38M0Hz. Be sure to set hfrco_clock_freq accordingly!",
+                "value": "cmuHFRCOFreq_32M0Hz",
+                "macro_name": "HFRCO_FREQUENCY_ENUM"
+            }
+        },
         "core": "Cortex-M4F",
         "macros_add": [
             "EFM32GG11B820F2048GL192"
@@ -6913,17 +6890,6 @@
         ],
         "device_name": "EFM32GG11B820F2048GL192",
         "public": false,
-        "bootloader_supported": true,
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        },
         "supported_application_profiles": [
             "full", "bare-metal"
         ]
@@ -6932,69 +6898,8 @@
         "inherits": [
             "EFM32GG11B820F2048GL192"
         ],
-        "device_name": "EFM32GG11B820F2048GL192",
-        "device_has": [
-            "ANALOGIN",
-            "CAN",
-            "CRC",
-            "EMAC",
-            "I2C",
-            "I2CSLAVE",
-            "I2C_ASYNCH",
-            "INTERRUPTIN",
-            "ITM",
-            "LPTICKER",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "QSPI",
-            "RESET_REASON",
-            "RTC",
-            "SERIAL",
-            "SERIAL_ASYNCH",
-            "SLEEP",
-            "SPI",
-            "SPISLAVE",
-            "SPI_ASYNCH",
-            "USTICKER",
-            "TRNG",
-            "FLASH",
-            "MPU",
-            "WATCHDOG"
-        ],
         "forced_reset_timeout": 5,
         "config": {
-            "hf_clock_src": {
-                "help": "Value: HFXO for external crystal, HFRCO for internal RC oscillator",
-                "value": "HFXO",
-                "macro_name": "CORE_CLOCK_SOURCE"
-            },
-            "hfxo_clock_freq": {
-                "help": "Value: External crystal frequency in hertz",
-                "value": "50000000",
-                "macro_name": "HFXO_FREQUENCY"
-            },
-            "lf_clock_src": {
-                "help": "Value: LFXO for external crystal, LFRCO for internal RC oscillator, ULFRCO for internal 1KHz RC oscillator",
-                "value": "LFXO",
-                "macro_name": "LOW_ENERGY_CLOCK_SOURCE"
-            },
-            "lfxo_clock_freq": {
-                "help": "Value: External crystal frequency in hertz",
-                "value": "32768",
-                "macro_name": "LFXO_FREQUENCY"
-            },
-            "hfrco_clock_freq": {
-                "help": "Value: Frequency in hertz, must correspond to setting of hfrco_band_select",
-                "value": "32000000",
-                "macro_name": "HFRCO_FREQUENCY"
-            },
-            "hfrco_band_select": {
-                "help": "Value: One of cmuHFRCOFreq_1M0Hz, cmuHFRCOFreq_2M0Hz, cmuHFRCOFreq_4M0Hz, cmuHFRCOFreq_7M0Hz, cmuHFRCOFreq_13M0Hz, cmuHFRCOFreq_16M0Hz, cmuHFRCOFreq_19M0Hz, cmuHFRCOFreq_26M0Hz, cmuHFRCOFreq_32M0Hz, cmuHFRCOFreq_38M0Hz. Be sure to set hfrco_clock_freq accordingly!",
-                "value": "cmuHFRCOFreq_32M0Hz",
-                "macro_name": "HFRCO_FREQUENCY_ENUM"
-            },
             "board_controller_enable": {
                 "help": "Pin to pull high for enabling the USB serial port",
                 "value": "PE1",
@@ -7007,12 +6912,16 @@
             }
         },
         "overrides": {
-            "network-default-interface-type": "ETHERNET"
+            "network-default-interface-type": "ETHERNET",
+            "hfxo_clock_freq": "50000000"
         },
         "detect_code": [
             "2042"
-        ]
+        ],
+        "image_url": "https://www.silabs.com/content/dam/siliconlabs/images/products/microcontrollers/32-bit_mcus/giant-gecko-gg11/efr32gg11-starter-kit.jpg"
     },
+
+    // Nordic NRF52832 Targets------------------------------------------------------------------------------------------
     "MCU_NRF52832": {
         "inherits": [
             "Target"
@@ -7144,7 +7053,8 @@
         ],
         "detect_code": [
             "1101"
-        ]
+        ],
+        "image_url": "https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF52-Series/nRF52-DK/nRF52-DK-render_prod-page.png?h=551&iar=0&mw=350&w=350&hash=DB87685680509C17DF15906A7DC9A289"
     },
     "SDT52832B": {
         "inherits": [
@@ -7156,7 +7066,8 @@
         "detect_code": [
             "3104"
         ],
-        "device_name": "nRF52832_xxAA"
+        "device_name": "nRF52832_xxAA",
+        "image_url": "https://www.devicemart.co.kr/data/collect_img/kind_0/goods/large/6500289.jpg"
     },
     "ARDUINO_NICLA_SENSE_ME": {
         "inherits": ["MCU_NRF52832"],

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3317,7 +3317,7 @@
             "STM32H723ZG"
         ],
         "config": {
-            
+
             "d11_configuration": {
                 "help": "Value: PB_5 for the default board configuration, PA_7 in case of solder bridge update (SB33 on/ SB35 off)",
                 "value": "PB_5",
@@ -5537,7 +5537,8 @@
         ],
         "release_versions": [
             "5"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/cache/platforms/t17_VBxJMp4.png.250x250_q85.png"
     },
 
     // ARM MPS2 FPGA prototyping targets -------------------------------------------------------------------------------
@@ -6210,7 +6211,7 @@
     },
     "MAX32620FTHR": {
         "inherits": [
-            "MCU_MAX32620C"
+            "MCU_MAX32620"
         ],
         "detect_code": [
             "0418"
@@ -6219,7 +6220,7 @@
     },
     "SDT32620B": {
         "inherits": [
-            "MCU_MAX32620C"
+            "MCU_MAX32620"
         ],
         "detect_code": [
             "3101"

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -4725,6 +4725,8 @@
         "device_name": "STM32L4S5VITx",
         "image_url": "https://www.st.com/bin/ecommerce/api/image.PF270120.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
+
+    // STM32L5 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32L5": {
         "inherits": [
             "MCU_STM32"
@@ -4795,7 +4797,8 @@
         "device_name": "STM32L552ZETxQ",
         "detect_code": [
             "0854"
-        ]
+        ],
+        "image_url": "https://cdn11.bigcommerce.com/s-3fd3md1ghs/images/stencil/500x659/products/30236/11949/NUCLEO-L552ZE-Q__51179.1642762880.jpg?c=2"
     },
     "MCU_STM32L562xE": {
         "inherits": [
@@ -4837,8 +4840,11 @@
         "device_name": "STM32L562QEIxQ",
         "detect_code": [
             "0854"
-        ]
+        ],
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF268050.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
+
+    // STM32U5 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32U5": {
         "inherits": [
             "MCU_STM32"
@@ -4919,7 +4925,8 @@
             // As shipped, this nucleo board connects VREFP to VDD_MCU, and connects VDD_MCU to 3.3V.
             // Jumper JP4 can be used to switch VDD_MCU to 1.8V in which case you should override this setting to 1.8.
             "default-adc-vref": 3.3
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF271812.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32U575xG": {
         "inherits": [
@@ -4971,7 +4978,8 @@
         },
         "detect_code": [
             "887"
-        ]
+        ],
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF271412.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
     "MCU_STM32U545xE": {
         "inherits": [
@@ -5002,7 +5010,8 @@
             // As shipped, this nucleo board connects VREFP to VDD_MCU, and connects VDD_MCU to 3.3V.
             // Jumper JP5 can be used to switch VDD_MCU to 1.8V in which case you should override this setting to 1.8.
             "default-adc-vref": 3.3
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF273877.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
     "MCU_STM32U5A5xJ": {
         "inherits": [
@@ -5033,8 +5042,11 @@
             // As shipped, this nucleo board connects VREFP to VDD_MCU, and connects VDD_MCU to 3.3V.
             // Jumper JP4 can be used to switch VDD_MCU to 1.8V in which case you should override this setting to 1.8.
             "default-adc-vref": 3.3
-        }
+        },
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF271812.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },        
+
+    // STM32WB Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32WB": {
         "inherits": [
             "MCU_STM32"
@@ -5109,7 +5121,8 @@
         "detect_code": [
             "0883"
         ],
-        "device_name": "STM32WB15CCUx"
+        "device_name": "STM32WB15CCUx",
+        "image_url": "https://www.mouser.com/images/stmicroelectronics/hd/NUCLEO-WB15CC_SPL.jpg"
     },
     "MCU_STM32WB55xG": {
         "inherits": [
@@ -5138,7 +5151,8 @@
         "device_has_add": [
             "USBDEVICE"
         ],
-        "device_name": "STM32WB55RGVx"
+        "device_name": "STM32WB55RGVx",
+        "image_url": "https://www.mouser.com/images/stmicroelectronics/hd/NUCLEO-WB15CC_SPL.jpg"
     },
     "MCU_STM32WB5MxG": {
         "inherits": [
@@ -5154,7 +5168,7 @@
             "MBEDTLS_CONFIG_HW_SUPPORT"
         ]
     },
-    "DISCO_WB5MMG": {
+    "DISCO_WB5MMG": { // AKA STM32WB5MM-DK
         "inherits": [
             "MCU_STM32WB5MxG"
         ],
@@ -5164,8 +5178,11 @@
         "detect_code": [
             "0884"
         ],
-        "device_name": "STM32WB55VGYx"
+        "device_name": "STM32WB55VGYx",
+        "image_url": "https://www.st.com/bin/ecommerce/api/image.PF271050.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
+
+    // STM32WL Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32WL": {
         "inherits": [
             "MCU_STM32"
@@ -5229,7 +5246,8 @@
         "detect_code": [
             "0866"
         ],
-        "device_name": "STM32WL55JCIx"
+        "device_name": "STM32WL55JCIx",
+        "image_url": "https://www.mouser.com/images/marketingid/2020/img/114771861.png?v=012324.0355"
     },
     "MCU_STM32WLE5xC": {
         "inherits": [
@@ -6258,7 +6276,7 @@
         "image_url": "https://www.renesas.com/sites/default/files/media/images/gr-mango-top.png"
     },
 
-    // Maxim Targets ---------------------------------------------------------------------------------------------------
+    // Maxim (now Analog Devices) Targets ------------------------------------------------------------------------------
     "MCU_MAX32620": {
         "inherits": [
             "Target"
@@ -6401,7 +6419,8 @@
         ],
         "detect_code": [
             "3102"
-        ]
+        ],
+        "image_url": "https://www.devicemart.co.kr/data/collect_img/kind_0/goods/large/6500287.jpg"
     },
     "MAX32625PICO": {
         "inherits": [
@@ -6413,7 +6432,8 @@
         "bootloader_supported": true,
         "detect_code": [
             "0444"
-        ]
+        ],
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/2592/MAX32625PICO%23.jpg"
     },
     "MAX32630FTHR": {
         "inherits": [
@@ -6471,7 +6491,8 @@
             "iar": [
                 "std"
             ]
-        }
+        },
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-maxim-images/max32630fthr.png?rev=38a579856b25448c9369e8f1931bef09&h=270&hash=55F09D9FF86FDDA9FDAE27520485245E"
     },
     "MAX32660": {
         "inherits": [
@@ -6549,7 +6570,8 @@
         },
         "detect_code": [
             "0421"
-        ]
+        ],
+        "image_url": "https://www.analog.com/en/_/media/analog/en/evaluation-board-maxim-images/max32660evsys.png?rev=1b007b133cb349f692e1695e7e55de01&h=270&hash=81B37460C25087CDD9A37B6B87FCB0A5"
     },
     "MAX32670": {
         "inherits": [
@@ -6631,7 +6653,8 @@
         ],
         "detect_code": [
             "0424"
-        ]
+        ],
+        "image_url": "https://os.mbed.com/media/uploads/sadik_maxim/max32670evkit_daplink_fw_update.png"
     },
     "EFM32": {
         "inherits": [

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -398,22 +398,19 @@
         ],
         "image_url": "https://os.mbed.com/media/cache/platforms/LPC1114_1_hXXAnmW.jpg.250x250_q85.jpg"
     },
-    "LPC1768": {
+    "MCU_LPC1768": {
         "inherits": [
             "LPCTarget"
         ],
+        "public": false,
         "core": "Cortex-M3",
         "extra_labels": [
             "NXP",
             "LPC176X",
-            "MBED_LPC1768",
             "NXP_EMAC"
         ],
         "supported_toolchains": [
             "GCC_ARM"
-        ],
-        "detect_code": [
-            "1010"
         ],
         "device_has": [
             "RTC",
@@ -441,9 +438,6 @@
             "WATCHDOG",
             "RESET_REASON"
         ],
-        "components_add": [
-            "LOCALFILESYSTEM"
-        ],
         "release_versions": [
             "5"
         ],
@@ -457,7 +451,6 @@
         },
         "overrides": {
             "network-default-interface-type": "ETHERNET",
-            "default-adc-vref": 3.3 // Per "mbed-005.1" schematic, Vref is 3.3V
         },
         "supported_c_libs": {
             "arm": [
@@ -470,33 +463,31 @@
         "supported_application_profiles": [
             "full", "bare-metal"
         ],
-        "is_mcu_family_target": true,
+        "is_mcu_family_target": true
+    },
+    "LPC1768": {
+        "inherits": [
+            "MCU_LPC1768"
+        ],
+        "core": "Cortex-M3",
+        "extra_labels_add": [
+            "MBED_LPC1768",
+        ],
+        "detect_code": [
+            "1010"
+        ],
+        "components_add": [
+            "LOCALFILESYSTEM"
+        ],
+        "overrides": {
+            "default-adc-vref": 3.3 // Per "mbed-005.1" schematic, Vref is 3.3V
+        },
         "image_url": "https://os.mbed.com/media/cache/platforms/LPC1768.jpg.250x250_q85.jpg"
     },
     "ARCH_PRO": {
         "supported_form_factors": [
             "ARDUINO"
         ],
-        "core": "Cortex-M3",
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-         "supported_application_profiles": [
-            "full", "bare-metal"
-        ],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ],
-            "iar": [
-                "std"
-            ]
-        },
         "extra_labels": [
             "NXP",
             "LPC176X",
@@ -506,41 +497,14 @@
             "TARGET_LPC1768"
         ],
         "inherits": [
-            "LPCTarget"
+            "MCU_LPC1768"
         ],
-        "device_has": [
-            "ANALOGIN",
-            "ANALOGOUT",
-            "CAN",
-            "DEBUG_AWARENESS",
-            "EMAC",
-            "I2C",
-            "I2CSLAVE",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "SERIAL",
-            "SERIAL_FC",
-            "SLEEP",
-            "SPI",
-            "SPISLAVE",
-            "FLASH",
-            "MPU",
-            "USBDEVICE",
-            "USTICKER",
-            "WATCHDOG",
-            "RESET_REASON"
-        ],
-        "device_name": "LPC1768",
-        "bootloader_supported": true,
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        },
         "detect_code": [
             "9004"
         ],
+        "overrides": {
+            "default-adc-vref": 3.3 // Per schematic, Vref is 3.3V
+        },
         "image_url": "https://files.seeedstudio.com/wiki/Arch_Pro/img/Arch_pro.jpg"
     },
 
@@ -4565,7 +4529,7 @@
     // Note: I have not been able to find any record of a board with this target ID ever being
     // sold by Multitech.  It was added by this PR: https://github.com/ARMmbed/mbed-os/pull/15012
     // If you cannot actually buy the board that this target is for, that would make it a candidate for removal.
-    // I have emailed multitech about it, we will see if they get back to me...
+    // I have emailed multitech about it, and they never responded.
     "MTS_DRAGONFLY_L496VG": {
         "inherits": [
             "MCU_STM32L496xG"
@@ -5044,7 +5008,7 @@
             "default-adc-vref": 3.3
         },
         "image_url": "https://www.st.com/bin/ecommerce/api/image.PF271812.en.feature-description-include-personalized-no-cpn-medium.jpg"
-    },        
+    },
 
     // STM32WB Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32WB": {
@@ -6420,7 +6384,7 @@
         "detect_code": [
             "3102"
         ],
-        "image_url": "https://www.devicemart.co.kr/data/collect_img/kind_0/goods/large/6500287.jpg"
+        "image_url": "https://os.mbed.com/media/cache/platforms/SDT32625B_size_ZxsNDPt.png.250x250_q85.png"
     },
     "MAX32625PICO": {
         "inherits": [
@@ -7565,7 +7529,7 @@
         "detect_code": [
             "1303"
         ],
-        "image_url": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.6.0/zephyr/_images/pfm_m487.jpg"
+        "image_url": "https://os.mbed.com/media/cache/platforms/Nu-mbed_M453_board_square.jpg.250x250_q85.jpg"
     },
     "NUMAKER_PFM_NANO130": {
         "core": "Cortex-M0",
@@ -9048,130 +9012,6 @@
         },
         "image_url": "https://manuals.plus/wp-content/uploads/2023/05/infineon-CYSBSYSKIT-DEV-01-Rapid-IoT-Connect-Developer-Kit-PRODUCT.png"
     },
-    "GD32_Target": {
-        "inherits": [
-            "Target"
-        ],
-        "public": false,
-        "extra_labels_add": [
-            "GigaDevice"
-        ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "device_has_add": [
-            "USTICKER",
-            "ANALOGIN",
-            "INTERRUPTIN",
-            "PORTIN",
-            "PORTINOUT",
-            "PORTOUT",
-            "PWMOUT",
-            "SERIAL"
-        ],
-        "supported_c_libs": {
-            "arm": [
-                "std",
-                "small"
-            ],
-            "gcc_arm": [
-                "std",
-                "small"
-            ]
-        },
-        "supported_application_profiles": [
-            "full", "bare-metal"
-        ]
-    },
-    "GD32_F307VG": {
-        "inherits": [
-            "GD32_Target"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "GD32F30X",
-            "GD32F307VG",
-            "GD_EMAC"
-        ],
-        "device_has_add": [
-            "RTC",
-            "I2C",
-            "CAN",
-            "I2CSLAVE",
-            "ANALOGOUT",
-            "SPI",
-            "SPISLAVE",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC",
-            "EMAC",
-            "FLASH",
-            "SLEEP",
-            "MPU"
-        ],
-        "detect_code": [
-            "1701"
-        ],
-        "macros_add": [
-            "GD32F30X_CL"
-        ],
-        "release_versions": [
-            "5"
-        ],
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
-    "GD32_F450ZI": {
-        "inherits": [
-            "GD32_Target"
-        ],
-        "supported_form_factors": [
-            "ARDUINO"
-        ],
-        "core": "Cortex-M4F",
-        "extra_labels_add": [
-            "GD32F4XX",
-            "GD32F450ZI",
-            "GD_EMAC",
-            "MBED_PSA_SRV"
-        ],
-        "features_add": [
-            "PSA"
-        ],
-        "device_has_add": [
-            "RTC",
-            "I2C",
-            "CAN",
-            "I2CSLAVE",
-            "ANALOGOUT",
-            "SPI",
-            "SPISLAVE",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC",
-            "EMAC",
-            "FLASH",
-            "SLEEP",
-            "MPU",
-            "TRNG"
-        ],
-        "device_name": "GD32F450ZI",
-        "detect_code": [
-            "1702"
-        ],
-        "macros_add": [
-            "GD32F450"
-        ],
-        "bootloader_supported": true,
-        "release_versions": [
-            "5"
-        ],
-        "overrides": {
-            "network-default-interface-type": "ETHERNET"
-        }
-    },
     "MCU_M261": {
         "core": "Cortex-M23",
         "default_toolchain": "ARMC6",
@@ -9303,7 +9143,8 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "is_mcu_family_target": true
     },
     "NUMAKER_IOT_M263A": {
         "inherits": [
@@ -9317,9 +9158,152 @@
             "usb-uart": "UART_0",
             "usb-uart-tx": "PB_13",
             "usb-uart-rx": "PB_12"
-        }
+        },
+        "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/3720/MFG_NuMaker-IoT-M263A_V2%28F%29.jpg"
     },
-    "S5JS100": {
+
+    // GigaDevices Targets ---------------------------------------------------------------------------------------------
+    "GD32_Target": {
+        "inherits": [
+            "Target"
+        ],
+        "public": false,
+        "extra_labels_add": [
+            "GigaDevice"
+        ],
+        "supported_toolchains": [
+            "GCC_ARM"
+        ],
+        "device_has_add": [
+            "USTICKER",
+            "ANALOGIN",
+            "INTERRUPTIN",
+            "PORTIN",
+            "PORTINOUT",
+            "PORTOUT",
+            "PWMOUT",
+            "SERIAL"
+        ],
+        "supported_c_libs": {
+            "arm": [
+                "std",
+                "small"
+            ],
+            "gcc_arm": [
+                "std",
+                "small"
+            ]
+        },
+        "supported_application_profiles": [
+            "full", "bare-metal"
+        ]
+    },
+
+    // As of Jun 2024, I cannot find the GD32 boards for sale anywhere.  Even people on the forums are wondering:
+    // https://os.mbed.com/questions/87215/GigaDevice-Board-GD32-F307VG-any-idea-wh/
+    // https://os.mbed.com/questions/86201/Purchase-this-board/
+    // But apparently it may still be available in Chinese language only shops.
+    "GD32_F307VG": {
+        "inherits": [
+            "GD32_Target"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "GD32F30X",
+            "GD32F307VG",
+            "GD_EMAC"
+        ],
+        "device_has_add": [
+            "RTC",
+            "I2C",
+            "CAN",
+            "I2CSLAVE",
+            "ANALOGOUT",
+            "SPI",
+            "SPISLAVE",
+            "SERIAL_ASYNCH",
+            "SERIAL_FC",
+            "EMAC",
+            "FLASH",
+            "SLEEP",
+            "MPU"
+        ],
+        "detect_code": [
+            "1701"
+        ],
+        "macros_add": [
+            "GD32F30X_CL"
+        ],
+        "release_versions": [
+            "5"
+        ],
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        },
+        "image_url": "https://os.mbed.com/media/uploads/Ray_Chen/307-1.png"
+    },
+    "GD32_F450ZI": {
+        "inherits": [
+            "GD32_Target"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "core": "Cortex-M4F",
+        "extra_labels_add": [
+            "GD32F4XX",
+            "GD32F450ZI",
+            "GD_EMAC",
+            "MBED_PSA_SRV"
+        ],
+        "features_add": [
+            "PSA"
+        ],
+        "device_has_add": [
+            "RTC",
+            "I2C",
+            "CAN",
+            "I2CSLAVE",
+            "ANALOGOUT",
+            "SPI",
+            "SPISLAVE",
+            "SERIAL_ASYNCH",
+            "SERIAL_FC",
+            "EMAC",
+            "FLASH",
+            "SLEEP",
+            "MPU",
+            "TRNG"
+        ],
+        "device_name": "GD32F450ZI",
+        "detect_code": [
+            "1702"
+        ],
+        "macros_add": [
+            "GD32F450"
+        ],
+        "bootloader_supported": true,
+        "release_versions": [
+            "5"
+        ],
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/2-1_W6zHQ3F.jpg.250x250_q85.jpg"
+    },
+
+    // Samsung Targets -------------------------------------------------------------------------------------------------
+
+    // As of June 2024, I cannot find evidence of this board being sold anywhere.
+    // It isn't documented on Samsung's site either.  However, the datasheet
+    // and other information does seem to be available here:
+    // https://github.com/ARMmbed/Samsung_CMSIS_Pack/blob/master/Samsung.S5JS100.pdsc
+    // But the datasheet in there is encrypted and cannot be opened!!
+    // So, back to square 1.  I'd say that this makes this board a candidate for removal.
+    "S5JS100": { // AKA S5JS100_SIDK
         "inherits": [
             "Target"
         ],
@@ -9352,7 +9336,7 @@
             "3701"
         ]
     },
-    "S1SBP6A": {
+    "S1SBP6A": { // AKA Samsung Bio-Processor S1SBP6A
         "inherits": ["Target"],
         "core": "Cortex-M4F",
         "supported_toolchains": [
@@ -9389,8 +9373,12 @@
         },
         "supported_application_profiles": [
             "full", "bare-metal"
-        ]
+        ],
+        "device_name": "S1SBP6A",
+        "image_url": "https://os.mbed.com/media/uploads/heuisam/pinout2.jpg"
     },
+
+    // Ambiq Micro Targets ---------------------------------------------------------------------------------------------
     "FAMILY_Apollo3": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
@@ -9441,33 +9429,41 @@
         "device_name": "AMA3B1KK-KBR",
         "is_mcu_family_target": true
     },
-    "SFE_ARTEMIS": {
-        "inherits": ["AMA3B1KK"]
+    "SFE_ARTEMIS": { // AKA SparkFun RedBoard Artemis
+        "inherits": ["AMA3B1KK"],
+        "image_url": "https://cdn.sparkfun.com/r/455-455/assets/parts/1/4/0/1/9/15444-SparkFun_RedBoard_Artemis-01.jpg"
     },
-    "SFE_ARTEMIS_ATP": {
-        "inherits": ["AMA3B1KK"]
+    "SFE_ARTEMIS_ATP": { // AKA SparkFun RedBoard Artemis ATP
+        "inherits": ["AMA3B1KK"],
+        "image_url": "https://cdn.sparkfun.com/r/455-455/assets/parts/1/4/0/1/7/15442-SparkFun_RedBoard_Artemis_ATP-05.jpg"
     },
-    "SFE_ARTEMIS_DK": {
+    "SFE_ARTEMIS_DK": { // AKA SparkFun Artemis Development Kit
         "inherits": ["AMA3B1KK"],
         "components_add": ["lis2dh12", "hm01b0"],
         "image_url": "https://cdn.sparkfun.com/assets/parts/1/5/7/4/6/16828-SparkFun_Artemis_Development_Kit-01.jpg"
     },
     "SFE_ARTEMIS_MODULE": {
+        "inherits": ["AMA3B1KK"],
+        "image_url": "https://cdn.sparkfun.com/r/455-455/assets/parts/1/4/0/7/4/15484-SparkFun_Artemis_Module_-_Low_Power_Machine_Learning_BLE_Cortex-M4F-01b.jpg"
+    },
+    "SFE_ARTEMIS_NANO": { // AKA SparkFun RedBoard Artemis Nano
+        "inherits": ["AMA3B1KK"],
+        "image_url": "https://cdn.sparkfun.com/r/455-455/assets/parts/1/4/0/1/8/15443-SparkFun_RedBoard_Artemis_Nano-05.jpg"
+    },
+    "SFE_ARTEMIS_THING_PLUS": { // AKA SparkFun Thing Plus - Artemis
         "inherits": ["AMA3B1KK"]
     },
-    "SFE_ARTEMIS_NANO": {
-        "inherits": ["AMA3B1KK"]
-    },
-    "SFE_ARTEMIS_THING_PLUS": {
-        "inherits": ["AMA3B1KK"]
-    },
+    // This target has been retired by the manufacturer (as far as I can tell), making it a candidate for removal
     "SFE_EDGE": {
         "inherits": ["AMA3B1KK"],
         "components_add": ["lis2dh12", "hm01b0"]
     },
-    "SFE_EDGE2": {
+
+    // This target has been retired by the manufacturer, making it a candidate for removal
+    "SFE_EDGE2": { // AKE SparkFun Edge 2 Development Board - Artemis
         "inherits": ["AMA3B1KK"],
-        "components_add": ["lis2dh12", "hm01b0"]
+        "components_add": ["lis2dh12", "hm01b0"],
+        "image_url": "https://cdn.sparkfun.com/r/455-455/assets/parts/1/3/9/7/5/15420-SparkFun_Edge_2_Development_Board_-_Artemis-01.jpg"
     },
     // Toshiba Targets -------------------------------------------------------------------------------------------------
     "TMPM46B": { // AKA AdBun-M46B
@@ -9528,7 +9524,7 @@
         },
         "image_url": "https://www.chip1stop.com/img/product/SSST/0109140533_5a544d9d16351.JPG"
     },
-    "TMPM4G9": {
+    "TMPM4G9": { // AKA AdBun-M4G9
         "inherits": [
             "Target"
         ],
@@ -9584,9 +9580,17 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/AdBun-TMPM4G9_Wm9FG1c.png.250x250_q85.jpg"
     },
-    "TMPM4KN": {
+    // As of Jun 2024, this board can still apparently be purchased by sending an email (!!)
+    // to these guys: https://www.esp.jp/tose/sub1.html
+    // Manual (Japanese): https://www.esp.jp/tose/SBK-M4KN-KIT.pdf
+    // I managed to find the schematics for this one on the Japanese version of the
+    // manufacturer's site:
+    // https://www.esp.jp/tos/sch/SBK-M4KN.pdf
+    // https://www.esp.jp/tos/sch/KES-P2.pdf
+    "TMPM4KN": { // AKA TMPM-M4KN-SBK from ESP Co.
         "inherits": ["Target"],
         "core": "Cortex-M4F",
         "is_disk_virtual": true,
@@ -9594,23 +9598,23 @@
         "macros": ["__TMPM4KN__"],
         "supported_toolchains": ["GCC_ARM"],
         "device_has": [
-        "ANALOGIN",
-        "INTERRUPTIN",
-        "CRC",
-        "I2C",
-        "I2CSLAVE",
-        "PORTIN",
-        "PORTINOUT",
-        "PORTOUT",
-        "PWMOUT",
-        "RESET_REASON",
-        "SERIAL",
-        "SLEEP",
-        "SPI",
-        "SPISLAVE",
-        "USTICKER",
-        "MPU",
-        "FLASH"
+            "ANALOGIN",
+            "INTERRUPTIN",
+            "CRC",
+            "I2C",
+            "I2CSLAVE",
+            "PORTIN",
+            "PORTINOUT",
+            "PORTOUT",
+            "PWMOUT",
+            "RESET_REASON",
+            "SERIAL",
+            "SLEEP",
+            "SPI",
+            "SPISLAVE",
+            "USTICKER",
+            "MPU",
+            "FLASH"
         ],
         "device_name": "TMPM4KNFYAFG",
         "detect_code": ["7020"],
@@ -9624,9 +9628,10 @@
             "gcc_arm": [
                 "std"
             ]
-        }
+        },
+        "image_url": "https://os.mbed.com/media/cache/platforms/M4KN_mbed_tw2kBoh.png.250x250_q85.png"
     },
-    "TMPM4NR": {
+    "TMPM4NR": { // AKA AdBun-M4NR
         "inherits": [
             "Target"
         ],
@@ -9640,7 +9645,7 @@
         ],
         "supported_toolchains": [
             "GCC_ARM"
-    ],
+        ],
         "device_has": [
             "ANALOGIN",
             "ANALOGOUT",
@@ -9681,10 +9686,10 @@
                 "std",
                 "small"
             ]
-        }
-
+        },
+        "image_url": "https://wiki.segger.com/images/thumb/8/8a/tmpm4nr.jpg/300px-tmpm4nr.jpg"
     },
-    "TMPM4GR": {
+    "TMPM4GR": { // AKA AdBun-M4GR
         "inherits": [
             "Target"
         ],
@@ -9698,7 +9703,7 @@
         ],
         "supported_toolchains": [
             "GCC_ARM"
-    ],
+        ],
         "device_has": [
             "ANALOGIN",
             "ANALOGOUT",
@@ -9739,7 +9744,8 @@
                 "std",
                 "small"
             ]
-        }
+        },
+        "image_url": "https://wiki.segger.com/images/thumb/6/68/tmpm4gr.jpg/402px-tmpm4gr.jpg"
     },
     "RP2040": {
         "public": false,
@@ -9772,7 +9778,8 @@
             "RESET_REASON",
             "RTC"
         ],
-        "is_mcu_family_target": true,
+        "device_name": "RP2040",
+        "is_mcu_family_target": true
     },
     "RASPBERRY_PI_PICO": {
         "inherits": ["RP2040"],
@@ -9793,7 +9800,8 @@
             // voltages higher than the I/O voltage are illegal for the analog pins
             // (so the ADC can never read 100%).
             "default-adc-vref": 3.3
-        }
+        },
+        "image_url": "https://cdn11.bigcommerce.com/s-2fbyfnm8ev/images/stencil/1280x1280/products/1212/4275/Pico3__75642.1611086462.jpg?c=2"
     },
     "RASPBERRY_PI_PICO_SWD": {
         "inherits": ["RASPBERRY_PI_PICO"],


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I have been working on this PR off and on for the past month plus.  I started this project with the primary goal of finding an image for each target to display in the [target list website](https://mbed-ce.github.io/mbed-ce-test-tools/targets/), and the secondary goal of understanding each target that Mbed currently supports, who makes it, and whether it's still in production (time is ticking by, after all, and some vendors are beginning to abandon some of their Mbed-targeted boards!)

As I worked on it, I also adopted a few other goals:
- Reorganize some targets into families better so that they show on the website more cleanly.
  - examples: LPC1768 and ARCH_PRO are now combined under MCU_LPC1768, K64F and SDT64B are now combined under MCU_K64F, etc
- Identify targets which are able to be removed in future MRs
- Organize targets.json5 into sections based on the MCU vendors.  Now, every MCU from each company is together in the file.
- Add some additional CMSIS MCU descriptions for targets missing them, so that RAM and flash amounts show up in the website

#### Impact of changes <!-- Optional -->
- Some MCUs have been moved in the hierarchy, e.g. additional parent targets have been added.  Should be no impact to those developing with Mbed CE, except that some additional defines will be defined (e.g. TARGET_MCU_LPC1768 will now be defined for LPC1768)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
(this is a primarily documentation based MR)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Unfortunately, we have no way to test some of these changes right now as I don't have access to some of the targets being restructured (e.g. K64F).  I tried my absolute best to double check every change I made to the JSON file for correctness, and I did verify that the website processor is able to read the targets.json5 file.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
