### PR TITLE
Fix CellularInterface functions never being defined

### DIFF
--- a/connectivity/cellular/source/framework/device/CellularContext.cpp
+++ b/connectivity/cellular/source/framework/device/CellularContext.cpp
@@ -25,6 +25,28 @@ MBED_WEAK CellularInterface *CellularInterface::get_target_default_instance()
     return mbed::CellularContext::get_default_instance();
 }
 
+void CellularInterface::set_default_parameters()
+{
+    /* CellularInterface is expected to attempt to work without any parameters - we
+     * will try, at least.
+     */
+#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN
+#ifndef MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME
+#define MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME NULL
+#endif
+#ifndef MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD
+#define MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD NULL
+#endif
+    set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+#endif
+#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN
+    set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+#endif
+#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_PLMN
+    set_plmn(MBED_CONF_NSAPI_DEFAULT_CELLULAR_PLMN);
+#endif
+}
+
 namespace mbed {
 
 MBED_WEAK CellularContext *CellularContext::get_default_instance()

--- a/connectivity/cellular/tests/UNITTESTS/doubles/CellularContext_stub.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/doubles/CellularContext_stub.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "CellularContext.h"
-#include "CellularInterface.h"
+#include "netsocket/CellularInterface.h"
 
 void CellularInterface::set_default_parameters()
 {

--- a/connectivity/cellular/tests/UNITTESTS/doubles/CellularContext_stub.cpp
+++ b/connectivity/cellular/tests/UNITTESTS/doubles/CellularContext_stub.cpp
@@ -16,6 +16,11 @@
  */
 
 #include "CellularContext.h"
+#include "CellularInterface.h"
+
+void CellularInterface::set_default_parameters()
+{
+}
 
 namespace mbed {
 

--- a/connectivity/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/connectivity/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -407,7 +407,7 @@ void mbedtls_ssl_conf_dtls_cookies(mbedtls_ssl_config *conf,
     }
     if (mbedtls_stub.cookie_obj && f_cookie_write && mbedtls_stub.cookie_len > 0) {
         unsigned char out[16];
-        unsigned char * ptr = out;
+        unsigned char *ptr = out;
         f_cookie_write(mbedtls_stub.cookie_obj, &ptr, out + mbedtls_stub.cookie_len, NULL, 0);
     }
 }

--- a/connectivity/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/connectivity/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -403,12 +403,12 @@ void mbedtls_ssl_conf_dtls_cookies(mbedtls_ssl_config *conf,
                                    void *p_cookie)
 {
     if (mbedtls_stub.cookie_obj && f_cookie_check && mbedtls_stub.cookie_len > 0) {
-        f_cookie_check(mbedtls_stub.cookie_obj, &mbedtls_stub.cookie_value, mbedtls_stub.cookie_len, NULL, 0);
+        f_cookie_check(mbedtls_stub.cookie_obj, mbedtls_stub.cookie_value, mbedtls_stub.cookie_len, NULL, 0);
     }
     if (mbedtls_stub.cookie_obj && f_cookie_write && mbedtls_stub.cookie_len > 0) {
         unsigned char out[16];
-        unsigned char *ptr = &out;
-        f_cookie_write(mbedtls_stub.cookie_obj, &ptr, ptr + mbedtls_stub.cookie_len, NULL, 0);
+        unsigned char * ptr = out;
+        f_cookie_write(mbedtls_stub.cookie_obj, &ptr, out + mbedtls_stub.cookie_len, NULL, 0);
     }
 }
 
@@ -420,9 +420,9 @@ void mbedtls_ssl_conf_export_keys_cb(mbedtls_ssl_config *conf,
     if (f_export_keys && p_export_keys) {
         unsigned char value[40];
         memset(&value, 1, 40);
-        f_export_keys(p_export_keys, &value, "", 0, 0, 0); //failure case
+        f_export_keys(p_export_keys, value, "", 0, 0, 0); //failure case
 
-        f_export_keys(p_export_keys, &value, "", 0, 20, 0); //success case
+        f_export_keys(p_export_keys, value, "", 0, 20, 0); //success case
     }
 }
 #endif

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -64,6 +64,11 @@ elseif("MBED_CONF_NSAPI_DEFAULT_STACK=NANOSTACK" IN_LIST MBED_CONFIG_DEFINITIONS
     target_link_libraries(mbed-netsocket-api PUBLIC mbed-nanostack)
 endif()
 
+# Pull in cellular if cellular is the default network interface (used by NetworkInterfaceDefaults.cpp)
+if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=CELLULAR" IN_LIST MBED_CONFIG_DEFINITIONS)
+    target_link_libraries(mbed-netsocket-api PUBLIC mbed-cellular)
+endif()
+
 if("DEVICE_EMAC=1" IN_LIST MBED_TARGET_DEFINITIONS)
     target_link_libraries(mbed-netsocket-api
         INTERFACE

--- a/connectivity/netsocket/source/NetworkInterfaceDefaults.cpp
+++ b/connectivity/netsocket/source/NetworkInterfaceDefaults.cpp
@@ -43,13 +43,6 @@ MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
     return get_target_default_instance();
 }
 
-#if MBED_CONF_CELLULAR_PRESENT
-MBED_WEAK CellularInterface *CellularInterface::get_default_instance()
-{
-    return get_target_default_instance();
-}
-#endif // MBED_CONF_CELLULAR_PRESENT
-
 /* For other types, we can provide a reasonable get_target_default_instance
  * in some cases. This is done in EthernetInterface.cpp, mbed-mesh-api and
  * OnboardCellularInterface.cpp. We have no implementation for WiFi, so a
@@ -91,30 +84,6 @@ void WiFiInterface::set_default_parameters()
     set_credentials(MBED_CONF_NSAPI_DEFAULT_WIFI_SSID, MBED_CONF_NSAPI_DEFAULT_WIFI_PASSWORD, SECURITY);
 #endif
 }
-
-#if MBED_CONF_CELLULAR_PRESENT
-void CellularInterface::set_default_parameters()
-{
-    /* CellularInterface is expected to attempt to work without any parameters - we
-     * will try, at least.
-     */
-#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN
-#ifndef MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME
-#define MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME NULL
-#endif
-#ifndef MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD
-#define MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD NULL
-#endif
-    set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
-#endif
-#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN
-    set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
-#endif
-#ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_PLMN
-    set_plmn(MBED_CONF_NSAPI_DEFAULT_CELLULAR_PLMN);
-#endif
-}
-#endif // MBED_CONF_CELLULAR_PRESENT
 
 /* Finally the dispatch from the JSON default interface type to the specific
  * subclasses. It's our job to configure - the default NetworkInterface is

--- a/connectivity/netsocket/tests/UNITTESTS/doubles/NetworkInterfaceDefaults_stub.cpp
+++ b/connectivity/netsocket/tests/UNITTESTS/doubles/NetworkInterfaceDefaults_stub.cpp
@@ -52,10 +52,6 @@ void WiFiInterface::set_default_parameters()
 {
 }
 
-void CellularInterface::set_default_parameters()
-{
-}
-
 MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
 {
     return NULL;

--- a/tools/python/mbed_tools/build/_internal/config/config.py
+++ b/tools/python/mbed_tools/build/_internal/config/config.py
@@ -56,6 +56,16 @@ class Config(UserDict):
                     "Please check your target_overrides are correct.\n"
                     f"The parameter `{override.namespace}.{override.name}` will not be added to the configuration."
                 )
+
+                valid_params_in_namespace = list(filter(
+                    lambda x: x.namespace == override.namespace,
+                    self.data.get(CONFIG_SECTION, []),
+                ))
+                valid_param_names = [f'"{param.namespace}.{param.name}"' for param in valid_params_in_namespace]
+
+                if len(valid_param_names) > 0:
+                    logger.warning(f'Valid config parameters in this namespace are: {", ".join(valid_param_names)}. '
+                                   f'Maybe you meant one of those?')
             else:
                 setting.value = override.value
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

In Mbed CE, the `MBED_CONF_CELLULAR_PRESENT` define is defined only by linking to the `mbed-cellular` library (compared to old Mbed OS, where it was defined globally for the entire OS, which was... not good).  NetworkInterfaceDefaults.cpp tried to use this define, but it's likely to be undefined there, since mbed-cellular is not guaranteed to be linked to this library.

This PR moves this function to `mbed-cellular`, where MBED_CONF_CELLULAR_PRESENT is guaranteed to be defined.  This fixes the "Undefined reference to vtable for CellularInterface" link error that it was possible to get.

NOTE: Even after this PR, `mbed-cellular` may still fail to link with an undefined reference due to #304.  That issue has its own workaround, check there for details.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

With the workaround for #304 plus this patch, I can now successfully link a program that uses mbed-cellular!    
    
----------------------------------------------------------------------------------------------------------------
