### PR TITLE
Upload:: Honor OUTPUT_EXT

### DIFF
--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -59,8 +59,9 @@ set(MBED_UPLOAD_RESTART_COMMANDS ${UPLOAD_RESTART_COMMANDS} CACHE INTERNAL "" FO
 
 function(mbed_generate_upload_target target)
 	# add upload target
-	gen_upload_target(${target}
-		${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${target}>.bin
-		${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${target}>.hex
-	)
+	if ("${MBED_OUTPUT_EXT}" STREQUAL "" OR MBED_OUTPUT_EXT STREQUAL "bin")
+		gen_upload_target(${target} ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${target}>.bin)
+	else()
+		gen_upload_target(${target} ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${target}>.hex)
+	endif()
 endfunction()

--- a/tools/cmake/upload_methods/UploadMethodARDUINO_BOSSAC.cmake
+++ b/tools/cmake/upload_methods/UploadMethodARDUINO_BOSSAC.cmake
@@ -16,7 +16,7 @@ if("${ARDUINO_BOSSAC_SERIAL_PORT}" STREQUAL "")
 endif()
 
 ### Function to generate upload target
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMAND ${ArduinoBossac}
@@ -25,7 +25,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		--usb-port=1
 		--info
 		--erase
-		--write ${BIN_FILE}
+		--write ${BINARY_FILE}
 		--reset)
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})

--- a/tools/cmake/upload_methods/UploadMethodJLINK.cmake
+++ b/tools/cmake/upload_methods/UploadMethodJLINK.cmake
@@ -47,12 +47,12 @@ else()
 endif()
 
 ### Function to generate upload target
