### PR TITLE
fix ambiguous global enum definition for SPI in OSPIFBlockDevice driver

### DIFF
--- a/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
@@ -85,10 +85,14 @@ enum ospif_bd_error {
     OSPIF_BD_ERROR_DEVICE_MAX_EXCEED     = -4007  /* Max active OSPIF devices exceeded */
 };
 
-enum _mode {
-    SPI,
-    SOPI,
-    DOPI
+/** Enum ospif opi modes
+ * 
+ *  @enum ospif_opi_mode
+ */
+enum ospif_opi_mode {
+    OSPIF_OPI_MODE_SPI = 0, /* SPI mode (OPI modes disabled)*/
+    OSPIF_OPI_MODE_SOPI,    /* STR-OPI mode */
+    OSPIF_OPI_MODE_DOPI     /* DTR-OPI mode */
 };
 
 /** Enum ospif polarity mode

--- a/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_OSPIF/include/OSPIF/OSPIFBlockDevice.h
@@ -86,7 +86,7 @@ enum ospif_bd_error {
 };
 
 /** Enum ospif opi modes
- * 
+ *
  *  @enum ospif_opi_mode
  */
 enum ospif_opi_mode {

--- a/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_OSPIF/source/OSPIFBlockDevice.cpp
@@ -389,7 +389,7 @@ int OSPIFBlockDevice::deinit()
     _wait_flag = NOT_STARTED;
 #endif
 
-    change_mode(SPI);
+    change_mode(OSPIF_OPI_MODE_SPI);
 
     // Disable Device for Writing
     ospi_status_t status = _ospi_send_general_command(OSPIF_INST_WRDI, OSPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
@@ -723,13 +723,13 @@ int OSPIFBlockDevice::change_mode(int mode)
     int status = OSPIF_BD_ERROR_OK;
     char config_reg2 = 0;
 
-    if (((mode == SPI) && (_read_instruction == OSPIF_INST_READ_4B)) ||
-            ((mode == SOPI) && (_read_instruction == DTROSPIF_INST_READ_OCTA_STR)) ||
-            ((mode == DOPI) && (_read_instruction == DTROSPIF_INST_READ_OCTA_DTR))) {
+    if (((mode == OSPIF_OPI_MODE_SPI) && (_read_instruction == OSPIF_INST_READ_4B)) ||
+            ((mode == OSPIF_OPI_MODE_SOPI) && (_read_instruction == DTROSPIF_INST_READ_OCTA_STR)) ||
+            ((mode == OSPIF_OPI_MODE_DOPI) && (_read_instruction == DTROSPIF_INST_READ_OCTA_DTR))) {
         tr_debug("Flash does not need change mode");
     }
 
-    if (mode == SOPI) {
+    if (mode == OSPIF_OPI_MODE_SOPI) {
         if ((_read_instruction != OSPIF_INST_READ_4B) && (_read_instruction != OSPIF_INST_READ_DEFAULT)) { //change mode from DOPI to SPI
             // Write new Status Register Setup
             if (_set_write_enable() != 0) {
@@ -781,7 +781,7 @@ int OSPIFBlockDevice::change_mode(int mode)
 
         _ospi.configure_format(_inst_width, _inst_size, _address_width, _address_size, OSPI_CFG_BUS_SINGLE,
                                0, _data_width, 0);
-    } else if (mode == DOPI) {
+    } else if (mode == OSPIF_OPI_MODE_DOPI) {
         if ((_read_instruction != OSPIF_INST_READ_4B) && (_read_instruction != OSPIF_INST_READ_DEFAULT)) {//chang mode from SOPI to SPI
             // Write new Status Register Setup
             if (_set_write_enable() != 0) {
@@ -833,7 +833,7 @@ int OSPIFBlockDevice::change_mode(int mode)
 
         _ospi.configure_format(_inst_width, _inst_size, _address_width, _address_size, OSPI_CFG_BUS_SINGLE,
                                0, _data_width, 0);
-    } else if (mode == SPI) {
+    } else if (mode == OSPIF_OPI_MODE_SPI) {
         // Write new Status Register Setup
         if (_set_write_enable() != 0) {
             tr_error("Write Enabe failed");
@@ -996,7 +996,7 @@ int OSPIFBlockDevice::_sfdp_parse_basic_param_table(Callback<int(bd_addr_t, mbed
     // Detect and Set fastest Bus mode (default 1-1-1)
     _sfdp_detect_best_bus_read_mode(param_table, sfdp_info.bptbl.size, shouldSetQuadEnable, is_qpi_mode, is_opi_mode);
     if (true == is_opi_mode) {
-        change_mode(DOPI);
+        change_mode(OSPIF_OPI_MODE_DOPI);
         tr_debug("Init - Setting DOPI mode");
     }
     if (true == shouldSetQuadEnable) {

--- a/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
@@ -112,7 +112,7 @@ public:
      * in the background while data is going to and from the card.
      *
      * @param enabled Whether usage of async %SPI is enabled.
-     * @param dma_usage_hint DMA usage hint to pass to the underlying %SPI instance.
+     * @param dma_usage_hint DMA usage hint to pass to the underlying #mbed::SPI instance.
      */
     void set_async_spi_mode(bool enabled, DMAUsage dma_usage_hint = DMAUsage::DMA_USAGE_NEVER);
 #endif

--- a/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
+++ b/storage/blockdevice/COMPONENT_SD/include/SD/SDBlockDevice.h
@@ -112,7 +112,7 @@ public:
      * in the background while data is going to and from the card.
      *
      * @param enabled Whether usage of async %SPI is enabled.
-     * @param dma_usage_hint DMA usage hint to pass to the underlying #SPI instance.
+     * @param dma_usage_hint DMA usage hint to pass to the underlying %SPI instance.
      */
     void set_async_spi_mode(bool enabled, DMAUsage dma_usage_hint = DMAUsage::DMA_USAGE_NEVER);
 #endif


### PR DESCRIPTION
### Summary of changes <!-- Required -->

OSPIFBlockDevice.h defined "SPI" as a global enum under the name _mode. 

Both are collision/ambiguity hazards so, using the global enum convention of the existing driver code
```
enum _mode {
    SPI,
    SOPI,
    DOPI
};

```
has been changed to:
```
enum ospif_opi_mode {
    OSPIF_OPI_MODE_SPI = 0, /* SPI mode (OPI modes disabled)*/
    OSPIF_OPI_MODE_SOPI,    /* STR-OPI mode */
    OSPIF_OPI_MODE_DOPI     /* DTR-OPI mode */
};

```
as well as any references in OSPIFBlockDevice.cpp

#### Impact of changes <!-- Optional -->

Any reference to the previous enum's in user code will result in preprocessor not defined errors.

#### Migration actions required <!-- Optional -->

All references to the previous enum's in user code will have to be updated with the new prefix OSPIF_OPI_MODE_

### Documentation <!-- Required -->

Update references in change_mode() references in https://mbed-ce.github.io/mbed-os/class_o_s_p_i_f_block_device.html)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
