### PR TITLE
Upload: PyOCD: Honor OUTPUT_EXT

### DIFF
--- a/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
@@ -36,7 +36,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		-f ${PYOCD_CLOCK_SPEED}
 		-t ${PYOCD_TARGET_NAME}
 		${PYOCD_PROBE_ARGS}
-		${BIN_FILE})
+		$<IF:$<BOOL:${MBED_OUTPUT_EXT}>,${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.${MBED_OUTPUT_EXT},${BIN_FILE}>)
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR tries to honor `OUTPUT_EXT` defined in `targets.json5` for **PYOCD** upload method flash. If it is defined, use image file with the specified extension `.<OUTPUT_EXT>` for flash, or default to `.bin`.

### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
