### PR TITLE
Fixes for SPI slave implementation

### DIFF
--- a/drivers/include/drivers/SPISlave.h
+++ b/drivers/include/drivers/SPISlave.h
@@ -33,7 +33,7 @@ namespace mbed {
 
 /** A SPI slave, used for communicating with a SPI master device.
  *
- * The default format is set to 8 bits, mode 0 and a clock frequency of 1MHz.
+ * The default format is set to 8 bits, mode 0.
  *
  * @note Synchronization level: Not protected
  *
@@ -96,12 +96,6 @@ public:
      */
     void format(int bits, int mode = 0);
 
-    /** Set the SPI bus clock frequency.
-     *
-     *  @param hz Clock frequency in hz (default = 1MHz).
-     */
-    void frequency(int hz = 1000000);
-
     /** Polls the SPI to see if data has been received.
      *
      *  @return Presence of received data.
@@ -133,8 +127,6 @@ protected:
     int _bits;
     /* Clock phase and polarity */
     int _mode;
-    /* Clock frequency */
-    int _hz;
 
 #endif //!defined(DOXYGEN_ONLY)
 };

--- a/drivers/include/drivers/SPISlave.h
+++ b/drivers/include/drivers/SPISlave.h
@@ -80,6 +80,11 @@ public:
     SPISlave(const spi_pinmap_t &pinmap);
     SPISlave(const spi_pinmap_t &&) = delete; // prevent passing of temporary objects
 