-function(gen_upload_target TARGET_NAME BIN_FILE HEX_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	# create command file for j-link
 	set(COMMAND_FILE_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/flash-${TARGET_NAME}.jlink)
 	file(GENERATE OUTPUT ${COMMAND_FILE_PATH} CONTENT
-"loadfile ${HEX_FILE}
+"loadfile ${BINARY_FILE}
 r
 go
 exit

--- a/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
+++ b/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
@@ -28,7 +28,7 @@ set(UPLOAD_LINKSERVER_FOUND ${LinkServer_FOUND})
 
 ### Function to generate upload target
 
-function(gen_upload_target TARGET_NAME BIN_FILE HEX_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMENT "Flashing ${TARGET_NAME} with LinkServer..."

--- a/tools/cmake/upload_methods/UploadMethodMBED.cmake
+++ b/tools/cmake/upload_methods/UploadMethodMBED.cmake
@@ -16,11 +16,11 @@ endif()
 set(MBED_TARGET_UID "" CACHE STRING "UID of mbed target to upload to if there are multiple connected.  You can get the UIDs from `python -m pyocd list`")
 
 ### Function to generate upload target
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMAND ${Python3_EXECUTABLE} -m install_bin_file
-			$<IF:$<BOOL:${MBED_OUTPUT_EXT}>,${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.${MBED_OUTPUT_EXT},BIN_FILE>
+			${BINARY_FILE}
 			${MBED_TARGET}
 			${MBED_RESET_BAUDRATE}
 			${MBED_TARGET_UID}

--- a/tools/cmake/upload_methods/UploadMethodNONE.cmake
+++ b/tools/cmake/upload_methods/UploadMethodNONE.cmake
@@ -9,7 +9,7 @@ set(UPLOAD_SUPPORTS_DEBUG FALSE)
 
 ### Function to generate upload target
 
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	# do nothing
 

--- a/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
@@ -39,7 +39,7 @@ if { [adapter name] == \"hla\" } {
 	set(OPENOCD_ADAPTER_SERIAL_COMMAND -f ${CMAKE_BINARY_DIR}/openocd_adapter_config.cfg CACHE INTERNAL "" FORCE)
 endif()
 
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	# unlike other upload methods, OpenOCD uses the elf file
 	add_custom_target(flash-${TARGET_NAME}
@@ -48,7 +48,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		${OPENOCD_CHIP_CONFIG_COMMANDS}
 		${OPENOCD_ADAPTER_SERIAL_COMMAND}
 		-c "gdb_port disabled" # Don't start a GDB server when just programming
-		-c "program $<IF:$<BOOL:${MBED_OUTPUT_EXT}>,${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.${MBED_OUTPUT_EXT},$<TARGET_FILE:${TARGET_NAME}>> reset exit"
+		-c "program ${BINARY_FILE} reset exit"
 		VERBATIM)
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})

--- a/tools/cmake/upload_methods/UploadMethodPICOTOOL.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPICOTOOL.cmake
@@ -19,7 +19,7 @@ set(PICOTOOL_TARGET_BUS "" CACHE STRING "If set, the given bus number is passed 
 set(PICOTOOL_TARGET_ADDRESS "" CACHE STRING "If set, the given address is passed to picotool to select the desired pico to program.  You can get the address from running `picotool list` with multiple picos plugged in.")
 
 ### Function to generate upload target
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	set(PICOTOOL_TARGET_ARGS "")
 	if(NOT "${PICOTOOL_TARGET_BUS}" STREQUAL "")

--- a/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
@@ -24,7 +24,7 @@ if(NOT "${PYOCD_PROBE_UID}" STREQUAL "")
 	set(PYOCD_PROBE_ARGS --probe ${PYOCD_PROBE_UID} CACHE INTERNAL "" FORCE)
 endif()
 
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMENT "Flashing ${TARGET_NAME} with pyOCD..."
@@ -36,7 +36,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		-f ${PYOCD_CLOCK_SPEED}
 		-t ${PYOCD_TARGET_NAME}
 		${PYOCD_PROBE_ARGS}
-		${BIN_FILE})
+		${BINARY_FILE})
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)

--- a/tools/cmake/upload_methods/UploadMethodSTLINK.cmake
+++ b/tools/cmake/upload_methods/UploadMethodSTLINK.cmake
@@ -22,7 +22,7 @@ else()
 endif()
 
 ### Function to generate upload target
-function(gen_upload_target TARGET_NAME BIN_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMENT "Flashing ${TARGET_NAME} with stlink..."
@@ -30,7 +30,7 @@ function(gen_upload_target TARGET_NAME BIN_FILE)
 		--reset # Reset chip after flashing
 		${STLINK_SERIAL_ARGUMENT}
 		${STLINK_ARGS}
-		write ${BIN_FILE} ${STLINK_LOAD_ADDRESS})
+		write ${BINARY_FILE} ${STLINK_LOAD_ADDRESS})
 
 	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)

--- a/tools/cmake/upload_methods/UploadMethodSTM32CUBE.cmake
+++ b/tools/cmake/upload_methods/UploadMethodSTM32CUBE.cmake
@@ -30,7 +30,7 @@ if(NOT "${STM32CUBE_PROBE_SN}" STREQUAL "")
 	set(STM32CUBE_GDB_PROBE_ARGS --serial-number ${STM32CUBE_PROBE_SN} CACHE INTERNAL "" FORCE)
 endif()
 
-function(gen_upload_target TARGET_NAME BIN_FILE HEX_FILE)
+function(gen_upload_target TARGET_NAME BINARY_FILE)
 
 	add_custom_target(flash-${TARGET_NAME}
 		COMMENT "Flashing ${TARGET_NAME} with STM32CubeProg..."


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR changes upload method `gen_upload_target` signature from:
```
function(gen_upload_target TARGET_NAME BIN_FILE HEX_FILE)
```
To:
```
function(gen_upload_target TARGET_NAME BINARY_FILE)
```

If `OUTPUT_EXT` is undefined or defined to "bin", BINARY_FILE is .bin file, otherwise .hex file.

The update applies to all UploadMethodXxx files.

Replace #329 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

