### PR TITLE
Upload: OpenOCD: Honor OUTPUT_EXT

### DIFF
--- a/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
@@ -48,7 +48,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		${OPENOCD_CHIP_CONFIG_COMMANDS}
 		${OPENOCD_ADAPTER_SERIAL_COMMAND}
 		-c "gdb_port disabled" # Don't start a GDB server when just programming
-		-c "program $<TARGET_FILE:${TARGET_NAME}> reset exit"
+		-c "program $<IF:$<BOOL:${MBED_OUTPUT_EXT}>,${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.${MBED_OUTPUT_EXT},$<TARGET_FILE:${TARGET_NAME}>> reset exit"
 		VERBATIM)
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to honor `OUTPUT_EXT` defined in `targets.json5` for **OPENOCD** upload method flash. If it is defined, use image file with the specified extension `.<OUTPUT_EXT>` for flash, or default to `.elf`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
