### PR TITLE
Fix linker script incorrectly selected for bare-metal profile

### DIFF
--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -120,18 +120,21 @@ function(mbed_set_post_build target)
     # add linker script. Skip for greentea test code, there the linker script is set in mbed_setup_linker_script()
     if (NOT MBED_IS_STANDALONE)
         if("${ARGN}" STREQUAL "")
-            if(TARGET mbed-os)
+            get_target_property(POST_BUILD_TARGET_LINK_LIBRARIES ${target} LINK_LIBRARIES)
+            if("mbed-os" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
                 get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
                 target_link_options(${target}
                 PRIVATE
                     "-T" "${LINKER_SCRIPT_PATH}"
             )
-            elseif(TARGET mbed-baremetal)
+            elseif("mbed-baremetal" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
                 get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
                 target_link_options(${target}
                 PRIVATE
                     "-T" "${LINKER_SCRIPT_PATH}"
             )
+            else()
+                message(FATAL_ERROR "Target ${target} used with mbed_set_post_build() but does not link to mbed-os or mbed-baremetal!")
             endif()
         else()
             message(STATUS "${target} uses custom linker script  ${ARGV1}")


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes linker script is incorrectly selected for bare-metal profile. `mbed-os` and `mbed-baremetal` library targets [both are created](https://github.com/mbed-ce/mbed-os/blob/b352953f8680494505cc14ea1b4e19f3b7c9f975/CMakeLists.txt#L284-L285), so we cannot use `if(TARGET mbed-os)` or `if(TARGET mbed-baremetal)` to determine which one the application target links to. Instead, determine by checking application target's `LINK_LIBRARIES` property.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

