### PR TITLE
Fix some DMA SPI issues with DMA IP v3 and/or word size > 8 bits

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32WB/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/stm_dma_info.h
@@ -35,7 +35,7 @@ static const DMALinkInfo SPITxDMALinks[] = {
 /// Mapping from SPI index to DMA link info for Rx
 static const DMALinkInfo SPIRxDMALinks[] = {
         {1, 2, DMA_REQUEST_SPI1_RX},
-#ifdef SPI4
+#ifdef SPI2
         {1, 4, DMA_REQUEST_SPI2_RX}
 #endif
 };

--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -684,11 +684,11 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
     if(direction == DMA_PERIPH_TO_MEMORY || direction == DMA_MEMORY_TO_MEMORY)
     {
         // Destination is memory
-        dmaHandle->Init.DestInc = memInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+        dmaHandle->Init.DestInc = memInc ? DMA_DINC_INCREMENTED : DMA_DINC_FIXED;
 
         switch(memDataAlignment) {
             case 4:
-                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD;
                 break;
             case 2:
                 dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
@@ -702,11 +702,11 @@ DMA_HandleTypeDef *stm_init_dma_link(const DMALinkInfo *dmaLink, uint32_t direct
     }
     else {
         // Destination is a peripheral
-        dmaHandle->Init.DestInc = periphInc ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
+        dmaHandle->Init.DestInc = periphInc ? DMA_DINC_INCREMENTED : DMA_DINC_FIXED;
 
         switch(periphDataAlignment) {
             case 4:
-                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+                dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD;
                 break;
             case 2:
                 dmaHandle->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -1562,8 +1562,8 @@ static void configure_dma_transfer_size(const uint32_t spiDataSize, DMA_HandleTy
         neededSizeVal2 = DMA_SRC_DATAWIDTH_WORD;
     }
 #else
-    uint32_t * const transferSizePtr = &dmaHandle->Init.PeriphDataAlignment;
-    uint32_t * const transferSizePtr2 = &dmaHandle->Init.MemDataAlignment;
+    uint32_t * const transferSizePtr1 = &dmaChannel->Init.PeriphDataAlignment;
+    uint32_t * const transferSizePtr2 = &dmaChannel->Init.MemDataAlignment;
     uint32_t neededSizeVal1;
     uint32_t neededSizeVal2;
 

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -853,9 +853,8 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             /*  SPI slave implemtation in MBED does not support the 3 wires SPI.
              *  (e.g. when MISO is not connected). So we're forcing slave in
              *  2LINES mode. As MISO is not connected, slave will only read
-             *  from master, and cannot write to it. Inform user.
+             *  from master, and cannot write to it.
              */
-            debug("3 wires SPI slave not supported - slave will only read\r\n");
             handle->Init.Direction = SPI_DIRECTION_2LINES;
         }
 
@@ -1536,6 +1535,63 @@ typedef enum {
     SPI_TRANSFER_TYPE_TXRX = 3,
 } transfer_type_t;
 
+/*
+ * Configure a DMA channel's transfer size to match the given SPI word size
+ */
+static void configure_dma_transfer_size(const uint32_t spiDataSize, DMA_HandleTypeDef * const dmaChannel)
+{
+#if DMA_IP_VERSION_V3
+    uint32_t * const transferSizePtr1 = &dmaChannel->Init.DestDataWidth;
+    uint32_t * const transferSizePtr2 = &dmaChannel->Init.SrcDataWidth;
+    uint32_t neededSizeVal1;
+    uint32_t neededSizeVal2;
+
+    if(spiDataSize <= SPI_DATASIZE_8BIT)
+    {
+        neededSizeVal1 = DMA_DEST_DATAWIDTH_BYTE;
+        neededSizeVal2 = DMA_SRC_DATAWIDTH_BYTE;
+    }
+    else if(spiDataSize <= SPI_DATASIZE_16BIT)
+    {
+        neededSizeVal1 = DMA_DEST_DATAWIDTH_HALFWORD;
+        neededSizeVal2 = DMA_SRC_DATAWIDTH_HALFWORD;
+    }
+    else
+    {
+        neededSizeVal1 = DMA_DEST_DATAWIDTH_WORD;
+        neededSizeVal2 = DMA_SRC_DATAWIDTH_WORD;
+    }
+#else
+    uint32_t * const transferSizePtr = &dmaHandle->Init.PeriphDataAlignment;
+    uint32_t * const transferSizePtr2 = &dmaHandle->Init.MemDataAlignment;
+    uint32_t neededSizeVal1;
+    uint32_t neededSizeVal2;
+
+    if(spiDataSize <= SPI_DATASIZE_8BIT)
+    {
+        neededSizeVal1 = DMA_PDATAALIGN_BYTE;
+        neededSizeVal2 = DMA_MDATAALIGN_BYTE;
+    }
+    else if(spiDataSize <= SPI_DATASIZE_16BIT)
+    {
+        neededSizeVal1 = DMA_PDATAALIGN_HALFWORD;
+        neededSizeVal2 = DMA_MDATAALIGN_HALFWORD;
+    }
+    else
+    {
+        neededSizeVal1 = DMA_PDATAALIGN_WORD;
+        neededSizeVal2 = DMA_MDATAALIGN_WORD;
+    }
+#endif
+
+    // Check values and reinit DMA if needed
+    if(*transferSizePtr1 != neededSizeVal1 || *transferSizePtr2 != neededSizeVal2)
+    {
+        *transferSizePtr1 = neededSizeVal1;
+        *transferSizePtr2 = neededSizeVal2;
+        HAL_DMA_Init(dmaChannel);
+    }
+}
 
 /// @returns True if DMA was used, false otherwise
 static bool spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer_type, const void *tx, void *rx, size_t length, DMAUsage hint)
@@ -1580,6 +1636,18 @@ static bool spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfe
         }
 
         useDMA = true;
+
+        // Make sure that the DMA word size matches the SPI word size.  Also check address alignment.
+        if(transfer_type == SPI_TRANSFER_TYPE_TXRX || transfer_type == SPI_TRANSFER_TYPE_TX)
+        {
+            MBED_ASSERT(((ptrdiff_t)tx) % (1 << bitshift) == 0); // <-- if you hit this assert you passed an unaligned pointer to an SPI async transfer
+            configure_dma_transfer_size(handle->Init.DataSize, handle->hdmatx);
+        }
+        if(transfer_type == SPI_TRANSFER_TYPE_TXRX || transfer_type == SPI_TRANSFER_TYPE_RX)
+        {
+            MBED_ASSERT(((ptrdiff_t)rx) % (1 << bitshift) == 0); // <-- if you hit this assert you passed an unaligned pointer to an SPI async transfer
+            configure_dma_transfer_size(handle->Init.DataSize, handle->hdmarx);
+        }
     }
 
     obj->spi.curr_transfer_uses_dma = useDMA;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Working on STM32H5 SPI support, I dug a bit deeper into some DMA SPI errors that we were seeing, and ended up finding and fixing a few bugs.  These were:
- in stm_dma_utils.c, some of the dest and src constants were swapped.  This had the effect of making app DMA IP v3 transfers increment the source address if you set the destination increment flag.  Oops!  Frankly I have no idea how it ever passed any tests at all like this, it should never have worked
- DMA_DEST_DATAWIDTH_WORD replaced by DMA_DEST_DATAWIDTH_BYTE in 2 places (spotted by @wdx04 in #196).  This could mess up the DMA system if you requested a 32-bit transfer
- If the word size is set to 16 or 32 bits, it turns out that the STM32 DMA HAL requires the DMA's transfer size to be set accordingly.  We were not doing this, causing any attempt to do wider transfers using DMA (on some STM processors at least) to fail.
- Initializing an SPI slave with MISO set to NC would print a warning, even though it did work as expected.  This warning has been removed.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
 On STM32H5, spi-basic test now passes completely!  Need to run tests on other devices.
----------------------------------------------------------------------------------------------------------------
