### PR TITLE
Upload: Mbed: Honor OUTPUT_EXT

### DIFF
--- a/tools/cmake/upload_methods/UploadMethodMBED.cmake
+++ b/tools/cmake/upload_methods/UploadMethodMBED.cmake
@@ -20,7 +20,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMAND ${Python3_EXECUTABLE} -m install_bin_file
-			${BIN_FILE}
+			$<IF:$<BOOL:${MBED_OUTPUT_EXT}>,${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.${MBED_OUTPUT_EXT},BIN_FILE>
 			${MBED_TARGET}
 			${MBED_RESET_BAUDRATE}
 			${MBED_TARGET_UID}


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to honor `OUTPUT_EXT` defined in `targets.json5` for **MBED** upload method flash. If it is defined, use image file with the specified extension `.<OUTPUT_EXT>` for flash, or default to `.bin`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
