### PR TITLE
M2354: Fix compile error with TF-M integration

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/CMakeLists.txt
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/CMakeLists.txt
@@ -18,3 +18,8 @@ target_sources(mbed-m2354-tfm
         platform_extra_secure_compat.c
         tfm_ns_interface.c
 )
+
+target_link_libraries(mbed-m2354-tfm
+    INTERFACE
+        mbed-psa
+)

--- a/targets/TARGET_NUVOTON/scripts/NUVOTON.py
+++ b/targets/TARGET_NUVOTON/scripts/NUVOTON.py
@@ -28,16 +28,16 @@ from datetime import datetime
 SCRIPT_DIR = dirname(abspath(__file__))
 MBED_OS_ROOT = abspath(path_join(SCRIPT_DIR, os.pardir, os.pardir, os.pardir))
 
-def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_bin):
+def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_binhex):
     SECURE_ROOT = abspath(tfm_import_path)
 
     secure_bin = path_join(SECURE_ROOT, 'tfm_s.bin') 
     assert os.path.isfile(secure_bin)
 
-    non_secure_bin = abspath(non_secure_bin)
-    assert os.path.isfile(non_secure_bin)
+    non_secure_binhex = abspath(non_secure_binhex)
+    assert os.path.isfile(non_secure_binhex)
 
-    build_dir = dirname(non_secure_bin)
+    build_dir = dirname(non_secure_binhex)
     tempdir = path_join(build_dir, 'temp')
     if not isdir(tempdir):
         os.makedirs(tempdir)
@@ -46,10 +46,17 @@ def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_bin):
 
     bl2_bin = path_join(SECURE_ROOT, 'bl2.bin')
     s_bin_basename = splitext(basename(secure_bin))[0]
-    ns_bin_basename = splitext(basename(non_secure_bin))[0]
+    ns_bin_basename = splitext(basename(non_secure_binhex))[0]
 
     signing_key = path_join(SECURE_ROOT, 'signing_key', signing_key)
     assert os.path.isfile(signing_key)
+
+    # Create non_secure_bin for signing if non_secure_binhex is hex
+    non_secure_bin = splitext(non_secure_binhex)[0] + ".bin"
+    if os.path.splitext(non_secure_binhex)[1].lower() == ".hex":
+        non_secure_ih = IntelHex()
+        non_secure_ih.loadhex(non_secure_binhex)
+        non_secure_ih.tobinfile(non_secure_bin)
 
     # Find Python 3 command name across platforms
     python3_cmd = "python3" if shutil.which("python3") is not None else "python"
@@ -162,7 +169,7 @@ def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_bin):
         signed_concat_bin = abspath(path_join(tempdir, 'tfm_s_signed_' + ns_bin_basename + '_signed_concat' + '.bin'))
         s_update_bin = abspath(path_join(build_dir, s_bin_basename + '_update' + '.bin'))
         ns_update_bin = abspath(path_join(build_dir, ns_bin_basename + '_update' + '.bin'))
-        
+
         #1. Run wrapper to sign the secure TF-M binary
         cmd_wrapper[pos_wrapper_signing_key] = signing_key
         cmd_wrapper[pos_wrapper_layout] = image_macros_s
@@ -206,8 +213,8 @@ def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_bin):
         out_ih = IntelHex()
         out_ih.loadbin(bl2_bin)
         out_ih.loadbin(signed_concat_bin, flash_area_0_offset)
-        out_ih.tofile(splitext(non_secure_bin)[0] + ".hex", 'hex')
-        out_ih.tobinfile(non_secure_bin)
+        out_ih.tofile(splitext(non_secure_binhex)[0] + ".bin", 'bin')
+        out_ih.tofile(splitext(non_secure_binhex)[0] + ".hex", 'hex')
 
         # Generate firmware update file for PSA Firmware Update
         shutil.copy(s_signed_bin, s_update_bin)
@@ -250,8 +257,8 @@ def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_bin):
         out_ih = IntelHex()
         out_ih.loadbin(bl2_bin)
         out_ih.loadbin(concat_signed_bin, flash_area_0_offset)
-        out_ih.tofile(splitext(non_secure_bin)[0] + ".hex", 'hex')
-        out_ih.tobinfile(non_secure_bin)
+        out_ih.tofile(splitext(non_secure_binhex)[0] + ".bin", 'bin')
+        out_ih.tofile(splitext(non_secure_binhex)[0] + ".hex", 'hex')
 
         # Generate firmware update file for PSA Firmware Update
         shutil.copy(concat_signed_bin, update_bin)
@@ -357,7 +364,7 @@ def parse_args():
     )
 
     parser_tfm_sign_image.add_argument(
-        "--non-secure-bin",
+        "--non-secure-binhex",
         help="Path to the non-secure binary",
         required=True
     )
@@ -368,4 +375,4 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    args.func(args.tfm_import_path, args.signing_key, args.signing_key_1, args.non_secure_bin)
+    args.func(args.tfm_import_path, args.signing_key, args.signing_key_1, args.non_secure_binhex)

--- a/targets/TARGET_NUVOTON/scripts/NUVOTON.py
+++ b/targets/TARGET_NUVOTON/scripts/NUVOTON.py
@@ -24,6 +24,7 @@ import shutil
 import argparse
 from intelhex import IntelHex
 from datetime import datetime
+import sys
 
 SCRIPT_DIR = dirname(abspath(__file__))
 MBED_OS_ROOT = abspath(path_join(SCRIPT_DIR, os.pardir, os.pardir, os.pardir))
@@ -59,7 +60,7 @@ def tfm_sign_image(tfm_import_path, signing_key, signing_key_1, non_secure_binhe
         non_secure_ih.tobinfile(non_secure_bin)
 
     # Find Python 3 command name across platforms
-    python3_cmd = "python3" if shutil.which("python3") is not None else "python"
+    python3_cmd = sys.executable
 
     # Specify image version
     #

--- a/targets/TARGET_NUVOTON/scripts/mbed_set_post_build_nuvoton.cmake
+++ b/targets/TARGET_NUVOTON/scripts/mbed_set_post_build_nuvoton.cmake
@@ -30,7 +30,7 @@ macro(mbed_post_build_nuvoton_tfm_sign_image
                         --tfm-import-path ${tfm_import_path}
                         --signing_key ${signing_key}
                         --signing_key_1 ${signing_key_1}
-                        --non-secure-bin $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.bin
+                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${MBED_OUTPUT_EXT}
                 )
             else()
                 add_custom_command(
@@ -43,7 +43,7 @@ macro(mbed_post_build_nuvoton_tfm_sign_image
                         tfm_sign_image
                         --tfm-import-path ${tfm_import_path}
                         --signing_key ${signing_key}
-                        --non-secure-bin $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.bin
+                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${MBED_OUTPUT_EXT}
                 )
             endif()
         endfunction()


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes compile errors with TF-M integration on `NU_M2354` target, including:
1. In CMake, `mbed-psa` moves out of `mbed-core`, its library type changeng to **STATIC** from **INTERFACE**. Following this modification, the platform TF-M code relying on `mbed-psa` needs to explicitly specify the dependency through `target_link_libraries()`.
2. Update post-build script to enable `OUTPUT_EXT` can be set to "bin" or "hex" in targets.json5.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
