### PR TITLE
Allow upload method configs to specify an OpenOCD version range

### DIFF
--- a/targets/upload_method_cfg/LPC1768.cmake
+++ b/targets/upload_method_cfg/LPC1768.cmake
@@ -37,6 +37,10 @@ set(OPENOCD_UPLOAD_ENABLED TRUE)
 set(OPENOCD_CHIP_CONFIG_COMMANDS
     -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/lpc1768.cfg)
 
+# For some reason, as of summer 2024, git version of OpenOCD does not work with LPC1768.  So, it seems like
+# the last compatible version will be the current release 0.12.
+set(OPENOCD_VERSION_RANGE 0.10...<0.13)
+
 # Config options for LINKSERVER
 # -------------------------------------------------------------
 set(LINKSERVER_UPLOAD_ENABLED TRUE)

--- a/tools/cmake/upload_methods/FindOpenOCD.cmake
+++ b/tools/cmake/upload_methods/FindOpenOCD.cmake
@@ -43,6 +43,20 @@ find_path(OpenOCD_SCRIPT_DIR
     PATHS /usr/share/openocd/scripts/
     DOC "Path to OpenOCD scripts folder.  Should contain interface/cmsis-dap.cfg.")
 
-find_package_handle_standard_args(OpenOCD FOUND_VAR OpenOCD_FOUND REQUIRED_VARS OpenOCD OpenOCD_SCRIPT_DIR)
+if(OpenOCD AND EXISTS "${OpenOCD}")
+    # Detect version (it writes to stderr)
+    execute_process(COMMAND ${OpenOCD} --version
+        ERROR_VARIABLE OpenOCD_VERSION_OUTPUT)
+
+    # Use a regex to grab the version number
+    string(REGEX MATCH "Open On-Chip Debugger ([^ ]+)" OpenOCD_VERSION_UNUSED_MATCH "${OpenOCD_VERSION_OUTPUT}")
+    set(OpenOCD_VERSION ${CMAKE_MATCH_1})
+endif()
+
+find_package_handle_standard_args(OpenOCD
+    HANDLE_VERSION_RANGE
+    FOUND_VAR OpenOCD_FOUND
+    VERSION_VAR OpenOCD_VERSION
+    REQUIRED_VARS OpenOCD OpenOCD_SCRIPT_DIR)
 
 

--- a/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
@@ -6,11 +6,13 @@
 # OPENOCD_CHIP_CONFIG_COMMANDS - Specifies all OpenOCD commands needed to configure openocd for your target processor.
 # This method creates the following options:
 # OPENOCD_ADAPTER_SERIAL - Serial number of the debug adapter to select for OpenOCD.  Set to empty to detect any matching adapter.
+# OPENOCD_VERSION_RANGE - Acceptable version range of OpenOCD.  This may be a single version, in which case it is treated as
+#   a minimum, or a versionMin...<versionMax constraint, e.g. 0.12...<0.13, to accept any 0.12.x version but not 0.13 or higher.
 
 set(UPLOAD_SUPPORTS_DEBUG TRUE)
 
 ### Check if upload method can be enabled on this machine
-find_package(OpenOCD)
+find_package(OpenOCD ${OPENOCD_VERSION_RANGE})
 set(UPLOAD_OPENOCD_FOUND ${OpenOCD_FOUND})
 
 ### Setup options


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Quick update to the OpenOCD upload method to allow the configuration to specify a valid range of OpenOCD versions that will work.

#### Impact of changes <!-- Optional -->
This will allow @ccli8 to make sure that Nuvoton upload methods only work with Nuvoton OpenOCD

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->

Updated the upload method page: https://github.com/mbed-ce/mbed-os/wiki/Upload-Methods

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Verified that you now get an error if you use an OpenOCD version that doesn't satisfy the constraint    

----------------------------------------------------------------------------------------------------------------