+    /**
+     * @brief Destructor.  Frees the SPI peripheral so it can be used elsewhere.
+     */
+    ~SPISlave();
+
     /** Configure the data transmission format.
      *
      *  @param bits Number of bits per SPI frame (4 - 16).

--- a/drivers/source/SPISlave.cpp
+++ b/drivers/source/SPISlave.cpp
@@ -24,23 +24,29 @@ namespace mbed {
 SPISlave::SPISlave(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
     _spi(),
     _bits(8),
-    _mode(0),
-    _hz(1000000)
+    _mode(0)
 {
     spi_init(&_spi, mosi, miso, sclk, ssel);
     spi_format(&_spi, _bits, _mode, 1);
-    spi_frequency(&_spi, _hz);
+
+    // For legacy compatibility, tell the HAL to set the frequency to 1MHz.
+    // This is done even though it does not make sense to set the frequency of a slave device;
+    // it has to run at whatever SCLK frequency the master supplies.
+    spi_frequency(&_spi, 1000000);
 }
 
 SPISlave::SPISlave(const spi_pinmap_t &pinmap) :
     _spi(),
     _bits(8),
-    _mode(0),
-    _hz(1000000)
+    _mode(0)
 {
     spi_init_direct(&_spi, &pinmap);
     spi_format(&_spi, _bits, _mode, 1);
-    spi_frequency(&_spi, _hz);
+
+    // For legacy compatibility, tell the HAL to set the frequency to 1MHz.
+    // This is done even though it does not make sense to set the frequency of a slave device;
+    // it has to run at whatever SCLK frequency the master supplies.
+    spi_frequency(&_spi, 1000000);
 }
 
 void SPISlave::format(int bits, int mode)
@@ -48,12 +54,6 @@ void SPISlave::format(int bits, int mode)
     _bits = bits;
     _mode = mode;
     spi_format(&_spi, _bits, _mode, 1);
-}
-
-void SPISlave::frequency(int hz)
-{
-    _hz = hz;
-    spi_frequency(&_spi, _hz);
 }
 
 int SPISlave::receive(void)

--- a/drivers/source/SPISlave.cpp
+++ b/drivers/source/SPISlave.cpp
@@ -49,6 +49,11 @@ SPISlave::SPISlave(const spi_pinmap_t &pinmap) :
     spi_frequency(&_spi, 1000000);
 }
 
+SPISlave::~SPISlave()
+{
+    spi_free(&_spi);
+}
+
 void SPISlave::format(int bits, int mode)
 {
     _bits = bits;

--- a/targets/TARGET_NXP/TARGET_LPC176X/objects.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/objects.h
@@ -71,6 +71,12 @@ struct i2c_s {
 struct spi_s {
     LPC_SSP_TypeDef *spi;
     uint8_t bits_per_word;
+
+    // Pin names, so that we can unmap them when the SPI is freed
+    PinName mosi_pin;
+    PinName miso_pin;
+    PinName sclk_pin;
+    PinName ssel_pin;
 };
 
 struct flash_s {

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -34,18 +34,30 @@ void spi_init_direct(spi_t *obj, const spi_pinmap_t *pinmap) {
         case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
     }
 
-    // pin out the spi pins
-    pin_function(pinmap->mosi_pin, pinmap->mosi_function);
-    pin_mode(pinmap->mosi_pin, PullNone);
-    pin_function(pinmap->miso_pin, pinmap->miso_function);
-    pin_mode(pinmap->miso_pin, PullNone);
+    // Pin out the spi pins.
+    // Note: SCLK is the only pin that is always required.
+    if(pinmap->mosi_pin != NC)
+    {
+        pin_function(pinmap->mosi_pin, pinmap->mosi_function);
+        pin_mode(pinmap->mosi_pin, PullNone);
+    }
+    if(pinmap->miso_pin != NC)
+    {
+        pin_function(pinmap->miso_pin, pinmap->miso_function);
+        pin_mode(pinmap->miso_pin, PullNone);
+    }
     pin_function(pinmap->sclk_pin, pinmap->sclk_function);
     pin_mode(pinmap->sclk_pin, PullNone);
-
     if (pinmap->ssel_pin != NC) {
         pin_function(pinmap->ssel_pin, pinmap->ssel_function);
         pin_mode(pinmap->ssel_pin, PullNone);
     }
+
+    // Save pins
+    obj->mosi_pin = pinmap->mosi_pin;
+    obj->miso_pin = pinmap->miso_pin;
+    obj->sclk_pin = pinmap->sclk_pin;
+    obj->ssel_pin = pinmap->ssel_pin;
 }
 
 SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
@@ -80,7 +92,14 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spi_init_direct(obj, &pinmap);
 }
 
-void spi_free(spi_t *obj) {}
+void spi_free(spi_t *obj)
+{
+    // Reset all pins to GPIO function
+    if(obj->mosi_pin != NC) pin_function(obj->mosi_pin, 0);
+    if(obj->miso_pin != NC) pin_function(obj->miso_pin, 0);
+    pin_function(obj->sclk_pin, 0);
+    if(obj->ssel_pin != NC) pin_function(obj->ssel_pin, 0);
+}
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_disable(obj);

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -252,7 +252,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj);
 }
 
 int spi_slave_read(spi_t *obj) {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Making this PR to capture a few fixes for issues I hit while testing the new [SPI slave test suite](https://github.com/mbed-ce/mbed-ce-test-tools/blob/master/CI-Shield-Tests/SPISlaveCommsTest.cpp) for the CI test shield.

Changes are:
- Remove useless SPISlave::frequency() function.  This function does not actually work because the SPI master sets the clock frequency; the slave has no control over it.
- Add destructor to SPISlave which calls `spi_free()`.  This makes sure that resources used by the SPI slave can actually be cleaned up like they are for an SPI master instance.
- LPC1768: unmap SPI pins in spi_free().  This is so that test cases will pass that involve remapping SPI pins as NC.
  - I realize that it's a bit unclear in many cases whether Mbed HALs are supposed to unmap pins in their free functions.  I think that ideally they always should but very few actually do, at present

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Available here: https://mbed-ce.github.io/mbed-ce-test-tools/tests/test-testshield-spi-slave-comms.html
    
----------------------------------------------------------------------------------------------------------------
