### PR TITLE
Update STM32H5 HAL driver, fix some DMA bugs

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/partition_stm32h5xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/partition_stm32h5xx.h
@@ -1,0 +1,79 @@
+/**
+  ******************************************************************************
+  * @file    partition_stm32h5xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS STM32H5xx Device Header File for Initial Setup for Secure /
+  *          Non-Secure Zones for ARMCM33 based on CMSIS CORE partition_ARMCM33.h
+  *          Template.
+  *
+  *          The file is included in system_stm32h5xx_s.c in secure application.
+  *          It includes the configuration section that allows to select the
+  *          STM32H5xx device partitioning file for system core secure attributes
+  *          and interrupt secure and non-secure assignment.
+  *
+  ******************************************************************************
+  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
+  * Copyright (c) 2023 STMicroelectronics. All rights reserved.  
+  *
+  * SPDX-License-Identifier: Apache-2.0
+  *
+  * Licensed under the Apache License, Version 2.0 (the License); you may
+  * not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32h5xx
+  * @{
+  */
+
+#ifndef PARTITION_STM32H5XX_H
+#define PARTITION_STM32H5XX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Secure_configuration_section
+  * @{
+  */
+
+#if defined(STM32H573xx)
+  #include "partition_stm32h573xx.h"
+#elif defined(STM32H563xx)
+  #include "partition_stm32h563xx.h"
+#elif defined(STM32H562xx)
+  #include "partition_stm32h562xx.h"
+#elif defined(STM32H533xx)
+  #include "partition_stm32h533xx.h"
+#elif defined(STM32H523xx)
+  #include "partition_stm32h523xx.h"
+#else
+  #error "Please select first the target STM32H5xx device used in your application (in stm32h5xx.h file)"
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* PARTITION_STM32H5XX_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h503xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h503xx.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
   ******************************************************************************
   * @file    stm32h503xx.h
   * @author  MCD Application Team
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -175,7 +175,7 @@ typedef enum
 
 /* --------  Configuration of the Cortex-M33 Processor and Core Peripherals  ------ */
 #define __CM33_REV                0x0000U   /* Core revision r0p1 */
-#define __SAUREGION_PRESENT       1U        /* SAU regions present */
+#define __SAUREGION_PRESENT       0U        /* SAU regions present */
 #define __MPU_PRESENT             1U        /* MPU present */
 #define __VTOR_PRESENT            1U        /* VTOR present */
 #define __NVIC_PRIO_BITS          4U        /* Number of Bits used for Priority Levels */
@@ -349,7 +349,6 @@ typedef struct
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
   __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
-  uint32_t RESERVED;
   __IO uint32_t HTCR;  /*!< RNG health test configuration register, Address offset: 0x10 */
 } RNG_TypeDef;
 
@@ -429,22 +428,22 @@ typedef struct
   __IO uint32_t SWIER1;         /*!< EXTI Software Interrupt event Register 1,        Address offset:   0x08 */
   __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
   __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
-  __IO uint32_t SECCFGR1;       /*!< EXTI Security Configuration Register 1,          Address offset:   0x14 */
+       uint32_t RESERVED1;      /*!< Reserved 1,                                      Address offset:   0x14 */
   __IO uint32_t PRIVCFGR1;      /*!< EXTI Privilege Configuration Register 1,         Address offset:   0x18 */
-       uint32_t RESERVED1;      /*!< Reserved 1,                                      Address offset:   0x1C */
+       uint32_t RESERVED2;      /*!< Reserved 2,                                      Address offset:   0x1C */
   __IO uint32_t RTSR2;          /*!< EXTI Rising Trigger Selection Register 2,        Address offset:   0x20 */
   __IO uint32_t FTSR2;          /*!< EXTI Falling Trigger Selection Register 2,       Address offset:   0x24 */
   __IO uint32_t SWIER2;         /*!< EXTI Software Interrupt event Register 2,        Address offset:   0x28 */
   __IO uint32_t RPR2;           /*!< EXTI Rising Pending Register 2,                  Address offset:   0x2C */
   __IO uint32_t FPR2;           /*!< EXTI Falling Pending Register 2,                 Address offset:   0x30 */
-  __IO uint32_t SECCFGR2;       /*!< EXTI Security Configuration Register 2,          Address offset:   0x34 */
+       uint32_t RESERVED3;      /*!< Reserved 3,                                      Address offset:   0x34 */
   __IO uint32_t PRIVCFGR2;      /*!< EXTI Privilege Configuration Register 2,         Address offset:   0x38 */
-       uint32_t RESERVED2[9];   /*!< Reserved 2,                                                 0x3C-- 0x5C */
+       uint32_t RESERVED4[9];   /*!< Reserved 4,                                                 0x3C-- 0x5C */
   __IO uint32_t EXTICR[4];      /*!< EXIT External Interrupt Configuration Register,            0x60 -- 0x6C */
-       uint32_t RESERVED3[4];   /*!< Reserved 3,                                                0x70 -- 0x7C */
+       uint32_t RESERVED5[4];   /*!< Reserved 5,                                                0x70 -- 0x7C */
   __IO uint32_t IMR1;           /*!< EXTI Interrupt Mask Register 1,                  Address offset:   0x80 */
   __IO uint32_t EMR1;           /*!< EXTI Event Mask Register 1,                      Address offset:   0x84 */
-       uint32_t RESERVED4[2];   /*!< Reserved 4,                                                0x88 -- 0x8C */
+       uint32_t RESERVED6[2];   /*!< Reserved 6,                                                0x88 -- 0x8C */
   __IO uint32_t IMR2;           /*!< EXTI Interrupt Mask Register 2,                  Address offset:   0x90 */
   __IO uint32_t EMR2;           /*!< EXTI Event Mask Register 2,                      Address offset:   0x94 */
 } EXTI_TypeDef;
@@ -537,8 +536,6 @@ typedef struct
        uint32_t RESERVED3[17];  /*!< Reserved3,                                                            Address offset: 0x2C-0x6C */
   __IO uint32_t MPCWM4ACFGR;    /*!< TZSC memory 4 sub-region A watermark configuration register,          Address offset: 0x70      */
   __IO uint32_t MPCWM4AR;       /*!< TZSC memory 4 sub-region A watermark register,                        Address offset: 0x74      */
-  __IO uint32_t MPCWM4BCFGR;    /*!< TZSC memory 4 sub-region B watermark configuration register,          Address offset: 0x78      */
-  __IO uint32_t MPCWM4BR;       /*!< TZSC memory 4 sub-region B watermark register,                        Address offset: 0x7c      */
 } GTZC_TZSC_TypeDef;
 
 typedef struct
@@ -591,7 +588,8 @@ typedef struct
   __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x5C */
   __IO uint32_t AF1;         /*!< TIM alternate function option register 1, Address offset: 0x60 */
   __IO uint32_t AF2;         /*!< TIM alternate function option register 2, Address offset: 0x64 */
-       uint32_t RESERVED0[221];/*!< Reserved,                               Address offset: 0x68 */
+  __IO uint32_t OR1 ;        /*!< TIM option register,                      Address offset: 0x68 */
+       uint32_t RESERVED0[220];/*!< Reserved,                               Address offset: 0x6C */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x3DC */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x3E0 */
 } TIM_TypeDef;
@@ -768,6 +766,7 @@ typedef struct
   uint32_t      RESERVED21;    /*!< Reserved,                                                                Address offset: 0x110 */
   __IO uint32_t PRIVCFGR;      /*!< RCC Privilege configuration register                                     Address offset: 0x114 */
 } RCC_TypeDef;
+
 
 /*
 * @brief RTC Specific device feature definitions
@@ -1064,10 +1063,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CSR;          /*!< ADC common status register,            Address offset: 0x300 + 0x00 */
-  uint32_t      RESERVED1;    /*!< Reserved,                              Address offset: 0x300 + 0x04 */
+  uint32_t      RESERVED1[2]; /*!< Reserved,                              Address offset: 0x300 + 0x00 */
   __IO uint32_t CCR;          /*!< ADC common configuration register,     Address offset: 0x300 + 0x08 */
-  __IO uint32_t CDR;          /*!< ADC common group regular data register Address offset: 0x300 + 0x0C */
 } ADC_Common_TypeDef;
 
 
@@ -1262,11 +1259,9 @@ typedef struct
 #define ADC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08000UL)
 #define ADC12_COMMON_BASE_NS     (AHB2PERIPH_BASE_NS + 0x08300UL)
 #define DAC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08400UL)
-
 #define HASH_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0400UL)
 #define HASH_DIGEST_BASE_NS      (AHB2PERIPH_BASE_NS + 0xA0710UL)
 #define RNG_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA0800UL)
-
 
 /*!< APB3 Non secure peripherals */
 #define SBS_BASE_NS              (APB3PERIPH_BASE_NS + 0x0400UL)
@@ -1284,11 +1279,9 @@ typedef struct
 
 /* Debug MCU registers base address */
 #define DBGMCU_BASE             (0x44024000UL)
-
 #define PACKAGE_BASE            (0x08FFF80EUL) /*!< Package data register base address     */
 #define UID_BASE                (0x08FFF800UL) /*!< Unique device ID register base address */
 #define FLASHSIZE_BASE          (0x08FFF80CUL) /*!< Flash size data register base address  */
-
 
 /* Internal Flash OTP Area */
 #define FLASH_OTP_BASE          (0x08FFF000UL) /*!< FLASH OTP (one-time programmable) base address */
@@ -1298,9 +1291,6 @@ typedef struct
 #define FLASH_SYSTEM_BASE_NS    (0x0BF80000UL) /*!< FLASH System non-secure base address  */
 #define FLASH_SYSTEM_SIZE       (0x8000U)      /*!< 32 Kbytes system Flash */
 
-
-/*!< USB PMA SIZE */
-#define USB_DRD_PMA_SIZE        (2048U)         /*!< USB PMA Size 2Kbyte */
 
 /*!< Non Secure Service Library */
 /************ RSSLIB SAU system Flash region definition constants *************/
@@ -3047,10 +3037,15 @@ typedef struct
 #define RNG_SR_SEIS_Msk                     (0x1UL << RNG_SR_SEIS_Pos)              /*!< 0x00000040 */
 #define RNG_SR_SEIS                         RNG_SR_SEIS_Msk
 
+
 /********************  Bits definition for RNG_HTCR register  *******************/
 #define RNG_HTCR_HTCFG_Pos                  (0U)
 #define RNG_HTCR_HTCFG_Msk                  (0xFFFFFFFFUL << RNG_HTCR_HTCFG_Pos)    /*!< 0xFFFFFFFF */
 #define RNG_HTCR_HTCFG                      RNG_HTCR_HTCFG_Msk
+
+/********************  RNG Nist Compliance Values  ******************************/
+#define RNG_CR_NIST_VALUE                   (0x00F00D00U)
+#define RNG_HTCR_NIST_VALUE                 (0xAAC7U)
 
 /******************************************************************************/
 /*                                                                            */
@@ -4286,104 +4281,6 @@ typedef struct
 #define EXTI_FPR1_FPIF16_Msk                (0x1UL << EXTI_FPR1_FPIF16_Pos)         /*!< 0x00010000 */
 #define EXTI_FPR1_FPIF16                    EXTI_FPR1_FPIF16_Msk                    /*!< Falling Pending Interrupt Flag on line 16 */
 
-/*******************  Bit definition for EXTI_SECENR1 register  ******************/
-#define EXTI_SECENR1_SEC0_Pos              (0U)
-#define EXTI_SECENR1_SEC0_Msk              (0x1UL << EXTI_SECENR1_SEC0_Pos)       /*!< 0x00000001 */
-#define EXTI_SECENR1_SEC0                  EXTI_SECENR1_SEC0_Msk                  /*!< Security enable on line 0 */
-#define EXTI_SECENR1_SEC1_Pos              (1U)
-#define EXTI_SECENR1_SEC1_Msk              (0x1UL << EXTI_SECENR1_SEC1_Pos)       /*!< 0x00000002 */
-#define EXTI_SECENR1_SEC1                  EXTI_SECENR1_SEC1_Msk                  /*!< Security enable on line 1 */
-#define EXTI_SECENR1_SEC2_Pos              (2U)
-#define EXTI_SECENR1_SEC2_Msk              (0x1UL << EXTI_SECENR1_SEC2_Pos)       /*!< 0x00000004 */
-#define EXTI_SECENR1_SEC2                  EXTI_SECENR1_SEC2_Msk                  /*!< Security enable on line 2 */
-#define EXTI_SECENR1_SEC3_Pos              (3U)
-#define EXTI_SECENR1_SEC3_Msk              (0x1UL << EXTI_SECENR1_SEC3_Pos)       /*!< 0x00000008 */
-#define EXTI_SECENR1_SEC3                  EXTI_SECENR1_SEC3_Msk                  /*!< Security enable on line 3 */
-#define EXTI_SECENR1_SEC4_Pos              (4U)
-#define EXTI_SECENR1_SEC4_Msk              (0x1UL << EXTI_SECENR1_SEC4_Pos)       /*!< 0x00000010 */
-#define EXTI_SECENR1_SEC4                  EXTI_SECENR1_SEC4_Msk                  /*!< Security enable on line 4 */
-#define EXTI_SECENR1_SEC5_Pos              (5U)
-#define EXTI_SECENR1_SEC5_Msk              (0x1UL << EXTI_SECENR1_SEC5_Pos)       /*!< 0x00000020 */
-#define EXTI_SECENR1_SEC5                  EXTI_SECENR1_SEC5_Msk                  /*!< Security enable on line 5 */
-#define EXTI_SECENR1_SEC6_Pos              (6U)
-#define EXTI_SECENR1_SEC6_Msk              (0x1UL << EXTI_SECENR1_SEC6_Pos)       /*!< 0x00000040 */
-#define EXTI_SECENR1_SEC6                  EXTI_SECENR1_SEC6_Msk                  /*!< Security enable on line 6 */
-#define EXTI_SECENR1_SEC7_Pos              (7U)
-#define EXTI_SECENR1_SEC7_Msk              (0x1UL << EXTI_SECENR1_SEC7_Pos)       /*!< 0x00000080 */
-#define EXTI_SECENR1_SEC7                  EXTI_SECENR1_SEC7_Msk                  /*!< Security enable on line 7 */
-#define EXTI_SECENR1_SEC8_Pos              (8U)
-#define EXTI_SECENR1_SEC8_Msk              (0x1UL << EXTI_SECENR1_SEC8_Pos)       /*!< 0x00000100 */
-#define EXTI_SECENR1_SEC8                  EXTI_SECENR1_SEC8_Msk                  /*!< Security enable on line 8 */
-#define EXTI_SECENR1_SEC9_Pos              (9U)
-#define EXTI_SECENR1_SEC9_Msk              (0x1UL << EXTI_SECENR1_SEC9_Pos)       /*!< 0x00000200 */
-#define EXTI_SECENR1_SEC9                  EXTI_SECENR1_SEC9_Msk                  /*!< Security enable on line 9 */
-#define EXTI_SECENR1_SEC10_Pos             (10U)
-#define EXTI_SECENR1_SEC10_Msk             (0x1UL << EXTI_SECENR1_SEC10_Pos)      /*!< 0x00000400 */
-#define EXTI_SECENR1_SEC10                 EXTI_SECENR1_SEC10_Msk                 /*!< Security enable on line 10 */
-#define EXTI_SECENR1_SEC11_Pos             (11U)
-#define EXTI_SECENR1_SEC11_Msk             (0x1UL << EXTI_SECENR1_SEC11_Pos)      /*!< 0x00000800 */
-#define EXTI_SECENR1_SEC11                 EXTI_SECENR1_SEC11_Msk                 /*!< Security enable on line 11 */
-#define EXTI_SECENR1_SEC12_Pos             (12U)
-#define EXTI_SECENR1_SEC12_Msk             (0x1UL << EXTI_SECENR1_SEC12_Pos)      /*!< 0x00001000 */
-#define EXTI_SECENR1_SEC12                 EXTI_SECENR1_SEC12_Msk                 /*!< Security enable on line 12 */
-#define EXTI_SECENR1_SEC13_Pos             (13U)
-#define EXTI_SECENR1_SEC13_Msk             (0x1UL << EXTI_SECENR1_SEC13_Pos)      /*!< 0x00002000 */
-#define EXTI_SECENR1_SEC13                 EXTI_SECENR1_SEC13_Msk                 /*!< Security enable on line 13 */
-#define EXTI_SECENR1_SEC14_Pos             (14U)
-#define EXTI_SECENR1_SEC14_Msk             (0x1UL << EXTI_SECENR1_SEC14_Pos)      /*!< 0x00004000 */
-#define EXTI_SECENR1_SEC14                 EXTI_SECENR1_SEC14_Msk                 /*!< Security enable on line 14 */
-#define EXTI_SECENR1_SEC15_Pos             (15U)
-#define EXTI_SECENR1_SEC15_Msk             (0x1UL << EXTI_SECENR1_SEC15_Pos)      /*!< 0x00008000 */
-#define EXTI_SECENR1_SEC15                 EXTI_SECENR1_SEC15_Msk                 /*!< Security enable on line 15 */
-#define EXTI_SECENR1_SEC16_Pos             (16U)
-#define EXTI_SECENR1_SEC16_Msk             (0x1UL << EXTI_SECENR1_SEC16_Pos)      /*!< 0x00010000 */
-#define EXTI_SECENR1_SEC16                 EXTI_SECENR1_SEC16_Msk                 /*!< Security enable on line 16 */
-#define EXTI_SECENR1_SEC17_Pos             (17U)
-#define EXTI_SECENR1_SEC17_Msk             (0x1UL << EXTI_SECENR1_SEC17_Pos)      /*!< 0x00020000 */
-#define EXTI_SECENR1_SEC17                 EXTI_SECENR1_SEC17_Msk                 /*!< Security enable on line 17 */
-#define EXTI_SECENR1_SEC18_Pos             (18U)
-#define EXTI_SECENR1_SEC18_Msk             (0x1UL << EXTI_SECENR1_SEC18_Pos)      /*!< 0x00040000 */
-#define EXTI_SECENR1_SEC18                 EXTI_SECENR1_SEC18_Msk                 /*!< Security enable on line 18 */
-#define EXTI_SECENR1_SEC19_Pos             (19U)
-#define EXTI_SECENR1_SEC19_Msk             (0x1UL << EXTI_SECENR1_SEC19_Pos)      /*!< 0x00080000 */
-#define EXTI_SECENR1_SEC19                 EXTI_SECENR1_SEC19_Msk                 /*!< Security enable on line 19 */
-#define EXTI_SECENR1_SEC20_Pos             (20U)
-#define EXTI_SECENR1_SEC20_Msk             (0x1UL << EXTI_SECENR1_SEC20_Pos)      /*!< 0x00100000 */
-#define EXTI_SECENR1_SEC20                 EXTI_SECENR1_SEC20_Msk                 /*!< Security enable on line 20 */
-#define EXTI_SECENR1_SEC21_Pos             (21U)
-#define EXTI_SECENR1_SEC21_Msk             (0x1UL << EXTI_SECENR1_SEC21_Pos)      /*!< 0x00200000 */
-#define EXTI_SECENR1_SEC21                 EXTI_SECENR1_SEC21_Msk                 /*!< Security enable on line 21 */
-#define EXTI_SECENR1_SEC22_Pos             (22U)
-#define EXTI_SECENR1_SEC22_Msk             (0x1UL << EXTI_SECENR1_SEC22_Pos)      /*!< 0x00400000 */
-#define EXTI_SECENR1_SEC22                 EXTI_SECENR1_SEC22_Msk                 /*!< Security enable on line 22 */
-#define EXTI_SECENR1_SEC23_Pos             (23U)
-#define EXTI_SECENR1_SEC23_Msk             (0x1UL << EXTI_SECENR1_SEC23_Pos)      /*!< 0x00800000 */
-#define EXTI_SECENR1_SEC23                 EXTI_SECENR1_SEC23_Msk                 /*!< Security enable on line 23 */
-#define EXTI_SECENR1_SEC24_Pos             (24U)
-#define EXTI_SECENR1_SEC24_Msk             (0x1UL << EXTI_SECENR1_SEC24_Pos)      /*!< 0x01000000 */
-#define EXTI_SECENR1_SEC24                 EXTI_SECENR1_SEC24_Msk                 /*!< Security enable on line 24 */
-#define EXTI_SECENR1_SEC25_Pos             (25U)
-#define EXTI_SECENR1_SEC25_Msk             (0x1UL << EXTI_SECENR1_SEC25_Pos)      /*!< 0x02000000 */
-#define EXTI_SECENR1_SEC25                 EXTI_SECENR1_SEC25_Msk                 /*!< Security enable on line 25 */
-#define EXTI_SECENR1_SEC26_Pos             (26U)
-#define EXTI_SECENR1_SEC26_Msk             (0x1UL << EXTI_SECENR1_SEC26_Pos)      /*!< 0x04000000 */
-#define EXTI_SECENR1_SEC26                 EXTI_SECENR1_SEC26_Msk                 /*!< Security enable on line 26 */
-#define EXTI_SECENR1_SEC27_Pos             (27U)
-#define EXTI_SECENR1_SEC27_Msk             (0x1UL << EXTI_SECENR1_SEC27_Pos)      /*!< 0x08000000 */
-#define EXTI_SECENR1_SEC27                 EXTI_SECENR1_SEC27_Msk                 /*!< Security enable on line 27 */
-#define EXTI_SECENR1_SEC28_Pos             (28U)
-#define EXTI_SECENR1_SEC28_Msk             (0x1UL << EXTI_SECENR1_SEC28_Pos)      /*!< 0x10000000 */
-#define EXTI_SECENR1_SEC28                 EXTI_SECENR1_SEC28_Msk                 /*!< Security enable on line 28 */
-#define EXTI_SECENR1_SEC29_Pos             (29U)
-#define EXTI_SECENR1_SEC29_Msk             (0x1UL << EXTI_SECENR1_SEC29_Pos)      /*!< 0x20000000 */
-#define EXTI_SECENR1_SEC29                 EXTI_SECENR1_SEC29_Msk                 /*!< Security enable on line 29 */
-#define EXTI_SECENR1_SEC30_Pos             (30U)
-#define EXTI_SECENR1_SEC30_Msk             (0x1UL << EXTI_SECENR1_SEC30_Pos)      /*!< 0x40000000 */
-#define EXTI_SECENR1_SEC30                 EXTI_SECENR1_SEC30_Msk                 /*!< Security enable on line 30 */
-#define EXTI_SECENR1_SEC31_Pos             (31U)
-#define EXTI_SECENR1_SEC31_Msk             (0x1UL << EXTI_SECENR1_SEC31_Pos)      /*!< 0x80000000 */
-#define EXTI_SECENR1_SEC31                 EXTI_SECENR1_SEC31_Msk                 /*!< Security enable on line 31 */
-
 
 /*******************  Bit definition for EXTI_PRIVENR1 register  ******************/
 #define EXTI_PRIVENR1_PRIV0_Pos             (0U)
@@ -4440,24 +4337,15 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV17_Pos            (17U)
 #define EXTI_PRIVENR1_PRIV17_Msk            (0x1UL << EXTI_PRIVENR1_PRIV17_Pos)     /*!< 0x00020000 */
 #define EXTI_PRIVENR1_PRIV17                EXTI_PRIVENR1_PRIV17_Msk                /*!< Privilege enable on line 17 */
-#define EXTI_PRIVENR1_PRIV18_Pos            (18U)
-#define EXTI_PRIVENR1_PRIV18_Msk            (0x1UL << EXTI_PRIVENR1_PRIV18_Pos)     /*!< 0x00040000 */
-#define EXTI_PRIVENR1_PRIV18                EXTI_PRIVENR1_PRIV18_Msk                /*!< Privilege enable on line 18 */
 #define EXTI_PRIVENR1_PRIV19_Pos            (19U)
 #define EXTI_PRIVENR1_PRIV19_Msk            (0x1UL << EXTI_PRIVENR1_PRIV19_Pos)     /*!< 0x00080000 */
 #define EXTI_PRIVENR1_PRIV19                EXTI_PRIVENR1_PRIV19_Msk                /*!< Privilege enable on line 19 */
-#define EXTI_PRIVENR1_PRIV20_Pos            (20U)
-#define EXTI_PRIVENR1_PRIV20_Msk            (0x1UL << EXTI_PRIVENR1_PRIV20_Pos)     /*!< 0x00100000 */
-#define EXTI_PRIVENR1_PRIV20                EXTI_PRIVENR1_PRIV20_Msk                /*!< Privilege enable on line 20 */
 #define EXTI_PRIVENR1_PRIV21_Pos            (21U)
 #define EXTI_PRIVENR1_PRIV21_Msk            (0x1UL << EXTI_PRIVENR1_PRIV21_Pos)     /*!< 0x00200000 */
 #define EXTI_PRIVENR1_PRIV21                EXTI_PRIVENR1_PRIV21_Msk                /*!< Privilege enable on line 21 */
 #define EXTI_PRIVENR1_PRIV22_Pos            (22U)
 #define EXTI_PRIVENR1_PRIV22_Msk            (0x1UL << EXTI_PRIVENR1_PRIV22_Pos)     /*!< 0x00400000 */
 #define EXTI_PRIVENR1_PRIV22                EXTI_PRIVENR1_PRIV22_Msk                /*!< Privilege enable on line 22 */
-#define EXTI_PRIVENR1_PRIV23_Pos            (23U)
-#define EXTI_PRIVENR1_PRIV23_Msk            (0x1UL << EXTI_PRIVENR1_PRIV23_Pos)     /*!< 0x00800000 */
-#define EXTI_PRIVENR1_PRIV23                EXTI_PRIVENR1_PRIV23_Msk                /*!< Privilege enable on line 23 */
 #define EXTI_PRIVENR1_PRIV24_Pos            (24U)
 #define EXTI_PRIVENR1_PRIV24_Msk            (0x1UL << EXTI_PRIVENR1_PRIV24_Pos)     /*!< 0x01000000 */
 #define EXTI_PRIVENR1_PRIV24                EXTI_PRIVENR1_PRIV24_Msk                /*!< Privilege enable on line 24 */
@@ -4476,45 +4364,30 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV29_Pos            (29U)
 #define EXTI_PRIVENR1_PRIV29_Msk            (0x1UL << EXTI_PRIVENR1_PRIV29_Pos)      /*!< 0x20000000 */
 #define EXTI_PRIVENR1_PRIV29                EXTI_PRIVENR1_PRIV29_Msk                 /*!< Privilege enable on line 29 */
-#define EXTI_PRIVENR1_PRIV30_Pos            (30U)
-#define EXTI_PRIVENR1_PRIV30_Msk            (0x1UL << EXTI_PRIVENR1_PRIV30_Pos)      /*!< 0x40000000 */
-#define EXTI_PRIVENR1_PRIV30                EXTI_PRIVENR1_PRIV30_Msk                 /*!< Privilege enable on line 30 */
-#define EXTI_PRIVENR1_PRIV31_Pos            (31U)
-#define EXTI_PRIVENR1_PRIV31_Msk            (0x1UL << EXTI_PRIVENR1_PRIV31_Pos)      /*!< 0x80000000 */
-#define EXTI_PRIVENR1_PRIV31                EXTI_PRIVENR1_PRIV31_Msk                 /*!< Privilege enable on line 31 */
 
 /******************  Bit definition for EXTI_RTSR2 register  *******************/
-#define EXTI_RTSR2_TR_Pos                   (14U)
-#define EXTI_RTSR2_TR_Msk                   (0x244UL << EXTI_RTSR2_TR_Pos)              /*!< 0x00244000 */
-#define EXTI_RTSR2_TR                       EXTI_RTSR2_TR_Msk                           /*!< Rising trigger event configuration bit */
-#define EXTI_RTSR2_TR46_Pos                 (14U)
-#define EXTI_RTSR2_TR46_Msk                 (0x1UL << EXTI_RTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_RTSR2_TR46                     EXTI_RTSR2_TR46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
-#define EXTI_RTSR2_TR50_Pos                 (18U)
-#define EXTI_RTSR2_TR50_Msk                 (0x1UL << EXTI_RTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_RTSR2_TR50                     EXTI_RTSR2_TR50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
-#define EXTI_RTSR2_TR53_Pos                 (21U)
-#define EXTI_RTSR2_TR53_Msk                 (0x1UL << EXTI_RTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_RTSR2_TR53                     EXTI_RTSR2_TR53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
+#define EXTI_RTSR2_RT_Pos                   (16U)
+#define EXTI_RTSR2_RT_Msk                   (0x24UL << EXTI_RTSR2_RT_Pos)               /*!< 0x00240000 */
+#define EXTI_RTSR2_RT                       EXTI_RTSR2_RT_Msk                           /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT50_Pos                 (18U)
+#define EXTI_RTSR2_RT50_Msk                 (0x1UL << EXTI_RTSR2_RT50_Pos)              /*!< 0x00040000 */
+#define EXTI_RTSR2_RT50                     EXTI_RTSR2_RT50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
+#define EXTI_RTSR2_RT53_Pos                 (21U)
+#define EXTI_RTSR2_RT53_Msk                 (0x1UL << EXTI_RTSR2_RT53_Pos)              /*!< 0x00200000 */
+#define EXTI_RTSR2_RT53                     EXTI_RTSR2_RT53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FTSR2 register  *******************/
-#define EXTI_FTSR2_TR_Pos                   (14U)
-#define EXTI_FTSR2_TR_Msk                   (0x244 << EXTI_FTSR2_TR_Pos)                /*!< 0x00244000 */
-#define EXTI_FTSR2_TR                       EXTI_FTSR2_TR_Msk                           /*!< Falling trigger event configuration bit */
-#define EXTI_FTSR2_TR46_Pos                 (14U)
-#define EXTI_FTSR2_TR46_Msk                 (0x1UL << EXTI_FTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_FTSR2_TR46                     EXTI_FTSR2_TR46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
-#define EXTI_FTSR2_TR50_Pos                 (18U)
-#define EXTI_FTSR2_TR50_Msk                 (0x1UL << EXTI_FTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_FTSR2_TR50                     EXTI_FTSR2_TR50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
-#define EXTI_FTSR2_TR53_Pos                 (21U)
-#define EXTI_FTSR2_TR53_Msk                 (0x1UL << EXTI_FTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_FTSR2_TR53                     EXTI_FTSR2_TR53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
+#define EXTI_FTSR2_FT_Pos                   (16U)
+#define EXTI_FTSR2_FT_Msk                   (0x24 << EXTI_FTSR2_FT_Pos)                 /*!< 0x00240000 */
+#define EXTI_FTSR2_FT                       EXTI_FTSR2_FT_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT50_Pos                 (18U)
+#define EXTI_FTSR2_FT50_Msk                 (0x1UL << EXTI_FTSR2_FT50_Pos)              /*!< 0x00040000 */
+#define EXTI_FTSR2_FT50                     EXTI_FTSR2_FT50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
+#define EXTI_FTSR2_FT53_Pos                 (21U)
+#define EXTI_FTSR2_FT53_Msk                 (0x1UL << EXTI_FTSR2_FT53_Pos)              /*!< 0x00200000 */
+#define EXTI_FTSR2_FT53                     EXTI_FTSR2_FT53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_SWIER2 register  ******************/
-#define EXTI_SWIER2_SWIER46_Pos            (14U)
-#define EXTI_SWIER2_SWIER46_Msk            (0x1UL << EXTI_SWIER2_SWIER46_Pos)          /*!< 0x00004000 */
-#define EXTI_SWIER2_SWIER46                EXTI_SWIER2_SWIER46_Msk                     /*!< Software Interrupt on line 46 */
 #define EXTI_SWIER2_SWIER50_Pos            (18U)
 #define EXTI_SWIER2_SWIER50_Msk            (0x1UL << EXTI_SWIER2_SWIER50_Pos)          /*!< 0x00040000 */
 #define EXTI_SWIER2_SWIER50                EXTI_SWIER2_SWIER50_Msk                     /*!< Software Interrupt on line 50 */
@@ -4523,12 +4396,9 @@ typedef struct
 #define EXTI_SWIER2_SWIER53                EXTI_SWIER2_SWIER53_Msk                     /*!< Software Interrupt on line 53 */
 
 /******************  Bit definition for EXTI_RPR2 register  *******************/
-#define EXTI_RPR2_RPIF_Pos                   (14U)
-#define EXTI_RPR2_RPIF_Msk                   (0x244UL << EXTI_RPR2_RPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_RPR2_RPIF_Pos                   (16U)
+#define EXTI_RPR2_RPIF_Msk                   (0x24UL << EXTI_RPR2_RPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_RPR2_RPIF                       EXTI_RPR2_RPIF_Msk                     /*!< Rising pending edge configuration bits */
-#define EXTI_RPR2_RPIF46_Pos                 (14U)
-#define EXTI_RPR2_RPIF46_Msk                 (0x1UL << EXTI_RPR2_RPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_RPR2_RPIF46                     EXTI_RPR2_RPIF46_Msk                   /*!< Rising pending edge configuration bit of line 46 */
 #define EXTI_RPR2_RPIF50_Pos                 (18U)
 #define EXTI_RPR2_RPIF50_Msk                 (0x1UL << EXTI_RPR2_RPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_RPR2_RPIF50                     EXTI_RPR2_RPIF50_Msk                   /*!< Rising pending edge configuration bit of line 50 */
@@ -4537,12 +4407,9 @@ typedef struct
 #define EXTI_RPR2_RPIF53                     EXTI_RPR2_RPIF53_Msk                   /*!< Rising pending edge configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FPR2 register  *******************/
-#define EXTI_FPR2_FPIF_Pos                   (14U)
-#define EXTI_FPR2_FPIF_Msk                   (0x244UL << EXTI_FPR2_FPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_FPR2_FPIF_Pos                   (16U)
+#define EXTI_FPR2_FPIF_Msk                   (0x24UL << EXTI_FPR2_FPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_FPR2_FPIF                       EXTI_FPR2_FPIF_Msk                     /*!< Rising falling edge configuration bits */
-#define EXTI_FPR2_FPIF46_Pos                 (14U)
-#define EXTI_FPR2_FPIF46_Msk                 (0x1UL << EXTI_FPR2_FPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_FPR2_FPIF46                     EXTI_FPR2_FPIF46_Msk                   /*!< Rising falling edge configuration bit of line 46 */
 #define EXTI_FPR2_FPIF50_Pos                 (18U)
 #define EXTI_FPR2_FPIF50_Msk                 (0x1UL << EXTI_FPR2_FPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_FPR2_FPIF50                     EXTI_FPR2_FPIF50_Msk                   /*!< Rising falling edge configuration bit of line 50 */
@@ -4550,102 +4417,7 @@ typedef struct
 #define EXTI_FPR2_FPIF53_Msk                 (0x1UL << EXTI_FPR2_FPIF53_Pos)        /*!< 0x00200000 */
 #define EXTI_FPR2_FPIF53                     EXTI_FPR2_FPIF53_Msk                   /*!< Rising falling edge configuration bit of line 53 */
 
-/*******************  Bit definition for EXTI_SECENR2 register  ******************/
-#define EXTI_SECENR2_SEC32_Pos              (0U)
-#define EXTI_SECENR2_SEC32_Msk              (0x1UL << EXTI_SECENR2_SEC32_Pos)       /*!< 0x00000001 */
-#define EXTI_SECENR2_SEC32                  EXTI_SECENR2_SEC32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_SECENR2_SEC33_Pos              (1U)
-#define EXTI_SECENR2_SEC33_Msk              (0x1UL << EXTI_SECENR2_SEC33_Pos)       /*!< 0x00000002 */
-#define EXTI_SECENR2_SEC33                  EXTI_SECENR2_SEC33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_SECENR2_SEC34_Pos              (2U)
-#define EXTI_SECENR2_SEC34_Msk              (0x1UL << EXTI_SECENR2_SEC34_Pos)       /*!< 0x00000004 */
-#define EXTI_SECENR2_SEC34                  EXTI_SECENR2_SEC34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_SECENR2_SEC35_Pos              (3U)
-#define EXTI_SECENR2_SEC35_Msk              (0x1UL << EXTI_SECENR2_SEC35_Pos)       /*!< 0x00000008 */
-#define EXTI_SECENR2_SEC35                  EXTI_SECENR2_SEC35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_SECENR2_SEC36_Pos              (4U)
-#define EXTI_SECENR2_SEC36_Msk              (0x1UL << EXTI_SECENR2_SEC36_Pos)       /*!< 0x00000010 */
-#define EXTI_SECENR2_SEC36                  EXTI_SECENR2_SEC36_Msk                  /*!< Security enable on line 4 */
-#define EXTI_SECENR2_SEC37_Pos              (5U)
-#define EXTI_SECENR2_SEC37_Msk              (0x1UL << EXTI_SECENR2_SEC37_Pos)       /*!< 0x00000020 */
-#define EXTI_SECENR2_SEC37                  EXTI_SECENR2_SEC37_Msk                  /*!< Security enable on line 5 */
-#define EXTI_SECENR2_SEC38_Pos              (6U)
-#define EXTI_SECENR2_SEC38_Msk              (0x1UL << EXTI_SECENR2_SEC38_Pos)       /*!< 0x00000040 */
-#define EXTI_SECENR2_SEC38                  EXTI_SECENR2_SEC38_Msk                  /*!< Security enable on line 6 */
-#define EXTI_SECENR2_SEC39_Pos              (7U)
-#define EXTI_SECENR2_SEC39_Msk              (0x1UL << EXTI_SECENR2_SEC39_Pos)       /*!< 0x00000080 */
-#define EXTI_SECENR2_SEC39                  EXTI_SECENR2_SEC39_Msk                  /*!< Security enable on line 7 */
-#define EXTI_SECENR2_SEC40_Pos              (8U)
-#define EXTI_SECENR2_SEC40_Msk              (0x1UL << EXTI_SECENR2_SEC40_Pos)       /*!< 0x00000100 */
-#define EXTI_SECENR2_SEC40                  EXTI_SECENR2_SEC40_Msk                  /*!< Security enable on line 8 */
-#define EXTI_SECENR2_SEC41_Pos              (9U)
-#define EXTI_SECENR2_SEC41_Msk              (0x1UL << EXTI_SECENR2_SEC41_Pos)       /*!< 0x00000200 */
-#define EXTI_SECENR2_SEC41                  EXTI_SECENR2_SEC41_Msk                  /*!< Security enable on line 9 */
-#define EXTI_SECENR2_SEC42_Pos             (10U)
-#define EXTI_SECENR2_SEC42_Msk             (0x1UL << EXTI_SECENR2_SEC42_Pos)        /*!< 0x00000400 */
-#define EXTI_SECENR2_SEC42                 EXTI_SECENR2_SEC42_Msk                   /*!< Security enable on line 10 */
-#define EXTI_SECENR2_SEC43_Pos             (11U)
-#define EXTI_SECENR2_SEC43_Msk             (0x1UL << EXTI_SECENR2_SEC43_Pos)        /*!< 0x00000800 */
-#define EXTI_SECENR2_SEC43                 EXTI_SECENR2_SEC43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_SECENR2_SEC44_Pos             (12U)
-#define EXTI_SECENR2_SEC44_Msk             (0x1UL << EXTI_SECENR2_SEC44_Pos)        /*!< 0x00001000 */
-#define EXTI_SECENR2_SEC44                 EXTI_SECENR2_SEC44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_SECENR2_SEC45_Pos             (13U)
-#define EXTI_SECENR2_SEC45_Msk             (0x1UL << EXTI_SECENR2_SEC45_Pos)        /*!< 0x00002000 */
-#define EXTI_SECENR2_SEC45                 EXTI_SECENR2_SEC45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_SECENR2_SEC46_Pos             (14U)
-#define EXTI_SECENR2_SEC46_Msk             (0x1UL << EXTI_SECENR2_SEC46_Pos)        /*!< 0x00004000 */
-#define EXTI_SECENR2_SEC46                 EXTI_SECENR2_SEC46_Msk                   /*!< Security enable on line 14 */
-#define EXTI_SECENR2_SEC47_Pos             (15U)
-#define EXTI_SECENR2_SEC47_Msk             (0x1UL << EXTI_SECENR2_SEC47_Pos)        /*!< 0x00008000 */
-#define EXTI_SECENR2_SEC47                 EXTI_SECENR2_SEC47_Msk                   /*!< Security enable on line 15 */
-#define EXTI_SECENR2_SEC48_Pos             (16U)
-#define EXTI_SECENR2_SEC48_Msk             (0x1UL << EXTI_SECENR2_SEC48_Pos)        /*!< 0x00010000 */
-#define EXTI_SECENR2_SEC48                 EXTI_SECENR2_SEC48_Msk                   /*!< Security enable on line 16 */
-#define EXTI_SECENR2_SEC49_Pos             (17U)
-#define EXTI_SECENR2_SEC49_Msk             (0x1UL << EXTI_SECENR2_SEC49_Pos)        /*!< 0x00020000 */
-#define EXTI_SECENR2_SEC49                 EXTI_SECENR2_SEC49_Msk                   /*!< Security enable on line 17 */
-#define EXTI_SECENR2_SEC50_Pos             (18U)
-#define EXTI_SECENR2_SEC50_Msk             (0x1UL << EXTI_SECENR2_SEC50_Pos)        /*!< 0x00040000 */
-#define EXTI_SECENR2_SEC50                 EXTI_SECENR2_SEC50_Msk                   /*!< Security enable on line 18 */
-#define EXTI_SECENR2_SEC51_Pos             (19U)
-#define EXTI_SECENR2_SEC51_Msk             (0x1UL << EXTI_SECENR2_SEC51_Pos)        /*!< 0x00080000 */
-#define EXTI_SECENR2_SEC51                 EXTI_SECENR2_SEC51_Msk                   /*!< Security enable on line 19 */
-#define EXTI_SECENR2_SEC52_Pos             (20U)
-#define EXTI_SECENR2_SEC52_Msk             (0x1UL << EXTI_SECENR2_SEC52_Pos)        /*!< 0x00100000 */
-#define EXTI_SECENR2_SEC52                 EXTI_SECENR2_SEC52_Msk                   /*!< Security enable on line 20 */
-#define EXTI_SECENR2_SEC53_Pos             (21U)
-#define EXTI_SECENR2_SEC53_Msk             (0x1UL << EXTI_SECENR2_SEC53_Pos)        /*!< 0x00200000 */
-#define EXTI_SECENR2_SEC53                 EXTI_SECENR2_SEC53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_SECENR2_SEC54_Pos             (22U)
-#define EXTI_SECENR2_SEC54_Msk             (0x1UL << EXTI_SECENR2_SEC54_Pos)        /*!< 0x00400000 */
-#define EXTI_SECENR2_SEC54                 EXTI_SECENR2_SEC54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_SECENR2_SEC55_Pos             (23U)
-#define EXTI_SECENR2_SEC55_Msk             (0x1UL << EXTI_SECENR2_SEC55_Pos)        /*!< 0x00800000 */
-#define EXTI_SECENR2_SEC55                 EXTI_SECENR2_SEC55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_SECENR2_SEC56_Pos             (24U)
-#define EXTI_SECENR2_SEC56_Msk             (0x1UL << EXTI_SECENR2_SEC56_Pos)        /*!< 0x01000000 */
-#define EXTI_SECENR2_SEC56                 EXTI_SECENR2_SEC56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_SECENR2_SEC57_Pos             (25U)
-#define EXTI_SECENR2_SEC57_Msk             (0x1UL << EXTI_SECENR2_SEC57_Pos)        /*!< 0x02000000 */
-#define EXTI_SECENR2_SEC57                 EXTI_SECENR2_SEC57_Msk                   /*!< Security enable on line 25 */
-
 /*******************  Bit definition for EXTI_PRIVENR2 register  ******************/
-#define EXTI_PRIVENR2_PRIV32_Pos              (0U)
-#define EXTI_PRIVENR2_PRIV32_Msk              (0x1UL << EXTI_PRIVENR2_PRIV32_Pos)       /*!< 0x00000001 */
-#define EXTI_PRIVENR2_PRIV32                  EXTI_PRIVENR2_PRIV32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_PRIVENR2_PRIV33_Pos              (1U)
-#define EXTI_PRIVENR2_PRIV33_Msk              (0x1UL << EXTI_PRIVENR2_PRIV33_Pos)       /*!< 0x00000002 */
-#define EXTI_PRIVENR2_PRIV33                  EXTI_PRIVENR2_PRIV33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_PRIVENR2_PRIV34_Pos              (2U)
-#define EXTI_PRIVENR2_PRIV34_Msk              (0x1UL << EXTI_PRIVENR2_PRIV34_Pos)       /*!< 0x00000004 */
-#define EXTI_PRIVENR2_PRIV34                  EXTI_PRIVENR2_PRIV34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_PRIVENR2_PRIV35_Pos              (3U)
-#define EXTI_PRIVENR2_PRIV35_Msk              (0x1UL << EXTI_PRIVENR2_PRIV35_Pos)       /*!< 0x00000008 */
-#define EXTI_PRIVENR2_PRIV35                  EXTI_PRIVENR2_PRIV35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_PRIVENR2_PRIV36_Pos              (4U)
-#define EXTI_PRIVENR2_PRIV36_Msk              (0x1UL << EXTI_PRIVENR2_PRIV36_Pos)       /*!< 0x00000010 */
-#define EXTI_PRIVENR2_PRIV36                  EXTI_PRIVENR2_PRIV36_Msk                  /*!< Security enable on line 4 */
 #define EXTI_PRIVENR2_PRIV37_Pos              (5U)
 #define EXTI_PRIVENR2_PRIV37_Msk              (0x1UL << EXTI_PRIVENR2_PRIV37_Pos)       /*!< 0x00000020 */
 #define EXTI_PRIVENR2_PRIV37                  EXTI_PRIVENR2_PRIV37_Msk                  /*!< Security enable on line 5 */
@@ -4664,51 +4436,18 @@ typedef struct
 #define EXTI_PRIVENR2_PRIV42_Pos             (10U)
 #define EXTI_PRIVENR2_PRIV42_Msk             (0x1UL << EXTI_PRIVENR2_PRIV42_Pos)        /*!< 0x00000400 */
 #define EXTI_PRIVENR2_PRIV42                 EXTI_PRIVENR2_PRIV42_Msk                   /*!< Security enable on line 10 */
-#define EXTI_PRIVENR2_PRIV43_Pos             (11U)
-#define EXTI_PRIVENR2_PRIV43_Msk             (0x1UL << EXTI_PRIVENR2_PRIV43_Pos)        /*!< 0x00000800 */
-#define EXTI_PRIVENR2_PRIV43                 EXTI_PRIVENR2_PRIV43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_PRIVENR2_PRIV44_Pos             (12U)
-#define EXTI_PRIVENR2_PRIV44_Msk             (0x1UL << EXTI_PRIVENR2_PRIV44_Pos)        /*!< 0x00001000 */
-#define EXTI_PRIVENR2_PRIV44                 EXTI_PRIVENR2_PRIV44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_PRIVENR2_PRIV45_Pos             (13U)
-#define EXTI_PRIVENR2_PRIV45_Msk             (0x1UL << EXTI_PRIVENR2_PRIV45_Pos)        /*!< 0x00002000 */
-#define EXTI_PRIVENR2_PRIV45                 EXTI_PRIVENR2_PRIV45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_PRIVENR2_PRIV46_Pos             (14U)
-#define EXTI_PRIVENR2_PRIV46_Msk             (0x1UL << EXTI_PRIVENR2_PRIV46_Pos)        /*!< 0x00004000 */
-#define EXTI_PRIVENR2_PRIV46                 EXTI_PRIVENR2_PRIV46_Msk                   /*!< Security enable on line 14 */
 #define EXTI_PRIVENR2_PRIV47_Pos             (15U)
 #define EXTI_PRIVENR2_PRIV47_Msk             (0x1UL << EXTI_PRIVENR2_PRIV47_Pos)        /*!< 0x00008000 */
 #define EXTI_PRIVENR2_PRIV47                 EXTI_PRIVENR2_PRIV47_Msk                   /*!< Security enable on line 15 */
-#define EXTI_PRIVENR2_PRIV48_Pos             (16U)
-#define EXTI_PRIVENR2_PRIV48_Msk             (0x1UL << EXTI_PRIVENR2_PRIV48_Pos)        /*!< 0x00010000 */
-#define EXTI_PRIVENR2_PRIV48                 EXTI_PRIVENR2_PRIV48_Msk                   /*!< Security enable on line 16 */
 #define EXTI_PRIVENR2_PRIV49_Pos             (17U)
 #define EXTI_PRIVENR2_PRIV49_Msk             (0x1UL << EXTI_PRIVENR2_PRIV49_Pos)        /*!< 0x00020000 */
 #define EXTI_PRIVENR2_PRIV49                 EXTI_PRIVENR2_PRIV49_Msk                   /*!< Security enable on line 17 */
 #define EXTI_PRIVENR2_PRIV50_Pos             (18U)
 #define EXTI_PRIVENR2_PRIV50_Msk             (0x1UL << EXTI_PRIVENR2_PRIV50_Pos)        /*!< 0x00040000 */
 #define EXTI_PRIVENR2_PRIV50                 EXTI_PRIVENR2_PRIV50_Msk                   /*!< Security enable on line 18 */
-#define EXTI_PRIVENR2_PRIV51_Pos             (19U)
-#define EXTI_PRIVENR2_PRIV51_Msk             (0x1UL << EXTI_PRIVENR2_PRIV51_Pos)        /*!< 0x00080000 */
-#define EXTI_PRIVENR2_PRIV51                 EXTI_PRIVENR2_PRIV51_Msk                   /*!< Security enable on line 19 */
-#define EXTI_PRIVENR2_PRIV52_Pos             (20U)
-#define EXTI_PRIVENR2_PRIV52_Msk             (0x1UL << EXTI_PRIVENR2_PRIV52_Pos)        /*!< 0x00100000 */
-#define EXTI_PRIVENR2_PRIV52                 EXTI_PRIVENR2_PRIV52_Msk                   /*!< Security enable on line 20 */
 #define EXTI_PRIVENR2_PRIV53_Pos             (21U)
 #define EXTI_PRIVENR2_PRIV53_Msk             (0x1UL << EXTI_PRIVENR2_PRIV53_Pos)        /*!< 0x00200000 */
 #define EXTI_PRIVENR2_PRIV53                 EXTI_PRIVENR2_PRIV53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_PRIVENR2_PRIV54_Pos             (22U)
-#define EXTI_PRIVENR2_PRIV54_Msk             (0x1UL << EXTI_PRIVENR2_PRIV54_Pos)        /*!< 0x00400000 */
-#define EXTI_PRIVENR2_PRIV54                 EXTI_PRIVENR2_PRIV54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_PRIVENR2_PRIV55_Pos             (23U)
-#define EXTI_PRIVENR2_PRIV55_Msk             (0x1UL << EXTI_PRIVENR2_PRIV55_Pos)        /*!< 0x00800000 */
-#define EXTI_PRIVENR2_PRIV55                 EXTI_PRIVENR2_PRIV55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_PRIVENR2_PRIV56_Pos             (24U)
-#define EXTI_PRIVENR2_PRIV56_Msk             (0x1UL << EXTI_PRIVENR2_PRIV56_Pos)        /*!< 0x01000000 */
-#define EXTI_PRIVENR2_PRIV56                 EXTI_PRIVENR2_PRIV56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_PRIVENR2_PRIV57_Pos             (25U)
-#define EXTI_PRIVENR2_PRIV57_Msk             (0x1UL << EXTI_PRIVENR2_PRIV57_Pos)        /*!< 0x02000000 */
-#define EXTI_PRIVENR2_PRIV57                 EXTI_PRIVENR2_PRIV57_Msk                   /*!< Security enable on line 25 */
 
 /*****************  Bit definition for EXTI_EXTICR1 register  **************/
 #define EXTI_EXTICR1_EXTI0_Pos              (0U)
@@ -4832,7 +4571,7 @@ typedef struct
 
 /*******************  Bit definition for EXTI_IMR1 register  ******************/
 #define EXTI_IMR1_IM_Pos                    (0U)
-#define EXTI_IMR1_IM_Msk                    (0xFFFFFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM_Msk                    (0x3F6BFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0x3F6BFFFF */
 #define EXTI_IMR1_IM                        EXTI_IMR1_IM_Msk                        /*!< Interrupt Mask */
 #define EXTI_IMR1_IM0_Pos                   (0U)
 #define EXTI_IMR1_IM0_Msk                   (0x1UL << EXTI_IMR1_IM0_Pos)            /*!< 0x00000001 */
@@ -4888,24 +4627,15 @@ typedef struct
 #define EXTI_IMR1_IM17_Pos                  (17U)
 #define EXTI_IMR1_IM17_Msk                  (0x1UL << EXTI_IMR1_IM17_Pos)           /*!< 0x00020000 */
 #define EXTI_IMR1_IM17                      EXTI_IMR1_IM17_Msk                      /*!< Interrupt Mask on line 17 */
-#define EXTI_IMR1_IM18_Pos                  (18U)
-#define EXTI_IMR1_IM18_Msk                  (0x1UL << EXTI_IMR1_IM18_Pos)           /*!< 0x00040000 */
-#define EXTI_IMR1_IM18                      EXTI_IMR1_IM18_Msk                      /*!< Interrupt Mask on line 18 */
 #define EXTI_IMR1_IM19_Pos                  (19U)
 #define EXTI_IMR1_IM19_Msk                  (0x1UL << EXTI_IMR1_IM19_Pos)           /*!< 0x00080000 */
 #define EXTI_IMR1_IM19                      EXTI_IMR1_IM19_Msk                      /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos                  (20U)
-#define EXTI_IMR1_IM20_Msk                  (0x1UL << EXTI_IMR1_IM20_Pos)           /*!< 0x00100000 */
-#define EXTI_IMR1_IM20                      EXTI_IMR1_IM20_Msk                      /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos                  (21U)
 #define EXTI_IMR1_IM21_Msk                  (0x1UL << EXTI_IMR1_IM21_Pos)           /*!< 0x00200000 */
 #define EXTI_IMR1_IM21                      EXTI_IMR1_IM21_Msk                      /*!< Interrupt Mask on line 21 */
 #define EXTI_IMR1_IM22_Pos                  (22U)
 #define EXTI_IMR1_IM22_Msk                  (0x1UL << EXTI_IMR1_IM22_Pos)           /*!< 0x00400000 */
 #define EXTI_IMR1_IM22                      EXTI_IMR1_IM22_Msk                      /*!< Interrupt Mask on line 22 */
-#define EXTI_IMR1_IM23_Pos                  (23U)
-#define EXTI_IMR1_IM23_Msk                  (0x1UL << EXTI_IMR1_IM23_Pos)           /*!< 0x00800000 */
-#define EXTI_IMR1_IM23                      EXTI_IMR1_IM23_Msk                      /*!< Interrupt Mask on line 23 */
 #define EXTI_IMR1_IM24_Pos                  (24U)
 #define EXTI_IMR1_IM24_Msk                  (0x1UL << EXTI_IMR1_IM24_Pos)           /*!< 0x01000000 */
 #define EXTI_IMR1_IM24                      EXTI_IMR1_IM24_Msk                      /*!< Interrupt Mask on line 24 */
@@ -4924,12 +4654,6 @@ typedef struct
 #define EXTI_IMR1_IM29_Pos                  (29U)
 #define EXTI_IMR1_IM29_Msk                  (0x1UL << EXTI_IMR1_IM29_Pos)           /*!< 0x20000000 */
 #define EXTI_IMR1_IM29                      EXTI_IMR1_IM29_Msk                      /*!< Interrupt Mask on line 29 */
-#define EXTI_IMR1_IM30_Pos                  (30U)
-#define EXTI_IMR1_IM30_Msk                  (0x1UL << EXTI_IMR1_IM30_Pos)           /*!< 0x40000000 */
-#define EXTI_IMR1_IM30                      EXTI_IMR1_IM30_Msk                      /*!< Interrupt Mask on line 30 */
-#define EXTI_IMR1_IM31_Pos                  (31U)
-#define EXTI_IMR1_IM31_Msk                  (0x1UL << EXTI_IMR1_IM31_Pos)           /*!< 0x80000000 */
-#define EXTI_IMR1_IM31                      EXTI_IMR1_IM31_Msk                      /*!< Interrupt Mask on line 31 */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
 #define EXTI_EMR1_EM_Pos                    (0U)
@@ -4989,24 +4713,15 @@ typedef struct
 #define EXTI_EMR1_EM17_Pos                  (17U)
 #define EXTI_EMR1_EM17_Msk                  (0x1UL << EXTI_EMR1_EM17_Pos)           /*!< 0x00020000 */
 #define EXTI_EMR1_EM17                      EXTI_EMR1_EM17_Msk                      /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos                  (18U)
-#define EXTI_EMR1_EM18_Msk                  (0x1UL << EXTI_EMR1_EM18_Pos)           /*!< 0x00040000 */
-#define EXTI_EMR1_EM18                      EXTI_EMR1_EM18_Msk                      /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos                  (19U)
 #define EXTI_EMR1_EM19_Msk                  (0x1UL << EXTI_EMR1_EM19_Pos)           /*!< 0x00080000 */
 #define EXTI_EMR1_EM19                      EXTI_EMR1_EM19_Msk                      /*!< Event Mask on line 19 */
-#define EXTI_EMR1_EM20_Pos                  (20U)
-#define EXTI_EMR1_EM20_Msk                  (0x1UL << EXTI_EMR1_EM20_Pos)           /*!< 0x00100000 */
-#define EXTI_EMR1_EM20                      EXTI_EMR1_EM20_Msk                      /*!< Event Mask on line 20 */
 #define EXTI_EMR1_EM21_Pos                  (21U)
 #define EXTI_EMR1_EM21_Msk                  (0x1UL << EXTI_EMR1_EM21_Pos)           /*!< 0x00200000 */
 #define EXTI_EMR1_EM21                      EXTI_EMR1_EM21_Msk                      /*!< Event Mask on line 21 */
 #define EXTI_EMR1_EM22_Pos                  (22U)
 #define EXTI_EMR1_EM22_Msk                  (0x1UL << EXTI_EMR1_EM22_Pos)           /*!< 0x00400000 */
 #define EXTI_EMR1_EM22                      EXTI_EMR1_EM22_Msk                      /*!< Event Mask on line 22 */
-#define EXTI_EMR1_EM23_Pos                  (23U)
-#define EXTI_EMR1_EM23_Msk                  (0x1UL << EXTI_EMR1_EM23_Pos)           /*!< 0x00800000 */
-#define EXTI_EMR1_EM23                      EXTI_EMR1_EM23_Msk                      /*!< Event Mask on line 23 */
 #define EXTI_EMR1_EM24_Pos                  (24U)
 #define EXTI_EMR1_EM24_Msk                  (0x1UL << EXTI_EMR1_EM24_Pos)           /*!< 0x01000000 */
 #define EXTI_EMR1_EM24                      EXTI_EMR1_EM24_Msk                      /*!< Event Mask on line 24 */
@@ -5025,32 +4740,11 @@ typedef struct
 #define EXTI_EMR1_EM29_Pos                  (29U)
 #define EXTI_EMR1_EM29_Msk                  (0x1UL << EXTI_EMR1_EM29_Pos)           /*!< 0x20000000 */
 #define EXTI_EMR1_EM29                      EXTI_EMR1_EM29_Msk                      /*!< Event Mask on line 29 */
-#define EXTI_EMR1_EM30_Pos                  (30U)
-#define EXTI_EMR1_EM30_Msk                  (0x1UL << EXTI_EMR1_EM30_Pos)           /*!< 0x40000000 */
-#define EXTI_EMR1_EM30                      EXTI_EMR1_EM30_Msk                      /*!< Event Mask on line 30 */
-#define EXTI_EMR1_EM31_Pos                  (31U)
-#define EXTI_EMR1_EM31_Msk                  (0x1UL << EXTI_EMR1_EM31_Pos)           /*!< 0x80000000 */
-#define EXTI_EMR1_EM31                      EXTI_EMR1_EM31_Msk                      /*!< Event Mask on line 31 */
 
 /*******************  Bit definition for EXTI_IMR2 register  *******************/
 #define EXTI_IMR2_IM_Pos                    (0U)
-#define EXTI_IMR2_IM_Msk                    (0x003FFFFFUL << EXTI_IMR2_IM_Pos)      /*!< 0x003FFFFF */
+#define EXTI_IMR2_IM_Msk                    (0x002687E0UL << EXTI_IMR2_IM_Pos)      /*!< 0x002687E0 */
 #define EXTI_IMR2_IM                        EXTI_IMR2_IM_Msk                        /*!< Interrupt Mask */
-#define EXTI_IMR2_IM32_Pos                  (0U)
-#define EXTI_IMR2_IM32_Msk                  (0x1UL << EXTI_IMR2_IM32_Pos)           /*!< 0x00000001 */
-#define EXTI_IMR2_IM32                      EXTI_IMR2_IM32_Msk                      /*!< Interrupt Mask on line 32 */
-#define EXTI_IMR2_IM33_Pos                  (1U)
-#define EXTI_IMR2_IM33_Msk                  (0x1UL << EXTI_IMR2_IM33_Pos)           /*!< 0x00000002 */
-#define EXTI_IMR2_IM33                      EXTI_IMR2_IM33_Msk                      /*!< Interrupt Mask on line 33 */
-#define EXTI_IMR2_IM34_Pos                  (2U)
-#define EXTI_IMR2_IM34_Msk                  (0x1UL << EXTI_IMR2_IM34_Pos)           /*!< 0x00000004 */
-#define EXTI_IMR2_IM34                      EXTI_IMR2_IM34_Msk                      /*!< Interrupt Mask on line 34 */
-#define EXTI_IMR2_IM35_Pos                  (3U)
-#define EXTI_IMR2_IM35_Msk                  (0x1UL << EXTI_IMR2_IM35_Pos)           /*!< 0x00000008 */
-#define EXTI_IMR2_IM35                      EXTI_IMR2_IM35_Msk                      /*!< Interrupt Mask on line 35 */
-#define EXTI_IMR2_IM36_Pos                  (4U)
-#define EXTI_IMR2_IM36_Msk                  (0x1UL << EXTI_IMR2_IM36_Pos)           /*!< 0x00000010 */
-#define EXTI_IMR2_IM36                      EXTI_IMR2_IM36_Msk                      /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM37_Pos                  (5U)
 #define EXTI_IMR2_IM37_Msk                  (0x1UL << EXTI_IMR2_IM37_Pos)           /*!< 0x00000020 */
 #define EXTI_IMR2_IM37                      EXTI_IMR2_IM37_Msk                      /*!< Interrupt Mask on line 37 */
@@ -5069,69 +4763,24 @@ typedef struct
 #define EXTI_IMR2_IM42_Pos                  (10U)
 #define EXTI_IMR2_IM42_Msk                  (0x1UL << EXTI_IMR2_IM42_Pos)           /*!< 0x00000400 */
 #define EXTI_IMR2_IM42                      EXTI_IMR2_IM42_Msk                      /*!< Interrupt Mask on line 42 */
-#define EXTI_IMR2_IM43_Pos                  (11U)
-#define EXTI_IMR2_IM43_Msk                  (0x1UL << EXTI_IMR2_IM43_Pos)           /*!< 0x00000800 */
-#define EXTI_IMR2_IM43                      EXTI_IMR2_IM43_Msk                      /*!< Interrupt Mask on line 43 */
-#define EXTI_IMR2_IM44_Pos                  (12U)
-#define EXTI_IMR2_IM44_Msk                  (0x1UL << EXTI_IMR2_IM44_Pos)           /*!< 0x00001000 */
-#define EXTI_IMR2_IM44                      EXTI_IMR2_IM44_Msk                      /*!< Interrupt Mask on line 44 */
-#define EXTI_IMR2_IM46_Pos                  (14U)
-#define EXTI_IMR2_IM46_Msk                  (0x1UL << EXTI_IMR2_IM46_Pos)           /*!< 0x00004000 */
-#define EXTI_IMR2_IM46                      EXTI_IMR2_IM46_Msk                      /*!< Interrupt Mask on line 46 */
 #define EXTI_IMR2_IM47_Pos                  (15U)
 #define EXTI_IMR2_IM47_Msk                  (0x1UL << EXTI_IMR2_IM47_Pos)           /*!< 0x00008000 */
 #define EXTI_IMR2_IM47                      EXTI_IMR2_IM47_Msk                      /*!< Interrupt Mask on line 47 */
-#define EXTI_IMR2_IM48_Pos                  (16U)
-#define EXTI_IMR2_IM48_Msk                  (0x1UL << EXTI_IMR2_IM48_Pos)           /*!< 0x00010000 */
-#define EXTI_IMR2_IM48                      EXTI_IMR2_IM48_Msk                      /*!< Interrupt Mask on line 48 */
 #define EXTI_IMR2_IM49_Pos                  (17U)
 #define EXTI_IMR2_IM49_Msk                  (0x1UL << EXTI_IMR2_IM49_Pos)           /*!< 0x00020000 */
 #define EXTI_IMR2_IM49                      EXTI_IMR2_IM49_Msk                      /*!< Interrupt Mask on line 49 */
 #define EXTI_IMR2_IM50_Pos                  (18U)
 #define EXTI_IMR2_IM50_Msk                  (0x1UL << EXTI_IMR2_IM50_Pos)           /*!< 0x00040000 */
 #define EXTI_IMR2_IM50                      EXTI_IMR2_IM50_Msk                      /*!< Interrupt Mask on line 50 */
-#define EXTI_IMR2_IM51_Pos                  (19U)
-#define EXTI_IMR2_IM51_Msk                  (0x1UL << EXTI_IMR2_IM51_Pos)           /*!< 0x00080000 */
-#define EXTI_IMR2_IM51                      EXTI_IMR2_IM51_Msk                      /*!< Interrupt Mask on line 51 */
-#define EXTI_IMR2_IM52_Pos                  (20U)
-#define EXTI_IMR2_IM52_Msk                  (0x1UL << EXTI_IMR2_IM52_Pos)           /*!< 0x00100000 */
-#define EXTI_IMR2_IM52                      EXTI_IMR2_IM52_Msk                      /*!< Interrupt Mask on line 52 */
 #define EXTI_IMR2_IM53_Pos                  (21U)
 #define EXTI_IMR2_IM53_Msk                  (0x1UL << EXTI_IMR2_IM53_Pos)           /*!< 0x00200000 */
 #define EXTI_IMR2_IM53                      EXTI_IMR2_IM53_Msk                      /*!< Interrupt Mask on line 53 */
-#define EXTI_IMR2_IM54_Pos                  (22U)
-#define EXTI_IMR2_IM54_Msk                  (0x1UL << EXTI_IMR2_IM54_Pos)           /*!< 0x00400000 */
-#define EXTI_IMR2_IM54                      EXTI_IMR2_IM54_Msk                      /*!< Interrupt Mask on line 54 */
-#define EXTI_IMR2_IM55_Pos                  (23U)
-#define EXTI_IMR2_IM55_Msk                  (0x1UL << EXTI_IMR2_IM55_Pos)           /*!< 0x00800000 */
-#define EXTI_IMR2_IM55                      EXTI_IMR2_IM55_Msk                      /*!< Interrupt Mask on line 55 */
-#define EXTI_IMR2_IM56_Pos                  (24U)
-#define EXTI_IMR2_IM56_Msk                  (0x1UL << EXTI_IMR2_IM56_Pos)           /*!< 0x01000000 */
-#define EXTI_IMR2_IM56                      EXTI_IMR2_IM56_Msk                      /*!< Interrupt Mask on line 56 */
-#define EXTI_IMR2_IM57_Pos                  (25U)
-#define EXTI_IMR2_IM57_Msk                  (0x1UL << EXTI_IMR2_IM57_Pos)           /*!< 0x02000000 */
-#define EXTI_IMR2_IM57                      EXTI_IMR2_IM57_Msk                      /*!< Interrupt Mask on line 57 */
 
 
 /*******************  Bit definition for EXTI_EMR2 register  *******************/
 #define EXTI_EMR2_EM_Pos                    (0U)
-#define EXTI_EMR2_EM_Msk                    (0x03FFFFFFUL << EXTI_EMR2_EM_Pos)      /*!< 0x03FFFFFF */
+#define EXTI_EMR2_EM_Msk                    (0x002687E0UL << EXTI_EMR2_EM_Pos)      /*!< 0x002687E0 */
 #define EXTI_EMR2_EM                        EXTI_EMR2_EM_Msk                        /*!< Event Mask */
-#define EXTI_EMR2_EM32_Pos                  (0U)
-#define EXTI_EMR2_EM32_Msk                  (0x1UL << EXTI_EMR2_EM32_Pos)           /*!< 0x00000001 */
-#define EXTI_EMR2_EM32                      EXTI_EMR2_EM32_Msk                      /*!< Event Mask on line 32*/
-#define EXTI_EMR2_EM33_Pos                  (1U)
-#define EXTI_EMR2_EM33_Msk                  (0x1UL << EXTI_EMR2_EM33_Pos)           /*!< 0x00000002 */
-#define EXTI_EMR2_EM33                      EXTI_EMR2_EM33_Msk                      /*!< Event Mask on line 33*/
-#define EXTI_EMR2_EM34_Pos                  (2U)
-#define EXTI_EMR2_EM34_Msk                  (0x1UL << EXTI_EMR2_EM34_Pos)           /*!< 0x00000004 */
-#define EXTI_EMR2_EM34                      EXTI_EMR2_EM34_Msk                      /*!< Event Mask on line 34*/
-#define EXTI_EMR2_EM35_Pos                  (3U)
-#define EXTI_EMR2_EM35_Msk                  (0x1UL << EXTI_EMR2_EM35_Pos)           /*!< 0x00000008 */
-#define EXTI_EMR2_EM35                      EXTI_EMR2_EM35_Msk                      /*!< Event Mask on line 35*/
-#define EXTI_EMR2_EM36_Pos                  (4U)
-#define EXTI_EMR2_EM36_Msk                  (0x1UL << EXTI_EMR2_EM36_Pos)           /*!< 0x00000010 */
-#define EXTI_EMR2_EM36                      EXTI_EMR2_EM36_Msk                      /*!< Event Mask on line 36*/
 #define EXTI_EMR2_EM37_Pos                  (5U)
 #define EXTI_EMR2_EM37_Msk                  (0x1UL << EXTI_EMR2_EM37_Pos)           /*!< 0x00000020 */
 #define EXTI_EMR2_EM37                      EXTI_EMR2_EM37_Msk                      /*!< Event Mask on line 37*/
@@ -5150,48 +4799,18 @@ typedef struct
 #define EXTI_EMR2_EM42_Pos                  (10U)
 #define EXTI_EMR2_EM42_Msk                  (0x1UL << EXTI_EMR2_EM42_Pos)           /*!< 0x00000400 */
 #define EXTI_EMR2_EM42                      EXTI_EMR2_EM42_Msk                      /*!< Event Mask on line 42 */
-#define EXTI_EMR2_EM43_Pos                  (11U)
-#define EXTI_EMR2_EM43_Msk                  (0x1UL << EXTI_EMR2_EM43_Pos)           /*!< 0x00000800 */
-#define EXTI_EMR2_EM43                      EXTI_EMR2_EM43_Msk                      /*!< Event Mask on line 43 */
-#define EXTI_EMR2_EM44_Pos                  (12U)
-#define EXTI_EMR2_EM44_Msk                  (0x1UL << EXTI_EMR2_EM44_Pos)           /*!< 0x00001000 */
-#define EXTI_EMR2_EM44                      EXTI_EMR2_EM44_Msk                      /*!< Event Mask on line 44 */
-#define EXTI_EMR2_EM46_Pos                  (14U)
-#define EXTI_EMR2_EM46_Msk                  (0x1UL << EXTI_EMR2_EM46_Pos)           /*!< 0x00004000 */
-#define EXTI_EMR2_EM46                      EXTI_EMR2_EM46_Msk                      /*!< Event Mask on line 46 */
 #define EXTI_EMR2_EM47_Pos                  (15U)
 #define EXTI_EMR2_EM47_Msk                  (0x1UL << EXTI_EMR2_EM47_Pos)           /*!< 0x00008000 */
 #define EXTI_EMR2_EM47                      EXTI_EMR2_EM47_Msk                      /*!< Event Mask on line 47 */
-#define EXTI_EMR2_EM48_Pos                  (16U)
-#define EXTI_EMR2_EM48_Msk                  (0x1UL << EXTI_EMR2_EM48_Pos)           /*!< 0x00010000 */
-#define EXTI_EMR2_EM48                      EXTI_EMR2_EM48_Msk                      /*!< Event Mask on line 48 */
 #define EXTI_EMR2_EM49_Pos                  (17U)
 #define EXTI_EMR2_EM49_Msk                  (0x1UL << EXTI_EMR2_EM49_Pos)           /*!< 0x00020000 */
 #define EXTI_EMR2_EM49                      EXTI_EMR2_EM49_Msk                      /*!< Event Mask on line 49 */
 #define EXTI_EMR2_EM50_Pos                  (18U)
 #define EXTI_EMR2_EM50_Msk                  (0x1UL << EXTI_EMR2_EM50_Pos)           /*!< 0x00040000 */
 #define EXTI_EMR2_EM50                      EXTI_EMR2_EM50_Msk                      /*!< Event Mask on line 50 */
-#define EXTI_EMR2_EM51_Pos                  (19U)
-#define EXTI_EMR2_EM51_Msk                  (0x1UL << EXTI_EMR2_EM51_Pos)           /*!< 0x00080000 */
-#define EXTI_EMR2_EM51                      EXTI_EMR2_EM51_Msk                      /*!< Event Mask on line 51 */
-#define EXTI_EMR2_EM52_Pos                  (20U)
-#define EXTI_EMR2_EM52_Msk                  (0x1UL << EXTI_EMR2_EM52_Pos)           /*!< 0x00100000 */
-#define EXTI_EMR2_EM52                      EXTI_EMR2_EM52_Msk                      /*!< Event Mask on line 52 */
 #define EXTI_EMR2_EM53_Pos                  (21U)
 #define EXTI_EMR2_EM53_Msk                  (0x1UL << EXTI_EMR2_EM53_Pos)           /*!< 0x00200000 */
 #define EXTI_EMR2_EM53                      EXTI_EMR2_EM53_Msk                      /*!< Event Mask on line 53 */
-#define EXTI_EMR2_EM54_Pos                  (22U)
-#define EXTI_EMR2_EM54_Msk                  (0x1UL << EXTI_EMR2_EM54_Pos)           /*!< 0x00400000 */
-#define EXTI_EMR2_EM54                      EXTI_EMR2_EM54_Msk                      /*!< Event Mask on line 54 */
-#define EXTI_EMR2_EM55_Pos                  (23U)
-#define EXTI_EMR2_EM55_Msk                  (0x1UL << EXTI_EMR2_EM55_Pos)           /*!< 0x00800000 */
-#define EXTI_EMR2_EM55                      EXTI_EMR2_EM55_Msk                      /*!< Event Mask on line 55 */
-#define EXTI_EMR2_EM56_Pos                  (24U)
-#define EXTI_EMR2_EM56_Msk                  (0x1UL << EXTI_EMR2_EM56_Pos)           /*!< 0x01000000 */
-#define EXTI_EMR2_EM56                      EXTI_EMR2_EM56_Msk                      /*!< Event Mask on line 56 */
-#define EXTI_EMR2_EM57_Pos                  (25U)
-#define EXTI_EMR2_EM57_Msk                  (0x1UL << EXTI_EMR2_EM57_Pos)           /*!< 0x02000000 */
-#define EXTI_EMR2_EM57                      EXTI_EMR2_EM57_Msk                      /*!< Event Mask on line 57 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -5775,7 +5394,7 @@ typedef struct
 /*                                    FLASH                                   */
 /*                                                                            */
 /******************************************************************************/
-#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /* FLASH Three Latency cycle */
+#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /*!< FLASH Three Latency cycle */
 #define FLASH_BLOCKBASED_NB_REG             (1U)                                    /*!< 1 Block-based registers for each Flash bank */
 #define FLASH_SIZE_DEFAULT                  (0x20000U)                              /*!< FLASH Size */
 #define FLASH_SECTOR_NB                     (8U)                                    /*!< Flash Sector number */
@@ -5959,10 +5578,10 @@ typedef struct
 
 /******************  Bits definition for FLASH_HDPEXTR register  *****************/
 #define FLASH_HDPEXTR_HDP1_EXT_Pos          (0U)
-#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP1_EXT_Pos)  /*!< 0x0000007F */
+#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x7UL << FLASH_HDPEXTR_HDP1_EXT_Pos)   /*!< 0x00000007 */
 #define FLASH_HDPEXTR_HDP1_EXT              FLASH_HDPEXTR_HDP1_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 1 */
 #define FLASH_HDPEXTR_HDP2_EXT_Pos          (16U)
-#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP2_EXT_Pos)  /*!< 0x007F0000 */
+#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x7UL << FLASH_HDPEXTR_HDP2_EXT_Pos)   /*!< 0x00070000 */
 #define FLASH_HDPEXTR_HDP2_EXT              FLASH_HDPEXTR_HDP2_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 2 */
 
 /*******************  Bits definition for FLASH_OPTSR register  ***************/
@@ -7652,27 +7271,27 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR1 register  *******************/
 #define TIM_CCR1_CCR1_Pos                   (0U)
-#define TIM_CCR1_CCR1_Msk                   (0xFFFFUL << TIM_CCR1_CCR1_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1_Msk                   (0xFFFFFFFFUL << TIM_CCR1_CCR1_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR1_CCR1                       TIM_CCR1_CCR1_Msk                       /*!<Capture/Compare 1 Value */
 
 /*******************  Bit definition for TIM_CCR2 register  *******************/
 #define TIM_CCR2_CCR2_Pos                   (0U)
-#define TIM_CCR2_CCR2_Msk                   (0xFFFFUL << TIM_CCR2_CCR2_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2_Msk                   (0xFFFFFFFFUL << TIM_CCR2_CCR2_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR2_CCR2                       TIM_CCR2_CCR2_Msk                       /*!<Capture/Compare 2 Value */
 
 /*******************  Bit definition for TIM_CCR3 register  *******************/
 #define TIM_CCR3_CCR3_Pos                   (0U)
-#define TIM_CCR3_CCR3_Msk                   (0xFFFFUL << TIM_CCR3_CCR3_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3_Msk                   (0xFFFFFFFFUL << TIM_CCR3_CCR3_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR3_CCR3                       TIM_CCR3_CCR3_Msk                       /*!<Capture/Compare 3 Value */
 
 /*******************  Bit definition for TIM_CCR4 register  *******************/
 #define TIM_CCR4_CCR4_Pos                   (0U)
-#define TIM_CCR4_CCR4_Msk                   (0xFFFFUL << TIM_CCR4_CCR4_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4_Msk                   (0xFFFFFFFFUL << TIM_CCR4_CCR4_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR4_CCR4                       TIM_CCR4_CCR4_Msk                       /*!<Capture/Compare 4 Value */
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos                   (0U)
-#define TIM_CCR5_CCR5_Msk                   (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)     /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk                   (0xFFFFFUL << TIM_CCR5_CCR5_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR5_CCR5                       TIM_CCR5_CCR5_Msk                       /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos                  (29U)
 #define TIM_CCR5_GC5C1_Msk                  (0x1UL << TIM_CCR5_GC5C1_Pos)           /*!< 0x20000000 */
@@ -7686,7 +7305,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR6 register  *******************/
 #define TIM_CCR6_CCR6_Pos                   (0U)
-#define TIM_CCR6_CCR6_Msk                   (0xFFFFUL << TIM_CCR6_CCR6_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6_Msk                   (0xFFFFFUL << TIM_CCR6_CCR6_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR6_CCR6                       TIM_CCR6_CCR6_Msk                       /*!<Capture/Compare 6 Value */
 
 /*******************  Bit definition for TIM_BDTR register  *******************/
@@ -7830,6 +7449,11 @@ typedef struct
 #define TIM1_AF2_OCRSEL_Msk                 (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
 #define TIM1_AF2_OCRSEL                     TIM1_AF2_OCRSEL_Msk                     /*!<OCREF_CLR source selection */
 #define TIM1_AF2_OCRSEL_0                   (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM_OR1 register  *********************/
+#define TIM_OR1_RTCPREEN_Pos                 (1U)
+#define TIM_OR1_RTCPREEN_Msk                 (0x1UL << TIM_OR1_RTCPREEN_Pos)           /*!< 0x00000002 */
+#define TIM_OR1_RTCPREEN                     TIM_OR1_RTCPREEN_Msk                      /*!< RTCPRE HSE divider enable */
 
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos                (0U)
@@ -8340,9 +7964,9 @@ typedef struct
 #define PWR_SCCR_LDOEN                       PWR_SCCR_LDOEN_Msk
 
 /********************  Bit definition for PWR_VMCR register  ******************/
-#define PWR_VMCR_PVDEN_Pos                    (0U)
-#define PWR_VMCR_PVDEN_Msk                    (0x1UL << PWR_VMCR_PVDEN_Pos)
-#define PWR_VMCR_PVDEN                        PWR_VMCR_PVDEN_Msk
+#define PWR_VMCR_PVDEN_Pos                   (0U)
+#define PWR_VMCR_PVDEN_Msk                   (0x1UL << PWR_VMCR_PVDEN_Pos)
+#define PWR_VMCR_PVDEN                       PWR_VMCR_PVDEN_Msk
 #define PWR_VMCR_PLS_Pos                     (1U)
 #define PWR_VMCR_PLS_Msk                     (0x7UL << PWR_VMCR_PLS_Pos)
 #define PWR_VMCR_PLS                         PWR_VMCR_PLS_Msk
@@ -9182,6 +8806,9 @@ typedef struct
 #define RCC_AHB2RSTR_RNGRST_Pos             (18U)
 #define RCC_AHB2RSTR_RNGRST_Msk             (0x1UL << RCC_AHB2RSTR_RNGRST_Pos)      /*!< 0x00040000 */
 #define RCC_AHB2RSTR_RNGRST                 RCC_AHB2RSTR_RNGRST_Msk
+#define RCC_AHB2RSTR_PKARST_Pos             (19U)
+#define RCC_AHB2RSTR_PKARST_Msk             (0x1UL << RCC_AHB2RSTR_PKARST_Pos)      /*!< 0x00080000 */
+#define RCC_AHB2RSTR_PKARST                 RCC_AHB2RSTR_PKARST_Msk
 
 /********************  Bit definition for RCC_APB1LRSTR register  **************/
 #define RCC_APB1LRSTR_TIM2RST_Pos           (0U)
@@ -9317,6 +8944,9 @@ typedef struct
 #define RCC_AHB2ENR_RNGEN_Pos               (18U)
 #define RCC_AHB2ENR_RNGEN_Msk               (0x1UL << RCC_AHB2ENR_RNGEN_Pos)        /*!< 0x00040000 */
 #define RCC_AHB2ENR_RNGEN                   RCC_AHB2ENR_RNGEN_Msk
+#define RCC_AHB2ENR_PKAEN_Pos               (19U)
+#define RCC_AHB2ENR_PKAEN_Msk               (0x1UL << RCC_AHB2ENR_PKAEN_Pos)        /*!< 0x00080000 */
+#define RCC_AHB2ENR_PKAEN                   RCC_AHB2ENR_PKAEN_Msk
 #define RCC_AHB2ENR_SRAM2EN_Pos             (30U)
 #define RCC_AHB2ENR_SRAM2EN_Msk             (0x1UL << RCC_AHB2ENR_SRAM2EN_Pos)      /*!< 0x40000000 */
 #define RCC_AHB2ENR_SRAM2EN                 RCC_AHB2ENR_SRAM2EN_Msk
@@ -11196,7 +10826,6 @@ typedef struct
 #define GTZC_TZSC_MPCWMR_SUBZ_LENGTH        GTZC_TZSC_MPCWMR_SUBZ_LENGTH_Msk
 
 /*******  Bits definition for TZSC _SECCFGRx/_PRIVCFGRx registers  *****/
-/*******  Bits definition for TZIC _IERx/_SRx/_IFCRx registers  ********/
 
 /***************  Bits definition for register x=1 (TZSC1) *************/
 #define GTZC_CFGR1_TIM2_Pos                 (0U)
@@ -11233,7 +10862,6 @@ typedef struct
 #define GTZC_CFGR1_DTS_Msk                  (0x01UL << GTZC_CFGR1_DTS_Pos)
 #define GTZC_CFGR1_LPTIM2_Pos               (31U)
 #define GTZC_CFGR1_LPTIM2_Msk               (0x01UL << GTZC_CFGR1_LPTIM2_Pos)
-
 
 /***************  Bits definition for register x=2 (TZSC1) *************/
 #define GTZC_CFGR2_FDCAN1_Pos               (0U)
@@ -11280,6 +10908,7 @@ typedef struct
 #define GTZC_CFGR4_FLASH_Msk                (0x01UL << GTZC_CFGR4_FLASH_Pos)
 #define GTZC_CFGR4_FLASH_REG_Pos            (3U)
 #define GTZC_CFGR4_FLASH_REG_Msk            (0x01UL << GTZC_CFGR4_FLASH_REG_Pos)
+
 #define GTZC_CFGR4_SBS_Pos                  (6U)
 #define GTZC_CFGR4_SBS_Msk                  (0x01UL << GTZC_CFGR4_SBS_Pos)
 #define GTZC_CFGR4_RTC_Pos                  (7U)
@@ -11304,6 +10933,7 @@ typedef struct
 #define GTZC_CFGR4_SRAM2_Msk                (0x01UL << GTZC_CFGR4_SRAM2_Pos)
 #define GTZC_CFGR4_MPCBB2_REG_Pos           (27U)
 #define GTZC_CFGR4_MPCBB2_REG_Msk           (0x01UL << GTZC_CFGR4_MPCBB2_REG_Pos)
+
 
 
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR1 register  ***************/
@@ -11355,6 +10985,8 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR2_LPTIM1_Msk         GTZC_CFGR2_LPTIM1_Msk
 
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR3 register  ***************/
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Pos           GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Msk           GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Pos            GTZC_CFGR3_CRC_Pos
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Msk            GTZC_CFGR3_CRC_Msk
 #define GTZC_TZSC1_PRIVCFGR3_ICACHE_REG_Pos     GTZC_CFGR3_ICACHE_REG_Pos
@@ -11369,79 +11001,6 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR3_RAMCFG_Msk         GTZC_CFGR3_RAMCFG_Msk
 
 
-/*******************  Bits definition for GTZC_MPCBB_CR register  *****************/
-#define GTZC_MPCBB_CR_GLOCK_Pos             (0U)
-#define GTZC_MPCBB_CR_GLOCK_Msk             (0x01UL << GTZC_MPCBB_CR_GLOCK_Pos)       /*!< 0x00000001 */
-#define GTZC_MPCBB_CR_INVSECSTATE_Pos       (30U)
-#define GTZC_MPCBB_CR_INVSECSTATE_Msk       (0x01UL << GTZC_MPCBB_CR_INVSECSTATE_Pos) /*!< 0x40000000 */
-#define GTZC_MPCBB_CR_SRWILADIS_Pos         (31U)
-#define GTZC_MPCBB_CR_SRWILADIS_Msk         (0x01UL << GTZC_MPCBB_CR_SRWILADIS_Pos)   /*!< 0x80000000 */
-
-/*******************  Bits definition for GTZC_MPCBB_CFGLOCKR1 register  ************/
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK0_Pos      (0U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK0_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK0_Pos) /*!< 0x00000001 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK1_Pos      (1U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK1_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK1_Pos) /*!< 0x00000002 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK2_Pos      (2U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK2_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK2_Pos) /*!< 0x00000004 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK3_Pos      (3U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK3_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK3_Pos) /*!< 0x00000008 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK4_Pos      (4U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK4_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK4_Pos) /*!< 0x00000010 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK5_Pos      (5U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK5_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK5_Pos) /*!< 0x00000020 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK6_Pos      (6U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK6_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK6_Pos) /*!< 0x00000040 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK7_Pos      (7U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK7_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK7_Pos) /*!< 0x00000080 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK8_Pos      (8U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK8_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK8_Pos) /*!< 0x00000100 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK9_Pos      (9U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK9_Msk      (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK9_Pos) /*!< 0x00000200 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK10_Pos     (10U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK10_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK10_Pos) /*!< 0x00000400 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK11_Pos     (11U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK11_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK11_Pos) /*!< 0x00000800 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK12_Pos     (12U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK12_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK12_Pos) /*!< 0x00001000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK13_Pos     (13U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK13_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK13_Pos) /*!< 0x00002000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK14_Pos     (14U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK14_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK14_Pos) /*!< 0x00004000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK15_Pos     (15U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK15_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK15_Pos) /*!< 0x00008000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK16_Pos     (16U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK16_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK16_Pos) /*!< 0x00010000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK17_Pos     (17U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK17_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK17_Pos) /*!< 0x00020000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK18_Pos     (18U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK18_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK18_Pos) /*!< 0x00040000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK19_Pos     (19U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK19_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK19_Pos) /*!< 0x00080000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK20_Pos     (20U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK20_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK20_Pos) /*!< 0x00100000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK21_Pos     (21U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK21_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK21_Pos) /*!< 0x00200000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK22_Pos     (22U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK22_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK22_Pos) /*!< 0x00400000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK23_Pos     (23U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK23_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK23_Pos) /*!< 0x00800000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK24_Pos     (24U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK24_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK24_Pos) /*!< 0x01000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK25_Pos     (25U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK25_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK25_Pos) /*!< 0x02000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK26_Pos     (26U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK26_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK26_Pos) /*!< 0x04000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK27_Pos     (27U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK27_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK27_Pos) /*!< 0x08000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK28_Pos     (28U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK28_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK28_Pos) /*!< 0x10000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK29_Pos     (29U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK29_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK29_Pos) /*!< 0x20000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK30_Pos     (30U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK30_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK30_Pos) /*!< 0x40000000 */
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK31_Pos     (31U)
-#define GTZC_MPCBB_CFGLOCKR1_SPLCK31_Msk     (0x01UL << GTZC_MPCBB_CFGLOCKR1_SPLCK31_Pos) /*!< 0x80000000 */
 
 
 
@@ -11450,6 +11009,7 @@ typedef struct
 /*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
 /*                                                                            */
 /******************************************************************************/
+#define USART_DMAREQUESTS_SW_WA
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_UE_Pos                    (0U)
 #define USART_CR1_UE_Msk                    (0x1UL << USART_CR1_UE_Pos)             /*!< 0x00000001 */
@@ -12774,6 +12334,15 @@ typedef struct
 #define I3C_BCR_BCR2_Pos                    (2U)
 #define I3C_BCR_BCR2_Msk                    (0x1UL << I3C_BCR_BCR2_Pos)             /*!< 0x00000004 */
 #define I3C_BCR_BCR2                        I3C_BCR_BCR2_Msk                        /*!< IBI Payload additional Mandatory Data Byte */
+#define I3C_BCR_BCR3_Pos                    (3U)
+#define I3C_BCR_BCR3_Msk                    (0x1UL << I3C_BCR_BCR3_Pos)             /*!< 0x00000008 */
+#define I3C_BCR_BCR3                        I3C_BCR_BCR3_Msk                        /*!< Offline capable */
+#define I3C_BCR_BCR4_Pos                    (4U)
+#define I3C_BCR_BCR4_Msk                    (0x1UL << I3C_BCR_BCR4_Pos)             /*!< 0x00000010 */
+#define I3C_BCR_BCR4                        I3C_BCR_BCR4_Msk                        /*!< Virtual target support */
+#define I3C_BCR_BCR5_Pos                    (5U)
+#define I3C_BCR_BCR5_Msk                    (0x1UL << I3C_BCR_BCR5_Pos)             /*!< 0x00000020 */
+#define I3C_BCR_BCR5                        I3C_BCR_BCR5_Msk                        /*!< Advanced capabilities */
 #define I3C_BCR_BCR6_Pos                    (6U)
 #define I3C_BCR_BCR6_Msk                    (0x1UL << I3C_BCR_BCR6_Pos)             /*!< 0x00000040 */
 #define I3C_BCR_BCR6                        I3C_BCR_BCR6_Msk                        /*!< Device Role shared during Dynamic Address Assignment */
@@ -13619,13 +13188,20 @@ typedef struct
 #define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
 #define USB_PMA_RXBD_COUNTMSK                      (0x03FFFFFFUL)
 
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE                                  (2048U)           /*!< USB PMA Size 2Kbyte */
+
+#define USB_DRD_FS_EP_NBR                                    (8U)           /*!< Number of USB Device endpoints */
+#define USB_DRD_FS_CH_NBR                                    (8U)           /*!< Number of USB Host channels */
+
+
+
 
 /** @addtogroup STM32H5xx_Peripheral_Exported_macros
   * @{
   */
 
 /******************************* ADC Instances ********************************/
-
 #define IS_ADC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == ADC1_NS))
 
 #define IS_ADC_MULTIMODE_MASTER_INSTANCE(INSTANCE) (((INSTANCE) == ADC1_NS))
@@ -13663,13 +13239,19 @@ typedef struct
                                                  ((INSTANCE) == GPDMA2_Channel6_NS)  || \
                                                  ((INSTANCE) == GPDMA2_Channel7_NS))
 
+#define IS_DMA_PFREQ_INSTANCE(INSTANCE) (((INSTANCE) == GPDMA1_Channel0_NS)  || \
+                                         ((INSTANCE) == GPDMA1_Channel7_NS)  || \
+                                         ((INSTANCE) == GPDMA2_Channel0_NS)  || \
+                                         ((INSTANCE) == GPDMA2_Channel7_NS))
+
 /****************************** RAMCFG Instances ********************************/
 #define IS_RAMCFG_ALL_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM1_NS) || \
                                           ((INSTANCE) == RAMCFG_SRAM2_NS) || \
                                           ((INSTANCE) == RAMCFG_BKPRAM_NS))
 
 /***************************** RAMCFG ECC Instances *****************************/
-#define IS_RAMCFG_ECC_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM2_NS) || \
+#define IS_RAMCFG_ECC_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM1_NS) || \
+                                          ((INSTANCE) == RAMCFG_SRAM2_NS) || \
                                           ((INSTANCE) == RAMCFG_BKPRAM_NS))
 
 /************************ RAMCFG Write Protection Instances *********************/

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h523xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h523xx.h
@@ -1,8 +1,8 @@
 /**
   ******************************************************************************
-  * @file    stm32h563xx.h
+  * @file    stm32h523xx.h
   * @author  MCD Application Team
-  * @brief   CMSIS STM32H563xx Device Peripheral Access Layer Header File.
+  * @brief   CMSIS STM32H523xx Device Peripheral Access Layer Header File.
   *
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
@@ -22,8 +22,8 @@
   ******************************************************************************
   */
 
-#ifndef STM32H563xx_H
-#define STM32H563xx_H
+#ifndef STM32H523xx_H
+#define STM32H523xx_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +34,7 @@ extern "C" {
   */
 
 
-/** @addtogroup STM32H563xx
+/** @addtogroup STM32H523xx
   * @{
   */
 
@@ -65,7 +65,7 @@ typedef enum
   PendSV_IRQn               =  -2,    /*!< -2  Pendable request for system service                           */
   SysTick_IRQn              =  -1,    /*!< -1  System Tick Timer                                             */
 
-/* ===========================================  STM32H563xx Specific Interrupt Numbers  ====================================== */
+/* ===========================================  STM32H523xx Specific Interrupt Numbers  ====================================== */
   WWDG_IRQn                 = 0,      /*!< Window WatchDog interrupt                                         */
   PVD_AVD_IRQn              = 1,      /*!< PVD/AVD through EXTI Line detection Interrupt                     */
   RTC_IRQn                  = 2,      /*!< RTC non-secure interrupt                                          */
@@ -137,8 +137,6 @@ typedef enum
   ADC2_IRQn                 = 69,     /*!< ADC2 global interrupt                                             */
   LPTIM2_IRQn               = 70,     /*!< LPTIM2 global interrupt                                           */
   TIM15_IRQn                = 71,     /*!< TIM15 global interrupt                                            */
-  TIM16_IRQn                = 72,     /*!< TIM16 global interrupt                                            */
-  TIM17_IRQn                = 73,     /*!< TIM17 global interrupt                                            */
   USB_DRD_FS_IRQn           = 74,     /*!< USB FS global interrupt                                           */
   CRS_IRQn                  = 75,     /*!< CRS global interrupt                                              */
   UCPD1_IRQn                = 76,     /*!< UCPD1 global interrupt                                            */
@@ -148,13 +146,7 @@ typedef enum
   I2C3_EV_IRQn              = 80,     /*!< I2C3 event interrupt                                              */
   I2C3_ER_IRQn              = 81,     /*!< I2C3 error interrupt                                              */
   SPI4_IRQn                 = 82,     /*!< SPI4 global interrupt                                             */
-  SPI5_IRQn                 = 83,     /*!< SPI5 global interrupt                                             */
-  SPI6_IRQn                 = 84,     /*!< SPI6 global interrupt                                             */
   USART6_IRQn               = 85,     /*!< USART6 global interrupt                                           */
-  USART10_IRQn              = 86,     /*!< USART10 global interrupt                                          */
-  USART11_IRQn              = 87,     /*!< USART11 global interrupt                                          */
-  SAI1_IRQn                 = 88,     /*!< Serial Audio Interface 1 global interrupt                         */
-  SAI2_IRQn                 = 89,     /*!< Serial Audio Interface 2 global interrupt                         */
   GPDMA2_Channel0_IRQn      = 90,     /*!< GPDMA2 Channel 0 global interrupt                                 */
   GPDMA2_Channel1_IRQn      = 91,     /*!< GPDMA2 Channel 1 global interrupt                                 */
   GPDMA2_Channel2_IRQn      = 92,     /*!< GPDMA2 Channel 2 global interrupt                                 */
@@ -163,37 +155,22 @@ typedef enum
   GPDMA2_Channel5_IRQn      = 95,     /*!< GPDMA2 Channel 5 global interrupt                                 */
   GPDMA2_Channel6_IRQn      = 96,     /*!< GPDMA2 Channel 6 global interrupt                                 */
   GPDMA2_Channel7_IRQn      = 97,     /*!< GPDMA2 Channel 7 global interrupt                                 */
-  UART7_IRQn                = 98,     /*!< UART7 global interrupt                                            */
-  UART8_IRQn                = 99,     /*!< UART8 global interrupt                                            */
-  UART9_IRQn                = 100,    /*!< UART9 global interrupt                                            */
-  UART12_IRQn               = 101,    /*!< UART12 global interrupt                                           */
-  SDMMC2_IRQn               = 102,    /*!< SDMMC2 global interrupt                                           */
   FPU_IRQn                  = 103,    /*!< FPU global interrupt                                              */
   ICACHE_IRQn               = 104,    /*!< Instruction cache global interrupt                                */
   DCACHE1_IRQn              = 105,    /*!< Data cache global interrupt                                       */
-  ETH_IRQn                  = 106,    /*!< Ethernet global interrupt                                         */
-  ETH_WKUP_IRQn             = 107,    /*!< Ethernet Wakeup global interrupt                                  */
   DCMI_PSSI_IRQn            = 108,    /*!< DCMI/PSSI global interrupt                                        */
   FDCAN2_IT0_IRQn           = 109,    /*!< FDCAN2 interrupt 0                                                */
   FDCAN2_IT1_IRQn           = 110,    /*!< FDCAN2 interrupt 1                                                */
-  CORDIC_IRQn               = 111,    /*!< CORDIC global interrupt                                           */
-  FMAC_IRQn                 = 112,    /*!< FMAC global interrupt                                             */
   DTS_IRQn                  = 113,    /*!< DTS global interrupt                                              */
   RNG_IRQn                  = 114,    /*!< RNG global interrupt                                              */
   HASH_IRQn                 = 117,    /*!< HASH global interrupt                                             */
   PKA_IRQn                  = 118,    /*!< PKA global interrupt                                              */
   CEC_IRQn                  = 119,    /*!< CEC-HDMI global interrupt                                         */
   TIM12_IRQn                = 120,    /*!< TIM12 global interrupt                                            */
-  TIM13_IRQn                = 121,    /*!< TIM13 global interrupt                                            */
-  TIM14_IRQn                = 122,    /*!< TIM14 global interrupt                                            */
   I3C1_EV_IRQn              = 123,    /*!< I3C1 event interrupt                                              */
   I3C1_ER_IRQn              = 124,    /*!< I3C1 error interrupt                                              */
-  I2C4_EV_IRQn              = 125,    /*!< I2C4 event interrupt                                              */
-  I2C4_ER_IRQn              = 126,    /*!< I2C4 error interrupt                                              */
-  LPTIM3_IRQn               = 127,    /*!< LPTIM3 global interrupt                                           */
-  LPTIM4_IRQn               = 128,    /*!< LPTIM4 global interrupt                                           */
-  LPTIM5_IRQn               = 129,    /*!< LPTIM5 global interrupt                                           */
-  LPTIM6_IRQn               = 130,    /*!< LPTIM6 global interrupt                                           */
+  I3C2_EV_IRQn              = 131,    /*!< I3C2 Event interrupt                                              */
+  I3C2_ER_IRQn              = 132,    /*!< I3C2 Error interrupt                                              */
 } IRQn_Type;
 
 
@@ -224,7 +201,6 @@ typedef enum
   #warning Not supported compiler type
 #endif
 
-#define SMPS       /*!< Switched mode power supply feature */
 
 /* --------  Configuration of the Cortex-M33 Processor and Core Peripherals  ------ */
 #define __CM33_REV                0x0000U   /* Core revision r0p1 */
@@ -402,7 +378,6 @@ typedef struct
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
   __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
-  __IO uint32_t NSCR;  /*!< RNG noise source control register ,     Address offset: 0x0C */
   __IO uint32_t HTCR;  /*!< RNG health test configuration register, Address offset: 0x10 */
 } RNG_TypeDef;
 
@@ -503,179 +478,6 @@ typedef struct
   __IO uint32_t CLLR;         /*!< DMA channel x linked-list address register,      Address offset: 0xCC + (x * 0x80) */
 } DMA_Channel_TypeDef;
 
-/**
-  * @brief Ethernet MAC
-  */
-typedef struct
-{
-  __IO uint32_t MACCR;
-  __IO uint32_t MACECR;
-  __IO uint32_t MACPFR;
-  __IO uint32_t MACWTR;
-  __IO uint32_t MACHT0R;
-  __IO uint32_t MACHT1R;
-  uint32_t      RESERVED1[14];
-  __IO uint32_t MACVTR;
-  uint32_t      RESERVED2;
-  __IO uint32_t MACVHTR;
-  uint32_t      RESERVED3;
-  __IO uint32_t MACVIR;
-  __IO uint32_t MACIVIR;
-  uint32_t      RESERVED4[2];
-  __IO uint32_t MACTFCR;
-  uint32_t      RESERVED5[7];
-  __IO uint32_t MACRFCR;
-  uint32_t      RESERVED6[7];
-  __IO uint32_t MACISR;
-  __IO uint32_t MACIER;
-  __IO uint32_t MACRXTXSR;
-  uint32_t      RESERVED7;
-  __IO uint32_t MACPCSR;
-  __IO uint32_t MACRWKPFR;
-  uint32_t      RESERVED8[2];
-  __IO uint32_t MACLCSR;
-  __IO uint32_t MACLTCR;
-  __IO uint32_t MACLETR;
-  __IO uint32_t MAC1USTCR;
-  uint32_t      RESERVED9[12];
-  __IO uint32_t MACVR;
-  __IO uint32_t MACDR;
-  uint32_t      RESERVED10;
-  __IO uint32_t MACHWF0R;
-  __IO uint32_t MACHWF1R;
-  __IO uint32_t MACHWF2R;
-  uint32_t      RESERVED11[54];
-  __IO uint32_t MACMDIOAR;
-  __IO uint32_t MACMDIODR;
-  uint32_t      RESERVED12[2];
-  __IO uint32_t MACARPAR;
-  uint32_t      RESERVED13[59];
-  __IO uint32_t MACA0HR;
-  __IO uint32_t MACA0LR;
-  __IO uint32_t MACA1HR;
-  __IO uint32_t MACA1LR;
-  __IO uint32_t MACA2HR;
-  __IO uint32_t MACA2LR;
-  __IO uint32_t MACA3HR;
-  __IO uint32_t MACA3LR;
-  uint32_t      RESERVED14[248];
-  __IO uint32_t MMCCR;
-  __IO uint32_t MMCRIR;
-  __IO uint32_t MMCTIR;
-  __IO uint32_t MMCRIMR;
-  __IO uint32_t MMCTIMR;
-  uint32_t      RESERVED15[14];
-  __IO uint32_t MMCTSCGPR;
-  __IO uint32_t MMCTMCGPR;
-  uint32_t      RESERVED16[5];
-  __IO uint32_t MMCTPCGR;
-  uint32_t      RESERVED17[10];
-  __IO uint32_t MMCRCRCEPR;
-  __IO uint32_t MMCRAEPR;
-  uint32_t      RESERVED18[10];
-  __IO uint32_t MMCRUPGR;
-  uint32_t      RESERVED19[9];
-  __IO uint32_t MMCTLPIMSTR;
-  __IO uint32_t MMCTLPITCR;
-  __IO uint32_t MMCRLPIMSTR;
-  __IO uint32_t MMCRLPITCR;
-  uint32_t      RESERVED20[65];
-  __IO uint32_t MACL3L4C0R;
-  __IO uint32_t MACL4A0R;
-  uint32_t      RESERVED21[2];
-  __IO uint32_t MACL3A0R0R;
-  __IO uint32_t MACL3A1R0R;
-  __IO uint32_t MACL3A2R0R;
-  __IO uint32_t MACL3A3R0R;
-  uint32_t      RESERVED22[4];
-  __IO uint32_t MACL3L4C1R;
-  __IO uint32_t MACL4A1R;
-  uint32_t      RESERVED23[2];
-  __IO uint32_t MACL3A0R1R;
-  __IO uint32_t MACL3A1R1R;
-  __IO uint32_t MACL3A2R1R;
-  __IO uint32_t MACL3A3R1R;
-  uint32_t      RESERVED24[108];
-  __IO uint32_t MACTSCR;
-  __IO uint32_t MACSSIR;
-  __IO uint32_t MACSTSR;
-  __IO uint32_t MACSTNR;
-  __IO uint32_t MACSTSUR;
-  __IO uint32_t MACSTNUR;
-  __IO uint32_t MACTSAR;
-  uint32_t      RESERVED25;
-  __IO uint32_t MACTSSR;
-  uint32_t      RESERVED26[3];
-  __IO uint32_t MACTTSSNR;
-  __IO uint32_t MACTTSSSR;
-  uint32_t      RESERVED27[2];
-  __IO uint32_t MACACR;
-  uint32_t      RESERVED28;
-  __IO uint32_t MACATSNR;
-  __IO uint32_t MACATSSR;
-  __IO uint32_t MACTSIACR;
-  __IO uint32_t MACTSEACR;
-  __IO uint32_t MACTSICNR;
-  __IO uint32_t MACTSECNR;
-  uint32_t      RESERVED29[4];
-  __IO uint32_t MACPPSCR;
-  uint32_t      RESERVED30[3];
-  __IO uint32_t MACPPSTTSR;
-  __IO uint32_t MACPPSTTNR;
-  __IO uint32_t MACPPSIR;
-  __IO uint32_t MACPPSWR;
-  uint32_t      RESERVED31[12];
-  __IO uint32_t MACPOCR;
-  __IO uint32_t MACSPI0R;
-  __IO uint32_t MACSPI1R;
-  __IO uint32_t MACSPI2R;
-  __IO uint32_t MACLMIR;
-  uint32_t      RESERVED32[11];
-  __IO uint32_t MTLOMR;
-  uint32_t      RESERVED33[7];
-  __IO uint32_t MTLISR;
-  uint32_t      RESERVED34[55];
-  __IO uint32_t MTLTQOMR;
-  __IO uint32_t MTLTQUR;
-  __IO uint32_t MTLTQDR;
-  uint32_t      RESERVED35[8];
-  __IO uint32_t MTLQICSR;
-  __IO uint32_t MTLRQOMR;
-  __IO uint32_t MTLRQMPOCR;
-  __IO uint32_t MTLRQDR;
-  uint32_t      RESERVED36[177];
-  __IO uint32_t DMAMR;
-  __IO uint32_t DMASBMR;
-  __IO uint32_t DMAISR;
-  __IO uint32_t DMADSR;
-  uint32_t      RESERVED37[60];
-  __IO uint32_t DMACCR;
-  __IO uint32_t DMACTCR;
-  __IO uint32_t DMACRCR;
-  uint32_t      RESERVED38[2];
-  __IO uint32_t DMACTDLAR;
-  uint32_t      RESERVED39;
-  __IO uint32_t DMACRDLAR;
-  __IO uint32_t DMACTDTPR;
-  uint32_t      RESERVED40;
-  __IO uint32_t DMACRDTPR;
-  __IO uint32_t DMACTDRLR;
-  __IO uint32_t DMACRDRLR;
-  __IO uint32_t DMACIER;
-  __IO uint32_t DMACRIWTR;
-  __IO uint32_t DMACSFCSR;
-  uint32_t      RESERVED41;
-  __IO uint32_t DMACCATDR;
-  uint32_t      RESERVED42;
-  __IO uint32_t DMACCARDR;
-  uint32_t      RESERVED43;
-  __IO uint32_t DMACCATBR;
-  uint32_t      RESERVED44;
-  __IO uint32_t DMACCARBR;
-  __IO uint32_t DMACSR;
-  uint32_t      RESERVED45[2];
-  __IO uint32_t DMACMFCR;
-}ETH_TypeDef;
 
 /**
   * @brief Asynch Interrupt/Event Controller (EXTI)
@@ -751,15 +553,9 @@ typedef struct
   __IO uint32_t OTPBLR_PRG;      /*!< FLASH OTP block Lock to program register,                          Address offset: 0x94 */
        uint32_t RESERVED5[2];    /*!< Reserved5,                                                         Address offset: 0x98-0x9C */
   __IO uint32_t SECBB1R1;        /*!< FLASH secure block-based bank 1 register 1,                        Address offset: 0xA0 */
-  __IO uint32_t SECBB1R2;        /*!< FLASH secure block-based bank 1 register 2,                        Address offset: 0xA4 */
-  __IO uint32_t SECBB1R3;        /*!< FLASH secure block-based bank 1 register 3,                        Address offset: 0xA8 */
-  __IO uint32_t SECBB1R4;        /*!< FLASH secure block-based bank 1 register 4,                        Address offset: 0xAC */
-       uint32_t RESERVED6[4];    /*!< Reserved6,                                                         Address offset: 0xB0-0xBC */
+       uint32_t RESERVED6[7];    /*!< Reserved6,                                                         Address offset: 0xA4-0xBF */
   __IO uint32_t PRIVBB1R1;       /*!< FLASH privilege block-based bank 1 register 1,                     Address offset: 0xC0 */
-  __IO uint32_t PRIVBB1R2;       /*!< FLASH privilege block-based bank 1 register 2,                     Address offset: 0xC4 */
-  __IO uint32_t PRIVBB1R3;       /*!< FLASH privilege block-based bank 1 register 3,                     Address offset: 0xC8 */
-  __IO uint32_t PRIVBB1R4;       /*!< FLASH privilege block-based bank 1 register 4,                     Address offset: 0xCC */
-       uint32_t RESERVED7[4];    /*!< Reserved7,                                                         Address offset: 0xD0-0xDC */
+       uint32_t RESERVED7[7];    /*!< Reserved7,                                                         Address offset: 0xC4-0xDC */
   __IO uint32_t SECWM1R_CUR;     /*!< FLASH secure watermark 1 current register,                         Address offset: 0xE0 */
   __IO uint32_t SECWM1R_PRG;     /*!< FLASH secure watermark 1 to program register,                      Address offset: 0xE4 */
   __IO uint32_t WRP1R_CUR;       /*!< FLASH write sector group protection current register for bank1,    Address offset: 0xE8 */
@@ -773,15 +569,9 @@ typedef struct
   __IO uint32_t ECCDR;           /*!< FLASH ECC data register,                                           Address offset: 0x108 */
        uint32_t RESERVED8[37];   /*!< Reserved8,                                                         Address offset: 0x10C-0x19C */
   __IO uint32_t SECBB2R1;        /*!< FLASH secure block-based bank 2 register 1,                        Address offset: 0x1A0 */
-  __IO uint32_t SECBB2R2;        /*!< FLASH secure block-based bank 2 register 2,                        Address offset: 0x1A4 */
-  __IO uint32_t SECBB2R3;        /*!< FLASH secure block-based bank 2 register 3,                        Address offset: 0x1A8 */
-  __IO uint32_t SECBB2R4;        /*!< FLASH secure block-based bank 2 register 4,                        Address offset: 0x1AC */
-       uint32_t RESERVED9[4];    /*!< Reserved9,                                                         Address offset: 0x1B0-0x1BC */
+       uint32_t RESERVED9[7];    /*!< Reserved9,                                                         Address offset: 0x1A4-0x1BF */
   __IO uint32_t PRIVBB2R1;       /*!< FLASH privilege block-based bank 2 register 1,                     Address offset: 0x1C0 */
-  __IO uint32_t PRIVBB2R2;       /*!< FLASH privilege block-based bank 2 register 2,                     Address offset: 0x1C4 */
-  __IO uint32_t PRIVBB2R3;       /*!< FLASH privilege block-based bank 2 register 3,                     Address offset: 0x1C8 */
-  __IO uint32_t PRIVBB2R4;       /*!< FLASH privilege block-based bank 2 register 4,                     Address offset: 0x1CC */
-       uint32_t RESERVED10[4];   /*!< Reserved10,                                                        Address offset: 0x1D0-0x1DC */
+       uint32_t RESERVED10[7];   /*!< Reserved10,                                                        Address offset: 0x1C4-0x1DC */
   __IO uint32_t SECWM2R_CUR;     /*!< FLASH secure watermark 2 current register,                         Address offset: 0x1E0 */
   __IO uint32_t SECWM2R_PRG;     /*!< FLASH secure watermark 2 to program register,                      Address offset: 0x1E4 */
   __IO uint32_t WRP2R_CUR;       /*!< FLASH write sector group protection current register for bank2,    Address offset: 0x1E8 */
@@ -791,21 +581,6 @@ typedef struct
   __IO uint32_t HDP2R_CUR;       /*!< FLASH HDP configuration current register for bank2,                Address offset: 0x1F8 */
   __IO uint32_t HDP2R_PRG;       /*!< FLASH HDP configuration to program register for bank2,             Address offset: 0x1FC */
 } FLASH_TypeDef;
-
-/**
-  * @brief FMAC
-  */
-typedef struct
-{
-  __IO uint32_t X1BUFCFG;        /*!< FMAC X1 Buffer Configuration register, Address offset: 0x00          */
-  __IO uint32_t X2BUFCFG;        /*!< FMAC X2 Buffer Configuration register, Address offset: 0x04          */
-  __IO uint32_t YBUFCFG;         /*!< FMAC Y Buffer Configuration register,  Address offset: 0x08          */
-  __IO uint32_t PARAM;           /*!< FMAC Parameter register,               Address offset: 0x0C          */
-  __IO uint32_t CR;              /*!< FMAC Control register,                 Address offset: 0x10          */
-  __IO uint32_t SR;              /*!< FMAC Status register,                  Address offset: 0x14          */
-  __IO uint32_t WDATA;           /*!< FMAC Write Data register,              Address offset: 0x18          */
-  __IO uint32_t RDATA;           /*!< FMAC Read Data register,               Address offset: 0x1C          */
-} FMAC_TypeDef;
 
 /**
   * @brief General Purpose I/O
@@ -1081,7 +856,7 @@ typedef struct
   __IO uint32_t ICR;      /*!< Interrupt Clear Register,          Address offset: 0x14 */
   __IO uint32_t WPR1;     /*!< SRAM Write Protection Register 1,  Address offset: 0x18 */
   __IO uint32_t WPR2;     /*!< SRAM Write Protection Register 2,  Address offset: 0x1C */
-  uint32_t      RESERVED; /*!< Reserved,                          Address offset: 0x20 */
+  __IO uint32_t WPR3;     /*!< SRAM Write Protection Register 3,  Address offset: 0x20 */
   __IO uint32_t ECCKEY;   /*!< SRAM ECC Key Register,             Address offset: 0x24 */
   __IO uint32_t ERKEYR;   /*!< SRAM Erase Key Register,           Address offset: 0x28 */
 }RAMCFG_TypeDef;
@@ -1288,28 +1063,6 @@ typedef struct
   __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C  */
 } USART_TypeDef;
 
-/**
-  * @brief Serial Audio Interface
-  */
-typedef struct
-{
-  __IO uint32_t GCR;          /*!< SAI global configuration register,        Address offset: 0x00 */
-  uint32_t      RESERVED[16]; /*!< Reserved,                         Address offset: 0x04 to 0x40 */
-  __IO uint32_t PDMCR;        /*!< SAI PDM control register,                 Address offset: 0x44 */
-  __IO uint32_t PDMDLY;       /*!< SAI PDM delay register,                   Address offset: 0x48 */
-} SAI_TypeDef;
-
-typedef struct
-{
-  __IO uint32_t CR1;         /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IO uint32_t CR2;         /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IO uint32_t FRCR;        /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IO uint32_t SLOTR;       /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IO uint32_t IMR;         /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IO uint32_t SR;          /*!< SAI block x status register,              Address offset: 0x18 */
-  __IO uint32_t CLRFR;       /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IO uint32_t DR;          /*!< SAI block x data register,                Address offset: 0x20 */
-} SAI_Block_TypeDef;
 /**
   * @brief System configuration, Boot and Security
   */
@@ -1555,18 +1308,6 @@ typedef struct
 } FMC_Bank3_TypeDef;
 
 /**
-  * @brief Flexible Memory Controller Bank5 and 6
-  */
-typedef struct
-{
-  __IO uint32_t SDCR[2];     /*!< SDRAM Control registers ,       Address offset: 0x140-0x144  */
-  __IO uint32_t SDTR[2];     /*!< SDRAM Timing registers ,        Address offset: 0x148-0x14C  */
-  __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150        */
-  __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154        */
-  __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158        */
-} FMC_Bank5_6_TypeDef;
-
-/**
   * @brief VREFBUF
   */
 typedef struct
@@ -1629,15 +1370,6 @@ typedef struct
   __IO uint32_t CDR;          /*!< ADC common group regular data register Address offset: 0x300 + 0x0C */
 } ADC_Common_TypeDef;
 
-/**
-  * @brief CORDIC
-  */
-typedef struct
-{
-  __IO uint32_t CSR;           /*!< CORDIC control and status register,        Address offset: 0x00 */
-  __IO uint32_t WDATA;         /*!< CORDIC argument register,                  Address offset: 0x04 */
-  __IO uint32_t RDATA;         /*!< CORDIC result register,                    Address offset: 0x08 */
-} CORDIC_TypeDef;
 
 /**
   * @brief IWDG
@@ -1706,7 +1438,7 @@ typedef struct
   __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
-/*@}*/ /* end of group STM32H563xx_Peripherals */
+/*@}*/ /* end of group STM32H523xx_Peripherals */
 
 
 /* --------  End of section using anonymous unions and disabling warnings  -------- */
@@ -1739,16 +1471,17 @@ typedef struct
   */
 
 /* Internal SRAMs size */
-#define SRAM1_SIZE               (0x40000UL)    /*!< SRAM1=256k */
-#define SRAM2_SIZE               (0x10000UL)    /*!< SRAM2=64k  */
-#define SRAM3_SIZE               (0x50000UL)    /*!< SRAM3=320k */
-#define BKPSRAM_SIZE             (0x01000UL)    /*!< BKPSRAM=4k */
+
+#define SRAM1_SIZE               (0x20000UL)    /*!< SRAM1=128k */
+#define SRAM2_SIZE               (0x14000UL)    /*!< SRAM2=80k  */
+#define SRAM3_SIZE               (0x10000UL)    /*!< SRAM3=64k */
+#define BKPSRAM_SIZE             (0x00800UL)    /*!< BKPSRAM=2k */
 
 /* Flash, Peripheral and internal SRAMs base addresses - Non secure */
-#define FLASH_BASE_NS            (0x08000000UL) /*!< FLASH (up to 2 MB) non-secure base address         */
-#define SRAM1_BASE_NS            (0x20000000UL) /*!< SRAM1 (256 KB) non-secure base address             */
-#define SRAM2_BASE_NS            (0x20040000UL) /*!< SRAM2 (64 KB) non-secure base address              */
-#define SRAM3_BASE_NS            (0x20050000UL) /*!< SRAM3 (320 KB) non-secure base address             */
+#define FLASH_BASE_NS            (0x08000000UL) /*!< FLASH (up to 512 KB) non-secure base address       */
+#define SRAM1_BASE_NS            (0x20000000UL) /*!< SRAM1 (128 KB) non-secure base address             */
+#define SRAM2_BASE_NS            (0x20020000UL) /*!< SRAM2 (80 KB) non-secure base address              */
+#define SRAM3_BASE_NS            (0x20034000UL) /*!< SRAM3 (64 KB) non-secure base address              */
 #define PERIPH_BASE_NS           (0x40000000UL) /*!< Peripheral non-secure base address                 */
 
 /* External memories base addresses - Not aliased */
@@ -1782,8 +1515,6 @@ typedef struct
 #define TIM6_BASE_NS             (APB1PERIPH_BASE_NS + 0x1000UL)
 #define TIM7_BASE_NS             (APB1PERIPH_BASE_NS + 0x1400UL)
 #define TIM12_BASE_NS            (APB1PERIPH_BASE_NS + 0x1800UL)
-#define TIM13_BASE_NS            (APB1PERIPH_BASE_NS + 0x1C00UL)
-#define TIM14_BASE_NS            (APB1PERIPH_BASE_NS + 0x2000UL)
 #define WWDG_BASE_NS             (APB1PERIPH_BASE_NS + 0x2C00UL)
 #define IWDG_BASE_NS             (APB1PERIPH_BASE_NS + 0x3000UL)
 #define SPI2_BASE_NS             (APB1PERIPH_BASE_NS + 0x3800UL)
@@ -1797,13 +1528,7 @@ typedef struct
 #define I3C1_BASE_NS             (APB1PERIPH_BASE_NS + 0x5C00UL)
 #define CRS_BASE_NS              (APB1PERIPH_BASE_NS + 0x6000UL)
 #define USART6_BASE_NS           (APB1PERIPH_BASE_NS + 0x6400UL)
-#define USART10_BASE_NS          (APB1PERIPH_BASE_NS + 0x6800UL)
-#define USART11_BASE_NS          (APB1PERIPH_BASE_NS + 0x6C00UL)
 #define CEC_BASE_NS              (APB1PERIPH_BASE_NS + 0x7000UL)
-#define UART7_BASE_NS            (APB1PERIPH_BASE_NS + 0x7800UL)
-#define UART8_BASE_NS            (APB1PERIPH_BASE_NS + 0x7C00UL)
-#define UART9_BASE_NS            (APB1PERIPH_BASE_NS + 0x8000UL)
-#define UART12_BASE_NS           (APB1PERIPH_BASE_NS + 0x8400UL)
 #define DTS_BASE_NS              (APB1PERIPH_BASE_NS + 0x8C00UL)
 #define LPTIM2_BASE_NS           (APB1PERIPH_BASE_NS + 0x9400UL)
 #define FDCAN1_BASE_NS           (APB1PERIPH_BASE_NS + 0xA400UL)
@@ -1818,16 +1543,7 @@ typedef struct
 #define TIM8_BASE_NS             (APB2PERIPH_BASE_NS + 0x3400UL)
 #define USART1_BASE_NS           (APB2PERIPH_BASE_NS + 0x3800UL)
 #define TIM15_BASE_NS            (APB2PERIPH_BASE_NS + 0x4000UL)
-#define TIM16_BASE_NS            (APB2PERIPH_BASE_NS + 0x4400UL)
-#define TIM17_BASE_NS            (APB2PERIPH_BASE_NS + 0x4800UL)
 #define SPI4_BASE_NS             (APB2PERIPH_BASE_NS + 0x4C00UL)
-#define SPI6_BASE_NS             (APB2PERIPH_BASE_NS + 0x5000UL)
-#define SAI1_BASE_NS             (APB2PERIPH_BASE_NS + 0x5400UL)
-#define SAI1_Block_A_BASE_NS     (SAI1_BASE_NS + 0x004UL)
-#define SAI1_Block_B_BASE_NS     (SAI1_BASE_NS + 0x024UL)
-#define SAI2_BASE_NS             (APB2PERIPH_BASE_NS + 0x5800UL)
-#define SAI2_Block_A_BASE_NS     (SAI2_BASE_NS + 0x004UL)
-#define SAI2_Block_B_BASE_NS     (SAI2_BASE_NS + 0x024UL)
 #define USB_DRD_BASE_NS          (APB2PERIPH_BASE_NS + 0x6000UL)
 #define USB_DRD_PMAADDR_NS       (APB2PERIPH_BASE_NS + 0x6400UL)
 
@@ -1836,11 +1552,7 @@ typedef struct
 #define GPDMA2_BASE_NS           (AHB1PERIPH_BASE_NS + 0x01000UL)
 #define FLASH_R_BASE_NS          (AHB1PERIPH_BASE_NS + 0x02000UL)
 #define CRC_BASE_NS              (AHB1PERIPH_BASE_NS + 0x03000UL)
-#define CORDIC_BASE_NS           (AHB1PERIPH_BASE_NS + 0x03800UL)
-#define FMAC_BASE_NS             (AHB1PERIPH_BASE_NS + 0x03C00UL)
 #define RAMCFG_BASE_NS           (AHB1PERIPH_BASE_NS + 0x06000UL)
-#define ETH_BASE_NS              (AHB1PERIPH_BASE_NS + 0x8000UL)
-#define ETH_MAC_BASE_NS          (ETH_BASE)
 #define ICACHE_BASE_NS           (AHB1PERIPH_BASE_NS + 0x10400UL)
 #define DCACHE1_BASE_NS          (AHB1PERIPH_BASE_NS + 0x11400UL)
 #define GTZC_TZSC1_BASE_NS       (AHB1PERIPH_BASE_NS + 0x12400UL)
@@ -1881,7 +1593,6 @@ typedef struct
 #define GPIOF_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01400UL)
 #define GPIOG_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01800UL)
 #define GPIOH_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01C00UL)
-#define GPIOI_BASE_NS            (AHB2PERIPH_BASE_NS + 0x02000UL)
 #define ADC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08000UL)
 #define ADC2_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08100UL)
 #define ADC12_COMMON_BASE_NS     (AHB2PERIPH_BASE_NS + 0x08300UL)
@@ -1896,15 +1607,10 @@ typedef struct
 
 /*!< APB3 Non secure peripherals */
 #define SBS_BASE_NS              (APB3PERIPH_BASE_NS + 0x0400UL)
-#define SPI5_BASE_NS             (APB3PERIPH_BASE_NS + 0x2000UL)
 #define LPUART1_BASE_NS          (APB3PERIPH_BASE_NS + 0x2400UL)
 #define I2C3_BASE_NS             (APB3PERIPH_BASE_NS + 0x2800UL)
-#define I2C4_BASE_NS             (APB3PERIPH_BASE_NS + 0x2C00UL)
+#define I3C2_BASE_NS             (APB3PERIPH_BASE_NS + 0x3000UL)
 #define LPTIM1_BASE_NS           (APB3PERIPH_BASE_NS + 0x4400UL)
-#define LPTIM3_BASE_NS           (APB3PERIPH_BASE_NS + 0x4800UL)
-#define LPTIM4_BASE_NS           (APB3PERIPH_BASE_NS + 0x4C00UL)
-#define LPTIM5_BASE_NS           (APB3PERIPH_BASE_NS + 0x5000UL)
-#define LPTIM6_BASE_NS           (APB3PERIPH_BASE_NS + 0x5400UL)
 #define VREFBUF_BASE_NS          (APB3PERIPH_BASE_NS + 0x7400UL)
 #define RTC_BASE_NS              (APB3PERIPH_BASE_NS + 0x7800UL)
 #define TAMP_BASE_NS             (APB3PERIPH_BASE_NS + 0x7C00UL)
@@ -1918,8 +1624,6 @@ typedef struct
 /*!< AHB4 Non secure peripherals */
 #define SDMMC1_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8000UL)
 #define DLYB_SDMMC1_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8400UL)
-#define SDMMC2_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8C00UL)
-#define DLYB_SDMMC2_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8800UL)
 #define FMC_R_BASE_NS            (AHB4PERIPH_BASE_NS + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_NS       (AHB4PERIPH_BASE_NS + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_NS    (AHB4PERIPH_BASE_NS + 0x0F000UL)
@@ -1928,13 +1632,12 @@ typedef struct
 #define FMC_Bank1_R_BASE_NS      (FMC_R_BASE_NS + 0x0000UL)
 #define FMC_Bank1E_R_BASE_NS     (FMC_R_BASE_NS + 0x0104UL)
 #define FMC_Bank3_R_BASE_NS      (FMC_R_BASE_NS + 0x0080UL)
-#define FMC_Bank5_6_R_BASE_NS    (FMC_R_BASE_NS + 0x0140UL)
 
 /* Flash, Peripheral and internal SRAMs base addresses - Secure */
-#define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 2 MB) secure base address */
-#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (256 KB) secure base address     */
-#define SRAM2_BASE_S            (0x30040000UL) /*!< SRAM2 (64 KB) secure base address      */
-#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (320 KB) secure base address     */
+#define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 512 KB) secure base address */
+#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (128 KB) secure base address     */
+#define SRAM2_BASE_S            (0x30020000UL) /*!< SRAM2 (80 KB) secure base address      */
+#define SRAM3_BASE_S            (0x30034000UL) /*!< SRAM3 (64 KB) secure base address      */
 #define PERIPH_BASE_S           (0x50000000UL) /*!< Peripheral secure base address         */
 
 /* Peripheral memory map - Secure */
@@ -1954,8 +1657,6 @@ typedef struct
 #define TIM6_BASE_S             (APB1PERIPH_BASE_S + 0x1000UL)
 #define TIM7_BASE_S             (APB1PERIPH_BASE_S + 0x1400UL)
 #define TIM12_BASE_S            (APB1PERIPH_BASE_S + 0x1800UL)
-#define TIM13_BASE_S            (APB1PERIPH_BASE_S + 0x1C00UL)
-#define TIM14_BASE_S            (APB1PERIPH_BASE_S + 0x2000UL)
 #define WWDG_BASE_S             (APB1PERIPH_BASE_S + 0x2C00UL)
 #define IWDG_BASE_S             (APB1PERIPH_BASE_S + 0x3000UL)
 #define SPI2_BASE_S             (APB1PERIPH_BASE_S + 0x3800UL)
@@ -1969,13 +1670,7 @@ typedef struct
 #define I3C1_BASE_S             (APB1PERIPH_BASE_S + 0x5C00UL)
 #define CRS_BASE_S              (APB1PERIPH_BASE_S + 0x6000UL)
 #define USART6_BASE_S           (APB1PERIPH_BASE_S + 0x6400UL)
-#define USART10_BASE_S          (APB1PERIPH_BASE_S + 0x6800UL)
-#define USART11_BASE_S          (APB1PERIPH_BASE_S + 0x6C00UL)
 #define CEC_BASE_S              (APB1PERIPH_BASE_S + 0x7000UL)
-#define UART7_BASE_S            (APB1PERIPH_BASE_S + 0x7800UL)
-#define UART8_BASE_S            (APB1PERIPH_BASE_S + 0x7C00UL)
-#define UART9_BASE_S            (APB1PERIPH_BASE_S + 0x8000UL)
-#define UART12_BASE_S           (APB1PERIPH_BASE_S + 0x8400UL)
 #define DTS_BASE_S              (APB1PERIPH_BASE_S + 0x8C00UL)
 #define LPTIM2_BASE_S           (APB1PERIPH_BASE_S + 0x9400UL)
 #define FDCAN1_BASE_S           (APB1PERIPH_BASE_S + 0xA400UL)
@@ -1990,16 +1685,7 @@ typedef struct
 #define TIM8_BASE_S             (APB2PERIPH_BASE_S + 0x3400UL)
 #define USART1_BASE_S           (APB2PERIPH_BASE_S + 0x3800UL)
 #define TIM15_BASE_S            (APB2PERIPH_BASE_S + 0x4000UL)
-#define TIM16_BASE_S            (APB2PERIPH_BASE_S + 0x4400UL)
-#define TIM17_BASE_S            (APB2PERIPH_BASE_S + 0x4800UL)
 #define SPI4_BASE_S             (APB2PERIPH_BASE_S + 0x4C00UL)
-#define SPI6_BASE_S             (APB2PERIPH_BASE_S + 0x5000UL)
-#define SAI1_BASE_S             (APB2PERIPH_BASE_S + 0x5400UL)
-#define SAI1_Block_A_BASE_S     (SAI1_BASE_S + 0x004UL)
-#define SAI1_Block_B_BASE_S     (SAI1_BASE_S + 0x024UL)
-#define SAI2_BASE_S             (APB2PERIPH_BASE_S + 0x5800UL)
-#define SAI2_Block_A_BASE_S     (SAI2_BASE_S + 0x004UL)
-#define SAI2_Block_B_BASE_S     (SAI2_BASE_S + 0x024UL)
 #define USB_DRD_BASE_S          (APB2PERIPH_BASE_S + 0x6000UL)
 #define USB_DRD_PMAADDR_S       (APB2PERIPH_BASE_S + 0x6400UL)
 
@@ -2008,11 +1694,7 @@ typedef struct
 #define GPDMA2_BASE_S           (AHB1PERIPH_BASE_S + 0x01000UL)
 #define FLASH_R_BASE_S          (AHB1PERIPH_BASE_S + 0x02000UL)
 #define CRC_BASE_S              (AHB1PERIPH_BASE_S + 0x03000UL)
-#define CORDIC_BASE_S           (AHB1PERIPH_BASE_S + 0x03800UL)
-#define FMAC_BASE_S             (AHB1PERIPH_BASE_S + 0x03C00UL)
 #define RAMCFG_BASE_S           (AHB1PERIPH_BASE_S + 0x06000UL)
-#define ETH_BASE_S              (AHB1PERIPH_BASE_S + 0x8000UL)
-#define ETH_MAC_BASE_S          (ETH_BASE_S)
 #define ICACHE_BASE_S           (AHB1PERIPH_BASE_S + 0x10400UL)
 #define DCACHE1_BASE_S          (AHB1PERIPH_BASE_S + 0x11400UL)
 #define GTZC_TZSC1_BASE_S       (AHB1PERIPH_BASE_S + 0x12400UL)
@@ -2051,7 +1733,6 @@ typedef struct
 #define GPIOF_BASE_S            (AHB2PERIPH_BASE_S + 0x01400UL)
 #define GPIOG_BASE_S            (AHB2PERIPH_BASE_S + 0x01800UL)
 #define GPIOH_BASE_S            (AHB2PERIPH_BASE_S + 0x01C00UL)
-#define GPIOI_BASE_S            (AHB2PERIPH_BASE_S + 0x02000UL)
 #define ADC1_BASE_S             (AHB2PERIPH_BASE_S + 0x08000UL)
 #define ADC2_BASE_S             (AHB2PERIPH_BASE_S + 0x08100UL)
 #define ADC12_COMMON_BASE_S     (AHB2PERIPH_BASE_S + 0x08300UL)
@@ -2066,15 +1747,10 @@ typedef struct
 
 /*!< APB3 secure peripherals */
 #define SBS_BASE_S              (APB3PERIPH_BASE_S + 0x0400UL)
-#define SPI5_BASE_S             (APB3PERIPH_BASE_S + 0x2000UL)
 #define LPUART1_BASE_S          (APB3PERIPH_BASE_S + 0x2400UL)
 #define I2C3_BASE_S             (APB3PERIPH_BASE_S + 0x2800UL)
-#define I2C4_BASE_S             (APB3PERIPH_BASE_S + 0x2C00UL)
+#define I3C2_BASE_S             (APB3PERIPH_BASE_S + 0x3000UL)
 #define LPTIM1_BASE_S           (APB3PERIPH_BASE_S + 0x4400UL)
-#define LPTIM3_BASE_S           (APB3PERIPH_BASE_S + 0x4800UL)
-#define LPTIM4_BASE_S           (APB3PERIPH_BASE_S + 0x4C00UL)
-#define LPTIM5_BASE_S           (APB3PERIPH_BASE_S + 0x5000UL)
-#define LPTIM6_BASE_S           (APB3PERIPH_BASE_S + 0x5400UL)
 #define VREFBUF_BASE_S          (APB3PERIPH_BASE_S + 0x7400UL)
 #define RTC_BASE_S              (APB3PERIPH_BASE_S + 0x7800UL)
 #define TAMP_BASE_S             (APB3PERIPH_BASE_S + 0x7C00UL)
@@ -2088,8 +1764,6 @@ typedef struct
 /*!< AHB4 secure peripherals */
 #define SDMMC1_BASE_S           (AHB4PERIPH_BASE_S + 0x8000UL)
 #define DLYB_SDMMC1_BASE_S      (AHB4PERIPH_BASE_S + 0x8400UL)
-#define SDMMC2_BASE_S           (AHB4PERIPH_BASE_S + 0x8C00UL)
-#define DLYB_SDMMC2_BASE_S      (AHB4PERIPH_BASE_S + 0x8800UL)
 #define FMC_R_BASE_S            (AHB4PERIPH_BASE_S + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_S       (AHB4PERIPH_BASE_S + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_S    (AHB4PERIPH_BASE_S + 0x0F000UL)
@@ -2098,7 +1772,6 @@ typedef struct
 #define FMC_Bank1_R_BASE_S      (FMC_R_BASE_S + 0x0000UL)
 #define FMC_Bank1E_R_BASE_S     (FMC_R_BASE_S + 0x0104UL)
 #define FMC_Bank3_R_BASE_S      (FMC_R_BASE_S + 0x0080UL)
-#define FMC_Bank5_6_R_BASE_S    (FMC_R_BASE_S + 0x0140UL)
 
 /* Debug MCU registers base address */
 #define DBGMCU_BASE             (0x44024000UL)
@@ -2344,13 +2017,7 @@ typedef struct
 #define I3C1_NS                ((I3C_TypeDef *)I3C1_BASE_NS)
 #define CRS_NS                 ((CRS_TypeDef *)CRS_BASE_NS)
 #define USART6_NS              ((USART_TypeDef *)USART6_BASE_NS)
-#define USART10_NS             ((USART_TypeDef *)USART10_BASE_NS)
-#define USART11_NS             ((USART_TypeDef *)USART11_BASE_NS)
 #define CEC_NS                 ((CEC_TypeDef *)CEC_BASE_NS)
-#define UART7_NS               ((USART_TypeDef *)UART7_BASE_NS)
-#define UART8_NS               ((USART_TypeDef *)UART8_BASE_NS)
-#define UART9_NS               ((USART_TypeDef *)UART9_BASE_NS)
-#define UART12_NS              ((USART_TypeDef *)UART12_BASE_NS)
 #define DTS_NS                 ((DTS_TypeDef *)DTS_BASE_NS)
 #define LPTIM2_NS              ((LPTIM_TypeDef *)LPTIM2_BASE_NS)
 #define FDCAN1_NS              ((FDCAN_GlobalTypeDef *)FDCAN1_BASE_NS)
@@ -2364,16 +2031,7 @@ typedef struct
 #define TIM8_NS                ((TIM_TypeDef *) TIM8_BASE_NS)
 #define USART1_NS              ((USART_TypeDef *) USART1_BASE_NS)
 #define TIM15_NS               ((TIM_TypeDef *) TIM15_BASE_NS)
-#define TIM16_NS               ((TIM_TypeDef *) TIM16_BASE_NS)
-#define TIM17_NS               ((TIM_TypeDef *) TIM17_BASE_NS)
 #define SPI4_NS                ((SPI_TypeDef *) SPI4_BASE_NS)
-#define SPI6_NS                ((SPI_TypeDef *) SPI6_BASE_NS)
-#define SAI1_NS                ((SAI_TypeDef *) SAI1_BASE_NS)
-#define SAI1_Block_A_NS        ((SAI_Block_TypeDef *)SAI1_Block_A_BASE_NS)
-#define SAI1_Block_B_NS        ((SAI_Block_TypeDef *)SAI1_Block_B_BASE_NS)
-#define SAI2_NS                ((SAI_TypeDef *) SAI2_BASE_NS)
-#define SAI2_Block_A_NS        ((SAI_Block_TypeDef *)SAI2_Block_A_BASE_NS)
-#define SAI2_Block_B_NS        ((SAI_Block_TypeDef *)SAI2_Block_B_BASE_NS)
 #define USB_DRD_FS_NS          ((USB_DRD_TypeDef *) USB_DRD_BASE_NS)
 #define USB_DRD_PMA_BUFF_NS    ((USB_DRD_PMABuffDescTypeDef *) USB_DRD_PMAADDR_NS)
 
@@ -2382,14 +2040,10 @@ typedef struct
 #define GPDMA2_NS              ((DMA_TypeDef *) GPDMA2_BASE_NS)
 #define FLASH_NS               ((FLASH_TypeDef *) FLASH_R_BASE_NS)
 #define CRC_NS                 ((CRC_TypeDef *) CRC_BASE_NS)
-#define CORDIC_NS              ((CORDIC_TypeDef *) CORDIC_BASE_NS)
-#define FMAC_NS                ((FMAC_TypeDef *) FMAC_BASE_NS)
 #define RAMCFG_SRAM1_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM1_BASE_NS)
 #define RAMCFG_SRAM2_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM2_BASE_NS)
 #define RAMCFG_SRAM3_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM3_BASE_NS)
 #define RAMCFG_BKPRAM_NS       ((RAMCFG_TypeDef *) RAMCFG_BKPRAM_BASE_NS)
-#define ETH_NS                 ((ETH_TypeDef *) ETH_BASE_NS)
-#define ETH_MAC_NS             ((ETH_TypeDef *) ETH_MAC_BASE_NS)
 #define ICACHE_NS              ((ICACHE_TypeDef *) ICACHE_BASE_NS)
 #define DCACHE1_NS             ((DCACHE_TypeDef *) DCACHE1_BASE_NS)
 #define GTZC_TZSC1_NS          ((GTZC_TZSC_TypeDef *) GTZC_TZSC1_BASE_NS)
@@ -2423,7 +2077,6 @@ typedef struct
 #define GPIOF_NS               ((GPIO_TypeDef *) GPIOF_BASE_NS)
 #define GPIOG_NS               ((GPIO_TypeDef *) GPIOG_BASE_NS)
 #define GPIOH_NS               ((GPIO_TypeDef *) GPIOH_BASE_NS)
-#define GPIOI_NS               ((GPIO_TypeDef *) GPIOI_BASE_NS)
 #define ADC1_NS                ((ADC_TypeDef *) ADC1_BASE_NS)
 #define ADC2_NS                ((ADC_TypeDef *) ADC2_BASE_NS)
 #define ADC12_COMMON_NS        ((ADC_Common_TypeDef *) ADC12_COMMON_BASE_NS)
@@ -2438,15 +2091,10 @@ typedef struct
 
 /*!< APB3 Non secure peripherals */
 #define SBS_NS                 ((SBS_TypeDef *) SBS_BASE_NS)
-#define SPI5_NS                ((SPI_TypeDef *) SPI5_BASE_NS)
 #define LPUART1_NS             ((USART_TypeDef *) LPUART1_BASE_NS)
 #define I2C3_NS                ((I2C_TypeDef *) I2C3_BASE_NS)
-#define I2C4_NS                ((I2C_TypeDef *) I2C4_BASE_NS)
+#define I3C2_NS                ((I3C_TypeDef *) I3C2_BASE_NS)
 #define LPTIM1_NS              ((LPTIM_TypeDef *) LPTIM1_BASE_NS)
-#define LPTIM3_NS              ((LPTIM_TypeDef *) LPTIM3_BASE_NS)
-#define LPTIM4_NS              ((LPTIM_TypeDef *) LPTIM4_BASE_NS)
-#define LPTIM5_NS              ((LPTIM_TypeDef *) LPTIM5_BASE_NS)
-#define LPTIM6_NS              ((LPTIM_TypeDef *) LPTIM6_BASE_NS)
 #define VREFBUF_NS             ((VREFBUF_TypeDef *) VREFBUF_BASE_NS)
 #define RTC_NS                 ((RTC_TypeDef *) RTC_BASE_NS)
 #define TAMP_NS                ((TAMP_TypeDef *) TAMP_BASE_NS)
@@ -2459,8 +2107,6 @@ typedef struct
 /*!< AHB4 Non secure peripherals */
 #define SDMMC1_NS              ((SDMMC_TypeDef *) SDMMC1_BASE_NS)
 #define DLYB_SDMMC1_NS         ((DLYB_TypeDef *) DLYB_SDMMC1_BASE_NS)
-#define SDMMC2_NS              ((SDMMC_TypeDef *) SDMMC2_BASE_NS)
-#define DLYB_SDMMC2_NS         ((DLYB_TypeDef *) DLYB_SDMMC2_BASE_NS)
 
 #define OCTOSPI1_NS            ((OCTOSPI_TypeDef *) OCTOSPI1_R_BASE_NS)
 #define DLYB_OCTOSPI1_NS       ((DLYB_TypeDef *) DLYB_OCTOSPI1_BASE_NS)
@@ -2469,7 +2115,6 @@ typedef struct
 #define FMC_Bank1_R_NS         ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE_NS)
 #define FMC_Bank1E_R_NS        ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE_NS)
 #define FMC_Bank3_R_NS         ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE_NS)
-#define FMC_Bank5_6_R_NS       ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE_NS)
 
 /*!< APB1 Secure peripherals */
 #define TIM2_S                 ((TIM_TypeDef *)TIM2_BASE_S)
@@ -2479,8 +2124,6 @@ typedef struct
 #define TIM6_S                 ((TIM_TypeDef *)TIM6_BASE_S)
 #define TIM7_S                 ((TIM_TypeDef *)TIM7_BASE_S)
 #define TIM12_S                ((TIM_TypeDef *)TIM12_BASE_S)
-#define TIM13_S                ((TIM_TypeDef *)TIM13_BASE_S)
-#define TIM14_S                ((TIM_TypeDef *)TIM14_BASE_S)
 #define WWDG_S                 ((WWDG_TypeDef *)WWDG_BASE_S)
 #define IWDG_S                 ((IWDG_TypeDef *)IWDG_BASE_S)
 #define SPI2_S                 ((SPI_TypeDef *)SPI2_BASE_S)
@@ -2494,13 +2137,7 @@ typedef struct
 #define I3C1_S                 ((I3C_TypeDef *)I3C1_BASE_S)
 #define CRS_S                  ((CRS_TypeDef *)CRS_BASE_S)
 #define USART6_S               ((USART_TypeDef *)USART6_BASE_S)
-#define USART10_S              ((USART_TypeDef *)USART10_BASE_S)
-#define USART11_S              ((USART_TypeDef *)USART11_BASE_S)
 #define CEC_S                  ((CEC_TypeDef *)CEC_BASE_S)
-#define UART7_S                ((USART_TypeDef *)UART7_BASE_S)
-#define UART8_S                ((USART_TypeDef *)UART8_BASE_S)
-#define UART9_S                ((USART_TypeDef *)UART9_BASE_S)
-#define UART12_S               ((USART_TypeDef *)UART12_BASE_S)
 #define DTS_S                  ((DTS_TypeDef *)DTS_BASE_S)
 #define LPTIM2_S               ((LPTIM_TypeDef *)LPTIM2_BASE_S)
 #define FDCAN1_S               ((FDCAN_GlobalTypeDef *)FDCAN1_BASE_S)
@@ -2514,16 +2151,7 @@ typedef struct
 #define TIM8_S                 ((TIM_TypeDef *) TIM8_BASE_S)
 #define USART1_S               ((USART_TypeDef *) USART1_BASE_S)
 #define TIM15_S                ((TIM_TypeDef *) TIM15_BASE_S)
-#define TIM16_S                ((TIM_TypeDef *) TIM16_BASE_S)
-#define TIM17_S                ((TIM_TypeDef *) TIM17_BASE_S)
 #define SPI4_S                 ((SPI_TypeDef *) SPI4_BASE_S)
-#define SPI6_S                 ((SPI_TypeDef *) SPI6_BASE_S)
-#define SAI1_S                 ((SAI_TypeDef *) SAI1_BASE_S)
-#define SAI1_Block_A_S         ((SAI_Block_TypeDef *)SAI1_Block_A_BASE_S)
-#define SAI1_Block_B_S         ((SAI_Block_TypeDef *)SAI1_Block_B_BASE_S)
-#define SAI2_S                 ((SAI_TypeDef *) SAI2_BASE_S)
-#define SAI2_Block_A_S         ((SAI_Block_TypeDef *)SAI2_Block_A_BASE_S)
-#define SAI2_Block_B_S         ((SAI_Block_TypeDef *)SAI2_Block_B_BASE_S)
 #define USB_DRD_FS_S           ((USB_DRD_TypeDef *)USB_DRD_BASE_S)
 #define USB_DRD_PMA_BUFF_S     ((USB_DRD_PMABuffDescTypeDef *) USB_DRD_PMAADDR_S)
 
@@ -2532,14 +2160,10 @@ typedef struct
 #define GPDMA2_S               ((DMA_TypeDef *) GPDMA2_BASE_S)
 #define FLASH_S                ((FLASH_TypeDef *) FLASH_R_BASE_S)
 #define CRC_S                  ((CRC_TypeDef *) CRC_BASE_S)
-#define CORDIC_S               ((CORDIC_TypeDef *) CORDIC_BASE_S)
-#define FMAC_S                 ((FMAC_TypeDef *) FMAC_BASE_S)
 #define RAMCFG_SRAM1_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM1_BASE_S)
 #define RAMCFG_SRAM2_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM2_BASE_S)
 #define RAMCFG_SRAM3_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM3_BASE_S)
 #define RAMCFG_BKPRAM_S        ((RAMCFG_TypeDef *) RAMCFG_BKPRAM_BASE_S)
-#define ETH_S                  ((ETH_TypeDef *) ETH_BASE_S)
-#define ETH_MAC_S              ((ETH_TypeDef *) ETH_MAC_BASE_S)
 #define ICACHE_S               ((ICACHE_TypeDef *) ICACHE_BASE_S)
 #define DCACHE1_S              ((DCACHE_TypeDef *) DCACHE1_BASE_S)
 #define GTZC_TZSC1_S           ((GTZC_TZSC_TypeDef *) GTZC_TZSC1_BASE_S)
@@ -2574,7 +2198,6 @@ typedef struct
 #define GPIOF_S                ((GPIO_TypeDef *) GPIOF_BASE_S)
 #define GPIOG_S                ((GPIO_TypeDef *) GPIOG_BASE_S)
 #define GPIOH_S                ((GPIO_TypeDef *) GPIOH_BASE_S)
-#define GPIOI_S                ((GPIO_TypeDef *) GPIOI_BASE_S)
 #define ADC1_S                 ((ADC_TypeDef *) ADC1_BASE_S)
 #define ADC2_S                 ((ADC_TypeDef *) ADC2_BASE_S)
 #define ADC12_COMMON_S         ((ADC_Common_TypeDef *) ADC12_COMMON_BASE_S)
@@ -2588,15 +2211,10 @@ typedef struct
 
 /*!< APB3 secure peripherals */
 #define SBS_S                  ((SBS_TypeDef *) SBS_BASE_S)
-#define SPI5_S                 ((SPI_TypeDef *) SPI5_BASE_S)
 #define LPUART1_S              ((USART_TypeDef *) LPUART1_BASE_S)
 #define I2C3_S                 ((I2C_TypeDef *) I2C3_BASE_S)
-#define I2C4_S                 ((I2C_TypeDef *) I2C4_BASE_S)
+#define I3C2_S                 ((I3C_TypeDef *) I3C2_BASE_S)
 #define LPTIM1_S               ((LPTIM_TypeDef *) LPTIM1_BASE_S)
-#define LPTIM3_S               ((LPTIM_TypeDef *) LPTIM3_BASE_S)
-#define LPTIM4_S               ((LPTIM_TypeDef *) LPTIM4_BASE_S)
-#define LPTIM5_S               ((LPTIM_TypeDef *) LPTIM5_BASE_S)
-#define LPTIM6_S               ((LPTIM_TypeDef *) LPTIM6_BASE_S)
 #define VREFBUF_S              ((VREFBUF_TypeDef *) VREFBUF_BASE_S)
 #define RTC_S                  ((RTC_TypeDef *) RTC_BASE_S)
 #define TAMP_S                 ((TAMP_TypeDef *) TAMP_BASE_S)
@@ -2609,13 +2227,10 @@ typedef struct
 /*!< AHB4 secure peripherals */
 #define SDMMC1_S               ((SDMMC_TypeDef *) SDMMC1_BASE_S)
 #define DLYB_SDMMC1_S          ((DLYB_TypeDef *) DLYB_SDMMC1_BASE_S)
-#define SDMMC2_S               ((SDMMC_TypeDef *) SDMMC2_BASE_S)
-#define DLYB_SDMMC2_S          ((DLYB_TypeDef *) DLYB_SDMMC2_BASE_S)
 
 #define FMC_Bank1_R_S          ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE_S)
 #define FMC_Bank1E_R_S         ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE_S)
 #define FMC_Bank3_R_S          ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE_S)
-#define FMC_Bank5_6_R_S        ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE_S)
 
 #define OCTOSPI1_S             ((OCTOSPI_TypeDef *) OCTOSPI1_R_BASE_S)
 #define DLYB_OCTOSPI1_S        ((DLYB_TypeDef *) DLYB_OCTOSPI1_BASE_S)
@@ -2645,9 +2260,6 @@ typedef struct
 #define AHB4PERIPH_BASE                AHB4PERIPH_BASE_S
 
 /*!< Instance aliases and base addresses for Secure peripherals */
-#define CORDIC                         CORDIC_S
-#define CORDIC_BASE                    CORDIC_BASE_S
-
 #define RCC                            RCC_S
 #define RCC_BASE                       RCC_BASE_S
 
@@ -2662,9 +2274,6 @@ typedef struct
 
 #define FLASH                          FLASH_S
 #define FLASH_R_BASE                   FLASH_R_BASE_S
-
-#define FMAC                           FMAC_S
-#define FMAC_BASE                      FMAC_BASE_S
 
 #define GPDMA1                         GPDMA1_S
 #define GPDMA1_BASE                    GPDMA1_BASE_S
@@ -2744,9 +2353,6 @@ typedef struct
 #define GPIOH                          GPIOH_S
 #define GPIOH_BASE                     GPIOH_BASE_S
 
-#define GPIOI                          GPIOI_S
-#define GPIOI_BASE                     GPIOI_BASE_S
-
 #define PWR                            PWR_S
 #define PWR_BASE                       PWR_BASE_S
 
@@ -2822,18 +2428,6 @@ typedef struct
 #define TIM12                          TIM12_S
 #define TIM12_BASE                     TIM12_BASE_S
 
-#define TIM13                          TIM13_S
-#define TIM13_BASE                     TIM13_BASE_S
-
-#define TIM14                          TIM14_S
-#define TIM14_BASE                     TIM14_BASE_S
-
-#define TIM16                          TIM16_S
-#define TIM16_BASE                     TIM16_BASE_S
-
-#define TIM17                          TIM17_S
-#define TIM17_BASE                     TIM17_BASE_S
-
 #define WWDG                           WWDG_S
 #define WWDG_BASE                      WWDG_BASE_S
 
@@ -2851,12 +2445,6 @@ typedef struct
 
 #define SPI4                           SPI4_S
 #define SPI4_BASE                      SPI4_BASE_S
-
-#define SPI5                           SPI5_S
-#define SPI5_BASE                      SPI5_BASE_S
-
-#define SPI6                           SPI6_S
-#define SPI6_BASE                      SPI6_BASE_S
 
 #define USART1                         USART1_S
 #define USART1_BASE                    USART1_BASE_S
@@ -2876,24 +2464,6 @@ typedef struct
 #define USART6                         USART6_S
 #define USART6_BASE                    USART6_BASE_S
 
-#define UART7                          UART7_S
-#define UART7_BASE                     UART7_BASE_S
-
-#define UART8                          UART8_S
-#define UART8_BASE                     UART8_BASE_S
-
-#define UART9                          UART9_S
-#define UART9_BASE                     UART9_BASE_S
-
-#define USART10                        USART10_S
-#define USART10_BASE                   USART10_BASE_S
-
-#define USART11                        USART11_S
-#define USART11_BASE                   USART11_BASE_S
-
-#define UART12                         UART12_S
-#define UART12_BASE                    UART12_BASE_S
-
 #define CEC                            CEC_S
 #define CEC_BASE                       CEC_BASE_S
 
@@ -2906,11 +2476,11 @@ typedef struct
 #define I2C3                           I2C3_S
 #define I2C3_BASE                      I2C3_BASE_S
 
-#define I2C4                           I2C4_S
-#define I2C4_BASE                      I2C4_BASE_S
-
 #define I3C1                           I3C1_S
 #define I3C1_BASE                      I3C1_BASE_S
+
+#define I3C2                           I3C2_S
+#define I3C2_BASE                      I3C2_BASE_S
 
 #define CRS                            CRS_S
 #define CRS_BASE                       CRS_BASE_S
@@ -2934,18 +2504,6 @@ typedef struct
 #define LPTIM2                         LPTIM2_S
 #define LPTIM2_BASE                    LPTIM2_BASE_S
 
-#define LPTIM3                         LPTIM3_S
-#define LPTIM3_BASE                    LPTIM3_BASE_S
-
-#define LPTIM4                         LPTIM4_S
-#define LPTIM4_BASE                    LPTIM4_BASE_S
-
-#define LPTIM5                         LPTIM5_S
-#define LPTIM5_BASE                    LPTIM5_BASE_S
-
-#define LPTIM6                         LPTIM6_S
-#define LPTIM6_BASE                    LPTIM6_BASE_S
-
 #define LPUART1                        LPUART1_S
 #define LPUART1_BASE                   LPUART1_BASE_S
 
@@ -2957,24 +2515,6 @@ typedef struct
 
 #define VREFBUF                        VREFBUF_S
 #define VREFBUF_BASE                   VREFBUF_BASE_S
-
-#define SAI1                           SAI1_S
-#define SAI1_BASE                      SAI1_BASE_S
-
-#define SAI1_Block_A                   SAI1_Block_A_S
-#define SAI1_Block_A_BASE              SAI1_Block_A_BASE_S
-
-#define SAI1_Block_B                   SAI1_Block_B_S
-#define SAI1_Block_B_BASE              SAI1_Block_B_BASE_S
-
-#define SAI2                           SAI2_S
-#define SAI2_BASE                      SAI2_BASE_S
-
-#define SAI2_Block_A                   SAI2_Block_A_S
-#define SAI2_Block_A_BASE              SAI2_Block_A_BASE_S
-
-#define SAI2_Block_B                   SAI2_Block_B_S
-#define SAI2_Block_B_BASE              SAI2_Block_B_BASE_S
 
 #define USB_DRD_FS                     USB_DRD_FS_S
 #define USB_DRD_BASE                   USB_DRD_BASE_S
@@ -3006,16 +2546,10 @@ typedef struct
 #define PKA_BASE                       PKA_BASE_S
 #define PKA_RAM_BASE                   PKA_RAM_BASE_S
 
-#define ETH                            ETH_S
-#define ETH_BASE                       ETH_BASE_S
-#define ETH_MAC                        ETH_MAC_S
-#define ETH_MAC_BASE                   ETH_MAC_BASE_S
 
 #define SDMMC1                         SDMMC1_S
 #define SDMMC1_BASE                    SDMMC1_BASE_S
 
-#define SDMMC2                         SDMMC2_S
-#define SDMMC2_BASE                    SDMMC2_BASE_S
 
 #define FMC_Bank1_R                    FMC_Bank1_R_S
 #define FMC_Bank1_R_BASE               FMC_Bank1_R_BASE_S
@@ -3026,17 +2560,11 @@ typedef struct
 #define FMC_Bank3_R                    FMC_Bank3_R_S
 #define FMC_Bank3_R_BASE               FMC_Bank3_R_BASE_S
 
-#define FMC_Bank5_6_R                  FMC_Bank5_6_R_S
-#define FMC_Bank5_6_R_BASE             FMC_Bank5_6_R_BASE_S
-
 #define OCTOSPI1                       OCTOSPI1_S
 #define OCTOSPI1_R_BASE                OCTOSPI1_R_BASE_S
 
 #define DLYB_SDMMC1                    DLYB_SDMMC1_S
 #define DLYB_SDMMC1_BASE               DLYB_SDMMC1_BASE_S
-
-#define DLYB_SDMMC2                    DLYB_SDMMC2_S
-#define DLYB_SDMMC2_BASE               DLYB_SDMMC2_BASE_S
 
 #define DLYB_OCTOSPI1                  DLYB_OCTOSPI1_S
 #define DLYB_OCTOSPI1_BASE             DLYB_OCTOSPI1_BASE_S
@@ -3065,9 +2593,6 @@ typedef struct
 #define AHB4PERIPH_BASE                AHB4PERIPH_BASE_NS
 
 /*!< Instance aliases and base addresses for Non secure peripherals */
-#define CORDIC                         CORDIC_NS
-#define CORDIC_BASE                    CORDIC_BASE_NS
-
 #define RCC                            RCC_NS
 #define RCC_BASE                       RCC_BASE_NS
 
@@ -3082,9 +2607,6 @@ typedef struct
 
 #define FLASH                          FLASH_NS
 #define FLASH_R_BASE                   FLASH_R_BASE_NS
-
-#define FMAC                           FMAC_NS
-#define FMAC_BASE                      FMAC_BASE_NS
 
 #define GPDMA1                         GPDMA1_NS
 #define GPDMA1_BASE                    GPDMA1_BASE_NS
@@ -3164,9 +2686,6 @@ typedef struct
 #define GPIOH                          GPIOH_NS
 #define GPIOH_BASE                     GPIOH_BASE_NS
 
-#define GPIOI                          GPIOI_NS
-#define GPIOI_BASE                     GPIOI_BASE_NS
-
 #define PWR                            PWR_NS
 #define PWR_BASE                       PWR_BASE_NS
 
@@ -3239,20 +2758,8 @@ typedef struct
 #define TIM12                          TIM12_NS
 #define TIM12_BASE                     TIM12_BASE_NS
 
-#define TIM13                          TIM13_NS
-#define TIM13_BASE                     TIM13_BASE_NS
-
-#define TIM14                          TIM14_NS
-#define TIM14_BASE                     TIM14_BASE_NS
-
 #define TIM15                          TIM15_NS
 #define TIM15_BASE                     TIM15_BASE_NS
-
-#define TIM16                          TIM16_NS
-#define TIM16_BASE                     TIM16_BASE_NS
-
-#define TIM17                          TIM17_NS
-#define TIM17_BASE                     TIM17_BASE_NS
 
 #define WWDG                           WWDG_NS
 #define WWDG_BASE                      WWDG_BASE_NS
@@ -3272,12 +2779,6 @@ typedef struct
 #define SPI4                           SPI4_NS
 #define SPI4_BASE                      SPI4_BASE_NS
 
-#define SPI5                           SPI5_NS
-#define SPI5_BASE                      SPI5_BASE_NS
-
-#define SPI6                           SPI6_NS
-#define SPI6_BASE                      SPI6_BASE_NS
-
 #define USART1                         USART1_NS
 #define USART1_BASE                    USART1_BASE_NS
 
@@ -3296,24 +2797,6 @@ typedef struct
 #define USART6                         USART6_NS
 #define USART6_BASE                    USART6_BASE_NS
 
-#define UART7                          UART7_NS
-#define UART7_BASE                     UART7_BASE_NS
-
-#define UART8                          UART8_NS
-#define UART8_BASE                     UART8_BASE_NS
-
-#define UART9                          UART9_NS
-#define UART9_BASE                     UART9_BASE_NS
-
-#define USART10                        USART10_NS
-#define USART10_BASE                   USART10_BASE_NS
-
-#define USART11                        USART11_NS
-#define USART11_BASE                   USART11_BASE_NS
-
-#define UART12                         UART12_NS
-#define UART12_BASE                    UART12_BASE_NS
-
 #define CEC                            CEC_NS
 #define CEC_BASE                       CEC_BASE_NS
 
@@ -3326,11 +2809,11 @@ typedef struct
 #define I2C3                           I2C3_NS
 #define I2C3_BASE                      I2C3_BASE_NS
 
-#define I2C4                           I2C4_NS
-#define I2C4_BASE                      I2C4_BASE_NS
-
 #define I3C1                           I3C1_NS
 #define I3C1_BASE                      I3C1_BASE_NS
+
+#define I3C2                           I3C2_NS
+#define I3C2_BASE                      I3C2_BASE_NS
 
 #define CRS                            CRS_NS
 #define CRS_BASE                       CRS_BASE_NS
@@ -3354,18 +2837,6 @@ typedef struct
 #define LPTIM2                         LPTIM2_NS
 #define LPTIM2_BASE                    LPTIM2_BASE_NS
 
-#define LPTIM3                         LPTIM3_NS
-#define LPTIM3_BASE                    LPTIM3_BASE_NS
-
-#define LPTIM4                         LPTIM4_NS
-#define LPTIM4_BASE                    LPTIM4_BASE_NS
-
-#define LPTIM5                         LPTIM5_NS
-#define LPTIM5_BASE                    LPTIM5_BASE_NS
-
-#define LPTIM6                         LPTIM6_NS
-#define LPTIM6_BASE                    LPTIM6_BASE_NS
-
 #define LPUART1                        LPUART1_NS
 #define LPUART1_BASE                   LPUART1_BASE_NS
 
@@ -3377,24 +2848,6 @@ typedef struct
 
 #define VREFBUF                        VREFBUF_NS
 #define VREFBUF_BASE                   VREFBUF_BASE_NS
-
-#define SAI1                           SAI1_NS
-#define SAI1_BASE                      SAI1_BASE_NS
-
-#define SAI1_Block_A                   SAI1_Block_A_NS
-#define SAI1_Block_A_BASE              SAI1_Block_A_BASE_NS
-
-#define SAI1_Block_B                   SAI1_Block_B_NS
-#define SAI1_Block_B_BASE              SAI1_Block_B_BASE_NS
-
-#define SAI2                           SAI2_NS
-#define SAI2_BASE                      SAI2_BASE_NS
-
-#define SAI2_Block_A                   SAI2_Block_A_NS
-#define SAI2_Block_A_BASE              SAI2_Block_A_BASE_NS
-
-#define SAI2_Block_B                   SAI2_Block_B_NS
-#define SAI2_Block_B_BASE              SAI2_Block_B_BASE_NS
 
 #define USB_DRD_FS                     USB_DRD_FS_NS
 #define USB_DRD_BASE                   USB_DRD_BASE_NS
@@ -3427,16 +2880,10 @@ typedef struct
 #define PKA_RAM_BASE                   PKA_RAM_BASE_NS
 
 
-#define ETH                            ETH_NS
-#define ETH_BASE                       ETH_BASE_NS
-#define ETH_MAC                        ETH_MAC_NS
-#define ETH_MAC_BASE                   ETH_MAC_BASE_NS
 
 #define SDMMC1                         SDMMC1_NS
 #define SDMMC1_BASE                    SDMMC1_BASE_NS
 
-#define SDMMC2                         SDMMC2_NS
-#define SDMMC2_BASE                    SDMMC2_BASE_NS
 
 #define FMC_Bank1_R                    FMC_Bank1_R_NS
 #define FMC_Bank1_R_BASE               FMC_Bank1_R_BASE_NS
@@ -3447,17 +2894,11 @@ typedef struct
 #define FMC_Bank3_R                    FMC_Bank3_R_NS
 #define FMC_Bank3_R_BASE               FMC_Bank3_R_BASE_NS
 
-#define FMC_Bank5_6_R                  FMC_Bank5_6_R_NS
-#define FMC_Bank5_6_R_BASE             FMC_Bank5_6_R_BASE_NS
-
 #define OCTOSPI1                       OCTOSPI1_NS
 #define OCTOSPI1_R_BASE                OCTOSPI1_R_BASE_NS
 
 #define DLYB_SDMMC1                    DLYB_SDMMC1_NS
 #define DLYB_SDMMC1_BASE               DLYB_SDMMC1_BASE_NS
-
-#define DLYB_SDMMC2                    DLYB_SDMMC2_NS
-#define DLYB_SDMMC2_BASE               DLYB_SDMMC2_BASE_NS
 
 #define DLYB_OCTOSPI1                  DLYB_OCTOSPI1_NS
 #define DLYB_OCTOSPI1_BASE             DLYB_OCTOSPI1_BASE_NS
@@ -4455,66 +3896,6 @@ typedef struct
 #define ADC_CDR_RDATA_SLV              ADC_CDR_RDATA_SLV_Msk                   /*!< ADC multimode slave group regular conversion data */
 
 
-/******************************************************************************/
-/*                                                                            */
-/*                          CORDIC calculation unit                           */
-/*                                                                            */
-/******************************************************************************/
-/*******************  Bit definition for CORDIC_CSR register  *****************/
-#define CORDIC_CSR_FUNC_Pos                 (0U)
-#define CORDIC_CSR_FUNC_Msk                 (0xFUL << CORDIC_CSR_FUNC_Pos)          /*!< 0x0000000F */
-#define CORDIC_CSR_FUNC                     CORDIC_CSR_FUNC_Msk                     /*!< Function */
-#define CORDIC_CSR_FUNC_0                   (0x1UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000001 */
-#define CORDIC_CSR_FUNC_1                   (0x2UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000002 */
-#define CORDIC_CSR_FUNC_2                   (0x4UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000004 */
-#define CORDIC_CSR_FUNC_3                   (0x8UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000008 */
-#define CORDIC_CSR_PRECISION_Pos            (4U)
-#define CORDIC_CSR_PRECISION_Msk            (0xFUL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x000000F0 */
-#define CORDIC_CSR_PRECISION                CORDIC_CSR_PRECISION_Msk                /*!< Precision */
-#define CORDIC_CSR_PRECISION_0              (0x1UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000010 */
-#define CORDIC_CSR_PRECISION_1              (0x2UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000020 */
-#define CORDIC_CSR_PRECISION_2              (0x4UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000040 */
-#define CORDIC_CSR_PRECISION_3              (0x8UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000080 */
-#define CORDIC_CSR_SCALE_Pos                (8U)
-#define CORDIC_CSR_SCALE_Msk                (0x7UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000700 */
-#define CORDIC_CSR_SCALE                    CORDIC_CSR_SCALE_Msk                    /*!< Scaling factor */
-#define CORDIC_CSR_SCALE_0                  (0x1UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000100 */
-#define CORDIC_CSR_SCALE_1                  (0x2UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000200 */
-#define CORDIC_CSR_SCALE_2                  (0x4UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000400 */
-#define CORDIC_CSR_IEN_Pos                  (16U)
-#define CORDIC_CSR_IEN_Msk                  (0x1UL << CORDIC_CSR_IEN_Pos)           /*!< 0x00010000 */
-#define CORDIC_CSR_IEN                      CORDIC_CSR_IEN_Msk                      /*!< Interrupt Enable */
-#define CORDIC_CSR_DMAREN_Pos               (17U)
-#define CORDIC_CSR_DMAREN_Msk               (0x1UL << CORDIC_CSR_DMAREN_Pos)        /*!< 0x00020000 */
-#define CORDIC_CSR_DMAREN                   CORDIC_CSR_DMAREN_Msk                   /*!< DMA Read channel Enable */
-#define CORDIC_CSR_DMAWEN_Pos               (18U)
-#define CORDIC_CSR_DMAWEN_Msk               (0x1UL << CORDIC_CSR_DMAWEN_Pos)        /*!< 0x00040000 */
-#define CORDIC_CSR_DMAWEN                   CORDIC_CSR_DMAWEN_Msk                   /*!< DMA Write channel Enable */
-#define CORDIC_CSR_NRES_Pos                 (19U)
-#define CORDIC_CSR_NRES_Msk                 (0x1UL << CORDIC_CSR_NRES_Pos)          /*!< 0x00080000 */
-#define CORDIC_CSR_NRES                     CORDIC_CSR_NRES_Msk                     /*!< Number of results in WDATA register */
-#define CORDIC_CSR_NARGS_Pos                (20U)
-#define CORDIC_CSR_NARGS_Msk                (0x1UL << CORDIC_CSR_NARGS_Pos)         /*!< 0x00100000 */
-#define CORDIC_CSR_NARGS                    CORDIC_CSR_NARGS_Msk                    /*!< Number of arguments in RDATA register */
-#define CORDIC_CSR_RESSIZE_Pos              (21U)
-#define CORDIC_CSR_RESSIZE_Msk              (0x1UL << CORDIC_CSR_RESSIZE_Pos)       /*!< 0x00200000 */
-#define CORDIC_CSR_RESSIZE                  CORDIC_CSR_RESSIZE_Msk                  /*!< Width of output data */
-#define CORDIC_CSR_ARGSIZE_Pos              (22U)
-#define CORDIC_CSR_ARGSIZE_Msk              (0x1UL << CORDIC_CSR_ARGSIZE_Pos)       /*!< 0x00400000 */
-#define CORDIC_CSR_ARGSIZE                  CORDIC_CSR_ARGSIZE_Msk                  /*!< Width of input data */
-#define CORDIC_CSR_RRDY_Pos                 (31U)
-#define CORDIC_CSR_RRDY_Msk                 (0x1UL << CORDIC_CSR_RRDY_Pos)          /*!< 0x80000000 */
-#define CORDIC_CSR_RRDY                     CORDIC_CSR_RRDY_Msk                     /*!< Result Ready Flag */
-
-/*******************  Bit definition for CORDIC_WDATA register  ***************/
-#define CORDIC_WDATA_ARG_Pos                (0U)
-#define CORDIC_WDATA_ARG_Msk                (0xFFFFFFFFUL << CORDIC_WDATA_ARG_Pos)  /*!< 0xFFFFFFFF */
-#define CORDIC_WDATA_ARG                    CORDIC_WDATA_ARG_Msk                    /*!< Input Argument */
-
-/*******************  Bit definition for CORDIC_RDATA register  ***************/
-#define CORDIC_RDATA_RES_Pos                (0U)
-#define CORDIC_RDATA_RES_Msk                (0xFFFFFFFFUL << CORDIC_RDATA_RES_Pos)  /*!< 0xFFFFFFFF */
-#define CORDIC_RDATA_RES                    CORDIC_RDATA_RES_Msk                    /*!< Output Result */
 
 /******************************************************************************/
 /*                                                                            */
@@ -4717,25 +4098,6 @@ typedef struct
 #define RNG_SR_SEIS_Msk                     (0x1UL << RNG_SR_SEIS_Pos)              /*!< 0x00000040 */
 #define RNG_SR_SEIS                         RNG_SR_SEIS_Msk
 
-/********************  Bits definition for RNG_NSCR register  *******************/
-#define RNG_NSCR_EN_OSC1_Pos                (0U)
-#define RNG_NSCR_EN_OSC1_Msk                (0x7UL << RNG_NSCR_EN_OSC1_Pos)         /*!< 0x00000007 */
-#define RNG_NSCR_EN_OSC1                    RNG_NSCR_EN_OSC1_Msk
-#define RNG_NSCR_EN_OSC2_Pos                (3U)
-#define RNG_NSCR_EN_OSC2_Msk                (0x7UL << RNG_NSCR_EN_OSC2_Pos)         /*!< 0x00000038 */
-#define RNG_NSCR_EN_OSC2                    RNG_NSCR_EN_OSC2_Msk
-#define RNG_NSCR_EN_OSC3_Pos                (6U)
-#define RNG_NSCR_EN_OSC3_Msk                (0x7UL << RNG_NSCR_EN_OSC3_Pos)         /*!< 0x000001C0 */
-#define RNG_NSCR_EN_OSC3                    RNG_NSCR_EN_OSC3_Msk
-#define RNG_NSCR_EN_OSC4_Pos                (9U)
-#define RNG_NSCR_EN_OSC4_Msk                (0x7UL << RNG_NSCR_EN_OSC4_Pos)         /*!< 0x00000E00 */
-#define RNG_NSCR_EN_OSC4                    RNG_NSCR_EN_OSC4_Msk
-#define RNG_NSCR_EN_OSC5_Pos                (12U)
-#define RNG_NSCR_EN_OSC5_Msk                (0x7UL << RNG_NSCR_EN_OSC5_Pos)         /*!< 0x00007000 */
-#define RNG_NSCR_EN_OSC5                    RNG_NSCR_EN_OSC5_Msk
-#define RNG_NSCR_EN_OSC6_Pos                (15U)
-#define RNG_NSCR_EN_OSC6_Msk                (0x7UL << RNG_NSCR_EN_OSC6_Pos)         /*!< 0x00038000 */
-#define RNG_NSCR_EN_OSC6                    RNG_NSCR_EN_OSC6_Msk
 
 /********************  Bits definition for RNG_HTCR register  *******************/
 #define RNG_HTCR_HTCFG_Pos                  (0U)
@@ -4743,9 +4105,8 @@ typedef struct
 #define RNG_HTCR_HTCFG                      RNG_HTCR_HTCFG_Msk
 
 /********************  RNG Nist Compliance Values  ******************************/
-#define RNG_CR_NIST_VALUE                   (0x00F00E00U)
-#define RNG_HTCR_NIST_VALUE                 (0x6A91U)
-#define RNG_NSCR_NIST_VALUE                 (0x3AF66U)
+#define RNG_CR_NIST_VALUE                   (0x00F00D00U)
+#define RNG_HTCR_NIST_VALUE                 (0xAAC7U)
 
 /******************************************************************************/
 /*                                                                            */
@@ -5184,12 +4545,6 @@ typedef struct
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP_Pos  (6U)
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM12_STOP_Pos)
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP      DBGMCU_APB1FZR1_DBG_TIM12_STOP_Msk
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP_Pos  (7U)
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM13_STOP_Pos)
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP      DBGMCU_APB1FZR1_DBG_TIM13_STOP_Msk
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP_Pos  (8U)
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM14_STOP_Pos)
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP      DBGMCU_APB1FZR1_DBG_TIM14_STOP_Msk
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos   (11U)
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk   (0x1UL << DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos)
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP       DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk
@@ -5221,35 +4576,17 @@ typedef struct
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP_Pos   (16U)
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM15_STOP_Pos)
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP       DBGMCU_APB2FZR_DBG_TIM15_STOP_Msk
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP_Pos   (17U)
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM16_STOP_Pos)
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP       DBGMCU_APB2FZR_DBG_TIM16_STOP_Msk
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP_Pos   (18U)
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM17_STOP_Pos)
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP       DBGMCU_APB2FZR_DBG_TIM17_STOP_Msk
 
 /********************  Bit definition for DBGMCU_APB3FZR register  ***********/
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP_Pos    (10U)
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I2C3_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP        DBGMCU_APB3FZR_DBG_I2C3_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP_Pos    (11U)
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I2C4_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP        DBGMCU_APB3FZR_DBG_I2C4_STOP_Msk
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP_Pos    (12U)
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I3C2_STOP_Pos)
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP        DBGMCU_APB3FZR_DBG_I3C2_STOP_Msk
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Pos  (17U)
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP      DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Pos  (18U)
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP      DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Pos  (19U)
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP      DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Pos  (20U)
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP      DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Pos  (21U)
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP      DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Msk
 #define DBGMCU_APB3FZR_DBG_RTC_STOP_Pos     (30U)
 #define DBGMCU_APB3FZR_DBG_RTC_STOP_Msk     (0x1UL << DBGMCU_APB3FZR_DBG_RTC_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_RTC_STOP         DBGMCU_APB3FZR_DBG_RTC_STOP_Msk
@@ -5640,1870 +4977,6 @@ typedef struct
 #define DCMI_DR_BYTE3_Pos                   (24U)
 #define DCMI_DR_BYTE3_Msk                   (0xFFUL << DCMI_DR_BYTE3_Pos)           /*!< 0xFF000000 */
 #define DCMI_DR_BYTE3                       DCMI_DR_BYTE3_Msk
-/******************************************************************************/
-/*                                                                            */
-/*                Ethernet MAC Registers bits definitions                     */
-/*                                                                            */
-/******************************************************************************/
-/* Bit definition for Ethernet MAC Configuration Register register */
-#define ETH_MACCR_ARP_Pos                             (31U)
-#define ETH_MACCR_ARP_Msk                             (0x1UL << ETH_MACCR_ARP_Pos) /*!< 0x80000000 */
-#define ETH_MACCR_ARP                                 ETH_MACCR_ARP_Msk        /* ARP Offload Enable */
-#define ETH_MACCR_SARC_Pos                            (28U)
-#define ETH_MACCR_SARC_Msk                            (0x7UL << ETH_MACCR_SARC_Pos) /*!< 0x70000000 */
-#define ETH_MACCR_SARC                                ETH_MACCR_SARC_Msk       /* Source Address Insertion or Replacement Control */
-#define ETH_MACCR_SARC_MTIATI                         ((uint32_t)0x00000000)   /* The mti_sa_ctrl_i and ati_sa_ctrl_i input signals control the SA field generation. */
-#define ETH_MACCR_SARC_INSADDR0_Pos                   (29U)
-#define ETH_MACCR_SARC_INSADDR0_Msk                   (0x1UL << ETH_MACCR_SARC_INSADDR0_Pos) /*!< 0x20000000 */
-#define ETH_MACCR_SARC_INSADDR0                       ETH_MACCR_SARC_INSADDR0_Msk /* Insert MAC Address0 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_INSADDR1_Pos                   (29U)
-#define ETH_MACCR_SARC_INSADDR1_Msk                   (0x3UL << ETH_MACCR_SARC_INSADDR1_Pos) /*!< 0x60000000 */
-#define ETH_MACCR_SARC_INSADDR1                       ETH_MACCR_SARC_INSADDR1_Msk /* Insert MAC Address1 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_REPADDR0_Pos                   (28U)
-#define ETH_MACCR_SARC_REPADDR0_Msk                   (0x3UL << ETH_MACCR_SARC_REPADDR0_Pos) /*!< 0x30000000 */
-#define ETH_MACCR_SARC_REPADDR0                       ETH_MACCR_SARC_REPADDR0_Msk /* Replace MAC Address0 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_REPADDR1_Pos                   (28U)
-#define ETH_MACCR_SARC_REPADDR1_Msk                   (0x7UL << ETH_MACCR_SARC_REPADDR1_Pos) /*!< 0x70000000 */
-#define ETH_MACCR_SARC_REPADDR1                       ETH_MACCR_SARC_REPADDR1_Msk /* Replace MAC Address1 in the SA field of all transmitted packets. */
-#define ETH_MACCR_IPC_Pos                             (27U)
-#define ETH_MACCR_IPC_Msk                             (0x1UL << ETH_MACCR_IPC_Pos) /*!< 0x08000000 */
-#define ETH_MACCR_IPC                                 ETH_MACCR_IPC_Msk        /* Checksum Offload */
-#define ETH_MACCR_IPG_Pos                             (24U)
-#define ETH_MACCR_IPG_Msk                             (0x7UL << ETH_MACCR_IPG_Pos) /*!< 0x07000000 */
-#define ETH_MACCR_IPG                                 ETH_MACCR_IPG_Msk        /* Inter-Packet Gap */
-#define ETH_MACCR_IPG_96BIT                           ((uint32_t)0x00000000)   /* Minimum IFG between Packets during transmission is 96Bit */
-#define ETH_MACCR_IPG_88BIT                           ((uint32_t)0x01000000)   /* Minimum IFG between Packets during transmission is 88Bit */
-#define ETH_MACCR_IPG_80BIT                           ((uint32_t)0x02000000)   /* Minimum IFG between Packets during transmission is 80Bit */
-#define ETH_MACCR_IPG_72BIT                           ((uint32_t)0x03000000)   /* Minimum IFG between Packets during transmission is 72Bit */
-#define ETH_MACCR_IPG_64BIT                           ((uint32_t)0x04000000)   /* Minimum IFG between Packets during transmission is 64Bit */
-#define ETH_MACCR_IPG_56BIT                           ((uint32_t)0x05000000)   /* Minimum IFG between Packets during transmission is 56Bit */
-#define ETH_MACCR_IPG_48BIT                           ((uint32_t)0x06000000)   /* Minimum IFG between Packets during transmission is 48Bit */
-#define ETH_MACCR_IPG_40BIT                           ((uint32_t)0x07000000)   /* Minimum IFG between Packets during transmission is 40Bit */
-#define ETH_MACCR_GPSLCE_Pos                          (23U)
-#define ETH_MACCR_GPSLCE_Msk                          (0x1UL << ETH_MACCR_GPSLCE_Pos) /*!< 0x00800000 */
-#define ETH_MACCR_GPSLCE                              ETH_MACCR_GPSLCE_Msk     /* Giant Packet Size Limit Control Enable */
-#define ETH_MACCR_S2KP_Pos                            (22U)
-#define ETH_MACCR_S2KP_Msk                            (0x1UL << ETH_MACCR_S2KP_Pos) /*!< 0x00400000 */
-#define ETH_MACCR_S2KP                                ETH_MACCR_S2KP_Msk       /* IEEE 802.3as Support for 2K Packets */
-#define ETH_MACCR_CST_Pos                             (21U)
-#define ETH_MACCR_CST_Msk                             (0x1UL << ETH_MACCR_CST_Pos) /*!< 0x00200000 */
-#define ETH_MACCR_CST                                 ETH_MACCR_CST_Msk        /* CRC stripping for Type packets */
-#define ETH_MACCR_ACS_Pos                             (20U)
-#define ETH_MACCR_ACS_Msk                             (0x1UL << ETH_MACCR_ACS_Pos) /*!< 0x00100000 */
-#define ETH_MACCR_ACS                                 ETH_MACCR_ACS_Msk        /* Automatic Pad or CRC Stripping */
-#define ETH_MACCR_WD_Pos                              (19U)
-#define ETH_MACCR_WD_Msk                              (0x1UL << ETH_MACCR_WD_Pos) /*!< 0x00080000 */
-#define ETH_MACCR_WD                                  ETH_MACCR_WD_Msk         /* Watchdog disable */
-#define ETH_MACCR_JD_Pos                              (17U)
-#define ETH_MACCR_JD_Msk                              (0x1UL << ETH_MACCR_JD_Pos) /*!< 0x00020000 */
-#define ETH_MACCR_JD                                  ETH_MACCR_JD_Msk         /* Jabber disable */
-#define ETH_MACCR_JE_Pos                              (16U)
-#define ETH_MACCR_JE_Msk                              (0x1UL << ETH_MACCR_JE_Pos) /*!< 0x00010000 */
-#define ETH_MACCR_JE                                  ETH_MACCR_JE_Msk         /* Jumbo Packet Enable */
-#define ETH_MACCR_FES_Pos                             (14U)
-#define ETH_MACCR_FES_Msk                             (0x1UL << ETH_MACCR_FES_Pos) /*!< 0x00004000 */
-#define ETH_MACCR_FES                                 ETH_MACCR_FES_Msk        /* Fast ethernet speed */
-#define ETH_MACCR_DM_Pos                              (13U)
-#define ETH_MACCR_DM_Msk                              (0x1UL << ETH_MACCR_DM_Pos) /*!< 0x00002000 */
-#define ETH_MACCR_DM                                  ETH_MACCR_DM_Msk         /* Duplex mode */
-#define ETH_MACCR_LM_Pos                              (12U)
-#define ETH_MACCR_LM_Msk                              (0x1UL << ETH_MACCR_LM_Pos) /*!< 0x00001000 */
-#define ETH_MACCR_LM                                  ETH_MACCR_LM_Msk         /* loopback mode */
-#define ETH_MACCR_ECRSFD_Pos                          (11U)
-#define ETH_MACCR_ECRSFD_Msk                          (0x1UL << ETH_MACCR_ECRSFD_Pos) /*!< 0x00000800 */
-#define ETH_MACCR_ECRSFD                              ETH_MACCR_ECRSFD_Msk     /* Enable Carrier Sense Before Transmission in Full-Duplex Mode */
-#define ETH_MACCR_DO_Pos                              (10U)
-#define ETH_MACCR_DO_Msk                              (0x1UL << ETH_MACCR_DO_Pos) /*!< 0x00000400 */
-#define ETH_MACCR_DO                                  ETH_MACCR_DO_Msk         /* Disable Receive own  */
-#define ETH_MACCR_DCRS_Pos                            (9U)
-#define ETH_MACCR_DCRS_Msk                            (0x1UL << ETH_MACCR_DCRS_Pos) /*!< 0x00000200 */
-#define ETH_MACCR_DCRS                                ETH_MACCR_DCRS_Msk       /* Disable Carrier Sense During Transmission */
-#define ETH_MACCR_DR_Pos                              (8U)
-#define ETH_MACCR_DR_Msk                              (0x1UL << ETH_MACCR_DR_Pos) /*!< 0x00000100 */
-#define ETH_MACCR_DR                                  ETH_MACCR_DR_Msk         /* Disable Retry */
-#define ETH_MACCR_BL_Pos                              (5U)
-#define ETH_MACCR_BL_Msk                              (0x3UL << ETH_MACCR_BL_Pos) /*!< 0x00000060 */
-#define ETH_MACCR_BL                                  ETH_MACCR_BL_Msk         /* Back-off limit mask */
-#define ETH_MACCR_BL_10                               (0x0UL << ETH_MACCR_BL_Pos) /*!< 0x00000000 */
-#define ETH_MACCR_BL_8                                (0x1UL << ETH_MACCR_BL_Pos) /*!< 0x00000020 */
-#define ETH_MACCR_BL_4                                (0x2UL << ETH_MACCR_BL_Pos) /*!< 0x00000040 */
-#define ETH_MACCR_BL_1                                (0x3UL << ETH_MACCR_BL_Pos) /*!< 0x00000060 */
-#define ETH_MACCR_DC_Pos                              (4U)
-#define ETH_MACCR_DC_Msk                              (0x1UL << ETH_MACCR_DC_Pos) /*!< 0x00000010 */
-#define ETH_MACCR_DC                                  ETH_MACCR_DC_Msk         /* Defferal check */
-#define ETH_MACCR_PRELEN_Pos                          (2U)
-#define ETH_MACCR_PRELEN_Msk                          (0x3UL << ETH_MACCR_PRELEN_Pos) /*!< 0x0000000C */
-#define ETH_MACCR_PRELEN                              ETH_MACCR_PRELEN_Msk     /* Preamble Length for Transmit packets */
-#define ETH_MACCR_PRELEN_7                            (0x0UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000000 */
-#define ETH_MACCR_PRELEN_5                            (0x1UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000004 */
-#define ETH_MACCR_PRELEN_3                            (0x2UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000008 */
-#define ETH_MACCR_TE_Pos                              (1U)
-#define ETH_MACCR_TE_Msk                              (0x1UL << ETH_MACCR_TE_Pos) /*!< 0x00000002 */
-#define ETH_MACCR_TE                                  ETH_MACCR_TE_Msk         /* Transmitter enable */
-#define ETH_MACCR_RE_Pos                              (0U)
-#define ETH_MACCR_RE_Msk                              (0x1UL << ETH_MACCR_RE_Pos) /*!< 0x00000001 */
-#define ETH_MACCR_RE                                  ETH_MACCR_RE_Msk         /* Receiver enable */
-
-/* Bit definition for Ethernet MAC Extended Configuration Register register */
-#define ETH_MACECR_EIPG_Pos                           (25U)
-#define ETH_MACECR_EIPG_Msk                           (0x1FUL << ETH_MACECR_EIPG_Pos) /*!< 0x3E000000 */
-#define ETH_MACECR_EIPG                               ETH_MACECR_EIPG_Msk      /* Extended Inter-Packet Gap */
-#define ETH_MACECR_EIPGEN_Pos                         (24U)
-#define ETH_MACECR_EIPGEN_Msk                         (0x1UL << ETH_MACECR_EIPGEN_Pos) /*!< 0x01000000 */
-#define ETH_MACECR_EIPGEN                             ETH_MACECR_EIPGEN_Msk    /* Extended Inter-Packet Gap Enable */
-#define ETH_MACECR_USP_Pos                            (18U)
-#define ETH_MACECR_USP_Msk                            (0x1UL << ETH_MACECR_USP_Pos) /*!< 0x00040000 */
-#define ETH_MACECR_USP                                ETH_MACECR_USP_Msk       /* Unicast Slow Protocol Packet Detect */
-#define ETH_MACECR_SPEN_Pos                           (17U)
-#define ETH_MACECR_SPEN_Msk                           (0x1UL << ETH_MACECR_SPEN_Pos) /*!< 0x00020000 */
-#define ETH_MACECR_SPEN                               ETH_MACECR_SPEN_Msk      /* Slow Protocol Detection Enable */
-#define ETH_MACECR_DCRCC_Pos                          (16U)
-#define ETH_MACECR_DCRCC_Msk                          (0x1UL << ETH_MACECR_DCRCC_Pos) /*!< 0x00010000 */
-#define ETH_MACECR_DCRCC                              ETH_MACECR_DCRCC_Msk     /* Disable CRC Checking for Received Packets */
-#define ETH_MACECR_GPSL_Pos                           (0U)
-#define ETH_MACECR_GPSL_Msk                           (0x3FFFUL << ETH_MACECR_GPSL_Pos) /*!< 0x00003FFF */
-#define ETH_MACECR_GPSL                               ETH_MACECR_GPSL_Msk      /* Giant Packet Size Limit */
-
-/* Bit definition for Ethernet MAC Packet Filter Register */
-#define ETH_MACPFR_RA_Pos                             (31U)
-#define ETH_MACPFR_RA_Msk                             (0x1UL << ETH_MACPFR_RA_Pos) /*!< 0x80000000 */
-#define ETH_MACPFR_RA                                 ETH_MACPFR_RA_Msk        /* Receive all */
-#define ETH_MACPFR_DNTU_Pos                           (21U)
-#define ETH_MACPFR_DNTU_Msk                           (0x1UL << ETH_MACPFR_DNTU_Pos) /*!< 0x00200000 */
-#define ETH_MACPFR_DNTU                               ETH_MACPFR_DNTU_Msk      /* Drop Non-TCP/UDP over IP Packets */
-#define ETH_MACPFR_IPFE_Pos                           (20U)
-#define ETH_MACPFR_IPFE_Msk                           (0x1UL << ETH_MACPFR_IPFE_Pos) /*!< 0x00100000 */
-#define ETH_MACPFR_IPFE                               ETH_MACPFR_IPFE_Msk      /* Layer 3 and Layer 4 Filter Enable */
-#define ETH_MACPFR_VTFE_Pos                           (16U)
-#define ETH_MACPFR_VTFE_Msk                           (0x1UL << ETH_MACPFR_VTFE_Pos) /*!< 0x00010000 */
-#define ETH_MACPFR_VTFE                               ETH_MACPFR_VTFE_Msk      /* VLAN Tag Filter Enable */
-#define ETH_MACPFR_HPF_Pos                            (10U)
-#define ETH_MACPFR_HPF_Msk                            (0x1UL << ETH_MACPFR_HPF_Pos) /*!< 0x00000400 */
-#define ETH_MACPFR_HPF                                ETH_MACPFR_HPF_Msk       /* Hash or perfect filter */
-#define ETH_MACPFR_SAF_Pos                            (9U)
-#define ETH_MACPFR_SAF_Msk                            (0x1UL << ETH_MACPFR_SAF_Pos) /*!< 0x00000200 */
-#define ETH_MACPFR_SAF                                ETH_MACPFR_SAF_Msk       /* Source address filter enable */
-#define ETH_MACPFR_SAIF_Pos                           (8U)
-#define ETH_MACPFR_SAIF_Msk                           (0x1UL << ETH_MACPFR_SAIF_Pos) /*!< 0x00000100 */
-#define ETH_MACPFR_SAIF                               ETH_MACPFR_SAIF_Msk      /* SA inverse filtering */
-#define ETH_MACPFR_PCF_Pos                            (6U)
-#define ETH_MACPFR_PCF_Msk                            (0x3UL << ETH_MACPFR_PCF_Pos) /*!< 0x000000C0 */
-#define ETH_MACPFR_PCF                                ETH_MACPFR_PCF_Msk       /* Pass control frames: 4 cases */
-#define ETH_MACPFR_PCF_BLOCKALL                       ((uint32_t)0x00000000)   /* MAC filters all control frames from reaching the application */
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Pos         (6U)
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Msk         (0x1UL << ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Pos) /*!< 0x00000040 */
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA             ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Msk /* MAC forwards all control frames except Pause packets to application even if they fail the Address Filter */
-#define ETH_MACPFR_PCF_FORWARDALL_Pos                 (7U)
-#define ETH_MACPFR_PCF_FORWARDALL_Msk                 (0x1UL << ETH_MACPFR_PCF_FORWARDALL_Pos) /*!< 0x00000080 */
-#define ETH_MACPFR_PCF_FORWARDALL                     ETH_MACPFR_PCF_FORWARDALL_Msk /* MAC forwards all control frames to application even if they fail the Address Filter */
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Pos    (6U)
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Msk    (0x3UL << ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Pos) /*!< 0x000000C0 */
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER        ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Msk /* MAC forwards control frames that pass the Address Filter. */
-#define ETH_MACPFR_DBF_Pos                            (5U)
-#define ETH_MACPFR_DBF_Msk                            (0x1UL << ETH_MACPFR_DBF_Pos) /*!< 0x00000020 */
-#define ETH_MACPFR_DBF                                ETH_MACPFR_DBF_Msk       /* Disable Broadcast Packets */
-#define ETH_MACPFR_PM_Pos                             (4U)
-#define ETH_MACPFR_PM_Msk                             (0x1UL << ETH_MACPFR_PM_Pos) /*!< 0x00000010 */
-#define ETH_MACPFR_PM                                 ETH_MACPFR_PM_Msk        /* Pass all mutlicast */
-#define ETH_MACPFR_DAIF_Pos                           (3U)
-#define ETH_MACPFR_DAIF_Msk                           (0x1UL << ETH_MACPFR_DAIF_Pos) /*!< 0x00000008 */
-#define ETH_MACPFR_DAIF                               ETH_MACPFR_DAIF_Msk      /* DA Inverse filtering */
-#define ETH_MACPFR_HMC_Pos                            (2U)
-#define ETH_MACPFR_HMC_Msk                            (0x1UL << ETH_MACPFR_HMC_Pos) /*!< 0x00000004 */
-#define ETH_MACPFR_HMC                                ETH_MACPFR_HMC_Msk       /* Hash multicast */
-#define ETH_MACPFR_HUC_Pos                            (1U)
-#define ETH_MACPFR_HUC_Msk                            (0x1UL << ETH_MACPFR_HUC_Pos) /*!< 0x00000002 */
-#define ETH_MACPFR_HUC                                ETH_MACPFR_HUC_Msk       /* Hash unicast */
-#define ETH_MACPFR_PR_Pos                             (0U)
-#define ETH_MACPFR_PR_Msk                             (0x1UL << ETH_MACPFR_PR_Pos) /*!< 0x00000001 */
-#define ETH_MACPFR_PR                                 ETH_MACPFR_PR_Msk        /* Promiscuous mode */
-
-/* Bit definition for Ethernet MAC Watchdog Timeout Register */
-#define ETH_MACWTR_PWE_Pos                            (8U)
-#define ETH_MACWTR_PWE_Msk                            (0x1UL << ETH_MACWTR_PWE_Pos) /*!< 0x00000100 */
-#define ETH_MACWTR_PWE                                ETH_MACWTR_PWE_Msk       /* Programmable Watchdog Enable */
-#define ETH_MACWTR_WTO_Pos                            (0U)
-#define ETH_MACWTR_WTO_Msk                            (0xFUL << ETH_MACWTR_WTO_Pos) /*!< 0x0000000F */
-#define ETH_MACWTR_WTO                                ETH_MACWTR_WTO_Msk       /* Watchdog Timeout */
-#define ETH_MACWTR_WTO_2KB                            ((uint32_t)0x00000000)   /* Maximum received packet length 2KB*/
-#define ETH_MACWTR_WTO_3KB                            ((uint32_t)0x00000001)   /* Maximum received packet length 3KB */
-#define ETH_MACWTR_WTO_4KB                            ((uint32_t)0x00000002)   /* Maximum received packet length 4KB */
-#define ETH_MACWTR_WTO_5KB                            ((uint32_t)0x00000003)   /* Maximum received packet length 5KB */
-#define ETH_MACWTR_WTO_6KB                            ((uint32_t)0x00000004)   /* Maximum received packet length 6KB */
-#define ETH_MACWTR_WTO_7KB                            ((uint32_t)0x00000005)   /* Maximum received packet length 7KB */
-#define ETH_MACWTR_WTO_8KB                            ((uint32_t)0x00000006)   /* Maximum received packet length 8KB */
-#define ETH_MACWTR_WTO_9KB                            ((uint32_t)0x00000007)   /* Maximum received packet length 9KB */
-#define ETH_MACWTR_WTO_10KB                           ((uint32_t)0x00000008)   /* Maximum received packet length 10KB */
-#define ETH_MACWTR_WTO_11KB                           ((uint32_t)0x00000009)   /* Maximum received packet length 11KB */
-#define ETH_MACWTR_WTO_12KB                           ((uint32_t)0x0000000A)   /* Maximum received packet length 12KB */
-#define ETH_MACWTR_WTO_13KB                           ((uint32_t)0x0000000B)   /* Maximum received packet length 13KB */
-#define ETH_MACWTR_WTO_14KB                           ((uint32_t)0x0000000C)   /* Maximum received packet length 14KB */
-#define ETH_MACWTR_WTO_15KB                           ((uint32_t)0x0000000D)   /* Maximum received packet length 15KB */
-#define ETH_MACWTR_WTO_16KB                           ((uint32_t)0x0000000E)   /* Maximum received packet length 16KB */
-
-/* Bit definition for Ethernet MAC Hash Table High Register */
-#define ETH_MACHTHR_HTH_Pos                           (0U)
-#define ETH_MACHTHR_HTH_Msk                           (0xFFFFFFFFUL << ETH_MACHTHR_HTH_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACHTHR_HTH                               ETH_MACHTHR_HTH_Msk      /* Hash table high */
-
-/* Bit definition for Ethernet MAC Hash Table Low Register */
-#define ETH_MACHTLR_HTL_Pos                           (0U)
-#define ETH_MACHTLR_HTL_Msk                           (0xFFFFFFFFUL << ETH_MACHTLR_HTL_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACHTLR_HTL                               ETH_MACHTLR_HTL_Msk      /* Hash table low */
-
-/* Bit definition for Ethernet MAC VLAN Tag Register */
-#define ETH_MACVTR_EIVLRXS_Pos                        (31U)
-#define ETH_MACVTR_EIVLRXS_Msk                        (0x1UL << ETH_MACVTR_EIVLRXS_Pos) /*!< 0x80000000 */
-#define ETH_MACVTR_EIVLRXS                            ETH_MACVTR_EIVLRXS_Msk   /* Enable Inner VLAN Tag in Rx Status */
-#define ETH_MACVTR_EIVLS_Pos                          (28U)
-#define ETH_MACVTR_EIVLS_Msk                          (0x3UL << ETH_MACVTR_EIVLS_Pos) /*!< 0x30000000 */
-#define ETH_MACVTR_EIVLS                              ETH_MACVTR_EIVLS_Msk     /* Enable Inner VLAN Tag Stripping on Receive */
-#define ETH_MACVTR_EIVLS_DONOTSTRIP                   ((uint32_t)0x00000000)   /* Do not strip */
-#define ETH_MACVTR_EIVLS_STRIPIFPASS_Pos              (28U)
-#define ETH_MACVTR_EIVLS_STRIPIFPASS_Msk              (0x1UL << ETH_MACVTR_EIVLS_STRIPIFPASS_Pos) /*!< 0x10000000 */
-#define ETH_MACVTR_EIVLS_STRIPIFPASS                  ETH_MACVTR_EIVLS_STRIPIFPASS_Msk /* Strip if VLAN filter passes */
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS_Pos             (29U)
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS_Msk             (0x1UL << ETH_MACVTR_EIVLS_STRIPIFFAILS_Pos) /*!< 0x20000000 */
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS                 ETH_MACVTR_EIVLS_STRIPIFFAILS_Msk /* Strip if VLAN filter fails */
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP_Pos              (28U)
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP_Msk              (0x3UL << ETH_MACVTR_EIVLS_ALWAYSSTRIP_Pos) /*!< 0x30000000 */
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP                  ETH_MACVTR_EIVLS_ALWAYSSTRIP_Msk /* Always strip */
-#define ETH_MACVTR_ERIVLT_Pos                         (27U)
-#define ETH_MACVTR_ERIVLT_Msk                         (0x1UL << ETH_MACVTR_ERIVLT_Pos) /*!< 0x08000000 */
-#define ETH_MACVTR_ERIVLT                             ETH_MACVTR_ERIVLT_Msk    /* Enable Inner VLAN Tag */
-#define ETH_MACVTR_EDVLP_Pos                          (26U)
-#define ETH_MACVTR_EDVLP_Msk                          (0x1UL << ETH_MACVTR_EDVLP_Pos) /*!< 0x04000000 */
-#define ETH_MACVTR_EDVLP                              ETH_MACVTR_EDVLP_Msk     /* Enable Double VLAN Processing */
-#define ETH_MACVTR_VTHM_Pos                           (25U)
-#define ETH_MACVTR_VTHM_Msk                           (0x1UL << ETH_MACVTR_VTHM_Pos) /*!< 0x02000000 */
-#define ETH_MACVTR_VTHM                               ETH_MACVTR_VTHM_Msk      /* VLAN Tag Hash Table Match Enable */
-#define ETH_MACVTR_EVLRXS_Pos                         (24U)
-#define ETH_MACVTR_EVLRXS_Msk                         (0x1UL << ETH_MACVTR_EVLRXS_Pos) /*!< 0x01000000 */
-#define ETH_MACVTR_EVLRXS                             ETH_MACVTR_EVLRXS_Msk    /* Enable VLAN Tag in Rx status */
-#define ETH_MACVTR_EVLS_Pos                           (21U)
-#define ETH_MACVTR_EVLS_Msk                           (0x3UL << ETH_MACVTR_EVLS_Pos) /*!< 0x00600000 */
-#define ETH_MACVTR_EVLS                               ETH_MACVTR_EVLS_Msk      /* Enable VLAN Tag Stripping on Receive */
-#define ETH_MACVTR_EVLS_DONOTSTRIP                    ((uint32_t)0x00000000)   /* Do not strip */
-#define ETH_MACVTR_EVLS_STRIPIFPASS_Pos               (21U)
-#define ETH_MACVTR_EVLS_STRIPIFPASS_Msk               (0x1UL << ETH_MACVTR_EVLS_STRIPIFPASS_Pos) /*!< 0x00200000 */
-#define ETH_MACVTR_EVLS_STRIPIFPASS                   ETH_MACVTR_EVLS_STRIPIFPASS_Msk /* Strip if VLAN filter passes */
-#define ETH_MACVTR_EVLS_STRIPIFFAILS_Pos              (22U)
-#define ETH_MACVTR_EVLS_STRIPIFFAILS_Msk              (0x1UL << ETH_MACVTR_EVLS_STRIPIFFAILS_Pos) /*!< 0x00400000 */
-#define ETH_MACVTR_EVLS_STRIPIFFAILS                  ETH_MACVTR_EVLS_STRIPIFFAILS_Msk /* Strip if VLAN filter fails */
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP_Pos               (21U)
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP_Msk               (0x3UL << ETH_MACVTR_EVLS_ALWAYSSTRIP_Pos) /*!< 0x00600000 */
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP                   ETH_MACVTR_EVLS_ALWAYSSTRIP_Msk /* Always strip */
-#define ETH_MACVTR_DOVLTC_Pos                         (20U)
-#define ETH_MACVTR_DOVLTC_Msk                         (0x1UL << ETH_MACVTR_DOVLTC_Pos) /*!< 0x00100000 */
-#define ETH_MACVTR_DOVLTC                             ETH_MACVTR_DOVLTC_Msk    /* Disable VLAN Type Check */
-#define ETH_MACVTR_ERSVLM_Pos                         (19U)
-#define ETH_MACVTR_ERSVLM_Msk                         (0x1UL << ETH_MACVTR_ERSVLM_Pos) /*!< 0x00080000 */
-#define ETH_MACVTR_ERSVLM                             ETH_MACVTR_ERSVLM_Msk    /* Enable Receive S-VLAN Match */
-#define ETH_MACVTR_ESVL_Pos                           (18U)
-#define ETH_MACVTR_ESVL_Msk                           (0x1UL << ETH_MACVTR_ESVL_Pos) /*!< 0x00040000 */
-#define ETH_MACVTR_ESVL                               ETH_MACVTR_ESVL_Msk      /* Enable S-VLAN */
-#define ETH_MACVTR_VTIM_Pos                           (17U)
-#define ETH_MACVTR_VTIM_Msk                           (0x1UL << ETH_MACVTR_VTIM_Pos) /*!< 0x00020000 */
-#define ETH_MACVTR_VTIM                               ETH_MACVTR_VTIM_Msk      /* VLAN Tag Inverse Match Enable */
-#define ETH_MACVTR_ETV_Pos                            (16U)
-#define ETH_MACVTR_ETV_Msk                            (0x1UL << ETH_MACVTR_ETV_Pos) /*!< 0x00010000 */
-#define ETH_MACVTR_ETV                                ETH_MACVTR_ETV_Msk       /* Enable 12-Bit VLAN Tag Comparison */
-#define ETH_MACVTR_VL_Pos                             (0U)
-#define ETH_MACVTR_VL_Msk                             (0xFFFFUL << ETH_MACVTR_VL_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVTR_VL                                 ETH_MACVTR_VL_Msk        /* VLAN Tag Identifier for Receive Packets */
-#define ETH_MACVTR_VL_UP_Pos                          (13U)
-#define ETH_MACVTR_VL_UP_Msk                          (0x7UL << ETH_MACVTR_VL_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACVTR_VL_UP                              ETH_MACVTR_VL_UP_Msk     /* User Priority */
-#define ETH_MACVTR_VL_CFIDEI_Pos                      (12U)
-#define ETH_MACVTR_VL_CFIDEI_Msk                      (0x1UL << ETH_MACVTR_VL_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACVTR_VL_CFIDEI                          ETH_MACVTR_VL_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACVTR_VL_VID_Pos                         (0U)
-#define ETH_MACVTR_VL_VID_Msk                         (0xFFFUL << ETH_MACVTR_VL_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACVTR_VL_VID                             ETH_MACVTR_VL_VID_Msk    /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC VLAN Hash Table Register */
-#define ETH_MACVHTR_VLHT_Pos                          (0U)
-#define ETH_MACVHTR_VLHT_Msk                          (0xFFFFUL << ETH_MACVHTR_VLHT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVHTR_VLHT                              ETH_MACVHTR_VLHT_Msk     /* VLAN Hash Table */
-
-/* Bit definition for Ethernet MAC VLAN Incl Register */
-#define ETH_MACVIR_VLTI_Pos                           (20U)
-#define ETH_MACVIR_VLTI_Msk                           (0x1UL << ETH_MACVIR_VLTI_Pos) /*!< 0x00100000 */
-#define ETH_MACVIR_VLTI                               ETH_MACVIR_VLTI_Msk      /* VLAN Tag Input */
-#define ETH_MACVIR_CSVL_Pos                           (19U)
-#define ETH_MACVIR_CSVL_Msk                           (0x1UL << ETH_MACVIR_CSVL_Pos) /*!< 0x00080000 */
-#define ETH_MACVIR_CSVL                               ETH_MACVIR_CSVL_Msk      /* C-VLAN or S-VLAN */
-#define ETH_MACVIR_VLP_Pos                            (18U)
-#define ETH_MACVIR_VLP_Msk                            (0x1UL << ETH_MACVIR_VLP_Pos) /*!< 0x00040000 */
-#define ETH_MACVIR_VLP                                ETH_MACVIR_VLP_Msk       /* VLAN Priority Control */
-#define ETH_MACVIR_VLC_Pos                            (16U)
-#define ETH_MACVIR_VLC_Msk                            (0x3UL << ETH_MACVIR_VLC_Pos) /*!< 0x00030000 */
-#define ETH_MACVIR_VLC                                ETH_MACVIR_VLC_Msk       /* VLAN Tag Control in Transmit Packets */
-#define ETH_MACVIR_VLC_NOVLANTAG                      ((uint32_t)0x00000000)   /* No VLAN tag deletion, insertion, or replacement */
-#define ETH_MACVIR_VLC_VLANTAGDELETE_Pos              (16U)
-#define ETH_MACVIR_VLC_VLANTAGDELETE_Msk              (0x1UL << ETH_MACVIR_VLC_VLANTAGDELETE_Pos) /*!< 0x00010000 */
-#define ETH_MACVIR_VLC_VLANTAGDELETE                  ETH_MACVIR_VLC_VLANTAGDELETE_Msk /* VLAN tag deletion */
-#define ETH_MACVIR_VLC_VLANTAGINSERT_Pos              (17U)
-#define ETH_MACVIR_VLC_VLANTAGINSERT_Msk              (0x1UL << ETH_MACVIR_VLC_VLANTAGINSERT_Pos) /*!< 0x00020000 */
-#define ETH_MACVIR_VLC_VLANTAGINSERT                  ETH_MACVIR_VLC_VLANTAGINSERT_Msk /* VLAN tag insertion */
-#define ETH_MACVIR_VLC_VLANTAGREPLACE_Pos             (16U)
-#define ETH_MACVIR_VLC_VLANTAGREPLACE_Msk             (0x3UL << ETH_MACVIR_VLC_VLANTAGREPLACE_Pos) /*!< 0x00030000 */
-#define ETH_MACVIR_VLC_VLANTAGREPLACE                 ETH_MACVIR_VLC_VLANTAGREPLACE_Msk /* VLAN tag replacement */
-#define ETH_MACVIR_VLT_Pos                            (0U)
-#define ETH_MACVIR_VLT_Msk                            (0xFFFFUL << ETH_MACVIR_VLT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVIR_VLT                                ETH_MACVIR_VLT_Msk       /* VLAN Tag for Transmit Packets */
-#define ETH_MACVIR_VLT_UP_Pos                         (13U)
-#define ETH_MACVIR_VLT_UP_Msk                         (0x7UL << ETH_MACVIR_VLT_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACVIR_VLT_UP                             ETH_MACVIR_VLT_UP_Msk    /* User Priority */
-#define ETH_MACVIR_VLT_CFIDEI_Pos                     (12U)
-#define ETH_MACVIR_VLT_CFIDEI_Msk                     (0x1UL << ETH_MACVIR_VLT_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACVIR_VLT_CFIDEI                         ETH_MACVIR_VLT_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACVIR_VLT_VID_Pos                        (0U)
-#define ETH_MACVIR_VLT_VID_Msk                        (0xFFFUL << ETH_MACVIR_VLT_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACVIR_VLT_VID                            ETH_MACVIR_VLT_VID_Msk   /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC Inner_VLAN Incl Register */
-#define ETH_MACIVIR_VLTI_Pos                          (20U)
-#define ETH_MACIVIR_VLTI_Msk                          (0x1UL << ETH_MACIVIR_VLTI_Pos) /*!< 0x00100000 */
-#define ETH_MACIVIR_VLTI                              ETH_MACIVIR_VLTI_Msk     /* VLAN Tag Input */
-#define ETH_MACIVIR_CSVL_Pos                          (19U)
-#define ETH_MACIVIR_CSVL_Msk                          (0x1UL << ETH_MACIVIR_CSVL_Pos) /*!< 0x00080000 */
-#define ETH_MACIVIR_CSVL                              ETH_MACIVIR_CSVL_Msk     /* C-VLAN or S-VLAN */
-#define ETH_MACIVIR_VLP_Pos                           (18U)
-#define ETH_MACIVIR_VLP_Msk                           (0x1UL << ETH_MACIVIR_VLP_Pos) /*!< 0x00040000 */
-#define ETH_MACIVIR_VLP                               ETH_MACIVIR_VLP_Msk      /* VLAN Priority Control */
-#define ETH_MACIVIR_VLC_Pos                           (16U)
-#define ETH_MACIVIR_VLC_Msk                           (0x3UL << ETH_MACIVIR_VLC_Pos) /*!< 0x00030000 */
-#define ETH_MACIVIR_VLC                               ETH_MACIVIR_VLC_Msk      /* VLAN Tag Control in Transmit Packets */
-#define ETH_MACIVIR_VLC_NOVLANTAG                     ((uint32_t)0x00000000)   /* No VLAN tag deletion, insertion, or replacement */
-#define ETH_MACIVIR_VLC_VLANTAGDELETE_Pos             (16U)
-#define ETH_MACIVIR_VLC_VLANTAGDELETE_Msk             (0x1UL << ETH_MACIVIR_VLC_VLANTAGDELETE_Pos) /*!< 0x00010000 */
-#define ETH_MACIVIR_VLC_VLANTAGDELETE                 ETH_MACIVIR_VLC_VLANTAGDELETE_Msk /* VLAN tag deletion */
-#define ETH_MACIVIR_VLC_VLANTAGINSERT_Pos             (17U)
-#define ETH_MACIVIR_VLC_VLANTAGINSERT_Msk             (0x1UL << ETH_MACIVIR_VLC_VLANTAGINSERT_Pos) /*!< 0x00020000 */
-#define ETH_MACIVIR_VLC_VLANTAGINSERT                 ETH_MACIVIR_VLC_VLANTAGINSERT_Msk /* VLAN tag insertion */
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE_Pos            (16U)
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE_Msk            (0x3UL << ETH_MACIVIR_VLC_VLANTAGREPLACE_Pos) /*!< 0x00030000 */
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE                ETH_MACIVIR_VLC_VLANTAGREPLACE_Msk /* VLAN tag replacement */
-#define ETH_MACIVIR_VLT_Pos                           (0U)
-#define ETH_MACIVIR_VLT_Msk                           (0xFFFFUL << ETH_MACIVIR_VLT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACIVIR_VLT                               ETH_MACIVIR_VLT_Msk      /* VLAN Tag for Transmit Packets */
-#define ETH_MACIVIR_VLT_UP_Pos                        (13U)
-#define ETH_MACIVIR_VLT_UP_Msk                        (0x7UL << ETH_MACIVIR_VLT_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACIVIR_VLT_UP                            ETH_MACIVIR_VLT_UP_Msk   /* User Priority */
-#define ETH_MACIVIR_VLT_CFIDEI_Pos                    (12U)
-#define ETH_MACIVIR_VLT_CFIDEI_Msk                    (0x1UL << ETH_MACIVIR_VLT_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACIVIR_VLT_CFIDEI                        ETH_MACIVIR_VLT_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACIVIR_VLT_VID_Pos                       (0U)
-#define ETH_MACIVIR_VLT_VID_Msk                       (0xFFFUL << ETH_MACIVIR_VLT_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACIVIR_VLT_VID                           ETH_MACIVIR_VLT_VID_Msk  /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC Tx Flow Ctrl Register */
-#define ETH_MACTFCR_PT_Pos                            (16U)
-#define ETH_MACTFCR_PT_Msk                            (0xFFFFUL << ETH_MACTFCR_PT_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACTFCR_PT                                ETH_MACTFCR_PT_Msk       /* Pause Time */
-#define ETH_MACTFCR_DZPQ_Pos                          (7U)
-#define ETH_MACTFCR_DZPQ_Msk                          (0x1UL << ETH_MACTFCR_DZPQ_Pos) /*!< 0x00000080 */
-#define ETH_MACTFCR_DZPQ                              ETH_MACTFCR_DZPQ_Msk     /* Disable Zero-Quanta Pause */
-#define ETH_MACTFCR_PLT_Pos                           (4U)
-#define ETH_MACTFCR_PLT_Msk                           (0x7UL << ETH_MACTFCR_PLT_Pos) /*!< 0x00000070 */
-#define ETH_MACTFCR_PLT                               ETH_MACTFCR_PLT_Msk      /* Pause Low Threshold */
-#define ETH_MACTFCR_PLT_MINUS4                        ((uint32_t)0x00000000)   /* Pause time minus 4 slot times */
-#define ETH_MACTFCR_PLT_MINUS28_Pos                   (4U)
-#define ETH_MACTFCR_PLT_MINUS28_Msk                   (0x1UL << ETH_MACTFCR_PLT_MINUS28_Pos) /*!< 0x00000010 */
-#define ETH_MACTFCR_PLT_MINUS28                       ETH_MACTFCR_PLT_MINUS28_Msk /* Pause time minus 28 slot times */
-#define ETH_MACTFCR_PLT_MINUS36_Pos                   (5U)
-#define ETH_MACTFCR_PLT_MINUS36_Msk                   (0x1UL << ETH_MACTFCR_PLT_MINUS36_Pos) /*!< 0x00000020 */
-#define ETH_MACTFCR_PLT_MINUS36                       ETH_MACTFCR_PLT_MINUS36_Msk /* Pause time minus 36 slot times */
-#define ETH_MACTFCR_PLT_MINUS144_Pos                  (4U)
-#define ETH_MACTFCR_PLT_MINUS144_Msk                  (0x3UL << ETH_MACTFCR_PLT_MINUS144_Pos) /*!< 0x00000030 */
-#define ETH_MACTFCR_PLT_MINUS144                      ETH_MACTFCR_PLT_MINUS144_Msk /* Pause time minus 144 slot times */
-#define ETH_MACTFCR_PLT_MINUS256_Pos                  (6U)
-#define ETH_MACTFCR_PLT_MINUS256_Msk                  (0x1UL << ETH_MACTFCR_PLT_MINUS256_Pos) /*!< 0x00000040 */
-#define ETH_MACTFCR_PLT_MINUS256                      ETH_MACTFCR_PLT_MINUS256_Msk /* Pause time minus 256 slot times */
-#define ETH_MACTFCR_PLT_MINUS512_Pos                  (4U)
-#define ETH_MACTFCR_PLT_MINUS512_Msk                  (0x5UL << ETH_MACTFCR_PLT_MINUS512_Pos) /*!< 0x00000050 */
-#define ETH_MACTFCR_PLT_MINUS512                      ETH_MACTFCR_PLT_MINUS512_Msk /* Pause time minus 512 slot times */
-#define ETH_MACTFCR_TFE_Pos                           (1U)
-#define ETH_MACTFCR_TFE_Msk                           (0x1UL << ETH_MACTFCR_TFE_Pos) /*!< 0x00000002 */
-#define ETH_MACTFCR_TFE                               ETH_MACTFCR_TFE_Msk      /* Transmit Flow Control Enable */
-#define ETH_MACTFCR_FCB_Pos                           (0U)
-#define ETH_MACTFCR_FCB_Msk                           (0x1UL << ETH_MACTFCR_FCB_Pos) /*!< 0x00000001 */
-#define ETH_MACTFCR_FCB                               ETH_MACTFCR_FCB_Msk      /* Flow Control Busy or Backpressure Activate */
-
-/* Bit definition for Ethernet MAC Rx Flow Ctrl Register */
-#define ETH_MACRFCR_UP_Pos                            (1U)
-#define ETH_MACRFCR_UP_Msk                            (0x1UL << ETH_MACRFCR_UP_Pos) /*!< 0x00000002 */
-#define ETH_MACRFCR_UP                                ETH_MACRFCR_UP_Msk       /* Unicast Pause Packet Detect */
-#define ETH_MACRFCR_RFE_Pos                           (0U)
-#define ETH_MACRFCR_RFE_Msk                           (0x1UL << ETH_MACRFCR_RFE_Pos) /*!< 0x00000001 */
-#define ETH_MACRFCR_RFE                               ETH_MACRFCR_RFE_Msk      /* Receive Flow Control Enable */
-
-/* Bit definition for Ethernet MAC Interrupt Status Register */
-#define ETH_MACISR_RXSTSIS_Pos                        (14U)
-#define ETH_MACISR_RXSTSIS_Msk                        (0x1UL << ETH_MACISR_RXSTSIS_Pos) /*!< 0x00004000 */
-#define ETH_MACISR_RXSTSIS                            ETH_MACISR_RXSTSIS_Msk   /* Receive Status Interrupt */
-#define ETH_MACISR_TXSTSIS_Pos                        (13U)
-#define ETH_MACISR_TXSTSIS_Msk                        (0x1UL << ETH_MACISR_TXSTSIS_Pos) /*!< 0x00002000 */
-#define ETH_MACISR_TXSTSIS                            ETH_MACISR_TXSTSIS_Msk   /* Transmit Status Interrupt */
-#define ETH_MACISR_TSIS_Pos                           (12U)
-#define ETH_MACISR_TSIS_Msk                           (0x1UL << ETH_MACISR_TSIS_Pos) /*!< 0x00001000 */
-#define ETH_MACISR_TSIS                               ETH_MACISR_TSIS_Msk      /* Timestamp Interrupt Status */
-#define ETH_MACISR_MMCTXIS_Pos                        (10U)
-#define ETH_MACISR_MMCTXIS_Msk                        (0x1UL << ETH_MACISR_MMCTXIS_Pos) /*!< 0x00000400 */
-#define ETH_MACISR_MMCTXIS                            ETH_MACISR_MMCTXIS_Msk   /* MMC Transmit Interrupt Status */
-#define ETH_MACISR_MMCRXIS_Pos                        (9U)
-#define ETH_MACISR_MMCRXIS_Msk                        (0x1UL << ETH_MACISR_MMCRXIS_Pos) /*!< 0x00000200 */
-#define ETH_MACISR_MMCRXIS                            ETH_MACISR_MMCRXIS_Msk   /* MMC Receive Interrupt Status */
-#define ETH_MACISR_MMCIS_Pos                          (8U)
-#define ETH_MACISR_MMCIS_Msk                          (0x1UL << ETH_MACISR_MMCIS_Pos) /*!< 0x00000100 */
-#define ETH_MACISR_MMCIS                              ETH_MACISR_MMCIS_Msk     /* MMC Interrupt Status */
-#define ETH_MACISR_LPIIS_Pos                          (5U)
-#define ETH_MACISR_LPIIS_Msk                          (0x1UL << ETH_MACISR_LPIIS_Pos) /*!< 0x00000020 */
-#define ETH_MACISR_LPIIS                              ETH_MACISR_LPIIS_Msk     /* LPI Interrupt Status */
-#define ETH_MACISR_PMTIS_Pos                          (4U)
-#define ETH_MACISR_PMTIS_Msk                          (0x1UL << ETH_MACISR_PMTIS_Pos) /*!< 0x00000010 */
-#define ETH_MACISR_PMTIS                              ETH_MACISR_PMTIS_Msk     /* PMT Interrupt Status */
-#define ETH_MACISR_PHYIS_Pos                          (3U)
-#define ETH_MACISR_PHYIS_Msk                          (0x1UL << ETH_MACISR_PHYIS_Pos) /*!< 0x00000008 */
-#define ETH_MACISR_PHYIS                              ETH_MACISR_PHYIS_Msk     /* PHY Interrupt */
-
-/* Bit definition for Ethernet MAC Interrupt Enable Register */
-#define ETH_MACIER_RXSTSIE_Pos                        (14U)
-#define ETH_MACIER_RXSTSIE_Msk                        (0x1UL << ETH_MACIER_RXSTSIE_Pos) /*!< 0x00004000 */
-#define ETH_MACIER_RXSTSIE                            ETH_MACIER_RXSTSIE_Msk   /* Receive Status Interrupt Enable */
-#define ETH_MACIER_TXSTSIE_Pos                        (13U)
-#define ETH_MACIER_TXSTSIE_Msk                        (0x1UL << ETH_MACIER_TXSTSIE_Pos) /*!< 0x00002000 */
-#define ETH_MACIER_TXSTSIE                            ETH_MACIER_TXSTSIE_Msk   /* Transmit Status Interrupt Enable */
-#define ETH_MACIER_TSIE_Pos                           (12U)
-#define ETH_MACIER_TSIE_Msk                           (0x1UL << ETH_MACIER_TSIE_Pos) /*!< 0x00001000 */
-#define ETH_MACIER_TSIE                               ETH_MACIER_TSIE_Msk      /* Timestamp Interrupt Enable */
-#define ETH_MACIER_LPIIE_Pos                          (5U)
-#define ETH_MACIER_LPIIE_Msk                          (0x1UL << ETH_MACIER_LPIIE_Pos) /*!< 0x00000020 */
-#define ETH_MACIER_LPIIE                              ETH_MACIER_LPIIE_Msk     /* LPI Interrupt Enable */
-#define ETH_MACIER_PMTIE_Pos                          (4U)
-#define ETH_MACIER_PMTIE_Msk                          (0x1UL << ETH_MACIER_PMTIE_Pos) /*!< 0x00000010 */
-#define ETH_MACIER_PMTIE                              ETH_MACIER_PMTIE_Msk     /* PMT Interrupt Enable */
-#define ETH_MACIER_PHYIE_Pos                          (3U)
-#define ETH_MACIER_PHYIE_Msk                          (0x1UL << ETH_MACIER_PHYIE_Pos) /*!< 0x00000008 */
-#define ETH_MACIER_PHYIE                              ETH_MACIER_PHYIE_Msk     /* PHY Interrupt Enable */
-
-/* Bit definition for Ethernet MAC Rx Tx Status Register */
-#define ETH_MACRXTXSR_RWT_Pos                         (8U)
-#define ETH_MACRXTXSR_RWT_Msk                         (0x1UL << ETH_MACRXTXSR_RWT_Pos) /*!< 0x00000100 */
-#define ETH_MACRXTXSR_RWT                             ETH_MACRXTXSR_RWT_Msk    /* Receive Watchdog Timeout */
-#define ETH_MACRXTXSR_EXCOL_Pos                       (5U)
-#define ETH_MACRXTXSR_EXCOL_Msk                       (0x1UL << ETH_MACRXTXSR_EXCOL_Pos) /*!< 0x00000020 */
-#define ETH_MACRXTXSR_EXCOL                           ETH_MACRXTXSR_EXCOL_Msk  /* Excessive Collisions */
-#define ETH_MACRXTXSR_LCOL_Pos                        (4U)
-#define ETH_MACRXTXSR_LCOL_Msk                        (0x1UL << ETH_MACRXTXSR_LCOL_Pos) /*!< 0x00000010 */
-#define ETH_MACRXTXSR_LCOL                            ETH_MACRXTXSR_LCOL_Msk   /* Late Collision */
-#define ETH_MACRXTXSR_EXDEF_Pos                       (3U)
-#define ETH_MACRXTXSR_EXDEF_Msk                       (0x1UL << ETH_MACRXTXSR_EXDEF_Pos) /*!< 0x00000008 */
-#define ETH_MACRXTXSR_EXDEF                           ETH_MACRXTXSR_EXDEF_Msk  /* Excessive Deferral */
-#define ETH_MACRXTXSR_LCARR_Pos                       (2U)
-#define ETH_MACRXTXSR_LCARR_Msk                       (0x1UL << ETH_MACRXTXSR_LCARR_Pos) /*!< 0x00000004 */
-#define ETH_MACRXTXSR_LCARR                           ETH_MACRXTXSR_LCARR_Msk  /* Loss of Carrier */
-#define ETH_MACRXTXSR_NCARR_Pos                       (1U)
-#define ETH_MACRXTXSR_NCARR_Msk                       (0x1UL << ETH_MACRXTXSR_NCARR_Pos) /*!< 0x00000002 */
-#define ETH_MACRXTXSR_NCARR                           ETH_MACRXTXSR_NCARR_Msk  /* No Carrier */
-#define ETH_MACRXTXSR_TJT_Pos                         (0U)
-#define ETH_MACRXTXSR_TJT_Msk                         (0x1UL << ETH_MACRXTXSR_TJT_Pos) /*!< 0x00000001 */
-#define ETH_MACRXTXSR_TJT                             ETH_MACRXTXSR_TJT_Msk    /* Transmit Jabber Timeout */
-
-/* Bit definition for Ethernet MAC PMT Control Status Register */
-#define ETH_MACPCSR_RWKFILTRST_Pos                    (31U)
-#define ETH_MACPCSR_RWKFILTRST_Msk                    (0x1UL << ETH_MACPCSR_RWKFILTRST_Pos) /*!< 0x80000000 */
-#define ETH_MACPCSR_RWKFILTRST                        ETH_MACPCSR_RWKFILTRST_Msk /* Remote Wake-Up Packet Filter Register Pointer Reset */
-#define ETH_MACPCSR_RWKPTR_Pos                        (24U)
-#define ETH_MACPCSR_RWKPTR_Msk                        (0x1FUL << ETH_MACPCSR_RWKPTR_Pos) /*!< 0x1F000000 */
-#define ETH_MACPCSR_RWKPTR                            ETH_MACPCSR_RWKPTR_Msk   /* Remote Wake-up FIFO Pointer */
-#define ETH_MACPCSR_RWKPFE_Pos                        (10U)
-#define ETH_MACPCSR_RWKPFE_Msk                        (0x1UL << ETH_MACPCSR_RWKPFE_Pos) /*!< 0x00000400 */
-#define ETH_MACPCSR_RWKPFE                            ETH_MACPCSR_RWKPFE_Msk   /* Remote Wake-up Packet Forwarding Enable */
-#define ETH_MACPCSR_GLBLUCAST_Pos                     (9U)
-#define ETH_MACPCSR_GLBLUCAST_Msk                     (0x1UL << ETH_MACPCSR_GLBLUCAST_Pos) /*!< 0x00000200 */
-#define ETH_MACPCSR_GLBLUCAST                         ETH_MACPCSR_GLBLUCAST_Msk /* Global Unicast */
-#define ETH_MACPCSR_RWKPRCVD_Pos                      (6U)
-#define ETH_MACPCSR_RWKPRCVD_Msk                      (0x1UL << ETH_MACPCSR_RWKPRCVD_Pos) /*!< 0x00000040 */
-#define ETH_MACPCSR_RWKPRCVD                          ETH_MACPCSR_RWKPRCVD_Msk /* Remote Wake-Up Packet Received */
-#define ETH_MACPCSR_MGKPRCVD_Pos                      (5U)
-#define ETH_MACPCSR_MGKPRCVD_Msk                      (0x1UL << ETH_MACPCSR_MGKPRCVD_Pos) /*!< 0x00000020 */
-#define ETH_MACPCSR_MGKPRCVD                          ETH_MACPCSR_MGKPRCVD_Msk /* Magic Packet Received */
-#define ETH_MACPCSR_RWKPKTEN_Pos                      (2U)
-#define ETH_MACPCSR_RWKPKTEN_Msk                      (0x1UL << ETH_MACPCSR_RWKPKTEN_Pos) /*!< 0x00000004 */
-#define ETH_MACPCSR_RWKPKTEN                          ETH_MACPCSR_RWKPKTEN_Msk /* Remote Wake-Up Packet Enable */
-#define ETH_MACPCSR_MGKPKTEN_Pos                      (1U)
-#define ETH_MACPCSR_MGKPKTEN_Msk                      (0x1UL << ETH_MACPCSR_MGKPKTEN_Pos) /*!< 0x00000002 */
-#define ETH_MACPCSR_MGKPKTEN                          ETH_MACPCSR_MGKPKTEN_Msk /* Magic Packet Enable */
-#define ETH_MACPCSR_PWRDWN_Pos                        (0U)
-#define ETH_MACPCSR_PWRDWN_Msk                        (0x1UL << ETH_MACPCSR_PWRDWN_Pos) /*!< 0x00000001 */
-#define ETH_MACPCSR_PWRDWN                            ETH_MACPCSR_PWRDWN_Msk   /* Power Down */
-
-/* Bit definition for Ethernet MAC Remote Wake-Up Packet Filter Register */
-#define ETH_MACRWUPFR_D_Pos                           (0U)
-#define ETH_MACRWUPFR_D_Msk                           (0xFFFFFFFFUL << ETH_MACRWUPFR_D_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACRWUPFR_D                               ETH_MACRWUPFR_D_Msk      /* Wake-up Packet filter register data */
-
-/* Bit definition for Ethernet MAC LPI Control Status Register */
-#define ETH_MACLCSR_LPITCSE_Pos                       (21U)
-#define ETH_MACLCSR_LPITCSE_Msk                       (0x1UL << ETH_MACLCSR_LPITCSE_Pos) /*!< 0x00200000 */
-#define ETH_MACLCSR_LPITCSE                           ETH_MACLCSR_LPITCSE_Msk  /* LPI Tx Clock Stop Enable */
-#define ETH_MACLCSR_LPITE_Pos                         (20U)
-#define ETH_MACLCSR_LPITE_Msk                         (0x1UL << ETH_MACLCSR_LPITE_Pos) /*!< 0x00100000 */
-#define ETH_MACLCSR_LPITE                             ETH_MACLCSR_LPITE_Msk    /* LPI Timer Enable */
-#define ETH_MACLCSR_LPITXA_Pos                        (19U)
-#define ETH_MACLCSR_LPITXA_Msk                        (0x1UL << ETH_MACLCSR_LPITXA_Pos) /*!< 0x00080000 */
-#define ETH_MACLCSR_LPITXA                            ETH_MACLCSR_LPITXA_Msk   /* LPI Tx Automate */
-#define ETH_MACLCSR_PLS_Pos                           (17U)
-#define ETH_MACLCSR_PLS_Msk                           (0x1UL << ETH_MACLCSR_PLS_Pos) /*!< 0x00020000 */
-#define ETH_MACLCSR_PLS                               ETH_MACLCSR_PLS_Msk      /* PHY Link Status */
-#define ETH_MACLCSR_LPIEN_Pos                         (16U)
-#define ETH_MACLCSR_LPIEN_Msk                         (0x1UL << ETH_MACLCSR_LPIEN_Pos) /*!< 0x00010000 */
-#define ETH_MACLCSR_LPIEN                             ETH_MACLCSR_LPIEN_Msk    /* LPI Enable */
-#define ETH_MACLCSR_RLPIST_Pos                        (9U)
-#define ETH_MACLCSR_RLPIST_Msk                        (0x1UL << ETH_MACLCSR_RLPIST_Pos) /*!< 0x00000200 */
-#define ETH_MACLCSR_RLPIST                            ETH_MACLCSR_RLPIST_Msk   /* Receive LPI State */
-#define ETH_MACLCSR_TLPIST_Pos                        (8U)
-#define ETH_MACLCSR_TLPIST_Msk                        (0x1UL << ETH_MACLCSR_TLPIST_Pos) /*!< 0x00000100 */
-#define ETH_MACLCSR_TLPIST                            ETH_MACLCSR_TLPIST_Msk   /* Transmit LPI State */
-#define ETH_MACLCSR_RLPIEX_Pos                        (3U)
-#define ETH_MACLCSR_RLPIEX_Msk                        (0x1UL << ETH_MACLCSR_RLPIEX_Pos) /*!< 0x00000008 */
-#define ETH_MACLCSR_RLPIEX                            ETH_MACLCSR_RLPIEX_Msk   /* Receive LPI Exit */
-#define ETH_MACLCSR_RLPIEN_Pos                        (2U)
-#define ETH_MACLCSR_RLPIEN_Msk                        (0x1UL << ETH_MACLCSR_RLPIEN_Pos) /*!< 0x00000004 */
-#define ETH_MACLCSR_RLPIEN                            ETH_MACLCSR_RLPIEN_Msk   /* Receive LPI Entry */
-#define ETH_MACLCSR_TLPIEX_Pos                        (1U)
-#define ETH_MACLCSR_TLPIEX_Msk                        (0x1UL << ETH_MACLCSR_TLPIEX_Pos) /*!< 0x00000002 */
-#define ETH_MACLCSR_TLPIEX                            ETH_MACLCSR_TLPIEX_Msk   /* Transmit LPI Exit */
-#define ETH_MACLCSR_TLPIEN_Pos                        (0U)
-#define ETH_MACLCSR_TLPIEN_Msk                        (0x1UL << ETH_MACLCSR_TLPIEN_Pos) /*!< 0x00000001 */
-#define ETH_MACLCSR_TLPIEN                            ETH_MACLCSR_TLPIEN_Msk   /* Transmit LPI Entry */
-
-/* Bit definition for Ethernet MAC LPI Timers Control Register */
-#define ETH_MACLTCR_LST_Pos                           (16U)
-#define ETH_MACLTCR_LST_Msk                           (0x3FFUL << ETH_MACLTCR_LST_Pos) /*!< 0x03FF0000 */
-#define ETH_MACLTCR_LST                               ETH_MACLTCR_LST_Msk      /* LPI LS TIMER */
-#define ETH_MACLTCR_TWT_Pos                           (0U)
-#define ETH_MACLTCR_TWT_Msk                           (0xFFFFUL << ETH_MACLTCR_TWT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACLTCR_TWT                               ETH_MACLTCR_TWT_Msk      /* LPI TW TIMER */
-
-/* Bit definition for Ethernet MAC LPI Entry Timer Register */
-#define ETH_MACLETR_LPIET_Pos                         (0U)
-#define ETH_MACLETR_LPIET_Msk                         (0xFFFFFUL << ETH_MACLETR_LPIET_Pos) /*!< 0x000FFFFF */
-#define ETH_MACLETR_LPIET                             ETH_MACLETR_LPIET_Msk    /* LPI Entry Timer */
-
-/* Bit definition for Ethernet MAC 1US Tic Counter Register */
-#define ETH_MAC1USTCR_TIC1USCNTR_Pos                  (0U)
-#define ETH_MAC1USTCR_TIC1USCNTR_Msk                  (0xFFFUL << ETH_MAC1USTCR_TIC1USCNTR_Pos) /*!< 0x00000FFF */
-#define ETH_MAC1USTCR_TIC1USCNTR                      ETH_MAC1USTCR_TIC1USCNTR_Msk /* 1US TIC Counter */
-
-/* Bit definition for Ethernet MAC Version Register */
-#define ETH_MACVR_USERVER_Pos                         (8U)
-#define ETH_MACVR_USERVER_Msk                         (0xFFUL << ETH_MACVR_USERVER_Pos) /*!< 0x0000FF00 */
-#define ETH_MACVR_USERVER                             ETH_MACVR_USERVER_Msk    /* User-defined Version */
-#define ETH_MACVR_SNPSVER_Pos                         (0U)
-#define ETH_MACVR_SNPSVER_Msk                         (0xFFUL << ETH_MACVR_SNPSVER_Pos) /*!< 0x000000FF */
-#define ETH_MACVR_SNPSVER                             ETH_MACVR_SNPSVER_Msk    /* Synopsys-defined Version */
-
-/* Bit definition for Ethernet MAC Debug Register */
-#define ETH_MACDR_TFCSTS_Pos                          (17U)
-#define ETH_MACDR_TFCSTS_Msk                          (0x3UL << ETH_MACDR_TFCSTS_Pos) /*!< 0x00060000 */
-#define ETH_MACDR_TFCSTS                              ETH_MACDR_TFCSTS_Msk     /* MAC Transmit Packet Controller Status */
-#define ETH_MACDR_TFCSTS_IDLE                         ((uint32_t)0x00000000)   /* Idle state */
-#define ETH_MACDR_TFCSTS_WAIT_Pos                     (17U)
-#define ETH_MACDR_TFCSTS_WAIT_Msk                     (0x1UL << ETH_MACDR_TFCSTS_WAIT_Pos) /*!< 0x00020000 */
-#define ETH_MACDR_TFCSTS_WAIT                         ETH_MACDR_TFCSTS_WAIT_Msk /* Waiting for status of the previous packet, IPG or backoff period to be over */
-#define ETH_MACDR_TFCSTS_GENERATEPCP_Pos              (18U)
-#define ETH_MACDR_TFCSTS_GENERATEPCP_Msk              (0x1UL << ETH_MACDR_TFCSTS_GENERATEPCP_Pos) /*!< 0x00040000 */
-#define ETH_MACDR_TFCSTS_GENERATEPCP                  ETH_MACDR_TFCSTS_GENERATEPCP_Msk /* Generating and transmitting a Pause control packet */
-#define ETH_MACDR_TFCSTS_TRASFERIP_Pos                (17U)
-#define ETH_MACDR_TFCSTS_TRASFERIP_Msk                (0x3UL << ETH_MACDR_TFCSTS_TRASFERIP_Pos) /*!< 0x00060000 */
-#define ETH_MACDR_TFCSTS_TRASFERIP                    ETH_MACDR_TFCSTS_TRASFERIP_Msk /* Transferring input packet for transmission */
-#define ETH_MACDR_TPESTS_Pos                          (16U)
-#define ETH_MACDR_TPESTS_Msk                          (0x1UL << ETH_MACDR_TPESTS_Pos) /*!< 0x00010000 */
-#define ETH_MACDR_TPESTS                              ETH_MACDR_TPESTS_Msk     /* MAC Receive Packet Controller FIFO Status */
-#define ETH_MACDR_RFCFCSTS_Pos                        (1U)
-#define ETH_MACDR_RFCFCSTS_Msk                        (0x3UL << ETH_MACDR_RFCFCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MACDR_RFCFCSTS                            ETH_MACDR_RFCFCSTS_Msk   /* MAC MII Transmit Protocol Engine Status */
-#define ETH_MACDR_RPESTS_Pos                          (0U)
-#define ETH_MACDR_RPESTS_Msk                          (0x1UL << ETH_MACDR_RPESTS_Pos) /*!< 0x00000001 */
-#define ETH_MACDR_RPESTS                              ETH_MACDR_RPESTS_Msk     /* MAC MII Receive Protocol Engine Status */
-
-/* Bit definition for Ethernet MAC HW Feature0 Register */
-#define ETH_MACHWF0R_ACTPHYSEL_Pos                    (28U)
-#define ETH_MACHWF0R_ACTPHYSEL_Msk                    (0x7UL << ETH_MACHWF0R_ACTPHYSEL_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF0R_ACTPHYSEL                        ETH_MACHWF0R_ACTPHYSEL_Msk /* Active PHY Selected */
-#define ETH_MACHWF0R_ACTPHYSEL_MII                    ((uint32_t)0x00000000)   /* MII */
-#define ETH_MACHWF0R_ACTPHYSEL_RMII_Pos               (30U)
-#define ETH_MACHWF0R_ACTPHYSEL_RMII_Msk               (0x1UL << ETH_MACHWF0R_ACTPHYSEL_RMII_Pos) /*!< 0x40000000 */
-#define ETH_MACHWF0R_ACTPHYSEL_RMII                   ETH_MACHWF0R_ACTPHYSEL_RMII_Msk /* RMII */
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII_Pos             (28U)
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII_Msk             (0x7UL << ETH_MACHWF0R_ACTPHYSEL_REVMII_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII                 ETH_MACHWF0R_ACTPHYSEL_REVMII_Msk /* RevMII */
-#define ETH_MACHWF0R_SAVLANINS_Pos                    (27U)
-#define ETH_MACHWF0R_SAVLANINS_Msk                    (0x1UL << ETH_MACHWF0R_SAVLANINS_Pos) /*!< 0x08000000 */
-#define ETH_MACHWF0R_SAVLANINS                        ETH_MACHWF0R_SAVLANINS_Msk /* Source Address or VLAN Insertion Enable */
-#define ETH_MACHWF0R_TSSTSSEL_Pos                     (25U)
-#define ETH_MACHWF0R_TSSTSSEL_Msk                     (0x3UL << ETH_MACHWF0R_TSSTSSEL_Pos) /*!< 0x06000000 */
-#define ETH_MACHWF0R_TSSTSSEL                         ETH_MACHWF0R_TSSTSSEL_Msk /* Timestamp System Time Source */
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL_Pos            (25U)
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL_Msk            (0x1UL << ETH_MACHWF0R_TSSTSSEL_INTERNAL_Pos) /*!< 0x02000000 */
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL                ETH_MACHWF0R_TSSTSSEL_INTERNAL_Msk /* Timestamp System Time Source: Internal */
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Pos            (26U)
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Msk            (0x1UL << ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Pos) /*!< 0x04000000 */
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL                ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Msk /* Timestamp System Time Source: External */
-#define ETH_MACHWF0R_TSSTSSEL_BOTH_Pos                (25U)
-#define ETH_MACHWF0R_TSSTSSEL_BOTH_Msk                (0x3UL << ETH_MACHWF0R_TSSTSSEL_BOTH_Pos) /*!< 0x06000000 */
-#define ETH_MACHWF0R_TSSTSSEL_BOTH                    ETH_MACHWF0R_TSSTSSEL_BOTH_Msk /* Timestamp System Time Source: Internal & External */
-#define ETH_MACHWF0R_MACADR64SEL_Pos                  (24U)
-#define ETH_MACHWF0R_MACADR64SEL_Msk                  (0x1UL << ETH_MACHWF0R_MACADR64SEL_Pos) /*!< 0x01000000 */
-#define ETH_MACHWF0R_MACADR64SEL                      ETH_MACHWF0R_MACADR64SEL_Msk /* MAC Addresses 64-127 Selected */
-#define ETH_MACHWF0R_MACADR32SEL_Pos                  (23U)
-#define ETH_MACHWF0R_MACADR32SEL_Msk                  (0x1UL << ETH_MACHWF0R_MACADR32SEL_Pos) /*!< 0x00800000 */
-#define ETH_MACHWF0R_MACADR32SEL                      ETH_MACHWF0R_MACADR32SEL_Msk /* MAC Addresses 32-63 Selected */
-#define ETH_MACHWF0R_ADDMACADRSEL_Pos                 (18U)
-#define ETH_MACHWF0R_ADDMACADRSEL_Msk                 (0x1FUL << ETH_MACHWF0R_ADDMACADRSEL_Pos) /*!< 0x007C0000 */
-#define ETH_MACHWF0R_ADDMACADRSEL                     ETH_MACHWF0R_ADDMACADRSEL_Msk /* MAC Addresses 1- 31 Selected */
-#define ETH_MACHWF0R_RXCOESEL_Pos                     (16U)
-#define ETH_MACHWF0R_RXCOESEL_Msk                     (0x1UL << ETH_MACHWF0R_RXCOESEL_Pos) /*!< 0x00010000 */
-#define ETH_MACHWF0R_RXCOESEL                         ETH_MACHWF0R_RXCOESEL_Msk /* Receive Checksum Offload Enabled */
-#define ETH_MACHWF0R_TXCOESEL_Pos                     (14U)
-#define ETH_MACHWF0R_TXCOESEL_Msk                     (0x1UL << ETH_MACHWF0R_TXCOESEL_Pos) /*!< 0x00004000 */
-#define ETH_MACHWF0R_TXCOESEL                         ETH_MACHWF0R_TXCOESEL_Msk /* Transmit Checksum Offload Enabled */
-#define ETH_MACHWF0R_EEESEL_Pos                       (13U)
-#define ETH_MACHWF0R_EEESEL_Msk                       (0x1UL << ETH_MACHWF0R_EEESEL_Pos) /*!< 0x00002000 */
-#define ETH_MACHWF0R_EEESEL                           ETH_MACHWF0R_EEESEL_Msk  /* Energy Efficient Ethernet Enabled */
-#define ETH_MACHWF0R_TSSEL_Pos                        (12U)
-#define ETH_MACHWF0R_TSSEL_Msk                        (0x1UL << ETH_MACHWF0R_TSSEL_Pos) /*!< 0x00001000 */
-#define ETH_MACHWF0R_TSSEL                            ETH_MACHWF0R_TSSEL_Msk   /* IEEE 1588-2008 Timestamp Enabled */
-#define ETH_MACHWF0R_ARPOFFSEL_Pos                    (9U)
-#define ETH_MACHWF0R_ARPOFFSEL_Msk                    (0x1UL << ETH_MACHWF0R_ARPOFFSEL_Pos) /*!< 0x00000200 */
-#define ETH_MACHWF0R_ARPOFFSEL                        ETH_MACHWF0R_ARPOFFSEL_Msk /* ARP Offload Enabled */
-#define ETH_MACHWF0R_MMCSEL_Pos                       (8U)
-#define ETH_MACHWF0R_MMCSEL_Msk                       (0x1UL << ETH_MACHWF0R_MMCSEL_Pos) /*!< 0x00000100 */
-#define ETH_MACHWF0R_MMCSEL                           ETH_MACHWF0R_MMCSEL_Msk  /* RMON Module Enable */
-#define ETH_MACHWF0R_MGKSEL_Pos                       (7U)
-#define ETH_MACHWF0R_MGKSEL_Msk                       (0x1UL << ETH_MACHWF0R_MGKSEL_Pos) /*!< 0x00000080 */
-#define ETH_MACHWF0R_MGKSEL                           ETH_MACHWF0R_MGKSEL_Msk  /* PMT Magic Packet Enable */
-#define ETH_MACHWF0R_RWKSEL_Pos                       (6U)
-#define ETH_MACHWF0R_RWKSEL_Msk                       (0x1UL << ETH_MACHWF0R_RWKSEL_Pos) /*!< 0x00000040 */
-#define ETH_MACHWF0R_RWKSEL                           ETH_MACHWF0R_RWKSEL_Msk  /* PMT Remote Wake-up Packet Enable */
-#define ETH_MACHWF0R_SMASEL_Pos                       (5U)
-#define ETH_MACHWF0R_SMASEL_Msk                       (0x1UL << ETH_MACHWF0R_SMASEL_Pos) /*!< 0x00000020 */
-#define ETH_MACHWF0R_SMASEL                           ETH_MACHWF0R_SMASEL_Msk  /* SMA (MDIO) Interface */
-#define ETH_MACHWF0R_VLHASH_Pos                       (4U)
-#define ETH_MACHWF0R_VLHASH_Msk                       (0x1UL << ETH_MACHWF0R_VLHASH_Pos) /*!< 0x00000010 */
-#define ETH_MACHWF0R_VLHASH                           ETH_MACHWF0R_VLHASH_Msk  /* VLAN Hash Filter Selected */
-#define ETH_MACHWF0R_PCSSEL_Pos                       (3U)
-#define ETH_MACHWF0R_PCSSEL_Msk                       (0x1UL << ETH_MACHWF0R_PCSSEL_Pos) /*!< 0x00000008 */
-#define ETH_MACHWF0R_PCSSEL                           ETH_MACHWF0R_PCSSEL_Msk  /* PCS Registers (TBI, SGMII, or RTBI PHY interface) */
-#define ETH_MACHWF0R_HDSEL_Pos                        (2U)
-#define ETH_MACHWF0R_HDSEL_Msk                        (0x1UL << ETH_MACHWF0R_HDSEL_Pos) /*!< 0x00000004 */
-#define ETH_MACHWF0R_HDSEL                            ETH_MACHWF0R_HDSEL_Msk   /* Half-duplex Support */
-#define ETH_MACHWF0R_GMIISEL_Pos                      (1U)
-#define ETH_MACHWF0R_GMIISEL_Msk                      (0x1UL << ETH_MACHWF0R_GMIISEL_Pos) /*!< 0x00000002 */
-#define ETH_MACHWF0R_GMIISEL                          ETH_MACHWF0R_GMIISEL_Msk /* 1000 Mbps Support */
-#define ETH_MACHWF0R_MIISEL_Pos                       (0U)
-#define ETH_MACHWF0R_MIISEL_Msk                       (0x1UL << ETH_MACHWF0R_MIISEL_Pos) /*!< 0x00000001 */
-#define ETH_MACHWF0R_MIISEL                           ETH_MACHWF0R_MIISEL_Msk  /* 10 or 100 Mbps Support */
-
-/* Bit definition for Ethernet MAC HW Feature1 Register */
-#define ETH_MACHWF1R_L3L4FNUM_Pos                     (27U)
-#define ETH_MACHWF1R_L3L4FNUM_Msk                     (0xFUL << ETH_MACHWF1R_L3L4FNUM_Pos) /*!< 0x78000000 */
-#define ETH_MACHWF1R_L3L4FNUM                         ETH_MACHWF1R_L3L4FNUM_Msk /* Total number of L3 or L4 Filters */
-#define ETH_MACHWF1R_HASHTBLSZ_Pos                    (24U)
-#define ETH_MACHWF1R_HASHTBLSZ_Msk                    (0x3UL << ETH_MACHWF1R_HASHTBLSZ_Pos) /*!< 0x03000000 */
-#define ETH_MACHWF1R_HASHTBLSZ                        ETH_MACHWF1R_HASHTBLSZ_Msk /* Hash Table Size */
-#define ETH_MACHWF1R_AVSEL_Pos                        (20U)
-#define ETH_MACHWF1R_AVSEL_Msk                        (0x1UL << ETH_MACHWF1R_AVSEL_Pos) /*!< 0x00100000 */
-#define ETH_MACHWF1R_AVSEL                            ETH_MACHWF1R_AVSEL_Msk   /* AV Feature Enabled */
-#define ETH_MACHWF1R_DBGMEMA_Pos                      (19U)
-#define ETH_MACHWF1R_DBGMEMA_Msk                      (0x1UL << ETH_MACHWF1R_DBGMEMA_Pos) /*!< 0x00080000 */
-#define ETH_MACHWF1R_DBGMEMA                          ETH_MACHWF1R_DBGMEMA_Msk /* Debug Memory Interface Enabled */
-#define ETH_MACHWF1R_TSOEN_Pos                        (18U)
-#define ETH_MACHWF1R_TSOEN_Msk                        (0x1UL << ETH_MACHWF1R_TSOEN_Pos) /*!< 0x00040000 */
-#define ETH_MACHWF1R_TSOEN                            ETH_MACHWF1R_TSOEN_Msk   /* TCP Segmentation Offload Enable */
-#define ETH_MACHWF1R_SPHEN_Pos                        (17U)
-#define ETH_MACHWF1R_SPHEN_Msk                        (0x1UL << ETH_MACHWF1R_SPHEN_Pos) /*!< 0x00020000 */
-#define ETH_MACHWF1R_SPHEN                            ETH_MACHWF1R_SPHEN_Msk   /* Split Header Feature Enable */
-#define ETH_MACHWF1R_DCBEN_Pos                        (16U)
-#define ETH_MACHWF1R_DCBEN_Msk                        (0x1UL << ETH_MACHWF1R_DCBEN_Pos) /*!< 0x00010000 */
-#define ETH_MACHWF1R_DCBEN                            ETH_MACHWF1R_DCBEN_Msk   /* DCB Feature Enable */
-#define ETH_MACHWF1R_ADDR64_Pos                       (14U)
-#define ETH_MACHWF1R_ADDR64_Msk                       (0x3UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x0000C000 */
-#define ETH_MACHWF1R_ADDR64                           ETH_MACHWF1R_ADDR64_Msk  /* Address Width */
-#define ETH_MACHWF1R_ADDR64_32                        (0x0UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00000000 */
-#define ETH_MACHWF1R_ADDR64_40                        (0x1UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00004000 */
-#define ETH_MACHWF1R_ADDR64_48                        (0x2UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00008000 */
-#define ETH_MACHWF1R_ADVTHWORD_Pos                    (13U)
-#define ETH_MACHWF1R_ADVTHWORD_Msk                    (0x1UL << ETH_MACHWF1R_ADVTHWORD_Pos) /*!< 0x00002000 */
-#define ETH_MACHWF1R_ADVTHWORD                        ETH_MACHWF1R_ADVTHWORD_Msk /* IEEE 1588 High Word Register Enable */
-#define ETH_MACHWF1R_PTOEN_Pos                        (12U)
-#define ETH_MACHWF1R_PTOEN_Msk                        (0x1UL << ETH_MACHWF1R_PTOEN_Pos) /*!< 0x00001000 */
-#define ETH_MACHWF1R_PTOEN                            ETH_MACHWF1R_PTOEN_Msk   /* PTP Offload Enable */
-#define ETH_MACHWF1R_OSTEN_Pos                        (11U)
-#define ETH_MACHWF1R_OSTEN_Msk                        (0x1UL << ETH_MACHWF1R_OSTEN_Pos) /*!< 0x00000800 */
-#define ETH_MACHWF1R_OSTEN                            ETH_MACHWF1R_OSTEN_Msk   /* One-Step Timestamping Enable */
-#define ETH_MACHWF1R_TXFIFOSIZE_Pos                   (6U)
-#define ETH_MACHWF1R_TXFIFOSIZE_Msk                   (0x1FUL << ETH_MACHWF1R_TXFIFOSIZE_Pos) /*!< 0x000007C0 */
-#define ETH_MACHWF1R_TXFIFOSIZE                       ETH_MACHWF1R_TXFIFOSIZE_Msk /* MTL Transmit FIFO Size */
-#define ETH_MACHWF1R_RXFIFOSIZE_Pos                   (0U)
-#define ETH_MACHWF1R_RXFIFOSIZE_Msk                   (0x1FUL << ETH_MACHWF1R_RXFIFOSIZE_Pos) /*!< 0x0000001F */
-#define ETH_MACHWF1R_RXFIFOSIZE                       ETH_MACHWF1R_RXFIFOSIZE_Msk /* MTL Receive FIFO Size */
-
-/* Bit definition for Ethernet MAC HW Feature2 Register */
-#define ETH_MACHWF2R_AUXSNAPNUM_Pos                   (28U)
-#define ETH_MACHWF2R_AUXSNAPNUM_Msk                   (0x7UL << ETH_MACHWF2R_AUXSNAPNUM_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF2R_AUXSNAPNUM                       ETH_MACHWF2R_AUXSNAPNUM_Msk /* Number of Auxiliary Snapshot Inputs */
-#define ETH_MACHWF2R_PPSOUTNUM_Pos                    (24U)
-#define ETH_MACHWF2R_PPSOUTNUM_Msk                    (0x7UL << ETH_MACHWF2R_PPSOUTNUM_Pos) /*!< 0x07000000 */
-#define ETH_MACHWF2R_PPSOUTNUM                        ETH_MACHWF2R_PPSOUTNUM_Msk /*  Number of PPS Outputs */
-#define ETH_MACHWF2R_TXCHCNT_Pos                      (18U)
-#define ETH_MACHWF2R_TXCHCNT_Msk                      (0xFUL << ETH_MACHWF2R_TXCHCNT_Pos) /*!< 0x003C0000 */
-#define ETH_MACHWF2R_TXCHCNT                          ETH_MACHWF2R_TXCHCNT_Msk /* Number of DMA Transmit Channels */
-#define ETH_MACHWF2R_RXCHCNT_Pos                      (13U)
-#define ETH_MACHWF2R_RXCHCNT_Msk                      (0x7UL << ETH_MACHWF2R_RXCHCNT_Pos) /*!< 0x0000E000 */
-#define ETH_MACHWF2R_RXCHCNT                          ETH_MACHWF2R_RXCHCNT_Msk /* Number of DMA Receive Channels */
-#define ETH_MACHWF2R_TXQCNT_Pos                       (6U)
-#define ETH_MACHWF2R_TXQCNT_Msk                       (0xFUL << ETH_MACHWF2R_TXQCNT_Pos) /*!< 0x000003C0 */
-#define ETH_MACHWF2R_TXQCNT                           ETH_MACHWF2R_TXQCNT_Msk  /* Number of MTL Transmit Queues */
-#define ETH_MACHWF2R_RXQCNT_Pos                       (0U)
-#define ETH_MACHWF2R_RXQCNT_Msk                       (0xFUL << ETH_MACHWF2R_RXQCNT_Pos) /*!< 0x0000000F */
-#define ETH_MACHWF2R_RXQCNT                           ETH_MACHWF2R_RXQCNT_Msk  /* Number of MTL Receive Queues */
-
-/* Bit definition for Ethernet MAC MDIO Address Register */
-#define ETH_MACMDIOAR_PSE_Pos                         (27U)
-#define ETH_MACMDIOAR_PSE_Msk                         (0x1UL << ETH_MACMDIOAR_PSE_Pos) /*!< 0x08000000 */
-#define ETH_MACMDIOAR_PSE                             ETH_MACMDIOAR_PSE_Msk    /* Preamble Suppression Enable */
-#define ETH_MACMDIOAR_BTB_Pos                         (26U)
-#define ETH_MACMDIOAR_BTB_Msk                         (0x1UL << ETH_MACMDIOAR_BTB_Pos) /*!< 0x04000000 */
-#define ETH_MACMDIOAR_BTB                             ETH_MACMDIOAR_BTB_Msk    /* Back to Back transactions */
-#define ETH_MACMDIOAR_PA_Pos                          (21U)
-#define ETH_MACMDIOAR_PA_Msk                          (0x1FUL << ETH_MACMDIOAR_PA_Pos) /*!< 0x03E00000 */
-#define ETH_MACMDIOAR_PA                              ETH_MACMDIOAR_PA_Msk     /* Physical Layer Address */
-#define ETH_MACMDIOAR_RDA_Pos                         (16U)
-#define ETH_MACMDIOAR_RDA_Msk                         (0x1FUL << ETH_MACMDIOAR_RDA_Pos) /*!< 0x001F0000 */
-#define ETH_MACMDIOAR_RDA                             ETH_MACMDIOAR_RDA_Msk    /* Register/Device Address */
-#define ETH_MACMDIOAR_NTC_Pos                         (12U)
-#define ETH_MACMDIOAR_NTC_Msk                         (0x7UL << ETH_MACMDIOAR_NTC_Pos) /*!< 0x00007000 */
-#define ETH_MACMDIOAR_NTC                             ETH_MACMDIOAR_NTC_Msk    /* Number of Trailing Clocks */
-#define ETH_MACMDIOAR_CR_Pos                          (8U)
-#define ETH_MACMDIOAR_CR_Msk                          (0xFUL << ETH_MACMDIOAR_CR_Pos) /*!< 0x00000F00 */
-#define ETH_MACMDIOAR_CR                              ETH_MACMDIOAR_CR_Msk     /* CSR Clock Range */
-#define ETH_MACMDIOAR_CR_DIV42                        ((uint32_t)0x00000000)   /* CSR clock/42 */
-#define ETH_MACMDIOAR_CR_DIV62_Pos                    (8U)
-#define ETH_MACMDIOAR_CR_DIV62_Msk                    (0x1UL << ETH_MACMDIOAR_CR_DIV62_Pos) /*!< 0x00000100 */
-#define ETH_MACMDIOAR_CR_DIV62                        ETH_MACMDIOAR_CR_DIV62_Msk /* CSR clock/62 */
-#define ETH_MACMDIOAR_CR_DIV16_Pos                    (9U)
-#define ETH_MACMDIOAR_CR_DIV16_Msk                    (0x1UL << ETH_MACMDIOAR_CR_DIV16_Pos) /*!< 0x00000200 */
-#define ETH_MACMDIOAR_CR_DIV16                        ETH_MACMDIOAR_CR_DIV16_Msk /* CSR clock/16 */
-#define ETH_MACMDIOAR_CR_DIV26_Pos                    (8U)
-#define ETH_MACMDIOAR_CR_DIV26_Msk                    (0x3UL << ETH_MACMDIOAR_CR_DIV26_Pos) /*!< 0x00000300 */
-#define ETH_MACMDIOAR_CR_DIV26                        ETH_MACMDIOAR_CR_DIV26_Msk /* CSR clock/26 */
-#define ETH_MACMDIOAR_CR_DIV102_Pos                   (10U)
-#define ETH_MACMDIOAR_CR_DIV102_Msk                   (0x1UL << ETH_MACMDIOAR_CR_DIV102_Pos) /*!< 0x00000400 */
-#define ETH_MACMDIOAR_CR_DIV102                       ETH_MACMDIOAR_CR_DIV102_Msk /* CSR clock/102 */
-#define ETH_MACMDIOAR_CR_DIV124_Pos                   (8U)
-#define ETH_MACMDIOAR_CR_DIV124_Msk                   (0x5UL << ETH_MACMDIOAR_CR_DIV124_Pos) /*!< 0x00000500 */
-#define ETH_MACMDIOAR_CR_DIV124                       ETH_MACMDIOAR_CR_DIV124_Msk /* CSR clock/124 */
-#define ETH_MACMDIOAR_CR_DIV4AR_Pos                   (11U)
-#define ETH_MACMDIOAR_CR_DIV4AR_Msk                   (0x1UL << ETH_MACMDIOAR_CR_DIV4AR_Pos) /*!< 0x00000800 */
-#define ETH_MACMDIOAR_CR_DIV4AR                       ETH_MACMDIOAR_CR_DIV4AR_Msk /* CSR clock/4: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV6AR_Pos                   (8U)
-#define ETH_MACMDIOAR_CR_DIV6AR_Msk                   (0x9UL << ETH_MACMDIOAR_CR_DIV6AR_Pos) /*!< 0x00000900 */
-#define ETH_MACMDIOAR_CR_DIV6AR                       ETH_MACMDIOAR_CR_DIV6AR_Msk /* CSR clock/6: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV8AR_Pos                   (9U)
-#define ETH_MACMDIOAR_CR_DIV8AR_Msk                   (0x5UL << ETH_MACMDIOAR_CR_DIV8AR_Pos) /*!< 0x00000A00 */
-#define ETH_MACMDIOAR_CR_DIV8AR                       ETH_MACMDIOAR_CR_DIV8AR_Msk /* CSR clock/8: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV10AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV10AR_Msk                  (0xBUL << ETH_MACMDIOAR_CR_DIV10AR_Pos) /*!< 0x00000B00 */
-#define ETH_MACMDIOAR_CR_DIV10AR                      ETH_MACMDIOAR_CR_DIV10AR_Msk /* CSR clock/10: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV12AR_Pos                  (10U)
-#define ETH_MACMDIOAR_CR_DIV12AR_Msk                  (0x3UL << ETH_MACMDIOAR_CR_DIV12AR_Pos) /*!< 0x00000C00 */
-#define ETH_MACMDIOAR_CR_DIV12AR                      ETH_MACMDIOAR_CR_DIV12AR_Msk /* CSR clock/12: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV14AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV14AR_Msk                  (0xDUL << ETH_MACMDIOAR_CR_DIV14AR_Pos) /*!< 0x00000D00 */
-#define ETH_MACMDIOAR_CR_DIV14AR                      ETH_MACMDIOAR_CR_DIV14AR_Msk /* CSR clock/14: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV16AR_Pos                  (9U)
-#define ETH_MACMDIOAR_CR_DIV16AR_Msk                  (0x7UL << ETH_MACMDIOAR_CR_DIV16AR_Pos) /*!< 0x00000E00 */
-#define ETH_MACMDIOAR_CR_DIV16AR                      ETH_MACMDIOAR_CR_DIV16AR_Msk /* CSR clock/16: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV18AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV18AR_Msk                  (0xFUL << ETH_MACMDIOAR_CR_DIV18AR_Pos) /*!< 0x00000F00 */
-#define ETH_MACMDIOAR_CR_DIV18AR                      ETH_MACMDIOAR_CR_DIV18AR_Msk /* CSR clock/18: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_SKAP_Pos                        (4U)
-#define ETH_MACMDIOAR_SKAP_Msk                        (0x1UL << ETH_MACMDIOAR_SKAP_Pos) /*!< 0x00000010 */
-#define ETH_MACMDIOAR_SKAP                            ETH_MACMDIOAR_SKAP_Msk   /* Skip Address Packet */
-#define ETH_MACMDIOAR_MOC_Pos                         (2U)
-#define ETH_MACMDIOAR_MOC_Msk                         (0x3UL << ETH_MACMDIOAR_MOC_Pos) /*!< 0x0000000C */
-#define ETH_MACMDIOAR_MOC                             ETH_MACMDIOAR_MOC_Msk    /* MII Operation Command */
-#define ETH_MACMDIOAR_MOC_WR_Pos                      (2U)
-#define ETH_MACMDIOAR_MOC_WR_Msk                      (0x1UL << ETH_MACMDIOAR_MOC_WR_Pos) /*!< 0x00000004 */
-#define ETH_MACMDIOAR_MOC_WR                          ETH_MACMDIOAR_MOC_WR_Msk /* Write */
-#define ETH_MACMDIOAR_MOC_PRDIA_Pos                   (3U)
-#define ETH_MACMDIOAR_MOC_PRDIA_Msk                   (0x1UL << ETH_MACMDIOAR_MOC_PRDIA_Pos) /*!< 0x00000008 */
-#define ETH_MACMDIOAR_MOC_PRDIA                       ETH_MACMDIOAR_MOC_PRDIA_Msk /* Post Read Increment Address for Clause 45 PHY */
-#define ETH_MACMDIOAR_MOC_RD_Pos                      (2U)
-#define ETH_MACMDIOAR_MOC_RD_Msk                      (0x3UL << ETH_MACMDIOAR_MOC_RD_Pos) /*!< 0x0000000C */
-#define ETH_MACMDIOAR_MOC_RD                          ETH_MACMDIOAR_MOC_RD_Msk /* Read */
-#define ETH_MACMDIOAR_C45E_Pos                        (1U)
-#define ETH_MACMDIOAR_C45E_Msk                        (0x1UL << ETH_MACMDIOAR_C45E_Pos) /*!< 0x00000002 */
-#define ETH_MACMDIOAR_C45E                            ETH_MACMDIOAR_C45E_Msk   /* Clause 45 PHY Enable */
-#define ETH_MACMDIOAR_MB_Pos                          (0U)
-#define ETH_MACMDIOAR_MB_Msk                          (0x1UL << ETH_MACMDIOAR_MB_Pos) /*!< 0x00000001 */
-#define ETH_MACMDIOAR_MB                              ETH_MACMDIOAR_MB_Msk     /* MII Busy */
-
-/* Bit definition for Ethernet MAC MDIO Data Register */
-#define ETH_MACMDIODR_RA_Pos                          (16U)
-#define ETH_MACMDIODR_RA_Msk                          (0xFFFFUL << ETH_MACMDIODR_RA_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACMDIODR_RA                              ETH_MACMDIODR_RA_Msk     /* Register Address */
-#define ETH_MACMDIODR_MD_Pos                          (0U)
-#define ETH_MACMDIODR_MD_Msk                          (0xFFFFUL << ETH_MACMDIODR_MD_Pos) /*!< 0x0000FFFF */
-#define ETH_MACMDIODR_MD                              ETH_MACMDIODR_MD_Msk     /* MII Data */
-
-/* Bit definition for Ethernet ARP Address Register */
-#define ETH_MACARPAR_ARPPA_Pos                         (0U)
-#define ETH_MACARPAR_ARPPA_Msk                         (0xFFFFFFFFUL << ETH_MACARPAR_ARPPA_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACARPAR_ARPPA                             ETH_MACARPAR_ARPPA_Msk     /* ARP Protocol Address */
-
-/* Bit definition for Ethernet MAC Address 0 High Register */
-#define ETH_MACA0HR_AE_Pos                            (31U)
-#define ETH_MACA0HR_AE_Msk                            (0x1UL << ETH_MACA0HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA0HR_AE                                ETH_MACA0HR_AE_Msk /* Address Enable*/
-#define ETH_MACA0HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA0HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA0HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA0HR_ADDRHI                            ETH_MACA0HR_ADDRHI_Msk   /* MAC Address 0*/
-
-/* Bit definition for Ethernet MAC Address 0 Low Register */
-#define ETH_MACA0LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA0LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA0LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA0LR_ADDRLO                            ETH_MACA0LR_ADDRLO_Msk   /* MAC Address 0*/
-
-/* Bit definition for Ethernet MAC Address 1 High Register */
-#define ETH_MACA1HR_AE_Pos                            (31U)
-#define ETH_MACA1HR_AE_Msk                            (0x1UL << ETH_MACA1HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA1HR_AE                                ETH_MACA1HR_AE_Msk /* Address Enable*/
-#define ETH_MACA1HR_SA_Pos                            (30U)
-#define ETH_MACA1HR_SA_Msk                            (0x1UL << ETH_MACA1HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA1HR_SA                                ETH_MACA1HR_SA_Msk /* Source Address */
-#define ETH_MACA1HR_MBC_Pos                           (24U)
-#define ETH_MACA1HR_MBC_Msk                           (0x3FUL << ETH_MACA1HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA1HR_MBC                               ETH_MACA1HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA1HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA1HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA1HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA1HR_ADDRHI                            ETH_MACA1HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 1 Low Register */
-#define ETH_MACA1LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA1LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA1LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA1LR_ADDRLO                            ETH_MACA1LR_ADDRLO_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 2 High Register */
-#define ETH_MACA2HR_AE_Pos                            (31U)
-#define ETH_MACA2HR_AE_Msk                            (0x1UL << ETH_MACA2HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA2HR_AE                                ETH_MACA2HR_AE_Msk /* Address Enable*/
-#define ETH_MACA2HR_SA_Pos                            (30U)
-#define ETH_MACA2HR_SA_Msk                            (0x1UL << ETH_MACA2HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA2HR_SA                                ETH_MACA2HR_SA_Msk /* Source Address */
-#define ETH_MACA2HR_MBC_Pos                           (24U)
-#define ETH_MACA2HR_MBC_Msk                           (0x3FUL << ETH_MACA2HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA2HR_MBC                               ETH_MACA2HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA2HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA2HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA2HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA2HR_ADDRHI                            ETH_MACA2HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 2 Low Register */
-#define ETH_MACA2LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA2LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA2LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA2LR_ADDRLO                            ETH_MACA2LR_ADDRLO_Msk   /* MAC Address 2*/
-
-/* Bit definition for Ethernet MAC Address 3 High Register */
-#define ETH_MACA3HR_AE_Pos                            (31U)
-#define ETH_MACA3HR_AE_Msk                            (0x1UL << ETH_MACA3HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA3HR_AE                                ETH_MACA3HR_AE_Msk /* Address Enable*/
-#define ETH_MACA3HR_SA_Pos                            (30U)
-#define ETH_MACA3HR_SA_Msk                            (0x1UL << ETH_MACA3HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA3HR_SA                                ETH_MACA3HR_SA_Msk /* Source Address */
-#define ETH_MACA3HR_MBC_Pos                           (24U)
-#define ETH_MACA3HR_MBC_Msk                           (0x3FUL << ETH_MACA3HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA3HR_MBC                               ETH_MACA3HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA3HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA3HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA3HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA3HR_ADDRHI                            ETH_MACA3HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 3 Low Register */
-#define ETH_MACA3LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA3LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA3LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA3LR_ADDRLO                            ETH_MACA3LR_ADDRLO_Msk   /* MAC Address 3*/
-
-/* Bit definition for Ethernet MAC Address High Register */
-#define ETH_MACAHR_AE_Pos                             (31U)
-#define ETH_MACAHR_AE_Msk                             (0x1UL << ETH_MACAHR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACAHR_AE                                 ETH_MACAHR_AE_Msk        /* Address enable */
-#define ETH_MACAHR_SA_Pos                             (30U)
-#define ETH_MACAHR_SA_Msk                             (0x1UL << ETH_MACAHR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACAHR_SA                                 ETH_MACAHR_SA_Msk        /* Source address */
-#define ETH_MACAHR_MBC_Pos                            (24U)
-#define ETH_MACAHR_MBC_Msk                            (0x3FUL << ETH_MACAHR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACAHR_MBC                                ETH_MACAHR_MBC_Msk       /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
-#define ETH_MACAHR_MBC_HBITS15_8                      ((uint32_t)0x20000000)   /* Mask MAC Address high reg bits [15:8] */
-#define ETH_MACAHR_MBC_HBITS7_0                       ((uint32_t)0x10000000)   /* Mask MAC Address high reg bits [7:0] */
-#define ETH_MACAHR_MBC_LBITS31_24                     ((uint32_t)0x08000000)   /* Mask MAC Address low reg bits [31:24] */
-#define ETH_MACAHR_MBC_LBITS23_16                     ((uint32_t)0x04000000)   /* Mask MAC Address low reg bits [23:16] */
-#define ETH_MACAHR_MBC_LBITS15_8                      ((uint32_t)0x02000000)   /* Mask MAC Address low reg bits [15:8] */
-#define ETH_MACAHR_MBC_LBITS7_0                       ((uint32_t)0x01000000)   /* Mask MAC Address low reg bits [7:0] */
-#define ETH_MACAHR_MACAH_Pos                          (0U)
-#define ETH_MACAHR_MACAH_Msk                          (0xFFFFUL << ETH_MACAHR_MACAH_Pos) /*!< 0x0000FFFF */
-#define ETH_MACAHR_MACAH                              ETH_MACAHR_MACAH_Msk     /* MAC address high */
-
-/* Bit definition for Ethernet MAC Address Low Register */
-#define ETH_MACALR_MACAL_Pos                          (0U)
-#define ETH_MACALR_MACAL_Msk                          (0xFFFFFFFFUL << ETH_MACALR_MACAL_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACALR_MACAL                              ETH_MACALR_MACAL_Msk     /* MAC address low */
-
-/* Bit definition for Ethernet MMC Control Register */
-#define ETH_MMCCR_UCDBC_Pos                           (8U)
-#define ETH_MMCCR_UCDBC_Msk                           (0x1UL << ETH_MMCCR_UCDBC_Pos) /*!< 0x00000100 */
-#define ETH_MMCCR_UCDBC                               ETH_MMCCR_UCDBC_Msk  /* Update MMC Counters for Dropped Broadcast Packets */
-#define ETH_MMCCR_CNTPRSTLVL_Pos                      (5U)
-#define ETH_MMCCR_CNTPRSTLVL_Msk                      (0x1UL << ETH_MMCCR_CNTPRSTLVL_Pos) /*!< 0x00000020 */
-#define ETH_MMCCR_CNTPRSTLVL                          ETH_MMCCR_CNTPRSTLVL_Msk  /* Full-Half Preset */
-#define ETH_MMCCR_CNTPRST_Pos                         (4U)
-#define ETH_MMCCR_CNTPRST_Msk                         (0x1UL << ETH_MMCCR_CNTPRST_Pos) /*!< 0x00000010 */
-#define ETH_MMCCR_CNTPRST                             ETH_MMCCR_CNTPRST_Msk  /* Counters Reset */
-#define ETH_MMCCR_CNTFREEZ_Pos                        (3U)
-#define ETH_MMCCR_CNTFREEZ_Msk                        (0x1UL << ETH_MMCCR_CNTFREEZ_Pos) /*!< 0x00000008 */
-#define ETH_MMCCR_CNTFREEZ                            ETH_MMCCR_CNTFREEZ_Msk  /* MMC Counter Freeze */
-#define ETH_MMCCR_RSTONRD_Pos                         (2U)
-#define ETH_MMCCR_RSTONRD_Msk                         (0x1UL << ETH_MMCCR_RSTONRD_Pos) /*!< 0x00000004 */
-#define ETH_MMCCR_RSTONRD                             ETH_MMCCR_RSTONRD_Msk  /* Reset On Read */
-#define ETH_MMCCR_CNTSTOPRO_Pos                       (1U)
-#define ETH_MMCCR_CNTSTOPRO_Msk                       (0x1UL << ETH_MMCCR_CNTSTOPRO_Pos) /*!< 0x00000002 */
-#define ETH_MMCCR_CNTSTOPRO                           ETH_MMCCR_CNTSTOPRO_Msk  /* Counter Stop Rollover */
-#define ETH_MMCCR_CNTRST_Pos                          (0U)
-#define ETH_MMCCR_CNTRST_Msk                          (0x1UL << ETH_MMCCR_CNTRST_Pos) /*!< 0x00000001 */
-#define ETH_MMCCR_CNTRST                              ETH_MMCCR_CNTRST_Msk  /* Counters Reset */
-
-/* Bit definition for Ethernet MMC Rx Interrupt Register */
-#define ETH_MMCRIR_RXLPITRCIS_Pos                     (27U)
-#define ETH_MMCRIR_RXLPITRCIS_Msk                     (0x1UL << ETH_MMCRIR_RXLPITRCIS_Pos) /*!< 0x08000000 */
-#define ETH_MMCRIR_RXLPITRCIS                         ETH_MMCRIR_RXLPITRCIS_Msk  /* MMC Receive LPI transition counter interrupt status */
-#define ETH_MMCRIR_RXLPIUSCIS_Pos                     (26U)
-#define ETH_MMCRIR_RXLPIUSCIS_Msk                     (0x1UL << ETH_MMCRIR_RXLPIUSCIS_Pos) /*!< 0x04000000 */
-#define ETH_MMCRIR_RXLPIUSCIS                         ETH_MMCRIR_RXLPIUSCIS_Msk  /* MMC Receive LPI microsecond counter interrupt status */
-#define ETH_MMCRIR_RXUCGPIS_Pos                       (17U)
-#define ETH_MMCRIR_RXUCGPIS_Msk                       (0x1UL << ETH_MMCRIR_RXUCGPIS_Pos) /*!< 0x00020000 */
-#define ETH_MMCRIR_RXUCGPIS                           ETH_MMCRIR_RXUCGPIS_Msk  /* MMC Receive Unicast Good Packet Counter Interrupt Status */
-#define ETH_MMCRIR_RXALGNERPIS_Pos                    (6U)
-#define ETH_MMCRIR_RXALGNERPIS_Msk                    (0x1UL << ETH_MMCRIR_RXALGNERPIS_Pos) /*!< 0x00000040 */
-#define ETH_MMCRIR_RXALGNERPIS                        ETH_MMCRIR_RXALGNERPIS_Msk  /* MMC Receive Alignment Error Packet Counter Interrupt Status */
-#define ETH_MMCRIR_RXCRCERPIS_Pos                     (5U)
-#define ETH_MMCRIR_RXCRCERPIS_Msk                     (0x1UL << ETH_MMCRIR_RXCRCERPIS_Pos) /*!< 0x00000020 */
-#define ETH_MMCRIR_RXCRCERPIS                         ETH_MMCRIR_RXCRCERPIS_Msk  /* MMC Receive CRC Error Packet Counter Interrupt Status */
-
-/* Bit definition for Ethernet MMC Tx Interrupt Register */
-#define ETH_MMCTIR_TXLPITRCIS_Pos                     (27U)
-#define ETH_MMCTIR_TXLPITRCIS_Msk                     (0x1UL << ETH_MMCTIR_TXLPITRCIS_Pos) /*!< 0x08000000 */
-#define ETH_MMCTIR_TXLPITRCIS                         ETH_MMCTIR_TXLPITRCIS_Msk  /* MMC Transmit LPI transition counter interrupt status */
-#define ETH_MMCTIR_TXLPIUSCIS_Pos                     (26U)
-#define ETH_MMCTIR_TXLPIUSCIS_Msk                     (0x1UL << ETH_MMCTIR_TXLPIUSCIS_Pos) /*!< 0x04000000 */
-#define ETH_MMCTIR_TXLPIUSCIS                         ETH_MMCTIR_TXLPIUSCIS_Msk  /* MMC Transmit LPI microsecond counter interrupt status */
-#define ETH_MMCTIR_TXGPKTIS_Pos                       (21U)
-#define ETH_MMCTIR_TXGPKTIS_Msk                       (0x1UL << ETH_MMCTIR_TXGPKTIS_Pos) /*!< 0x00200000 */
-#define ETH_MMCTIR_TXGPKTIS                           ETH_MMCTIR_TXGPKTIS_Msk  /* MMC Transmit Good Packet Counter Interrupt Status */
-#define ETH_MMCTIR_TXMCOLGPIS_Pos                     (15U)
-#define ETH_MMCTIR_TXMCOLGPIS_Msk                     (0x1UL << ETH_MMCTIR_TXMCOLGPIS_Pos) /*!< 0x00008000 */
-#define ETH_MMCTIR_TXMCOLGPIS                         ETH_MMCTIR_TXMCOLGPIS_Msk  /* MMC Transmit Multiple Collision Good Packet Counter Interrupt Status */
-#define ETH_MMCTIR_TXSCOLGPIS_Pos                     (14U)
-#define ETH_MMCTIR_TXSCOLGPIS_Msk                     (0x1UL << ETH_MMCTIR_TXSCOLGPIS_Pos) /*!< 0x00004000 */
-#define ETH_MMCTIR_TXSCOLGPIS                         ETH_MMCTIR_TXSCOLGPIS_Msk  /* MMC Transmit Single Collision Good Packet Counter Interrupt Status */
-
-/* Bit definition for Ethernet MMC Rx interrupt Mask register */
-#define ETH_MMCRIMR_RXLPITRCIM_Pos                    (27U)
-#define ETH_MMCRIMR_RXLPITRCIM_Msk                    (0x1UL << ETH_MMCRIMR_RXLPITRCIM_Pos) /*!< 0x08000000 */
-#define ETH_MMCRIMR_RXLPITRCIM                        ETH_MMCRIMR_RXLPITRCIM_Msk  /* MMC Receive LPI transition counter interrupt Mask */
-#define ETH_MMCRIMR_RXLPIUSCIM_Pos                    (26U)
-#define ETH_MMCRIMR_RXLPIUSCIM_Msk                    (0x1UL << ETH_MMCRIMR_RXLPIUSCIM_Pos) /*!< 0x04000000 */
-#define ETH_MMCRIMR_RXLPIUSCIM                        ETH_MMCRIMR_RXLPIUSCIM_Msk  /* MMC Receive LPI microsecond counter interrupt Mask */
-#define ETH_MMCRIMR_RXUCGPIM_Pos                      (17U)
-#define ETH_MMCRIMR_RXUCGPIM_Msk                      (0x1UL << ETH_MMCRIMR_RXUCGPIM_Pos) /*!< 0x00020000 */
-#define ETH_MMCRIMR_RXUCGPIM                          ETH_MMCRIMR_RXUCGPIM_Msk  /* MMC Receive Unicast Good Packet Counter Interrupt Mask */
-#define ETH_MMCRIMR_RXALGNERPIM_Pos                   (6U)
-#define ETH_MMCRIMR_RXALGNERPIM_Msk                   (0x1UL << ETH_MMCRIMR_RXALGNERPIM_Pos) /*!< 0x00000040 */
-#define ETH_MMCRIMR_RXALGNERPIM                       ETH_MMCRIMR_RXALGNERPIM_Msk  /* MMC Receive Alignment Error Packet Counter Interrupt Mask */
-#define ETH_MMCRIMR_RXCRCERPIM_Pos                    (5U)
-#define ETH_MMCRIMR_RXCRCERPIM_Msk                    (0x1UL << ETH_MMCRIMR_RXCRCERPIM_Pos) /*!< 0x00000020 */
-#define ETH_MMCRIMR_RXCRCERPIM                        ETH_MMCRIMR_RXCRCERPIM_Msk  /* MMC Receive CRC Error Packet Counter Interrupt Mask */
-
-/* Bit definition for Ethernet MMC Tx Interrupt Mask Register */
-#define ETH_MMCTIMR_TXLPITRCIM_Pos                    (27U)
-#define ETH_MMCTIMR_TXLPITRCIM_Msk                    (0x1UL << ETH_MMCTIMR_TXLPITRCIM_Pos) /*!< 0x08000000 */
-#define ETH_MMCTIMR_TXLPITRCIM                        ETH_MMCTIMR_TXLPITRCIM_Msk  /* MMC Transmit LPI transition counter interrupt Mask*/
-#define ETH_MMCTIMR_TXLPIUSCIM_Pos                    (26U)
-#define ETH_MMCTIMR_TXLPIUSCIM_Msk                    (0x1UL << ETH_MMCTIMR_TXLPIUSCIM_Pos) /*!< 0x04000000 */
-#define ETH_MMCTIMR_TXLPIUSCIM                        ETH_MMCTIMR_TXLPIUSCIM_Msk  /* MMC Transmit LPI microsecond counter interrupt Mask*/
-#define ETH_MMCTIMR_TXGPKTIM_Pos                      (21U)
-#define ETH_MMCTIMR_TXGPKTIM_Msk                      (0x1UL << ETH_MMCTIMR_TXGPKTIM_Pos) /*!< 0x00200000 */
-#define ETH_MMCTIMR_TXGPKTIM                          ETH_MMCTIMR_TXGPKTIM_Msk  /* MMC Transmit Good Packet Counter Interrupt Mask*/
-#define ETH_MMCTIMR_TXMCOLGPIM_Pos                    (15U)
-#define ETH_MMCTIMR_TXMCOLGPIM_Msk                    (0x1UL << ETH_MMCTIMR_TXMCOLGPIM_Pos) /*!< 0x00008000 */
-#define ETH_MMCTIMR_TXMCOLGPIM                        ETH_MMCTIMR_TXMCOLGPIM_Msk  /* MMC Transmit Multiple Collision Good Packet Counter Interrupt Mask */
-#define ETH_MMCTIMR_TXSCOLGPIM_Pos                    (14U)
-#define ETH_MMCTIMR_TXSCOLGPIM_Msk                    (0x1UL << ETH_MMCTIMR_TXSCOLGPIM_Pos) /*!< 0x00004000 */
-#define ETH_MMCTIMR_TXSCOLGPIM                        ETH_MMCTIMR_TXSCOLGPIM_Msk  /* MMC Transmit Single Collision Good Packet Counter Interrupt Mask */
-
-/* Bit definition for Ethernet MMC Tx Single Collision Good Packets Register */
-#define ETH_MMCTSCGPR_TXSNGLCOLG_Pos                  (0U)
-#define ETH_MMCTSCGPR_TXSNGLCOLG_msk                  (0xFFFFFFFFUL <<  ETH_MMCTSCGPR_TXSNGLCOLG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTSCGPR_TXSNGLCOLG                      ETH_MMCTSCGPR_TXSNGLCOLG_msk /* Tx Single Collision Good Packets */
-
-/* Bit definition for Ethernet MMC Tx Multiple Collision Good Packets Register */
-#define ETH_MMCTMCGPR_TXMULTCOLG_Pos                  (0U)
-#define ETH_MMCTMCGPR_TXMULTCOLG_msk                  (0xFFFFFFFFUL <<  ETH_MMCTMCGPR_TXMULTCOLG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTMCGPR_TXMULTCOLG                      ETH_MMCTMCGPR_TXMULTCOLG_msk /* Tx Multiple Collision Good Packets */
-
-/* Bit definition for Ethernet MMC Tx Packet Count Good Register */
-#define ETH_MMCTPCGR_TXPKTG_Pos                       (0U)
-#define ETH_MMCTPCGR_TXPKTG_msk                       (0xFFFFFFFFUL <<  ETH_MMCTPCGR_TXPKTG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTPCGR_TXPKTG                           ETH_MMCTPCGR_TXPKTG_msk /* Tx Packet Count Good */
-
-/* Bit definition for Ethernet MMC Rx CRC Error Packets Register */
-#define ETH_MMCRCRCEPR_RXCRCERR_Pos                   (0U)
-#define ETH_MMCRCRCEPR_RXCRCERR_msk                   (0xFFFFFFFFUL <<  ETH_MMCRCRCEPR_RXCRCERR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRCRCEPR_RXCRCERR                       ETH_MMCRCRCEPR_RXCRCERR_msk /* Rx CRC Error Packets */
-
-/* Bit definition for Ethernet MMC Rx alignment error packets register */
-#define ETH_MMCRAEPR_RXALGNERR_Pos                    (0U)
-#define ETH_MMCRAEPR_RXALGNERR_msk                    (0xFFFFFFFFUL <<  ETH_MMCRAEPR_RXALGNERR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRAEPR_RXALGNERR                        ETH_MMCRAEPR_RXALGNERR_msk /* Rx Alignment Error Packets */
-
-/* Bit definition for Ethernet MMC Rx Unicast Packets Good Register */
-#define ETH_MMCRUPGR_RXUCASTG_Pos                     (0U)
-#define ETH_MMCRUPGR_RXUCASTG_msk                     (0xFFFFFFFFUL <<  ETH_MMCRUPGR_RXUCASTG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRUPGR_RXUCASTG                         ETH_MMCRUPGR_RXUCASTG_msk /* Rx Unicast Packets Good */
-
-/* Bit definition for Ethernet MMC Tx LPI Microsecond Timer Register */
-#define ETH_MMCTLPIMSTR_TXLPIUSC_Pos                  (0U)
-#define ETH_MMCTLPIMSTR_TXLPIUSC_msk                  (0xFFFFFFFFUL <<  ETH_MMCTLPIMSTR_TXLPIUSC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTLPIMSTR_TXLPIUSC                      ETH_MMCTLPIMSTR_TXLPIUSC_msk /* Tx LPI Microseconds Counter */
-
-/* Bit definition for Ethernet MMC Tx LPI Transition Counter Register */
-#define ETH_MMCTLPITCR_TXLPITRC_Pos                   (0U)
-#define ETH_MMCTLPITCR_TXLPITRC_msk                   (0xFFFFFFFFUL <<  ETH_MMCTLPITCR_TXLPITRC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTLPITCR_TXLPITRC                       ETH_MMCTLPITCR_TXLPITRC_msk /* Tx LPI Transition counter */
-
-/* Bit definition for Ethernet MMC Rx LPI Microsecond Counter Register */
-#define ETH_MMCRLPIMSTR_RXLPIUSC_Pos                  (0U)
-#define ETH_MMCRLPIMSTR_RXLPIUSC_msk                  (0xFFFFFFFFUL <<  ETH_MMCRLPIMSTR_RXLPIUSC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRLPIMSTR_RXLPIUSC                      ETH_MMCRLPIMSTR_RXLPIUSC_msk /* Rx LPI Microseconds Counter */
-
-/* Bit definition for Ethernet MMC Rx LPI Transition Counter Register */
-#define ETH_MMCRLPITCR_RXLPITRC_Pos                   (0U)
-#define ETH_MMCRLPITCR_RXLPITRC_msk                   (0xFFFFFFFFUL <<  ETH_MMCRLPITCR_RXLPITRC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRLPITCR_RXLPITRC                       ETH_MMCRLPITCR_RXLPITRC_msk /* Rx LPI Transition counter */
-
-/* Bit definition for Ethernet MAC L3 L4 Control Register */
-#define ETH_MACL3L4CR_L4DPIM_Pos                      (21U)
-#define ETH_MACL3L4CR_L4DPIM_Msk                      (0x1UL << ETH_MACL3L4CR_L4DPIM_Pos) /*!< 0x00200000 */
-#define ETH_MACL3L4CR_L4DPIM                          ETH_MACL3L4CR_L4DPIM_Msk /* Layer 4 Destination Port Inverse Match Enable */
-#define ETH_MACL3L4CR_L4DPM_Pos                       (20U)
-#define ETH_MACL3L4CR_L4DPM_Msk                       (0x1UL << ETH_MACL3L4CR_L4DPM_Pos) /*!< 0x00100000 */
-#define ETH_MACL3L4CR_L4DPM                           ETH_MACL3L4CR_L4DPM_Msk  /* Layer 4 Destination Port Match Enable */
-#define ETH_MACL3L4CR_L4SPIM_Pos                      (19U)
-#define ETH_MACL3L4CR_L4SPIM_Msk                      (0x1UL << ETH_MACL3L4CR_L4SPIM_Pos) /*!< 0x00080000 */
-#define ETH_MACL3L4CR_L4SPIM                          ETH_MACL3L4CR_L4SPIM_Msk /* Layer 4 Source Port Inverse Match Enable */
-#define ETH_MACL3L4CR_L4SPM_Pos                       (18U)
-#define ETH_MACL3L4CR_L4SPM_Msk                       (0x1UL << ETH_MACL3L4CR_L4SPM_Pos) /*!< 0x00040000 */
-#define ETH_MACL3L4CR_L4SPM                           ETH_MACL3L4CR_L4SPM_Msk  /* Layer 4 Source Port Match Enable */
-#define ETH_MACL3L4CR_L4PEN_Pos                       (16U)
-#define ETH_MACL3L4CR_L4PEN_Msk                       (0x1UL << ETH_MACL3L4CR_L4PEN_Pos) /*!< 0x00010000 */
-#define ETH_MACL3L4CR_L4PEN                           ETH_MACL3L4CR_L4PEN_Msk  /* Layer 4 Protocol Enable */
-#define ETH_MACL3L4CR_L3HDBM_Pos                      (11U)
-#define ETH_MACL3L4CR_L3HDBM_Msk                      (0x1FUL << ETH_MACL3L4CR_L3HDBM_Pos) /*!< 0x0000F800 */
-#define ETH_MACL3L4CR_L3HDBM                          ETH_MACL3L4CR_L3HDBM_Msk /* Layer 3 IP DA Higher Bits Match */
-#define ETH_MACL3L4CR_L3HSBM_Pos                      (6U)
-#define ETH_MACL3L4CR_L3HSBM_Msk                      (0x1FUL << ETH_MACL3L4CR_L3HSBM_Pos) /*!< 0x000007C0 */
-#define ETH_MACL3L4CR_L3HSBM                          ETH_MACL3L4CR_L3HSBM_Msk /* Layer 3 IP SA Higher Bits Match */
-#define ETH_MACL3L4CR_L3DAIM_Pos                      (5U)
-#define ETH_MACL3L4CR_L3DAIM_Msk                      (0x1UL << ETH_MACL3L4CR_L3DAIM_Pos) /*!< 0x00000020 */
-#define ETH_MACL3L4CR_L3DAIM                          ETH_MACL3L4CR_L3DAIM_Msk /* Layer 3 IP DA Inverse Match Enable */
-#define ETH_MACL3L4CR_L3DAM_Pos                       (4U)
-#define ETH_MACL3L4CR_L3DAM_Msk                       (0x1UL << ETH_MACL3L4CR_L3DAM_Pos) /*!< 0x00000010 */
-#define ETH_MACL3L4CR_L3DAM                           ETH_MACL3L4CR_L3DAM_Msk  /* Layer 3 IP DA Match Enable */
-#define ETH_MACL3L4CR_L3SAIM_Pos                      (3U)
-#define ETH_MACL3L4CR_L3SAIM_Msk                      (0x1UL << ETH_MACL3L4CR_L3SAIM_Pos) /*!< 0x00000008 */
-#define ETH_MACL3L4CR_L3SAIM                          ETH_MACL3L4CR_L3SAIM_Msk /* Layer 3 IP SA Inverse Match Enable */
-#define ETH_MACL3L4CR_L3SAM_Pos                       (2U)
-#define ETH_MACL3L4CR_L3SAM_Msk                       (0x1UL << ETH_MACL3L4CR_L3SAM_Pos) /*!< 0x00000004 */
-#define ETH_MACL3L4CR_L3SAM                           ETH_MACL3L4CR_L3SAM_Msk  /* Layer 3 IP SA Match Enable*/
-#define ETH_MACL3L4CR_L3PEN_Pos                       (0U)
-#define ETH_MACL3L4CR_L3PEN_Msk                       (0x1UL << ETH_MACL3L4CR_L3PEN_Pos) /*!< 0x00000001 */
-#define ETH_MACL3L4CR_L3PEN                           ETH_MACL3L4CR_L3PEN_Msk  /* Layer 3 Protocol Enable */
-
-/* Bit definition for Ethernet MAC L4 Address Register */
-#define ETH_MACL4AR_L4DP_Pos                          (16U)
-#define ETH_MACL4AR_L4DP_Msk                          (0xFFFFUL << ETH_MACL4AR_L4DP_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACL4AR_L4DP                              ETH_MACL4AR_L4DP_Msk     /* Layer 4 Destination Port Number Field */
-#define ETH_MACL4AR_L4SP_Pos                          (0U)
-#define ETH_MACL4AR_L4SP_Msk                          (0xFFFFUL << ETH_MACL4AR_L4SP_Pos) /*!< 0x0000FFFF */
-#define ETH_MACL4AR_L4SP                              ETH_MACL4AR_L4SP_Msk     /* Layer 4 Source Port Number Field */
-
-/* Bit definition for Ethernet MAC L3 Address0 Register */
-#define ETH_MACL3A0R_L3A0_Pos                         (0U)
-#define ETH_MACL3A0R_L3A0_Msk                         (0xFFFFFFFFUL << ETH_MACL3A0R_L3A0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A0R_L3A0                             ETH_MACL3A0R_L3A0_Msk    /* Layer 3 Address 0 Field */
-
-/* Bit definition for Ethernet MAC L4 Address1 Register */
-#define ETH_MACL3A1R_L3A1_Pos                         (0U)
-#define ETH_MACL3A1R_L3A1_Msk                         (0xFFFFFFFFUL << ETH_MACL3A1R_L3A1_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A1R_L3A1                             ETH_MACL3A1R_L3A1_Msk    /* Layer 3 Address 1 Field */
-
-/* Bit definition for Ethernet MAC L4 Address2 Register */
-#define ETH_MACL3A2R_L3A2_Pos                         (0U)
-#define ETH_MACL3A2R_L3A2_Msk                         (0xFFFFFFFFUL << ETH_MACL3A2R_L3A2_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A2R_L3A2                             ETH_MACL3A2R_L3A2_Msk    /* Layer 3 Address 2 Field */
-
-/* Bit definition for Ethernet MAC L4 Address3 Register */
-#define ETH_MACL3A3R_L3A3_Pos                         (0U)
-#define ETH_MACL3A3R_L3A3_Msk                         (0xFFFFFFFFUL << ETH_MACL3A3R_L3A3_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A3R_L3A3                             ETH_MACL3A3R_L3A3_Msk    /* Layer 3 Address 3 Field */
-
-/* Bit definition for Ethernet MAC Timestamp Control Register */
-#define ETH_MACTSCR_TXTSSTSM_Pos                      (24U)
-#define ETH_MACTSCR_TXTSSTSM_Msk                      (0x1UL << ETH_MACTSCR_TXTSSTSM_Pos) /*!< 0x01000000 */
-#define ETH_MACTSCR_TXTSSTSM                          ETH_MACTSCR_TXTSSTSM_Msk  /* Transmit Timestamp Status Mode */
-#define ETH_MACTSCR_CSC_Pos                           (19U)
-#define ETH_MACTSCR_CSC_Msk                           (0x1UL << ETH_MACTSCR_CSC_Pos) /*!< 0x00080000 */
-#define ETH_MACTSCR_CSC                               ETH_MACTSCR_CSC_Msk  /* Enable checksum correction during OST for PTP over UDP/IPv4 packets */
-#define ETH_MACTSCR_TSENMACADDR_Pos                   (18U)
-#define ETH_MACTSCR_TSENMACADDR_Msk                   (0x1UL << ETH_MACTSCR_TSENMACADDR_Pos) /*!< 0x00040000 */
-#define ETH_MACTSCR_TSENMACADDR                       ETH_MACTSCR_TSENMACADDR_Msk  /* Enable MAC Address for PTP Packet Filtering */
-#define ETH_MACTSCR_SNAPTYPSEL_Pos                    (16U)
-#define ETH_MACTSCR_SNAPTYPSEL_Msk                    (0x3UL << ETH_MACTSCR_SNAPTYPSEL_Pos) /*!< 0x00030000 */
-#define ETH_MACTSCR_SNAPTYPSEL                        ETH_MACTSCR_SNAPTYPSEL_Msk  /* Select PTP packets for Taking Snapshots */
-#define ETH_MACTSCR_TSMSTRENA_Pos                     (15U)
-#define ETH_MACTSCR_TSMSTRENA_Msk                     (0x1UL << ETH_MACTSCR_TSMSTRENA_Pos) /*!< 0x00008000 */
-#define ETH_MACTSCR_TSMSTRENA                         ETH_MACTSCR_TSMSTRENA_Msk  /* Enable Snapshot for Messages Relevant to Master */
-#define ETH_MACTSCR_TSEVNTENA_Pos                     (14U)
-#define ETH_MACTSCR_TSEVNTENA_Msk                     (0x1UL << ETH_MACTSCR_TSEVNTENA_Pos) /*!< 0x00004000 */
-#define ETH_MACTSCR_TSEVNTENA                         ETH_MACTSCR_TSEVNTENA_Msk  /* Enable Timestamp Snapshot for Event Messages */
-#define ETH_MACTSCR_TSIPV4ENA_Pos                     (13U)
-#define ETH_MACTSCR_TSIPV4ENA_Msk                     (0x1UL << ETH_MACTSCR_TSIPV4ENA_Pos) /*!< 0x00002000 */
-#define ETH_MACTSCR_TSIPV4ENA                         ETH_MACTSCR_TSIPV4ENA_Msk  /* Enable Processing of PTP Packets Sent over IPv4-UDP */
-#define ETH_MACTSCR_TSIPV6ENA_Pos                     (12U)
-#define ETH_MACTSCR_TSIPV6ENA_Msk                     (0x1UL << ETH_MACTSCR_TSIPV6ENA_Pos) /*!< 0x00001000 */
-#define ETH_MACTSCR_TSIPV6ENA                         ETH_MACTSCR_TSIPV6ENA_Msk  /* Enable Processing of PTP Packets Sent over IPv6-UDP */
-#define ETH_MACTSCR_TSIPENA_Pos                       (11U)
-#define ETH_MACTSCR_TSIPENA_Msk                       (0x1UL << ETH_MACTSCR_TSIPENA_Pos) /*!< 0x00000800 */
-#define ETH_MACTSCR_TSIPENA                           ETH_MACTSCR_TSIPENA_Msk  /* Enable Processing of PTP over Ethernet Packets */
-#define ETH_MACTSCR_TSVER2ENA_Pos                     (10U)
-#define ETH_MACTSCR_TSVER2ENA_Msk                     (0x1UL << ETH_MACTSCR_TSVER2ENA_Pos) /*!< 0x00000400 */
-#define ETH_MACTSCR_TSVER2ENA                         ETH_MACTSCR_TSVER2ENA_Msk  /* Enable PTP Packet Processing for Version 2 Format */
-#define ETH_MACTSCR_TSCTRLSSR_Pos                     (9U)
-#define ETH_MACTSCR_TSCTRLSSR_Msk                     (0x1UL << ETH_MACTSCR_TSCTRLSSR_Pos) /*!< 0x00000200 */
-#define ETH_MACTSCR_TSCTRLSSR                         ETH_MACTSCR_TSCTRLSSR_Msk  /* Timestamp Digital or Binary Rollover Control */
-#define ETH_MACTSCR_TSENALL_Pos                       (8U)
-#define ETH_MACTSCR_TSENALL_Msk                       (0x1UL << ETH_MACTSCR_TSENALL_Pos) /*!< 0x00000100 */
-#define ETH_MACTSCR_TSENALL                           ETH_MACTSCR_TSENALL_Msk  /* Enable Timestamp for All Packets */
-#define ETH_MACTSCR_TSADDREG_Pos                      (5U)
-#define ETH_MACTSCR_TSADDREG_Msk                      (0x1UL << ETH_MACTSCR_TSADDREG_Pos) /*!< 0x00000020 */
-#define ETH_MACTSCR_TSADDREG                          ETH_MACTSCR_TSADDREG_Msk  /* Update Addend Register */
-#define ETH_MACTSCR_TSUPDT_Pos                        (3U)
-#define ETH_MACTSCR_TSUPDT_Msk                        (0x1UL << ETH_MACTSCR_TSUPDT_Pos) /*!< 0x00000008 */
-#define ETH_MACTSCR_TSUPDT                            ETH_MACTSCR_TSUPDT_Msk  /* Update Timestamp */
-#define ETH_MACTSCR_TSINIT_Pos                        (2U)
-#define ETH_MACTSCR_TSINIT_Msk                        (0x1UL << ETH_MACTSCR_TSINIT_Pos) /*!< 0x00000004 */
-#define ETH_MACTSCR_TSINIT                             ETH_MACTSCR_TSINIT_Msk  /* Initialize Timestamp */
-#define ETH_MACTSCR_TSCFUPDT_Pos                      (1U)
-#define ETH_MACTSCR_TSCFUPDT_Msk                      (0x1UL << ETH_MACTSCR_TSCFUPDT_Pos) /*!< 0x00000002 */
-#define ETH_MACTSCR_TSCFUPDT                          ETH_MACTSCR_TSCFUPDT_Msk  /* Fine or Coarse Timestamp Update*/
-#define ETH_MACTSCR_TSENA_Pos                         (0U)
-#define ETH_MACTSCR_TSENA_Msk                         (0x1UL << ETH_MACTSCR_TSENA_Pos) /*!< 0x00000001 */
-#define ETH_MACTSCR_TSENA                             ETH_MACTSCR_TSENA_Msk  /* Enable Timestamp */
-
-/* Bit definition for Ethernet MAC Sub-second Increment Register */
-#define ETH_MACMACSSIR_SSINC_Pos                      (16U)
-#define ETH_MACMACSSIR_SSINC_Msk                      (0xFFUL << ETH_MACMACSSIR_SSINC_Pos) /*!< 0x0000FF00 */
-#define ETH_MACMACSSIR_SSINC                          ETH_MACMACSSIR_SSINC_Msk  /* Sub-second Increment Value */
-#define ETH_MACMACSSIR_SNSINC_Pos                     (8U)
-#define ETH_MACMACSSIR_SNSINC_Msk                     (0xFFUL << ETH_MACMACSSIR_SNSINC_Pos) /*!< 0x000000FF */
-#define ETH_MACMACSSIR_SNSINC                         ETH_MACMACSSIR_SNSINC_Msk  /* Sub-nanosecond Increment Value */
-
-/* Bit definition for Ethernet MAC System Time Seconds Register */
-#define ETH_MACSTSR_TSS_Pos                           (0U)
-#define ETH_MACSTSR_TSS_Msk                           (0xFFFFFFFFUL << ETH_MACSTSR_TSS_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSTSR_TSS                               ETH_MACSTSR_TSS_Msk  /* Timestamp Second */
-
-/* Bit definition for Ethernet MAC System Time Nanoseconds Register */
-#define ETH_MACSTNR_TSSS_Pos                          (0U)
-#define ETH_MACSTNR_TSSS_Msk                          (0x7FFFFFFFUL << ETH_MACSTNR_TSSS_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACSTNR_TSSS                              ETH_MACSTNR_TSSS_Msk  /* Timestamp Sub-seconds */
-
-/* Bit definition for Ethernet MAC System Time Seconds Update Register */
-#define ETH_MACSTSUR_TSS_Pos                          (0U)
-#define ETH_MACSTSUR_TSS_Msk                          (0xFFFFFFFFUL << ETH_MACSTSUR_TSS_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSTSUR_TSS                              ETH_MACSTSUR_TSS_Msk  /* Timestamp Seconds */
-
-/* Bit definition for Ethernet MAC System Time Nanoseconds Update Register */
-#define ETH_MACSTNUR_ADDSUB_Pos                       (31U)
-#define ETH_MACSTNUR_ADDSUB_Msk                       (0x1UL << ETH_MACSTNUR_ADDSUB_Pos) /*!< 0x80000000 */
-#define ETH_MACSTNUR_ADDSUB                           ETH_MACSTNUR_ADDSUB_Msk  /* Add or Subtract Time */
-#define ETH_MACSTNUR_TSSS_Pos                         (0U)
-#define ETH_MACSTNUR_TSSS_Msk                         (0x7FFFFFFFUL << ETH_MACSTNUR_TSSS_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACSTNUR_TSSS                             ETH_MACSTNUR_TSSS_Msk  /* Timestamp Sub-seconds */
-
-/* Bit definition for Ethernet MAC Timestamp Addend Register */
-#define ETH_MACTSAR_TSAR_Pos                          (0U)
-#define ETH_MACTSAR_TSAR_Msk                          (0xFFFFFFFFUL << ETH_MACTSAR_TSAR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSAR_TSAR                              ETH_MACTSAR_TSAR_Msk  /* Timestamp Addend Register */
-
-/* Bit definition for Ethernet MAC Timestamp Status Register */
-#define ETH_MACTSSR_ATSNS_Pos                         (25U)
-#define ETH_MACTSSR_ATSNS_Msk                         (0x1FUL << ETH_MACTSSR_ATSNS_Pos) /*!< 0x3E000000 */
-#define ETH_MACTSSR_ATSNS                             ETH_MACTSSR_ATSNS_Msk  /* Number of Auxiliary Timestamp Snapshots */
-#define ETH_MACTSSR_ATSSTM_Pos                        (24U)
-#define ETH_MACTSSR_ATSSTM_Msk                        (0x1UL << ETH_MACTSSR_ATSSTM_Pos) /*!< 0x01000000 */
-#define ETH_MACTSSR_ATSSTM                            ETH_MACTSSR_ATSSTM_Msk  /* Auxiliary Timestamp Snapshot Trigger Missed */
-#define ETH_MACTSSR_ATSSTN_Pos                        (16U)
-#define ETH_MACTSSR_ATSSTN_Msk                        (0xFUL << ETH_MACTSSR_ATSSTN_Pos) /*!< 0x000F0000 */
-#define ETH_MACTSSR_ATSSTN                            ETH_MACTSSR_ATSSTN_Msk  /* Auxiliary Timestamp Snapshot Trigger Identifier */
-#define ETH_MACTSSR_TXTSSIS_Pos                       (15U)
-#define ETH_MACTSSR_TXTSSIS_Msk                       (0x1UL << ETH_MACTSSR_TXTSSIS_Pos) /*!< 0x00008000 */
-#define ETH_MACTSSR_TXTSSIS                           ETH_MACTSSR_TXTSSIS_Msk  /* Tx Timestamp Status Interrupt Status */
-#define ETH_MACTSSR_TSTRGTERR0_Pos                    (3U)
-#define ETH_MACTSSR_TSTRGTERR0_Msk                    (0x1UL << ETH_MACTSSR_TSTRGTERR0_Pos) /*!< 0x00000008 */
-#define ETH_MACTSSR_TSTRGTERR0                        ETH_MACTSSR_TSTRGTERR0_Msk  /* Timestamp Target Time Error */
-#define ETH_MACTSSR_AUXTSTRIG_Pos                     (2U)
-#define ETH_MACTSSR_AUXTSTRIG_Msk                     (0x1UL << ETH_MACTSSR_AUXTSTRIG_Pos) /*!< 0x00000004 */
-#define ETH_MACTSSR_AUXTSTRIG                         ETH_MACTSSR_AUXTSTRIG_Msk  /* Auxiliary Timestamp Trigger Snapshot*/
-#define ETH_MACTSSR_TSTARGT0_Pos                      (1U)
-#define ETH_MACTSSR_TSTARGT0_Msk                      (0x1UL << ETH_MACTSSR_TSTARGT0_Pos) /*!< 0x00000002 */
-#define ETH_MACTSSR_TSTARGT0                          ETH_MACTSSR_TSTARGT0_Msk  /* Timestamp Target Time Reached */
-#define ETH_MACTSSR_TSSOVF_Pos                        (0U)
-#define ETH_MACTSSR_TSSOVF_Msk                        (0x1UL << ETH_MACTSSR_TSSOVF_Pos) /*!< 0x00000001 */
-#define ETH_MACTSSR_TSSOVF                            ETH_MACTSSR_TSSOVF_Msk  /* Timestamp Seconds Overflow */
-
-/* Bit definition for Ethernet MAC Tx Timestamp Status Nanoseconds Register */
-#define ETH_MACTTSSNR_TXTSSMIS_Pos                    (31U)
-#define ETH_MACTTSSNR_TXTSSMIS_Msk                    (0x1UL << ETH_MACTTSSNR_TXTSSMIS_Pos) /*!< 0x80000000 */
-#define ETH_MACTTSSNR_TXTSSMIS                        ETH_MACTTSSNR_TXTSSMIS_Msk  /* Transmit Timestamp Status Missed */
-#define ETH_MACTTSSNR_TXTSSLO_Pos                     (0U)
-#define ETH_MACTTSSNR_TXTSSLO_Msk                     (0x7FFFFFFFUL << ETH_MACTTSSNR_TXTSSLO_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACTTSSNR_TXTSSLO                         ETH_MACTTSSNR_TXTSSLO_Msk  /* Transmit Timestamp Status Low */
-
-/* Bit definition for Ethernet MAC Tx Timestamp Status Seconds Register */
-#define ETH_MACTTSSSR_TXTSSHI_Pos                     (0U)
-#define ETH_MACTTSSSR_TXTSSHI_Msk                     (0xFFFFFFFFUL << ETH_MACTTSSSR_TXTSSHI_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTTSSSR_TXTSSHI                         ETH_MACTTSSSR_TXTSSHI_Msk  /* Transmit Timestamp Status High */
-
-/* Bit definition for Ethernet MAC Auxiliary Control Register*/
-#define ETH_MACACR_ATSEN3_Pos                         (7U)
-#define ETH_MACACR_ATSEN3_Msk                         (0x1UL << ETH_MACACR_ATSEN3_Pos) /*!< 0x00000080 */
-#define ETH_MACACR_ATSEN3                             ETH_MACACR_ATSEN3_Msk  /* Auxiliary Snapshot 3 Enable */
-#define ETH_MACACR_ATSEN2_Pos                         (6U)
-#define ETH_MACACR_ATSEN2_Msk                         (0x1UL << ETH_MACACR_ATSEN2_Pos) /*!< 0x00000040 */
-#define ETH_MACACR_ATSEN2                             ETH_MACACR_ATSEN2_Msk  /* Auxiliary Snapshot 2 Enable */
-#define ETH_MACACR_ATSEN1_Pos                         (5U)
-#define ETH_MACACR_ATSEN1_Msk                         (0x1UL << ETH_MACACR_ATSEN1_Pos) /*!< 0x00000020 */
-#define ETH_MACACR_ATSEN1                             ETH_MACACR_ATSEN1_Msk  /* Auxiliary Snapshot 1 Enable */
-#define ETH_MACACR_ATSEN0_Pos                         (4U)
-#define ETH_MACACR_ATSEN0_Msk                         (0x1UL << ETH_MACACR_ATSEN0_Pos) /*!< 0x00000010 */
-#define ETH_MACACR_ATSEN0                             ETH_MACACR_ATSEN0_Msk  /* Auxiliary Snapshot 0 Enable */
-#define ETH_MACACR_ATSFC_Pos                          (0U)
-#define ETH_MACACR_ATSFC_Msk                          (0x1UL << ETH_MACACR_ATSFC_Pos) /*!< 0x00000001 */
-#define ETH_MACACR_ATSFC                              ETH_MACACR_ATSFC_Msk  /* Auxiliary Snapshot FIFO Clear */
-
-/* Bit definition for Ethernet MAC Auxiliary Timestamp Nanoseconds Register */
-#define ETH_MACATSNR_AUXTSLO_Pos                      (0U)
-#define ETH_MACATSNR_AUXTSLO_Msk                      (0x7FFFFFFFUL << ETH_MACATSNR_AUXTSLO_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACATSNR_AUXTSLO                          ETH_MACATSNR_AUXTSLO_Msk  /* Auxiliary Timestamp */
-
-/* Bit definition for Ethernet MAC Auxiliary Timestamp Seconds Register */
-#define ETH_MACATSSR_AUXTSHI_Pos                      (0U)
-#define ETH_MACATSSR_AUXTSHI_Msk                      (0xFFFFFFFFUL << ETH_MACATSSR_AUXTSHI_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACATSSR_AUXTSHI                          ETH_MACATSSR_AUXTSHI_Msk  /* Auxiliary Timestamp */
-
-/* Bit definition for Ethernet MAC Timestamp Ingress Asymmetric Correction Register */
-#define ETH_MACTSIACR_OSTIAC_Pos                      (0U)
-#define ETH_MACTSIACR_OSTIAC_Msk                      (0xFFFFFFFFUL << ETH_MACTSIACR_OSTIAC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSIACR_OSTIAC                          ETH_MACTSIACR_OSTIAC_Msk  /* One-Step Timestamp Ingress Asymmetry Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Egress Asymmetric Correction Register */
-#define ETH_MACTSEACR_OSTEAC_Pos                      (0U)
-#define ETH_MACTSEACR_OSTEAC_Msk                      (0xFFFFFFFFUL << ETH_MACTSEACR_OSTEAC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSEACR_OSTEAC                          ETH_MACTSEACR_OSTEAC_Msk  /* One-Step Timestamp Egress Asymmetry Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Ingress Correction Nanosecond Register */
-#define ETH_MACTSICNR_TSIC_Pos                        (0U)
-#define ETH_MACTSICNR_TSIC_Msk                        (0xFFFFFFFFUL << ETH_MACTSICNR_TSIC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSICNR_TSIC                            ETH_MACTSICNR_TSIC_Msk  /* Timestamp Ingress Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Egress correction Nanosecond Register */
-#define ETH_MACTSECNR_TSEC_Pos                        (0U)
-#define ETH_MACTSECNR_TSEC_Msk                        (0xFFFFFFFFUL << ETH_MACTSECNR_TSEC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSECNR_TSEC                            ETH_MACTSECNR_TSEC_Msk  /* Timestamp Egress Correction */
-
-/* Bit definition for Ethernet MAC PPS Control Register */
-#define ETH_MACPPSCR_TRGTMODSEL0_Pos                  (5U)
-#define ETH_MACPPSCR_TRGTMODSEL0_Msk                  (0x3UL << ETH_MACPPSCR_TRGTMODSEL0_Pos) /*!< 0x00000060 */
-#define ETH_MACPPSCR_TRGTMODSEL0                      ETH_MACPPSCR_TRGTMODSEL0_Msk  /* Target Time Register Mode for PPS Output */
-#define ETH_MACPPSCR_PPSEN0_Pos                       (4U)
-#define ETH_MACPPSCR_PPSEN0_Msk                       (0x1UL << ETH_MACPPSCR_PPSEN0_Pos) /*!< 0x00000010 */
-#define ETH_MACPPSCR_PPSEN0                           ETH_MACPPSCR_PPSEN0_Msk  /* Flexible PPS Output Mode Enable */
-#define ETH_MACPPSCR_PPSCTRL_Pos                      (0U)
-#define ETH_MACPPSCR_PPSCTRL_Msk                      (0xFUL << ETH_MACPPSCR_PPSCTRL_Pos) /*!< 0x0000000F */
-#define ETH_MACPPSCR_PPSCTRL                          ETH_MACPPSCR_PPSCTRL_Msk  /* PPS Output Frequency Control */
-
-/* Bit definition for Ethernet MAC PPS Target Time Seconds Register */
-#define ETH_MACPPSTTSR_TSTRH0_Pos                     (0U)
-#define ETH_MACPPSTTSR_TSTRH0_Msk                     (0xFFFFFFFFUL << ETH_MACPPSTTSR_TSTRH0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSTTSR_TSTRH0                         ETH_MACPPSTTSR_TSTRH0_Msk  /* PPS Target Time Seconds Register */
-
-/* Bit definition for Ethernet MAC PPS Target Time Nanoseconds Register */
-#define ETH_MACPPSTTNR_TRGTBUSY0_Pos                  (31U)
-#define ETH_MACPPSTTNR_TRGTBUSY0_Msk                  (0x1UL << ETH_MACPPSTTNR_TRGTBUSY0_Pos) /*!< 0x80000000 */
-#define ETH_MACPPSTTNR_TRGTBUSY0                      ETH_MACPPSTTNR_TRGTBUSY0_Msk  /* PPS Target Time Register Busy */
-#define ETH_MACPPSTTNR_TTSL0_Pos                      (0U)
-#define ETH_MACPPSTTNR_TTSL0_Msk                      (0x7FFFFFFFUL << ETH_MACPPSTTNR_TTSL0_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACPPSTTNR_TTSL0                          ETH_MACPPSTTNR_TTSL0_Msk  /* Target Time Low for PPS Register */
-
-/* Bit definition for Ethernet MAC PPS Interval Register */
-#define ETH_MACPPSIR_PPSINT0_Pos                      (0U)
-#define ETH_MACPPSIR_PPSINT0_Msk                      (0xFFFFFFFFUL << ETH_MACPPSIR_PPSINT0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSIR_PPSINT0                          ETH_MACPPSIR_PPSINT0_Msk  /* PPS Output Signal Interval */
-
-/* Bit definition for Ethernet MAC PPS Width Register */
-#define ETH_MACPPSWR_PPSWIDTH0_Pos                    (0U)
-#define ETH_MACPPSWR_PPSWIDTH0_Msk                    (0xFFFFFFFFUL << ETH_MACPPSWR_PPSWIDTH0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSWR_PPSWIDTH0                        ETH_MACPPSWR_PPSWIDTH0_Msk  /* PPS Output Signal Width */
-
-/* Bit definition for Ethernet MAC PTP Offload Control Register */
-#define ETH_MACPOCR_DN_Pos                            (8U)
-#define ETH_MACPOCR_DN_Msk                            (0xFFUL << ETH_MACPOCR_DN_Pos) /*!< 0x0000FF00 */
-#define ETH_MACPOCR_DN                                ETH_MACPOCR_DN_Msk  /* Domain Number */
-#define ETH_MACPOCR_DRRDIS_Pos                        (6U)
-#define ETH_MACPOCR_DRRDIS_Msk                        (0x1UL << ETH_MACPOCR_DRRDIS_Pos) /*!< 0x00000040 */
-#define ETH_MACPOCR_DRRDIS                            ETH_MACPOCR_DRRDIS_Msk  /* Disable PTO Delay Request/Response response generation */
-#define ETH_MACPOCR_APDREQTRIG_Pos                    (5U)
-#define ETH_MACPOCR_APDREQTRIG_Msk                    (0x1UL << ETH_MACPOCR_APDREQTRIG_Pos) /*!< 0x00000020 */
-#define ETH_MACPOCR_APDREQTRIG                        ETH_MACPOCR_APDREQTRIG_Msk  /* Automatic PTP Pdelay_Req message Trigger */
-#define ETH_MACPOCR_ASYNCTRIG_Pos                     (4U)
-#define ETH_MACPOCR_ASYNCTRIG_Msk                     (0x1UL << ETH_MACPOCR_ASYNCTRIG_Pos) /*!< 0x00000010 */
-#define ETH_MACPOCR_ASYNCTRIG                         ETH_MACPOCR_ASYNCTRIG_Msk  /* Automatic PTP SYNC message Trigger */
-#define ETH_MACPOCR_APDREQEN_Pos                      (2U)
-#define ETH_MACPOCR_APDREQEN_Msk                      (0x1UL << ETH_MACPOCR_APDREQEN_Pos) /*!< 0x00000004 */
-#define ETH_MACPOCR_APDREQEN                          ETH_MACPOCR_APDREQEN_Msk  /* Automatic PTP Pdelay_Req message Enable */
-#define ETH_MACPOCR_ASYNCEN_Pos                       (1U)
-#define ETH_MACPOCR_ASYNCEN_Msk                       (0x1UL << ETH_MACPOCR_ASYNCEN_Pos) /*!< 0x00000002 */
-#define ETH_MACPOCR_ASYNCEN                           ETH_MACPOCR_ASYNCEN_Msk  /* Automatic PTP SYNC message Enable */
-#define ETH_MACPOCR_PTOEN_Pos                         (0U)
-#define ETH_MACPOCR_PTOEN_Msk                         (0x1UL << ETH_MACPOCR_PTOEN_Pos) /*!< 0x00000001 */
-#define ETH_MACPOCR_PTOEN                             ETH_MACPOCR_PTOEN_Msk  /* PTP Offload Enable */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 0 Register */
-#define ETH_MACSPI0R_SPI0_Pos                         (0U)
-#define ETH_MACSPI0R_SPI0_Msk                         (0xFFFFFFFFUL << ETH_MACSPI0R_SPI0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSPI0R_SPI0                             ETH_MACSPI0R_SPI0_Msk  /* Source Port Identity 0 */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 1 Register */
-#define ETH_MACSPI1R_SPI1_Pos                         (0U)
-#define ETH_MACSPI1R_SPI1_Msk                         (0xFFFFFFFFUL << ETH_MACSPI1R_SPI1_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSPI1R_SPI1                             ETH_MACSPI1R_SPI1_Msk  /* Source Port Identity 1 */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 2 Register */
-#define ETH_MACSPI2R_SPI2_Pos                         (0U)
-#define ETH_MACSPI2R_SPI2_Msk                         (0xFFFFUL << ETH_MACSPI2R_SPI2_Pos) /*!< 0x0000FFFF */
-#define ETH_MACSPI2R_SPI2                             ETH_MACSPI2R_SPI2_Msk  /* Source Port Identity 2 */
-
-/* Bit definition for Ethernet MAC Log Message Interval Register */
-#define ETH_MACLMIR_LMPDRI_Pos                        (24U)
-#define ETH_MACLMIR_LMPDRI_Msk                        (0xFFUL << ETH_MACLMIR_LMPDRI_Pos) /*!< 0xFF000000 */
-#define ETH_MACLMIR_LMPDRI                             ETH_MACLMIR_LMPDRI_Msk  /* Log Min Pdelay_Req Interval */
-#define ETH_MACLMIR_DRSYNCR_Pos                       (8U)
-#define ETH_MACLMIR_DRSYNCR_Msk                       (0x7UL << ETH_MACLMIR_DRSYNCR_Pos) /*!< 0x00000700 */
-#define ETH_MACLMIR_DRSYNCR                           ETH_MACLMIR_DRSYNCR_Msk  /* Delay_Req to SYNC Ratio */
-#define ETH_MACLMIR_LSI_Pos                           (0U)
-#define ETH_MACLMIR_LSI_Msk                           (0xFFUL << ETH_MACLMIR_LSI_Pos) /*!< 0x000000FF */
-#define ETH_MACLMIR_LSI                               ETH_MACLMIR_LSI_Msk  /* Log Sync Interval */
-
-/* Bit definition for Ethernet MTL Operation Mode Register */
-#define ETH_MTLOMR_CNTCLR_Pos                         (9U)
-#define ETH_MTLOMR_CNTCLR_Msk                         (0x1UL << ETH_MTLOMR_CNTCLR_Pos) /*!< 0x00000200 */
-#define ETH_MTLOMR_CNTCLR                             ETH_MTLOMR_CNTCLR_Msk    /* Counters Reset */
-#define ETH_MTLOMR_CNTPRST_Pos                        (8U)
-#define ETH_MTLOMR_CNTPRST_Msk                        (0x1UL << ETH_MTLOMR_CNTPRST_Pos) /*!< 0x00000100 */
-#define ETH_MTLOMR_CNTPRST                            ETH_MTLOMR_CNTPRST_Msk   /* Counters Preset */
-#define ETH_MTLOMR_DTXSTS_Pos                         (1U)
-#define ETH_MTLOMR_DTXSTS_Msk                         (0x1UL << ETH_MTLOMR_DTXSTS_Pos) /*!< 0x00000002 */
-#define ETH_MTLOMR_DTXSTS                             ETH_MTLOMR_DTXSTS_Msk  /* Drop Transmit Status */
-
-/* Bit definition for Ethernet MTL Interrupt Status Register */
-#define ETH_MTLISR_MACIS_Pos                          (16U)
-#define ETH_MTLISR_MACIS_Msk                          (0x1UL << ETH_MTLISR_MACIS_Pos) /*!< 0x00010000 */
-#define ETH_MTLISR_MACIS                              ETH_MTLISR_MACIS_Msk     /* MAC Interrupt Status */
-#define ETH_MTLISR_QIS_Pos                            (0U)
-#define ETH_MTLISR_QIS_Msk                            (0x1UL << ETH_MTLISR_QIS_Pos) /*!< 0x00000001 */
-#define ETH_MTLISR_QIS                                ETH_MTLISR_QIS_Msk       /* Queue Interrupt status */
-
-/* Bit definition for Ethernet MTL Tx Queue Operation Mode Register */
-#define ETH_MTLTQOMR_TTC_Pos                          (4U)
-#define ETH_MTLTQOMR_TTC_Msk                          (0x7UL << ETH_MTLTQOMR_TTC_Pos) /*!< 0x00000070 */
-#define ETH_MTLTQOMR_TTC                              ETH_MTLTQOMR_TTC_Msk     /* Transmit Threshold Control */
-#define ETH_MTLTQOMR_TTC_32BITS                       ((uint32_t)0x00000000)   /* 32 bits Threshold */
-#define ETH_MTLTQOMR_TTC_64BITS                       ((uint32_t)0x00000010)   /* 64  bits Threshold */
-#define ETH_MTLTQOMR_TTC_96BITS                       ((uint32_t)0x00000020)   /* 96 bits Threshold */
-#define ETH_MTLTQOMR_TTC_128BITS                      ((uint32_t)0x00000030)   /* 128 bits Threshold */
-#define ETH_MTLTQOMR_TTC_192BITS                      ((uint32_t)0x00000040)   /* 192 bits Threshold */
-#define ETH_MTLTQOMR_TTC_256BITS                      ((uint32_t)0x00000050)   /* 256 bits Threshold */
-#define ETH_MTLTQOMR_TTC_384BITS                      ((uint32_t)0x00000060)   /* 384 bits Threshold */
-#define ETH_MTLTQOMR_TTC_512BITS                      ((uint32_t)0x00000070)   /* 512 bits Threshold */
-#define ETH_MTLTQOMR_TSF_Pos                          (1U)
-#define ETH_MTLTQOMR_TSF_Msk                          (0x1UL << ETH_MTLTQOMR_TSF_Pos) /*!< 0x00000002 */
-#define ETH_MTLTQOMR_TSF                              ETH_MTLTQOMR_TSF_Msk     /* Transmit Store and Forward */
-#define ETH_MTLTQOMR_FTQ_Pos                          (0U)
-#define ETH_MTLTQOMR_FTQ_Msk                          (0x1UL << ETH_MTLTQOMR_FTQ_Pos) /*!< 0x00000001 */
-#define ETH_MTLTQOMR_FTQ                              ETH_MTLTQOMR_FTQ_Msk     /* Flush Transmit Queue */
-
-/* Bit definition for Ethernet MTL Tx Queue Underflow Register */
-#define ETH_MTLTQUR_UFCNTOVF_Pos                      (11U)
-#define ETH_MTLTQUR_UFCNTOVF_Msk                      (0x1UL << ETH_MTLTQUR_UFCNTOVF_Pos) /*!< 0x00000800 */
-#define ETH_MTLTQUR_UFCNTOVF                          ETH_MTLTQUR_UFCNTOVF_Msk /* Overflow Bit for Underflow Packet Counter */
-#define ETH_MTLTQUR_UFPKTCNT_Pos                      (0U)
-#define ETH_MTLTQUR_UFPKTCNT_Msk                      (0x7FFUL << ETH_MTLTQUR_UFPKTCNT_Pos) /*!< 0x000007FF */
-#define ETH_MTLTQUR_UFPKTCNT                          ETH_MTLTQUR_UFPKTCNT_Msk /* Underflow Packet Counter */
-
-/* Bit definition for Ethernet MTL Tx Queue Debug Register */
-#define ETH_MTLTQDR_STXSTSF_Pos                       (20U)
-#define ETH_MTLTQDR_STXSTSF_Msk                       (0x7UL << ETH_MTLTQDR_STXSTSF_Pos) /*!< 0x00700000 */
-#define ETH_MTLTQDR_STXSTSF                           ETH_MTLTQDR_STXSTSF_Msk  /* Number of Status Words in the Tx Status FIFO of Queue */
-#define ETH_MTLTQDR_PTXQ_Pos                          (16U)
-#define ETH_MTLTQDR_PTXQ_Msk                          (0x7UL << ETH_MTLTQDR_PTXQ_Pos) /*!< 0x00070000 */
-#define ETH_MTLTQDR_PTXQ                              ETH_MTLTQDR_PTXQ_Msk     /* Number of Packets in the Transmit Queue */
-#define ETH_MTLTQDR_TXSTSFSTS_Pos                     (5U)
-#define ETH_MTLTQDR_TXSTSFSTS_Msk                     (0x1UL << ETH_MTLTQDR_TXSTSFSTS_Pos) /*!< 0x00000020 */
-#define ETH_MTLTQDR_TXSTSFSTS                         ETH_MTLTQDR_TXSTSFSTS_Msk /* MTL Tx Status FIFO Full Status */
-#define ETH_MTLTQDR_TXQSTS_Pos                        (4U)
-#define ETH_MTLTQDR_TXQSTS_Msk                        (0x1UL << ETH_MTLTQDR_TXQSTS_Pos) /*!< 0x00000010 */
-#define ETH_MTLTQDR_TXQSTS                            ETH_MTLTQDR_TXQSTS_Msk   /* MTL Tx Queue Not Empty Status */
-#define ETH_MTLTQDR_TWCSTS_Pos                        (3U)
-#define ETH_MTLTQDR_TWCSTS_Msk                        (0x1UL << ETH_MTLTQDR_TWCSTS_Pos) /*!< 0x00000008 */
-#define ETH_MTLTQDR_TWCSTS                            ETH_MTLTQDR_TWCSTS_Msk   /* MTL Tx Queue Write Controller Status */
-#define ETH_MTLTQDR_TRCSTS_Pos                        (1U)
-#define ETH_MTLTQDR_TRCSTS_Msk                        (0x3UL << ETH_MTLTQDR_TRCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MTLTQDR_TRCSTS                            ETH_MTLTQDR_TRCSTS_Msk  /* MTL Tx Queue Read Controller Status */
-#define ETH_MTLTQDR_TRCSTS_IDLE                       ((uint32_t)0x00000000)  /* Idle state */
-#define ETH_MTLTQDR_TRCSTS_READ                       ((uint32_t)0x00000002)  /* Read state (transferring data to the MAC transmitter) */
-#define ETH_MTLTQDR_TRCSTS_WAITING                    ((uint32_t)0x00000004)  /* Waiting for pending Tx Status from the MAC transmitter */
-#define ETH_MTLTQDR_TRCSTS_FLUSHING                   ((uint32_t)0x00000006)  /* Flushing the Tx queue because of the Packet Abort request from the MAC */
-#define ETH_MTLTQDR_TXQPAUSED_Pos                     (0U)
-#define ETH_MTLTQDR_TXQPAUSED_Msk                     (0x1UL << ETH_MTLTQDR_TXQPAUSED_Pos) /*!< 0x00000001 */
-#define ETH_MTLTQDR_TXQPAUSED                         ETH_MTLTQDR_TXQPAUSED_Msk /* Transmit Queue in Pause */
-
-/* Bit definition for Ethernet MTL Queue Interrupt Control Status Register */
-#define ETH_MTLQICSR_RXOIE_Pos                        (24U)
-#define ETH_MTLQICSR_RXOIE_Msk                        (0x1UL << ETH_MTLQICSR_RXOIE_Pos) /*!< 0x01000000 */
-#define ETH_MTLQICSR_RXOIE                            ETH_MTLQICSR_RXOIE_Msk   /* Receive Queue Overflow Interrupt Enable */
-#define ETH_MTLQICSR_RXOVFIS_Pos                      (16U)
-#define ETH_MTLQICSR_RXOVFIS_Msk                      (0x1UL << ETH_MTLQICSR_RXOVFIS_Pos) /*!< 0x00010000 */
-#define ETH_MTLQICSR_RXOVFIS                          ETH_MTLQICSR_RXOVFIS_Msk /* Receive Queue Overflow Interrupt Status */
-#define ETH_MTLQICSR_TXUIE_Pos                        (8U)
-#define ETH_MTLQICSR_TXUIE_Msk                        (0x1UL << ETH_MTLQICSR_TXUIE_Pos) /*!< 0x00000100 */
-#define ETH_MTLQICSR_TXUIE                            ETH_MTLQICSR_TXUIE_Msk   /* Transmit Queue Underflow Interrupt Enable */
-#define ETH_MTLQICSR_TXUNFIS_Pos                      (0U)
-#define ETH_MTLQICSR_TXUNFIS_Msk                      (0x1UL << ETH_MTLQICSR_TXUNFIS_Pos) /*!< 0x00000001 */
-#define ETH_MTLQICSR_TXUNFIS                          ETH_MTLQICSR_TXUNFIS_Msk /* Transmit Queue Underflow Interrupt Status */
-
-/* Bit definition for Ethernet MTL Rx Queue Operation Mode Register */
-#define ETH_MTLRQOMR_RQS_Pos                          (20U)
-#define ETH_MTLRQOMR_RQS_Msk                          (0x7UL << ETH_MTLRQOMR_RQS_Pos) /*!< 0x00700000 */
-#define ETH_MTLRQOMR_RQS                              ETH_MTLRQOMR_RQS_Msk /* Receive Queue Size */
-#define ETH_MTLRQOMR_RFD_Pos                          (14U)
-#define ETH_MTLRQOMR_RFD_Msk                          (0x7UL << ETH_MTLRQOMR_RFD_Pos) /*!< 0x0001C000 */
-#define ETH_MTLRQOMR_RFD                              ETH_MTLRQOMR_RFD_Msk /* Threshold for Deactivating Flow Control (in half-duplex and full-duplex modes) */
-#define ETH_MTLRQOMR_RFA_Pos                          (8U)
-#define ETH_MTLRQOMR_RFA_Msk                          (0x7UL << ETH_MTLRQOMR_RFA_Pos) /*!< 0x00000700 */
-#define ETH_MTLRQOMR_RFA                              ETH_MTLRQOMR_RFA_Msk /* Threshold for Activating Flow Control (in half-duplex and full-duplex */
-#define ETH_MTLRQOMR_EHFC_Pos                         (7U)
-#define ETH_MTLRQOMR_EHFC_Msk                         (0x1UL << ETH_MTLRQOMR_EHFC_Pos) /*!< 0x00000080 */
-#define ETH_MTLRQOMR_EHFC                             ETH_MTLRQOMR_EHFC_Msk /* DEnable Hardware Flow Control */
-#define ETH_MTLRQOMR_DISTCPEF_Pos                     (6U)
-#define ETH_MTLRQOMR_DISTCPEF_Msk                     (0x1UL << ETH_MTLRQOMR_DISTCPEF_Pos) /*!< 0x00000040 */
-#define ETH_MTLRQOMR_DISTCPEF                         ETH_MTLRQOMR_DISTCPEF_Msk /* Disable Dropping of TCP/IP Checksum Error Packets */
-#define ETH_MTLRQOMR_RSF_Pos                          (5U)
-#define ETH_MTLRQOMR_RSF_Msk                          (0x1UL << ETH_MTLRQOMR_RSF_Pos) /*!< 0x00000020 */
-#define ETH_MTLRQOMR_RSF                              ETH_MTLRQOMR_RSF_Msk     /* Receive Queue Store and Forward */
-#define ETH_MTLRQOMR_FEP_Pos                          (4U)
-#define ETH_MTLRQOMR_FEP_Msk                          (0x1UL << ETH_MTLRQOMR_FEP_Pos) /*!< 0x00000010 */
-#define ETH_MTLRQOMR_FEP                              ETH_MTLRQOMR_FEP_Msk     /* Forward Error Packets */
-#define ETH_MTLRQOMR_FUP_Pos                          (3U)
-#define ETH_MTLRQOMR_FUP_Msk                          (0x1UL << ETH_MTLRQOMR_FUP_Pos) /*!< 0x00000008 */
-#define ETH_MTLRQOMR_FUP                              ETH_MTLRQOMR_FUP_Msk     /* Forward Undersized Good Packets */
-#define ETH_MTLRQOMR_RTC_Pos                          (0U)
-#define ETH_MTLRQOMR_RTC_Msk                          (0x3UL << ETH_MTLRQOMR_RTC_Pos) /*!< 0x00000003 */
-#define ETH_MTLRQOMR_RTC                              ETH_MTLRQOMR_RTC_Msk     /* Receive Queue Threshold Control */
-#define ETH_MTLRQOMR_RTC_64BITS                       ((uint32_t)0x00000000)   /* 64 bits Threshold */
-#define ETH_MTLRQOMR_RTC_32BITS                       ((uint32_t)0x00000001)   /* 32 bits Threshold */
-#define ETH_MTLRQOMR_RTC_96BITS                       ((uint32_t)0x00000002)   /* 96 bits Threshold */
-#define ETH_MTLRQOMR_RTC_128BITS                      ((uint32_t)0x00000003)   /* 128 bits Threshold */
-
-/* Bit definition for Ethernet MTL Rx Queue Missed Packet Overflow Cnt Register */
-#define ETH_MTLRQMPOCR_MISCNTOVF_Pos                  (27U)
-#define ETH_MTLRQMPOCR_MISCNTOVF_Msk                  (0x1UL << ETH_MTLRQMPOCR_MISCNTOVF_Pos) /*!< 0x08000000 */
-#define ETH_MTLRQMPOCR_MISCNTOVF                      ETH_MTLRQMPOCR_MISCNTOVF_Msk /* Missed Packet Counter Overflow Bit */
-#define ETH_MTLRQMPOCR_MISPKTCNT_Pos                  (16U)
-#define ETH_MTLRQMPOCR_MISPKTCNT_Msk                  (0x7FFUL << ETH_MTLRQMPOCR_MISPKTCNT_Pos) /*!< 0x07FF0000 */
-#define ETH_MTLRQMPOCR_MISPKTCNT                      ETH_MTLRQMPOCR_MISPKTCNT_Msk /* Missed Packet Counter */
-#define ETH_MTLRQMPOCR_OVFCNTOVF_Pos                  (11U)
-#define ETH_MTLRQMPOCR_OVFCNTOVF_Msk                  (0x1UL << ETH_MTLRQMPOCR_OVFCNTOVF_Pos) /*!< 0x00000800 */
-#define ETH_MTLRQMPOCR_OVFCNTOVF                      ETH_MTLRQMPOCR_OVFCNTOVF_Msk /* Overflow Counter Overflow Bit */
-#define ETH_MTLRQMPOCR_OVFPKTCNT_Pos                  (0U)
-#define ETH_MTLRQMPOCR_OVFPKTCNT_Msk                  (0x7FFUL << ETH_MTLRQMPOCR_OVFPKTCNT_Pos) /*!< 0x000007FF */
-#define ETH_MTLRQMPOCR_OVFPKTCNT                      ETH_MTLRQMPOCR_OVFPKTCNT_Msk /* Overflow Packet Counter */
-
-/* Bit definition for Ethernet MTL Rx Queue Debug Register */
-#define ETH_MTLRQDR_PRXQ_Pos                          (16U)
-#define ETH_MTLRQDR_PRXQ_Msk                          (0x3FFFUL << ETH_MTLRQDR_PRXQ_Pos) /*!< 0x3FFF0000 */
-#define ETH_MTLRQDR_PRXQ                              ETH_MTLRQDR_PRXQ_Msk     /* Number of Packets in Receive Queue */
-#define ETH_MTLRQDR_RXQSTS_Pos                        (4U)
-#define ETH_MTLRQDR_RXQSTS_Msk                        (0x3UL << ETH_MTLRQDR_RXQSTS_Pos) /*!< 0x00000030 */
-#define ETH_MTLRQDR_RXQSTS                            ETH_MTLRQDR_RXQSTS_Msk   /* MTL Rx Queue Fill-Level Status */
-#define ETH_MTLRQDR_RXQSTS_EMPTY                      ((uint32_t)0x00000000)   /* Rx Queue empty */
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Pos         (4U)
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Msk         (0x1UL << ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Pos) /*!< 0x00000010 */
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD             ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Msk /* Rx Queue fill-level below flow-control deactivate threshold */
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Pos         (5U)
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Msk         (0x1UL << ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Pos) /*!< 0x00000020 */
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD             ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Msk /* Rx Queue fill-level above flow-control activate threshold */
-#define ETH_MTLRQDR_RXQSTS_FULL_Pos                   (4U)
-#define ETH_MTLRQDR_RXQSTS_FULL_Msk                   (0x3UL << ETH_MTLRQDR_RXQSTS_FULL_Pos) /*!< 0x00000030 */
-#define ETH_MTLRQDR_RXQSTS_FULL                       ETH_MTLRQDR_RXQSTS_FULL_Msk /* Rx Queue full */
-#define ETH_MTLRQDR_RRCSTS_Pos                        (1U)
-#define ETH_MTLRQDR_RRCSTS_Msk                        (0x3UL << ETH_MTLRQDR_RRCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MTLRQDR_RRCSTS                            ETH_MTLRQDR_RRCSTS_Msk   /* MTL Rx Queue Read Controller State */
-#define ETH_MTLRQDR_RRCSTS_IDLE                       ((uint32_t)0x00000000)   /* Idle state */
-#define ETH_MTLRQDR_RRCSTS_READINGDATA_Pos            (1U)
-#define ETH_MTLRQDR_RRCSTS_READINGDATA_Msk            (0x1UL << ETH_MTLRQDR_RRCSTS_READINGDATA_Pos) /*!< 0x00000002 */
-#define ETH_MTLRQDR_RRCSTS_READINGDATA                ETH_MTLRQDR_RRCSTS_READINGDATA_Msk /* Reading packet data */
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS_Pos          (2U)
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS_Msk          (0x1UL << ETH_MTLRQDR_RRCSTS_READINGSTATUS_Pos) /*!< 0x00000004 */
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS              ETH_MTLRQDR_RRCSTS_READINGSTATUS_Msk /* Reading packet status (or timestamp) */
-#define ETH_MTLRQDR_RRCSTS_FLUSHING_Pos               (1U)
-#define ETH_MTLRQDR_RRCSTS_FLUSHING_Msk               (0x3UL << ETH_MTLRQDR_RRCSTS_FLUSHING_Pos) /*!< 0x00000006 */
-#define ETH_MTLRQDR_RRCSTS_FLUSHING                   ETH_MTLRQDR_RRCSTS_FLUSHING_Msk /* Flushing the packet data and status */
-#define ETH_MTLRQDR_RWCSTS_Pos                        (0U)
-#define ETH_MTLRQDR_RWCSTS_Msk                        (0x1UL << ETH_MTLRQDR_RWCSTS_Pos) /*!< 0x00000001 */
-#define ETH_MTLRQDR_RWCSTS                            ETH_MTLRQDR_RWCSTS_Msk   /* MTL Rx Queue Write Controller Active Status */
-
-/* Bit definition for Ethernet MTL Rx Queue Control Register */
-#define ETH_MTLRQCR_RQPA_Pos                          (3U)
-#define ETH_MTLRQCR_RQPA_Msk                          (0x1UL << ETH_MTLRQCR_RQPA_Pos) /*!< 0x00000008 */
-#define ETH_MTLRQCR_RQPA                              ETH_MTLRQCR_RQPA_Msk     /* Receive Queue Packet Arbitration */
-#define ETH_MTLRQCR_RQW_Pos                           (0U)
-#define ETH_MTLRQCR_RQW_Msk                           (0x7UL << ETH_MTLRQCR_RQW_Pos) /*!< 0x00000007 */
-#define ETH_MTLRQCR_RQW                               ETH_MTLRQCR_RQW_Msk      /* Receive Queue Weight */
-
-/* Bit definition for Ethernet DMA Mode Register */
-#define ETH_DMAMR_INTM_Pos                            (16U)
-#define ETH_DMAMR_INTM_Msk                            (0x3UL << ETH_DMAMR_INTM_Pos) /*!< 0x00030000 */
-#define ETH_DMAMR_INTM                                ETH_DMAMR_INTM_Msk       /* This field defines the interrupt mode */
-#define ETH_DMAMR_INTM_0                              (0x0UL << ETH_DMAMR_INTM_Pos) /*!< 0x00000000 */
-#define ETH_DMAMR_INTM_1                              (0x1UL << ETH_DMAMR_INTM_Pos) /*!< 0x00010000 */
-#define ETH_DMAMR_INTM_2                              (0x2UL << ETH_DMAMR_INTM_Pos) /*!< 0x00020000 */
-#define ETH_DMAMR_PR_Pos                              (12U)
-#define ETH_DMAMR_PR_Msk                              (0x7UL << ETH_DMAMR_PR_Pos) /*!< 0x00007000 */
-#define ETH_DMAMR_PR                                  ETH_DMAMR_PR_Msk         /* Priority Ratio */
-#define ETH_DMAMR_PR_1_1                              ((uint32_t)0x00000000)   /* The priority ratio is 1:1 */
-#define ETH_DMAMR_PR_2_1                              ((uint32_t)0x00001000)   /* The priority ratio is 2:1 */
-#define ETH_DMAMR_PR_3_1                              ((uint32_t)0x00002000)   /* The priority ratio is 3:1 */
-#define ETH_DMAMR_PR_4_1                              ((uint32_t)0x00003000)   /* The priority ratio is 4:1 */
-#define ETH_DMAMR_PR_5_1                              ((uint32_t)0x00004000)   /* The priority ratio is 5:1 */
-#define ETH_DMAMR_PR_6_1                              ((uint32_t)0x00005000)   /* The priority ratio is 6:1 */
-#define ETH_DMAMR_PR_7_1                              ((uint32_t)0x00006000)   /* The priority ratio is 7:1 */
-#define ETH_DMAMR_PR_8_1                              ((uint32_t)0x00007000)   /* The priority ratio is 8:1 */
-#define ETH_DMAMR_TXPR_Pos                            (11U)
-#define ETH_DMAMR_TXPR_Msk                            (0x1UL << ETH_DMAMR_TXPR_Pos) /*!< 0x00000800 */
-#define ETH_DMAMR_TXPR                                ETH_DMAMR_TXPR_Msk       /* Transmit Priority */
-#define ETH_DMAMR_DA_Pos                              (1U)
-#define ETH_DMAMR_DA_Msk                              (0x1UL << ETH_DMAMR_DA_Pos) /*!< 0x00000002 */
-#define ETH_DMAMR_DA                                  ETH_DMAMR_DA_Msk         /* DMA Tx or Rx Arbitration Scheme */
-#define ETH_DMAMR_SWR_Pos                             (0U)
-#define ETH_DMAMR_SWR_Msk                             (0x1UL << ETH_DMAMR_SWR_Pos) /*!< 0x00000001 */
-#define ETH_DMAMR_SWR                                 ETH_DMAMR_SWR_Msk        /* Software Reset */
-
-/* Bit definition for Ethernet DMA SysBus Mode Register */
-#define ETH_DMASBMR_RB_Pos                            (15U)
-#define ETH_DMASBMR_RB_Msk                            (0x1UL << ETH_DMASBMR_RB_Pos) /*!< 0x00008000 */
-#define ETH_DMASBMR_RB                                ETH_DMASBMR_RB_Msk       /* Rebuild INCRx Burst */
-#define ETH_DMASBMR_MB_Pos                            (14U)
-#define ETH_DMASBMR_MB_Msk                            (0x1UL << ETH_DMASBMR_MB_Pos) /*!< 0x00004000 */
-#define ETH_DMASBMR_MB                                ETH_DMASBMR_MB_Msk       /* Mixed Burst */
-#define ETH_DMASBMR_AAL_Pos                           (12U)
-#define ETH_DMASBMR_AAL_Msk                           (0x1UL << ETH_DMASBMR_AAL_Pos) /*!< 0x00001000 */
-#define ETH_DMASBMR_AAL                               ETH_DMASBMR_AAL_Msk      /* Address-Aligned Beats */
-#define ETH_DMASBMR_FB_Pos                            (0U)
-#define ETH_DMASBMR_FB_Msk                            (0x1UL << ETH_DMASBMR_FB_Pos) /*!< 0x00000001 */
-#define ETH_DMASBMR_FB                                ETH_DMASBMR_FB_Msk       /* Fixed Burst Length */
-
-/* Bit definition for Ethernet DMA Interrupt Status Register */
-#define ETH_DMAISR_MACIS_Pos                          (17U)
-#define ETH_DMAISR_MACIS_Msk                          (0x1UL << ETH_DMAISR_MACIS_Pos) /*!< 0x00020000 */
-#define ETH_DMAISR_MACIS                              ETH_DMAISR_MACIS_Msk     /* MAC Interrupt Status */
-#define ETH_DMAISR_MTLIS_Pos                          (16U)
-#define ETH_DMAISR_MTLIS_Msk                          (0x1UL << ETH_DMAISR_MTLIS_Pos) /*!< 0x00010000 */
-#define ETH_DMAISR_MTLIS                              ETH_DMAISR_MTLIS_Msk     /* MAC Interrupt Status */
-#define ETH_DMAISR_DMACIS_Pos                         (0U)
-#define ETH_DMAISR_DMACIS_Msk                         (0x1UL << ETH_DMAISR_DMACIS_Pos) /*!< 0x00000001 */
-#define ETH_DMAISR_DMACIS                             ETH_DMAISR_DMACIS_Msk    /* DMA Channel Interrupt Status */
-
-/* Bit definition for Ethernet DMA Debug Status Register */
-#define ETH_DMADSR_TPS_Pos                            (12U)
-#define ETH_DMADSR_TPS_Msk                            (0xFUL << ETH_DMADSR_TPS_Pos) /*!< 0x0000F000 */
-#define ETH_DMADSR_TPS                                ETH_DMADSR_TPS_Msk       /* DMA Channel Transmit Process State */
-#define ETH_DMADSR_TPS_STOPPED                        ((uint32_t)0x00000000)   /* Stopped (Reset or Stop Transmit Command issued) */
-#define ETH_DMADSR_TPS_FETCHING_Pos                   (12U)
-#define ETH_DMADSR_TPS_FETCHING_Msk                   (0x1UL << ETH_DMADSR_TPS_FETCHING_Pos) /*!< 0x00001000 */
-#define ETH_DMADSR_TPS_FETCHING                       ETH_DMADSR_TPS_FETCHING_Msk /* Running (Fetching Tx Transfer Descriptor) */
-#define ETH_DMADSR_TPS_WAITING_Pos                    (13U)
-#define ETH_DMADSR_TPS_WAITING_Msk                    (0x1UL << ETH_DMADSR_TPS_WAITING_Pos) /*!< 0x00002000 */
-#define ETH_DMADSR_TPS_WAITING                        ETH_DMADSR_TPS_WAITING_Msk /* Running (Waiting for status) */
-#define ETH_DMADSR_TPS_READING_Pos                    (12U)
-#define ETH_DMADSR_TPS_READING_Msk                    (0x3UL << ETH_DMADSR_TPS_READING_Pos) /*!< 0x00003000 */
-#define ETH_DMADSR_TPS_READING                        ETH_DMADSR_TPS_READING_Msk /* Running (Reading Data from system memory buffer and queuing it to the Tx buffer (Tx FIFO)) */
-#define ETH_DMADSR_TPS_TIMESTAMP_WR_Pos               (14U)
-#define ETH_DMADSR_TPS_TIMESTAMP_WR_Msk               (0x1UL << ETH_DMADSR_TPS_TIMESTAMP_WR_Pos) /*!< 0x00004000 */
-#define ETH_DMADSR_TPS_TIMESTAMP_WR                   ETH_DMADSR_TPS_TIMESTAMP_WR_Msk /* Timestamp write state */
-#define ETH_DMADSR_TPS_SUSPENDED_Pos                  (13U)
-#define ETH_DMADSR_TPS_SUSPENDED_Msk                  (0x3UL << ETH_DMADSR_TPS_SUSPENDED_Pos) /*!< 0x00006000 */
-#define ETH_DMADSR_TPS_SUSPENDED                      ETH_DMADSR_TPS_SUSPENDED_Msk /* Suspended (Tx Descriptor Unavailable or Tx Buffer Underflow) */
-#define ETH_DMADSR_TPS_CLOSING_Pos                    (12U)
-#define ETH_DMADSR_TPS_CLOSING_Msk                    (0x7UL << ETH_DMADSR_TPS_CLOSING_Pos) /*!< 0x00007000 */
-#define ETH_DMADSR_TPS_CLOSING                        ETH_DMADSR_TPS_CLOSING_Msk /* Running (Closing Tx Descriptor) */
-#define ETH_DMADSR_RPS_Pos                            (8U)
-#define ETH_DMADSR_RPS_Msk                            (0xFUL << ETH_DMADSR_RPS_Pos) /*!< 0x00000F00 */
-#define ETH_DMADSR_RPS                                ETH_DMADSR_RPS_Msk       /* DMA Channel Receive Process State */
-#define ETH_DMADSR_RPS_STOPPED                        ((uint32_t)0x00000000)   /* Stopped (Reset or Stop Receive Command issued) */
-#define ETH_DMADSR_RPS_FETCHING_Pos                   (12U)
-#define ETH_DMADSR_RPS_FETCHING_Msk                   (0x1UL << ETH_DMADSR_RPS_FETCHING_Pos) /*!< 0x00001000 */
-#define ETH_DMADSR_RPS_FETCHING                       ETH_DMADSR_RPS_FETCHING_Msk /* Running (Fetching Rx Transfer Descriptor) */
-#define ETH_DMADSR_RPS_WAITING_Pos                    (12U)
-#define ETH_DMADSR_RPS_WAITING_Msk                    (0x3UL << ETH_DMADSR_RPS_WAITING_Pos) /*!< 0x00003000 */
-#define ETH_DMADSR_RPS_WAITING                        ETH_DMADSR_RPS_WAITING_Msk /* Running (Waiting for status) */
-#define ETH_DMADSR_RPS_SUSPENDED_Pos                  (14U)
-#define ETH_DMADSR_RPS_SUSPENDED_Msk                  (0x1UL << ETH_DMADSR_RPS_SUSPENDED_Pos) /*!< 0x00004000 */
-#define ETH_DMADSR_RPS_SUSPENDED                      ETH_DMADSR_RPS_SUSPENDED_Msk /* Suspended (Rx Descriptor Unavailable) */
-#define ETH_DMADSR_RPS_CLOSING_Pos                    (12U)
-#define ETH_DMADSR_RPS_CLOSING_Msk                    (0x5UL << ETH_DMADSR_RPS_CLOSING_Pos) /*!< 0x00005000 */
-#define ETH_DMADSR_RPS_CLOSING                        ETH_DMADSR_RPS_CLOSING_Msk /* Running (Closing the Rx Descriptor) */
-#define ETH_DMADSR_RPS_TIMESTAMP_WR_Pos               (13U)
-#define ETH_DMADSR_RPS_TIMESTAMP_WR_Msk               (0x3UL << ETH_DMADSR_RPS_TIMESTAMP_WR_Pos) /*!< 0x00006000 */
-#define ETH_DMADSR_RPS_TIMESTAMP_WR                   ETH_DMADSR_RPS_TIMESTAMP_WR_Msk /* Timestamp write state */
-#define ETH_DMADSR_RPS_TRANSFERRING_Pos               (12U)
-#define ETH_DMADSR_RPS_TRANSFERRING_Msk               (0x7UL << ETH_DMADSR_RPS_TRANSFERRING_Pos) /*!< 0x00007000 */
-#define ETH_DMADSR_RPS_TRANSFERRING                   ETH_DMADSR_RPS_TRANSFERRING_Msk /* Running (Transferring the received packet data from the Rx buffer to the system memory) */
-
-/* Bit definition for Ethernet DMA Channel Control Register */
-#define ETH_DMACCR_DSL_Pos                            (18U)
-#define ETH_DMACCR_DSL_Msk                            (0x7UL << ETH_DMACCR_DSL_Pos) /*!< 0x001C0000 */
-#define ETH_DMACCR_DSL                                ETH_DMACCR_DSL_Msk       /* Descriptor Skip Length */
-#define ETH_DMACCR_DSL_0BIT                           ((uint32_t)0x00000000)
-#define ETH_DMACCR_DSL_32BIT                          ((uint32_t)0x00040000)
-#define ETH_DMACCR_DSL_64BIT                          ((uint32_t)0x00080000)
-#define ETH_DMACCR_DSL_128BIT                         ((uint32_t)0x00100000)
-#define ETH_DMACCR_8PBL                               ((uint32_t)0x00010000)   /* 8xPBL mode */
-#define ETH_DMACCR_MSS_Pos                            (0U)
-#define ETH_DMACCR_MSS_Msk                            (0x3FFFUL << ETH_DMACCR_MSS_Pos) /*!< 0x00003FFF */
-#define ETH_DMACCR_MSS                                ETH_DMACCR_MSS_Msk       /* Maximum Segment Size */
-
-/* Bit definition for Ethernet DMA Channel Tx Control Register */
-#define ETH_DMACTCR_TPBL_Pos                          (16U)
-#define ETH_DMACTCR_TPBL_Msk                          (0x3FUL << ETH_DMACTCR_TPBL_Pos) /*!< 0x003F0000 */
-#define ETH_DMACTCR_TPBL                              ETH_DMACTCR_TPBL_Msk     /* Transmit Programmable Burst Length */
-#define ETH_DMACTCR_TPBL_1PBL                         ((uint32_t)0x00010000)   /* Transmit Programmable Burst Length 1 */
-#define ETH_DMACTCR_TPBL_2PBL                         ((uint32_t)0x00020000)   /* Transmit Programmable Burst Length 2 */
-#define ETH_DMACTCR_TPBL_4PBL                         ((uint32_t)0x00040000)   /* Transmit Programmable Burst Length 4 */
-#define ETH_DMACTCR_TPBL_8PBL                         ((uint32_t)0x00080000)   /* Transmit Programmable Burst Length 8 */
-#define ETH_DMACTCR_TPBL_16PBL                        ((uint32_t)0x00100000)   /* Transmit Programmable Burst Length 16 */
-#define ETH_DMACTCR_TPBL_32PBL                        ((uint32_t)0x00200000)   /* Transmit Programmable Burst Length 32 */
-#define ETH_DMACTCR_TSE_Pos                           (12U)
-#define ETH_DMACTCR_TSE_Msk                           (0x1UL << ETH_DMACTCR_TSE_Pos) /*!< 0x00001000 */
-#define ETH_DMACTCR_TSE                               ETH_DMACTCR_TSE_Msk      /* TCP Segmentation Enabled */
-#define ETH_DMACTCR_OSP_Pos                           (4U)
-#define ETH_DMACTCR_OSP_Msk                           (0x1UL << ETH_DMACTCR_OSP_Pos) /*!< 0x00000010 */
-#define ETH_DMACTCR_OSP                               ETH_DMACTCR_OSP_Msk      /* Operate on Second Packet */
-#define ETH_DMACTCR_ST_Pos                            (0U)
-#define ETH_DMACTCR_ST_Msk                            (0x1UL << ETH_DMACTCR_ST_Pos) /*!< 0x00000001 */
-#define ETH_DMACTCR_ST                                ETH_DMACTCR_ST_Msk       /* Start or Stop Transmission Command */
-
-/* Bit definition for Ethernet DMA Channel Rx Control Register */
-#define ETH_DMACRCR_RPF_Pos                           (31U)
-#define ETH_DMACRCR_RPF_Msk                           (0x1UL << ETH_DMACRCR_RPF_Pos) /*!< 0x80000000 */
-#define ETH_DMACRCR_RPF                               ETH_DMACRCR_RPF_Msk      /* Rx Packet Flush */
-#define ETH_DMACRCR_RPBL_Pos                          (16U)
-#define ETH_DMACRCR_RPBL_Msk                          (0x3FUL << ETH_DMACRCR_RPBL_Pos) /*!< 0x003F0000 */
-#define ETH_DMACRCR_RPBL                              ETH_DMACRCR_RPBL_Msk     /* Receive Programmable Burst Length */
-#define ETH_DMACRCR_RPBL_1PBL                         ((uint32_t)0x00010000)   /* Receive Programmable Burst Length 1 */
-#define ETH_DMACRCR_RPBL_2PBL                         ((uint32_t)0x00020000)   /* Receive Programmable Burst Length 2 */
-#define ETH_DMACRCR_RPBL_4PBL                         ((uint32_t)0x00040000)   /* Receive Programmable Burst Length 4 */
-#define ETH_DMACRCR_RPBL_8PBL                         ((uint32_t)0x00080000)   /* Receive Programmable Burst Length 8 */
-#define ETH_DMACRCR_RPBL_16PBL                        ((uint32_t)0x00100000)   /* Receive Programmable Burst Length 16 */
-#define ETH_DMACRCR_RPBL_32PBL                        ((uint32_t)0x00200000)   /* Receive Programmable Burst Length 32 */
-#define ETH_DMACRCR_RBSZ_Pos                          (1U)
-#define ETH_DMACRCR_RBSZ_Msk                          (0x3FFFUL << ETH_DMACRCR_RBSZ_Pos) /*!< 0x00007FFE */
-#define ETH_DMACRCR_RBSZ                              ETH_DMACRCR_RBSZ_Msk     /* Receive Buffer size */
-#define ETH_DMACRCR_SR_Pos                            (0U)
-#define ETH_DMACRCR_SR_Msk                            (0x1UL << ETH_DMACRCR_SR_Pos) /*!< 0x00000001 */
-#define ETH_DMACRCR_SR                                ETH_DMACRCR_SR_Msk       /* Start or Stop Receive */
-
-/* Bit definition for Ethernet DMA CH Tx Desc List Address Register */
-#define ETH_DMACTDLAR_TDESLA_Pos                      (2U)
-#define ETH_DMACTDLAR_TDESLA_Msk                      (0x3FFFFFFFUL << ETH_DMACTDLAR_TDESLA_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACTDLAR_TDESLA                          ETH_DMACTDLAR_TDESLA_Msk /* Start of Transmit List */
-
-/* Bit definition for Ethernet DMA CH Rx Desc List Address Register */
-#define ETH_DMACRDLAR_RDESLA_Pos                      (2U)
-#define ETH_DMACRDLAR_RDESLA_Msk                      (0x3FFFFFFFUL << ETH_DMACRDLAR_RDESLA_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACRDLAR_RDESLA                          ETH_DMACRDLAR_RDESLA_Msk /* Start of Receive List */
-
-/* Bit definition for Ethernet DMA CH Tx Desc Tail Pointer Register */
-#define ETH_DMACTDTPR_TDT_Pos                         (2U)
-#define ETH_DMACTDTPR_TDT_Msk                         (0x3FFFFFFFUL << ETH_DMACTDTPR_TDT_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACTDTPR_TDT                             ETH_DMACTDTPR_TDT_Msk    /* Transmit Descriptor Tail Pointer */
-
-/* Bit definition for Ethernet DMA CH Rx Desc Tail Pointer Register */
-#define ETH_DMACRDTPR_RDT_Pos                         (2U)
-#define ETH_DMACRDTPR_RDT_Msk                         (0x3FFFFFFFUL << ETH_DMACRDTPR_RDT_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACRDTPR_RDT                             ETH_DMACRDTPR_RDT_Msk    /* Receive Descriptor Tail Pointer */
-
-/* Bit definition for Ethernet DMA CH Tx Desc Ring Length Register */
-#define ETH_DMACTDRLR_TDRL_Pos                        (0U)
-#define ETH_DMACTDRLR_TDRL_Msk                        (0x3FFUL << ETH_DMACTDRLR_TDRL_Pos) /*!< 0x000003FF */
-#define ETH_DMACTDRLR_TDRL                            ETH_DMACTDRLR_TDRL_Msk   /* Transmit Descriptor Ring Length */
-
-/* Bit definition for Ethernet DMA CH Rx Desc Ring Length Register */
-#define ETH_DMACRDRLR_RDRL_Pos                        (0U)
-#define ETH_DMACRDRLR_RDRL_Msk                        (0x3FFUL << ETH_DMACRDRLR_RDRL_Pos) /*!< 0x000003FF */
-#define ETH_DMACRDRLR_RDRL                            ETH_DMACRDRLR_RDRL_Msk   /* Receive Descriptor Ring Length */
-
-/* Bit definition for Ethernet DMA Channel Interrupt Enable Register */
-#define ETH_DMACIER_NIE_Pos                           (15U)
-#define ETH_DMACIER_NIE_Msk                           (0x1UL << ETH_DMACIER_NIE_Pos) /*!< 0x00008000 */
-#define ETH_DMACIER_NIE                               ETH_DMACIER_NIE_Msk      /* Normal Interrupt Summary Enable */
-#define ETH_DMACIER_AIE_Pos                           (14U)
-#define ETH_DMACIER_AIE_Msk                           (0x1UL << ETH_DMACIER_AIE_Pos) /*!< 0x00004000 */
-#define ETH_DMACIER_AIE                               ETH_DMACIER_AIE_Msk      /* Abnormal Interrupt Summary Enable */
-#define ETH_DMACIER_CDEE_Pos                          (13U)
-#define ETH_DMACIER_CDEE_Msk                          (0x1UL << ETH_DMACIER_CDEE_Pos) /*!< 0x00002000 */
-#define ETH_DMACIER_CDEE                              ETH_DMACIER_CDEE_Msk     /* Context Descriptor Error Enable */
-#define ETH_DMACIER_FBEE_Pos                          (12U)
-#define ETH_DMACIER_FBEE_Msk                          (0x1UL << ETH_DMACIER_FBEE_Pos) /*!< 0x00001000 */
-#define ETH_DMACIER_FBEE                              ETH_DMACIER_FBEE_Msk     /* Fatal Bus Error Enable */
-#define ETH_DMACIER_ERIE_Pos                          (11U)
-#define ETH_DMACIER_ERIE_Msk                          (0x1UL << ETH_DMACIER_ERIE_Pos) /*!< 0x00000800 */
-#define ETH_DMACIER_ERIE                              ETH_DMACIER_ERIE_Msk     /* Early Receive Interrupt Enable */
-#define ETH_DMACIER_ETIE_Pos                          (10U)
-#define ETH_DMACIER_ETIE_Msk                          (0x1UL << ETH_DMACIER_ETIE_Pos) /*!< 0x00000400 */
-#define ETH_DMACIER_ETIE                              ETH_DMACIER_ETIE_Msk     /* Early Transmit Interrupt Enable */
-#define ETH_DMACIER_RWTE_Pos                          (9U)
-#define ETH_DMACIER_RWTE_Msk                          (0x1UL << ETH_DMACIER_RWTE_Pos) /*!< 0x00000200 */
-#define ETH_DMACIER_RWTE                              ETH_DMACIER_RWTE_Msk     /* Receive Watchdog Timeout Enable */
-#define ETH_DMACIER_RSE_Pos                           (8U)
-#define ETH_DMACIER_RSE_Msk                           (0x1UL << ETH_DMACIER_RSE_Pos) /*!< 0x00000100 */
-#define ETH_DMACIER_RSE                               ETH_DMACIER_RSE_Msk      /* Receive Stopped Enable */
-#define ETH_DMACIER_RBUE_Pos                          (7U)
-#define ETH_DMACIER_RBUE_Msk                          (0x1UL << ETH_DMACIER_RBUE_Pos) /*!< 0x00000080 */
-#define ETH_DMACIER_RBUE                              ETH_DMACIER_RBUE_Msk     /* Receive Buffer Unavailable Enable */
-#define ETH_DMACIER_RIE_Pos                           (6U)
-#define ETH_DMACIER_RIE_Msk                           (0x1UL << ETH_DMACIER_RIE_Pos) /*!< 0x00000040 */
-#define ETH_DMACIER_RIE                               ETH_DMACIER_RIE_Msk      /* Receive Interrupt Enable */
-#define ETH_DMACIER_TBUE_Pos                          (2U)
-#define ETH_DMACIER_TBUE_Msk                          (0x1UL << ETH_DMACIER_TBUE_Pos) /*!< 0x00000004 */
-#define ETH_DMACIER_TBUE                              ETH_DMACIER_TBUE_Msk     /* Transmit Buffer Unavailable Enable */
-#define ETH_DMACIER_TXSE_Pos                          (1U)
-#define ETH_DMACIER_TXSE_Msk                          (0x1UL << ETH_DMACIER_TXSE_Pos) /*!< 0x00000002 */
-#define ETH_DMACIER_TXSE                              ETH_DMACIER_TXSE_Msk     /* Transmit Stopped Enable */
-#define ETH_DMACIER_TIE_Pos                           (0U)
-#define ETH_DMACIER_TIE_Msk                           (0x1UL << ETH_DMACIER_TIE_Pos) /*!< 0x00000001 */
-#define ETH_DMACIER_TIE                               ETH_DMACIER_TIE_Msk      /* Transmit Interrupt Enable */
-
-/* Bit definition for Ethernet DMA Channel Rx Interrupt Watchdog Timer Register */
-#define ETH_DMACRIWTR_RWT_Pos                         (0U)
-#define ETH_DMACRIWTR_RWT_Msk                         (0xFFUL << ETH_DMACRIWTR_RWT_Pos) /*!< 0x000000FF */
-#define ETH_DMACRIWTR_RWT                             ETH_DMACRIWTR_RWT_Msk    /* Receive Interrupt Watchdog Timer Count */
-
-/* Bit definition for Ethernet DMA Channel Current App Tx Desc Register */
-#define ETH_DMACCATDR_CURTDESAPTR_Pos                 (0U)
-#define ETH_DMACCATDR_CURTDESAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCATDR_CURTDESAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCATDR_CURTDESAPTR                     ETH_DMACCATDR_CURTDESAPTR_Msk /* Application Transmit Descriptor Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Rx Desc Register */
-#define ETH_DMACCARDR_CURRDESAPTR_Pos                 (0U)
-#define ETH_DMACCARDR_CURRDESAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCARDR_CURRDESAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCARDR_CURRDESAPTR                     ETH_DMACCARDR_CURRDESAPTR_Msk /* Application Receive Descriptor Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Tx Buffer Register */
-#define ETH_DMACCATBR_CURTBUFAPTR_Pos                 (0U)
-#define ETH_DMACCATBR_CURTBUFAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCATBR_CURTBUFAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCATBR_CURTBUFAPTR                     ETH_DMACCATBR_CURTBUFAPTR_Msk /* Application Transmit Buffer Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Rx Buffer Register */
-#define ETH_DMACCARBR_CURRBUFAPTR_Pos                 (0U)
-#define ETH_DMACCARBR_CURRBUFAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCARBR_CURRBUFAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCARBR_CURRBUFAPTR                     ETH_DMACCARBR_CURRBUFAPTR_Msk /* Application Receive Buffer Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Status Register */
-#define ETH_DMACSR_REB_Pos                            (19U)
-#define ETH_DMACSR_REB_Msk                            (0x7UL << ETH_DMACSR_REB_Pos) /*!< 0x00380000 */
-#define ETH_DMACSR_REB                                ETH_DMACSR_REB_Msk       /* Rx DMA Error Bits */
-#define ETH_DMACSR_TEB_Pos                            (16U)
-#define ETH_DMACSR_TEB_Msk                            (0x7UL << ETH_DMACSR_TEB_Pos) /*!< 0x00070000 */
-#define ETH_DMACSR_TEB                                ETH_DMACSR_TEB_Msk       /* Tx DMA Error Bits */
-#define ETH_DMACSR_NIS_Pos                            (15U)
-#define ETH_DMACSR_NIS_Msk                            (0x1UL << ETH_DMACSR_NIS_Pos) /*!< 0x00008000 */
-#define ETH_DMACSR_NIS                                ETH_DMACSR_NIS_Msk       /* Normal Interrupt Summary */
-#define ETH_DMACSR_AIS_Pos                            (14U)
-#define ETH_DMACSR_AIS_Msk                            (0x1UL << ETH_DMACSR_AIS_Pos) /*!< 0x00004000 */
-#define ETH_DMACSR_AIS                                ETH_DMACSR_AIS_Msk       /* Abnormal Interrupt Summary */
-#define ETH_DMACSR_CDE_Pos                            (13U)
-#define ETH_DMACSR_CDE_Msk                            (0x1UL << ETH_DMACSR_CDE_Pos) /*!< 0x00002000 */
-#define ETH_DMACSR_CDE                                ETH_DMACSR_CDE_Msk       /* Context Descriptor Error */
-#define ETH_DMACSR_FBE_Pos                            (12U)
-#define ETH_DMACSR_FBE_Msk                            (0x1UL << ETH_DMACSR_FBE_Pos) /*!< 0x00001000 */
-#define ETH_DMACSR_FBE                                ETH_DMACSR_FBE_Msk       /* Fatal Bus Error */
-#define ETH_DMACSR_ERI_Pos                            (11U)
-#define ETH_DMACSR_ERI_Msk                            (0x1UL << ETH_DMACSR_ERI_Pos) /*!< 0x00000800 */
-#define ETH_DMACSR_ERI                                ETH_DMACSR_ERI_Msk       /* Early Receive Interrupt */
-#define ETH_DMACSR_ETI_Pos                            (10U)
-#define ETH_DMACSR_ETI_Msk                            (0x1UL << ETH_DMACSR_ETI_Pos) /*!< 0x00000400 */
-#define ETH_DMACSR_ETI                                ETH_DMACSR_ETI_Msk       /* Early Transmit Interrupt */
-#define ETH_DMACSR_RWT_Pos                            (9U)
-#define ETH_DMACSR_RWT_Msk                            (0x1UL << ETH_DMACSR_RWT_Pos) /*!< 0x00000200 */
-#define ETH_DMACSR_RWT                                ETH_DMACSR_RWT_Msk       /* Receive Watchdog Timeout */
-#define ETH_DMACSR_RPS_Pos                            (8U)
-#define ETH_DMACSR_RPS_Msk                            (0x1UL << ETH_DMACSR_RPS_Pos) /*!< 0x00000100 */
-#define ETH_DMACSR_RPS                                ETH_DMACSR_RPS_Msk       /* Receive Process Stopped */
-#define ETH_DMACSR_RBU_Pos                            (7U)
-#define ETH_DMACSR_RBU_Msk                            (0x1UL << ETH_DMACSR_RBU_Pos) /*!< 0x00000080 */
-#define ETH_DMACSR_RBU                                ETH_DMACSR_RBU_Msk       /* Receive Buffer Unavailable */
-#define ETH_DMACSR_RI_Pos                             (6U)
-#define ETH_DMACSR_RI_Msk                             (0x1UL << ETH_DMACSR_RI_Pos) /*!< 0x00000040 */
-#define ETH_DMACSR_RI                                 ETH_DMACSR_RI_Msk        /* Receive Interrupt */
-#define ETH_DMACSR_TBU_Pos                            (2U)
-#define ETH_DMACSR_TBU_Msk                            (0x1UL << ETH_DMACSR_TBU_Pos) /*!< 0x00000004 */
-#define ETH_DMACSR_TBU                                ETH_DMACSR_TBU_Msk       /* Transmit Buffer Unavailable */
-#define ETH_DMACSR_TPS_Pos                            (1U)
-#define ETH_DMACSR_TPS_Msk                            (0x1UL << ETH_DMACSR_TPS_Pos) /*!< 0x00000002 */
-#define ETH_DMACSR_TPS                                ETH_DMACSR_TPS_Msk       /* Transmit Process Stopped */
-#define ETH_DMACSR_TI_Pos                             (0U)
-#define ETH_DMACSR_TI_Msk                             (0x1UL << ETH_DMACSR_TI_Pos) /*!< 0x00000001 */
-#define ETH_DMACSR_TI                                 ETH_DMACSR_TI_Msk        /* Transmit Interrupt */
-
-/* Bit definition for Ethernet DMA Channel missed frame count register */
-#define ETH_DMACMFCR_MFCO_Pos                         (15U)
-#define ETH_DMACMFCR_MFCO_Msk                         (0x1UL << ETH_DMACMFCR_MFCO_Pos) /*!< 0x00008000 */
-#define ETH_DMACMFCR_MFCO                             ETH_DMACMFCR_MFCO_Msk    /* Overflow status of the MFC Counter */
-#define ETH_DMACMFCR_MFC_Pos                          (0U)
-#define ETH_DMACMFCR_MFC_Msk                          (0x7FFUL << ETH_DMACMFCR_MFC_Pos) /*!< 0x000007FF */
-#define ETH_DMACMFCR_MFC                              ETH_DMACMFCR_MFC_Msk     /* The number of packet counters dropped by the DMA */
 /******************************************************************************/
 /*                                                                            */
 /*                           DMA Controller (DMA)                             */
@@ -8264,9 +5737,6 @@ typedef struct
 #define EXTI_SECENR1_SEC30_Pos             (30U)
 #define EXTI_SECENR1_SEC30_Msk             (0x1UL << EXTI_SECENR1_SEC30_Pos)      /*!< 0x40000000 */
 #define EXTI_SECENR1_SEC30                 EXTI_SECENR1_SEC30_Msk                 /*!< Security enable on line 30 */
-#define EXTI_SECENR1_SEC31_Pos             (31U)
-#define EXTI_SECENR1_SEC31_Msk             (0x1UL << EXTI_SECENR1_SEC31_Pos)      /*!< 0x80000000 */
-#define EXTI_SECENR1_SEC31                 EXTI_SECENR1_SEC31_Msk                 /*!< Security enable on line 31 */
 
 
 /*******************  Bit definition for EXTI_PRIVENR1 register  ******************/
@@ -8363,17 +5833,11 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV30_Pos            (30U)
 #define EXTI_PRIVENR1_PRIV30_Msk            (0x1UL << EXTI_PRIVENR1_PRIV30_Pos)      /*!< 0x40000000 */
 #define EXTI_PRIVENR1_PRIV30                EXTI_PRIVENR1_PRIV30_Msk                 /*!< Privilege enable on line 30 */
-#define EXTI_PRIVENR1_PRIV31_Pos            (31U)
-#define EXTI_PRIVENR1_PRIV31_Msk            (0x1UL << EXTI_PRIVENR1_PRIV31_Pos)      /*!< 0x80000000 */
-#define EXTI_PRIVENR1_PRIV31                EXTI_PRIVENR1_PRIV31_Msk                 /*!< Privilege enable on line 31 */
 
 /******************  Bit definition for EXTI_RTSR2 register  *******************/
-#define EXTI_RTSR2_RT_Pos                   (12U)
-#define EXTI_RTSR2_RT_Msk                   (0x244UL << EXTI_RTSR2_RT_Pos)              /*!< 0x00244000 */
+#define EXTI_RTSR2_RT_Pos                   (16U)
+#define EXTI_RTSR2_RT_Msk                   (0x24UL << EXTI_RTSR2_RT_Pos)               /*!< 0x00240000 */
 #define EXTI_RTSR2_RT                       EXTI_RTSR2_RT_Msk                           /*!< Rising trigger event configuration bit */
-#define EXTI_RTSR2_RT46_Pos                 (14U)
-#define EXTI_RTSR2_RT46_Msk                 (0x1UL << EXTI_RTSR2_RT46_Pos)              /*!< 0x00004000 */
-#define EXTI_RTSR2_RT46                     EXTI_RTSR2_RT46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
 #define EXTI_RTSR2_RT50_Pos                 (18U)
 #define EXTI_RTSR2_RT50_Msk                 (0x1UL << EXTI_RTSR2_RT50_Pos)              /*!< 0x00040000 */
 #define EXTI_RTSR2_RT50                     EXTI_RTSR2_RT50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
@@ -8382,12 +5846,9 @@ typedef struct
 #define EXTI_RTSR2_RT53                     EXTI_RTSR2_RT53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FTSR2 register  *******************/
-#define EXTI_FTSR2_FT_Pos                   (12U)
-#define EXTI_FTSR2_FT_Msk                   (0x244 << EXTI_FTSR2_FT_Pos)                /*!< 0x00244000 */
+#define EXTI_FTSR2_FT_Pos                   (16U)
+#define EXTI_FTSR2_FT_Msk                   (0x24 << EXTI_FTSR2_FT_Pos)                 /*!< 0x00240000 */
 #define EXTI_FTSR2_FT                       EXTI_FTSR2_FT_Msk                           /*!< Falling trigger event configuration bit */
-#define EXTI_FTSR2_FT46_Pos                 (14U)
-#define EXTI_FTSR2_FT46_Msk                 (0x1UL << EXTI_FTSR2_FT46_Pos)              /*!< 0x00004000 */
-#define EXTI_FTSR2_FT46                     EXTI_FTSR2_FT46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
 #define EXTI_FTSR2_FT50_Pos                 (18U)
 #define EXTI_FTSR2_FT50_Msk                 (0x1UL << EXTI_FTSR2_FT50_Pos)              /*!< 0x00040000 */
 #define EXTI_FTSR2_FT50                     EXTI_FTSR2_FT50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
@@ -8396,9 +5857,6 @@ typedef struct
 #define EXTI_FTSR2_FT53                     EXTI_FTSR2_FT53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_SWIER2 register  ******************/
-#define EXTI_SWIER2_SWIER46_Pos            (14U)
-#define EXTI_SWIER2_SWIER46_Msk            (0x1UL << EXTI_SWIER2_SWIER46_Pos)          /*!< 0x00004000 */
-#define EXTI_SWIER2_SWIER46                EXTI_SWIER2_SWIER46_Msk                     /*!< Software Interrupt on line 46 */
 #define EXTI_SWIER2_SWIER50_Pos            (18U)
 #define EXTI_SWIER2_SWIER50_Msk            (0x1UL << EXTI_SWIER2_SWIER50_Pos)          /*!< 0x00040000 */
 #define EXTI_SWIER2_SWIER50                EXTI_SWIER2_SWIER50_Msk                     /*!< Software Interrupt on line 50 */
@@ -8407,12 +5865,9 @@ typedef struct
 #define EXTI_SWIER2_SWIER53                EXTI_SWIER2_SWIER53_Msk                     /*!< Software Interrupt on line 53 */
 
 /******************  Bit definition for EXTI_RPR2 register  *******************/
-#define EXTI_RPR2_RPIF_Pos                   (12U)
-#define EXTI_RPR2_RPIF_Msk                   (0x244UL << EXTI_RPR2_RPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_RPR2_RPIF_Pos                   (16U)
+#define EXTI_RPR2_RPIF_Msk                   (0x24UL << EXTI_RPR2_RPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_RPR2_RPIF                       EXTI_RPR2_RPIF_Msk                     /*!< Rising pending edge configuration bits */
-#define EXTI_RPR2_RPIF46_Pos                 (14U)
-#define EXTI_RPR2_RPIF46_Msk                 (0x1UL << EXTI_RPR2_RPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_RPR2_RPIF46                     EXTI_RPR2_RPIF46_Msk                   /*!< Rising pending edge configuration bit of line 46 */
 #define EXTI_RPR2_RPIF50_Pos                 (18U)
 #define EXTI_RPR2_RPIF50_Msk                 (0x1UL << EXTI_RPR2_RPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_RPR2_RPIF50                     EXTI_RPR2_RPIF50_Msk                   /*!< Rising pending edge configuration bit of line 50 */
@@ -8421,12 +5876,9 @@ typedef struct
 #define EXTI_RPR2_RPIF53                     EXTI_RPR2_RPIF53_Msk                   /*!< Rising pending edge configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FPR2 register  *******************/
-#define EXTI_FPR2_FPIF_Pos                   (12U)
-#define EXTI_FPR2_FPIF_Msk                   (0x244UL << EXTI_FPR2_FPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_FPR2_FPIF_Pos                   (16U)
+#define EXTI_FPR2_FPIF_Msk                   (0x24UL << EXTI_FPR2_FPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_FPR2_FPIF                       EXTI_FPR2_FPIF_Msk                     /*!< Rising falling edge configuration bits */
-#define EXTI_FPR2_FPIF46_Pos                 (14U)
-#define EXTI_FPR2_FPIF46_Msk                 (0x1UL << EXTI_FPR2_FPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_FPR2_FPIF46                     EXTI_FPR2_FPIF46_Msk                   /*!< Rising falling edge configuration bit of line 46 */
 #define EXTI_FPR2_FPIF50_Pos                 (18U)
 #define EXTI_FPR2_FPIF50_Msk                 (0x1UL << EXTI_FPR2_FPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_FPR2_FPIF50                     EXTI_FPR2_FPIF50_Msk                   /*!< Rising falling edge configuration bit of line 50 */
@@ -8435,21 +5887,6 @@ typedef struct
 #define EXTI_FPR2_FPIF53                     EXTI_FPR2_FPIF53_Msk                   /*!< Rising falling edge configuration bit of line 53 */
 
 /*******************  Bit definition for EXTI_SECENR2 register  ******************/
-#define EXTI_SECENR2_SEC32_Pos              (0U)
-#define EXTI_SECENR2_SEC32_Msk              (0x1UL << EXTI_SECENR2_SEC32_Pos)       /*!< 0x00000001 */
-#define EXTI_SECENR2_SEC32                  EXTI_SECENR2_SEC32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_SECENR2_SEC33_Pos              (1U)
-#define EXTI_SECENR2_SEC33_Msk              (0x1UL << EXTI_SECENR2_SEC33_Pos)       /*!< 0x00000002 */
-#define EXTI_SECENR2_SEC33                  EXTI_SECENR2_SEC33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_SECENR2_SEC34_Pos              (2U)
-#define EXTI_SECENR2_SEC34_Msk              (0x1UL << EXTI_SECENR2_SEC34_Pos)       /*!< 0x00000004 */
-#define EXTI_SECENR2_SEC34                  EXTI_SECENR2_SEC34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_SECENR2_SEC35_Pos              (3U)
-#define EXTI_SECENR2_SEC35_Msk              (0x1UL << EXTI_SECENR2_SEC35_Pos)       /*!< 0x00000008 */
-#define EXTI_SECENR2_SEC35                  EXTI_SECENR2_SEC35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_SECENR2_SEC36_Pos              (4U)
-#define EXTI_SECENR2_SEC36_Msk              (0x1UL << EXTI_SECENR2_SEC36_Pos)       /*!< 0x00000010 */
-#define EXTI_SECENR2_SEC36                  EXTI_SECENR2_SEC36_Msk                  /*!< Security enable on line 4 */
 #define EXTI_SECENR2_SEC37_Pos              (5U)
 #define EXTI_SECENR2_SEC37_Msk              (0x1UL << EXTI_SECENR2_SEC37_Pos)       /*!< 0x00000020 */
 #define EXTI_SECENR2_SEC37                  EXTI_SECENR2_SEC37_Msk                  /*!< Security enable on line 5 */
@@ -8471,15 +5908,6 @@ typedef struct
 #define EXTI_SECENR2_SEC43_Pos             (11U)
 #define EXTI_SECENR2_SEC43_Msk             (0x1UL << EXTI_SECENR2_SEC43_Pos)        /*!< 0x00000800 */
 #define EXTI_SECENR2_SEC43                 EXTI_SECENR2_SEC43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_SECENR2_SEC44_Pos             (12U)
-#define EXTI_SECENR2_SEC44_Msk             (0x1UL << EXTI_SECENR2_SEC44_Pos)        /*!< 0x00001000 */
-#define EXTI_SECENR2_SEC44                 EXTI_SECENR2_SEC44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_SECENR2_SEC45_Pos             (13U)
-#define EXTI_SECENR2_SEC45_Msk             (0x1UL << EXTI_SECENR2_SEC45_Pos)        /*!< 0x00002000 */
-#define EXTI_SECENR2_SEC45                 EXTI_SECENR2_SEC45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_SECENR2_SEC46_Pos             (14U)
-#define EXTI_SECENR2_SEC46_Msk             (0x1UL << EXTI_SECENR2_SEC46_Pos)        /*!< 0x00004000 */
-#define EXTI_SECENR2_SEC46                 EXTI_SECENR2_SEC46_Msk                   /*!< Security enable on line 14 */
 #define EXTI_SECENR2_SEC47_Pos             (15U)
 #define EXTI_SECENR2_SEC47_Msk             (0x1UL << EXTI_SECENR2_SEC47_Pos)        /*!< 0x00008000 */
 #define EXTI_SECENR2_SEC47                 EXTI_SECENR2_SEC47_Msk                   /*!< Security enable on line 15 */
@@ -8501,35 +5929,11 @@ typedef struct
 #define EXTI_SECENR2_SEC53_Pos             (21U)
 #define EXTI_SECENR2_SEC53_Msk             (0x1UL << EXTI_SECENR2_SEC53_Pos)        /*!< 0x00200000 */
 #define EXTI_SECENR2_SEC53                 EXTI_SECENR2_SEC53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_SECENR2_SEC54_Pos             (22U)
-#define EXTI_SECENR2_SEC54_Msk             (0x1UL << EXTI_SECENR2_SEC54_Pos)        /*!< 0x00400000 */
-#define EXTI_SECENR2_SEC54                 EXTI_SECENR2_SEC54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_SECENR2_SEC55_Pos             (23U)
-#define EXTI_SECENR2_SEC55_Msk             (0x1UL << EXTI_SECENR2_SEC55_Pos)        /*!< 0x00800000 */
-#define EXTI_SECENR2_SEC55                 EXTI_SECENR2_SEC55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_SECENR2_SEC56_Pos             (24U)
-#define EXTI_SECENR2_SEC56_Msk             (0x1UL << EXTI_SECENR2_SEC56_Pos)        /*!< 0x01000000 */
-#define EXTI_SECENR2_SEC56                 EXTI_SECENR2_SEC56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_SECENR2_SEC57_Pos             (25U)
-#define EXTI_SECENR2_SEC57_Msk             (0x1UL << EXTI_SECENR2_SEC57_Pos)        /*!< 0x02000000 */
-#define EXTI_SECENR2_SEC57                 EXTI_SECENR2_SEC57_Msk                   /*!< Security enable on line 25 */
+#define EXTI_SECENR2_SEC58_Pos             (26U)
+#define EXTI_SECENR2_SEC58_Msk             (0x1UL << EXTI_SECENR2_SEC58_Pos)        /*!< 0x04000000 */
+#define EXTI_SECENR2_SEC58                 EXTI_SECENR2_SEC58_Msk                   /*!< Security enable on line 26 */
 
 /*******************  Bit definition for EXTI_PRIVENR2 register  ******************/
-#define EXTI_PRIVENR2_PRIV32_Pos              (0U)
-#define EXTI_PRIVENR2_PRIV32_Msk              (0x1UL << EXTI_PRIVENR2_PRIV32_Pos)       /*!< 0x00000001 */
-#define EXTI_PRIVENR2_PRIV32                  EXTI_PRIVENR2_PRIV32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_PRIVENR2_PRIV33_Pos              (1U)
-#define EXTI_PRIVENR2_PRIV33_Msk              (0x1UL << EXTI_PRIVENR2_PRIV33_Pos)       /*!< 0x00000002 */
-#define EXTI_PRIVENR2_PRIV33                  EXTI_PRIVENR2_PRIV33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_PRIVENR2_PRIV34_Pos              (2U)
-#define EXTI_PRIVENR2_PRIV34_Msk              (0x1UL << EXTI_PRIVENR2_PRIV34_Pos)       /*!< 0x00000004 */
-#define EXTI_PRIVENR2_PRIV34                  EXTI_PRIVENR2_PRIV34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_PRIVENR2_PRIV35_Pos              (3U)
-#define EXTI_PRIVENR2_PRIV35_Msk              (0x1UL << EXTI_PRIVENR2_PRIV35_Pos)       /*!< 0x00000008 */
-#define EXTI_PRIVENR2_PRIV35                  EXTI_PRIVENR2_PRIV35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_PRIVENR2_PRIV36_Pos              (4U)
-#define EXTI_PRIVENR2_PRIV36_Msk              (0x1UL << EXTI_PRIVENR2_PRIV36_Pos)       /*!< 0x00000010 */
-#define EXTI_PRIVENR2_PRIV36                  EXTI_PRIVENR2_PRIV36_Msk                  /*!< Security enable on line 4 */
 #define EXTI_PRIVENR2_PRIV37_Pos              (5U)
 #define EXTI_PRIVENR2_PRIV37_Msk              (0x1UL << EXTI_PRIVENR2_PRIV37_Pos)       /*!< 0x00000020 */
 #define EXTI_PRIVENR2_PRIV37                  EXTI_PRIVENR2_PRIV37_Msk                  /*!< Security enable on line 5 */
@@ -8551,15 +5955,6 @@ typedef struct
 #define EXTI_PRIVENR2_PRIV43_Pos             (11U)
 #define EXTI_PRIVENR2_PRIV43_Msk             (0x1UL << EXTI_PRIVENR2_PRIV43_Pos)        /*!< 0x00000800 */
 #define EXTI_PRIVENR2_PRIV43                 EXTI_PRIVENR2_PRIV43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_PRIVENR2_PRIV44_Pos             (12U)
-#define EXTI_PRIVENR2_PRIV44_Msk             (0x1UL << EXTI_PRIVENR2_PRIV44_Pos)        /*!< 0x00001000 */
-#define EXTI_PRIVENR2_PRIV44                 EXTI_PRIVENR2_PRIV44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_PRIVENR2_PRIV45_Pos             (13U)
-#define EXTI_PRIVENR2_PRIV45_Msk             (0x1UL << EXTI_PRIVENR2_PRIV45_Pos)        /*!< 0x00002000 */
-#define EXTI_PRIVENR2_PRIV45                 EXTI_PRIVENR2_PRIV45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_PRIVENR2_PRIV46_Pos             (14U)
-#define EXTI_PRIVENR2_PRIV46_Msk             (0x1UL << EXTI_PRIVENR2_PRIV46_Pos)        /*!< 0x00004000 */
-#define EXTI_PRIVENR2_PRIV46                 EXTI_PRIVENR2_PRIV46_Msk                   /*!< Security enable on line 14 */
 #define EXTI_PRIVENR2_PRIV47_Pos             (15U)
 #define EXTI_PRIVENR2_PRIV47_Msk             (0x1UL << EXTI_PRIVENR2_PRIV47_Pos)        /*!< 0x00008000 */
 #define EXTI_PRIVENR2_PRIV47                 EXTI_PRIVENR2_PRIV47_Msk                   /*!< Security enable on line 15 */
@@ -8581,18 +5976,9 @@ typedef struct
 #define EXTI_PRIVENR2_PRIV53_Pos             (21U)
 #define EXTI_PRIVENR2_PRIV53_Msk             (0x1UL << EXTI_PRIVENR2_PRIV53_Pos)        /*!< 0x00200000 */
 #define EXTI_PRIVENR2_PRIV53                 EXTI_PRIVENR2_PRIV53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_PRIVENR2_PRIV54_Pos             (22U)
-#define EXTI_PRIVENR2_PRIV54_Msk             (0x1UL << EXTI_PRIVENR2_PRIV54_Pos)        /*!< 0x00400000 */
-#define EXTI_PRIVENR2_PRIV54                 EXTI_PRIVENR2_PRIV54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_PRIVENR2_PRIV55_Pos             (23U)
-#define EXTI_PRIVENR2_PRIV55_Msk             (0x1UL << EXTI_PRIVENR2_PRIV55_Pos)        /*!< 0x00800000 */
-#define EXTI_PRIVENR2_PRIV55                 EXTI_PRIVENR2_PRIV55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_PRIVENR2_PRIV56_Pos             (24U)
-#define EXTI_PRIVENR2_PRIV56_Msk             (0x1UL << EXTI_PRIVENR2_PRIV56_Pos)        /*!< 0x01000000 */
-#define EXTI_PRIVENR2_PRIV56                 EXTI_PRIVENR2_PRIV56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_PRIVENR2_PRIV57_Pos             (25U)
-#define EXTI_PRIVENR2_PRIV57_Msk             (0x1UL << EXTI_PRIVENR2_PRIV57_Pos)        /*!< 0x02000000 */
-#define EXTI_PRIVENR2_PRIV57                 EXTI_PRIVENR2_PRIV57_Msk                   /*!< Security enable on line 25 */
+#define EXTI_PRIVENR2_PRIV58_Pos             (26U)
+#define EXTI_PRIVENR2_PRIV58_Msk             (0x1UL << EXTI_PRIVENR2_PRIV58_Pos)        /*!< 0x04000000 */
+#define EXTI_PRIVENR2_PRIV58                 EXTI_PRIVENR2_PRIV58_Msk                   /*!< Security enable on line 26 */
 
 /*****************  Bit definition for EXTI_EXTICR1 register  **************/
 #define EXTI_EXTICR1_EXTI0_Pos              (0U)
@@ -8721,7 +6107,7 @@ typedef struct
 
 /*******************  Bit definition for EXTI_IMR1 register  ******************/
 #define EXTI_IMR1_IM_Pos                    (0U)
-#define EXTI_IMR1_IM_Msk                    (0xFFFFFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM_Msk                    (0x7FFFFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0x7FFFFFFF */
 #define EXTI_IMR1_IM                        EXTI_IMR1_IM_Msk                        /*!< Interrupt Mask */
 #define EXTI_IMR1_IM0_Pos                   (0U)
 #define EXTI_IMR1_IM0_Msk                   (0x1UL << EXTI_IMR1_IM0_Pos)            /*!< 0x00000001 */
@@ -8816,9 +6202,6 @@ typedef struct
 #define EXTI_IMR1_IM30_Pos                  (30U)
 #define EXTI_IMR1_IM30_Msk                  (0x1UL << EXTI_IMR1_IM30_Pos)           /*!< 0x40000000 */
 #define EXTI_IMR1_IM30                      EXTI_IMR1_IM30_Msk                      /*!< Interrupt Mask on line 30 */
-#define EXTI_IMR1_IM31_Pos                  (31U)
-#define EXTI_IMR1_IM31_Msk                  (0x1UL << EXTI_IMR1_IM31_Pos)           /*!< 0x80000000 */
-#define EXTI_IMR1_IM31                      EXTI_IMR1_IM31_Msk                      /*!< Interrupt Mask on line 31 */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
 #define EXTI_EMR1_EM_Pos                    (0U)
@@ -8917,29 +6300,11 @@ typedef struct
 #define EXTI_EMR1_EM30_Pos                  (30U)
 #define EXTI_EMR1_EM30_Msk                  (0x1UL << EXTI_EMR1_EM30_Pos)           /*!< 0x40000000 */
 #define EXTI_EMR1_EM30                      EXTI_EMR1_EM30_Msk                      /*!< Event Mask on line 30 */
-#define EXTI_EMR1_EM31_Pos                  (31U)
-#define EXTI_EMR1_EM31_Msk                  (0x1UL << EXTI_EMR1_EM31_Pos)           /*!< 0x80000000 */
-#define EXTI_EMR1_EM31                      EXTI_EMR1_EM31_Msk                      /*!< Event Mask on line 31 */
 
 /*******************  Bit definition for EXTI_IMR2 register  *******************/
 #define EXTI_IMR2_IM_Pos                    (0U)
-#define EXTI_IMR2_IM_Msk                    (0x03FFFFFFUL << EXTI_IMR2_IM_Pos)      /*!< 0x03FFFFFF */
+#define EXTI_IMR2_IM_Msk                    (0x042F8FE0UL << EXTI_IMR2_IM_Pos)      /*!< 0x04278FE0 */
 #define EXTI_IMR2_IM                        EXTI_IMR2_IM_Msk                        /*!< Interrupt Mask */
-#define EXTI_IMR2_IM32_Pos                  (0U)
-#define EXTI_IMR2_IM32_Msk                  (0x1UL << EXTI_IMR2_IM32_Pos)           /*!< 0x00000001 */
-#define EXTI_IMR2_IM32                      EXTI_IMR2_IM32_Msk                      /*!< Interrupt Mask on line 32 */
-#define EXTI_IMR2_IM33_Pos                  (1U)
-#define EXTI_IMR2_IM33_Msk                  (0x1UL << EXTI_IMR2_IM33_Pos)           /*!< 0x00000002 */
-#define EXTI_IMR2_IM33                      EXTI_IMR2_IM33_Msk                      /*!< Interrupt Mask on line 33 */
-#define EXTI_IMR2_IM34_Pos                  (2U)
-#define EXTI_IMR2_IM34_Msk                  (0x1UL << EXTI_IMR2_IM34_Pos)           /*!< 0x00000004 */
-#define EXTI_IMR2_IM34                      EXTI_IMR2_IM34_Msk                      /*!< Interrupt Mask on line 34 */
-#define EXTI_IMR2_IM35_Pos                  (3U)
-#define EXTI_IMR2_IM35_Msk                  (0x1UL << EXTI_IMR2_IM35_Pos)           /*!< 0x00000008 */
-#define EXTI_IMR2_IM35                      EXTI_IMR2_IM35_Msk                      /*!< Interrupt Mask on line 35 */
-#define EXTI_IMR2_IM36_Pos                  (4U)
-#define EXTI_IMR2_IM36_Msk                  (0x1UL << EXTI_IMR2_IM36_Pos)           /*!< 0x00000010 */
-#define EXTI_IMR2_IM36                      EXTI_IMR2_IM36_Msk                      /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM37_Pos                  (5U)
 #define EXTI_IMR2_IM37_Msk                  (0x1UL << EXTI_IMR2_IM37_Pos)           /*!< 0x00000020 */
 #define EXTI_IMR2_IM37                      EXTI_IMR2_IM37_Msk                      /*!< Interrupt Mask on line 37 */
@@ -8961,15 +6326,6 @@ typedef struct
 #define EXTI_IMR2_IM43_Pos                  (11U)
 #define EXTI_IMR2_IM43_Msk                  (0x1UL << EXTI_IMR2_IM43_Pos)           /*!< 0x00000800 */
 #define EXTI_IMR2_IM43                      EXTI_IMR2_IM43_Msk                      /*!< Interrupt Mask on line 43 */
-#define EXTI_IMR2_IM44_Pos                  (12U)
-#define EXTI_IMR2_IM44_Msk                  (0x1UL << EXTI_IMR2_IM44_Pos)           /*!< 0x00001000 */
-#define EXTI_IMR2_IM44                      EXTI_IMR2_IM44_Msk                      /*!< Interrupt Mask on line 44 */
-#define EXTI_IMR2_IM45_Pos                  (13U)
-#define EXTI_IMR2_IM45_Msk                  (0x1UL << EXTI_IMR2_IM45_Pos)           /*!< 0x00002000 */
-#define EXTI_IMR2_IM45                      EXTI_IMR2_IM45_Msk                      /*!< Interrupt Mask on line 45 */
-#define EXTI_IMR2_IM46_Pos                  (14U)
-#define EXTI_IMR2_IM46_Msk                  (0x1UL << EXTI_IMR2_IM46_Pos)           /*!< 0x00004000 */
-#define EXTI_IMR2_IM46                      EXTI_IMR2_IM46_Msk                      /*!< Interrupt Mask on line 46 */
 #define EXTI_IMR2_IM47_Pos                  (15U)
 #define EXTI_IMR2_IM47_Msk                  (0x1UL << EXTI_IMR2_IM47_Pos)           /*!< 0x00008000 */
 #define EXTI_IMR2_IM47                      EXTI_IMR2_IM47_Msk                      /*!< Interrupt Mask on line 47 */
@@ -8985,45 +6341,18 @@ typedef struct
 #define EXTI_IMR2_IM51_Pos                  (19U)
 #define EXTI_IMR2_IM51_Msk                  (0x1UL << EXTI_IMR2_IM51_Pos)           /*!< 0x00080000 */
 #define EXTI_IMR2_IM51                      EXTI_IMR2_IM51_Msk                      /*!< Interrupt Mask on line 51 */
-#define EXTI_IMR2_IM52_Pos                  (20U)
-#define EXTI_IMR2_IM52_Msk                  (0x1UL << EXTI_IMR2_IM52_Pos)           /*!< 0x00100000 */
-#define EXTI_IMR2_IM52                      EXTI_IMR2_IM52_Msk                      /*!< Interrupt Mask on line 52 */
 #define EXTI_IMR2_IM53_Pos                  (21U)
 #define EXTI_IMR2_IM53_Msk                  (0x1UL << EXTI_IMR2_IM53_Pos)           /*!< 0x00200000 */
 #define EXTI_IMR2_IM53                      EXTI_IMR2_IM53_Msk                      /*!< Interrupt Mask on line 53 */
-#define EXTI_IMR2_IM54_Pos                  (22U)
-#define EXTI_IMR2_IM54_Msk                  (0x1UL << EXTI_IMR2_IM54_Pos)           /*!< 0x00400000 */
-#define EXTI_IMR2_IM54                      EXTI_IMR2_IM54_Msk                      /*!< Interrupt Mask on line 54 */
-#define EXTI_IMR2_IM55_Pos                  (23U)
-#define EXTI_IMR2_IM55_Msk                  (0x1UL << EXTI_IMR2_IM55_Pos)           /*!< 0x00800000 */
-#define EXTI_IMR2_IM55                      EXTI_IMR2_IM55_Msk                      /*!< Interrupt Mask on line 55 */
-#define EXTI_IMR2_IM56_Pos                  (24U)
-#define EXTI_IMR2_IM56_Msk                  (0x1UL << EXTI_IMR2_IM56_Pos)           /*!< 0x01000000 */
-#define EXTI_IMR2_IM56                      EXTI_IMR2_IM56_Msk                      /*!< Interrupt Mask on line 56 */
-#define EXTI_IMR2_IM57_Pos                  (25U)
-#define EXTI_IMR2_IM57_Msk                  (0x1UL << EXTI_IMR2_IM57_Pos)           /*!< 0x02000000 */
-#define EXTI_IMR2_IM57                      EXTI_IMR2_IM57_Msk                      /*!< Interrupt Mask on line 57 */
+#define EXTI_IMR2_IM58_Pos                  (26U)
+#define EXTI_IMR2_IM58_Msk                  (0x1UL << EXTI_IMR2_IM58_Pos)           /*!< 0x04000000 */
+#define EXTI_IMR2_IM58                      EXTI_IMR2_IM58_Msk                      /*!< Interrupt Mask on line 58 */
 
 
 /*******************  Bit definition for EXTI_EMR2 register  *******************/
 #define EXTI_EMR2_EM_Pos                    (0U)
-#define EXTI_EMR2_EM_Msk                    (0x03FFFFFFUL << EXTI_EMR2_EM_Pos)      /*!< 0x03FFFFFF */
+#define EXTI_EMR2_EM_Msk                    (0x042F8FE0UL << EXTI_EMR2_EM_Pos)      /*!< 0x042F8FE0 */
 #define EXTI_EMR2_EM                        EXTI_EMR2_EM_Msk                        /*!< Event Mask */
-#define EXTI_EMR2_EM32_Pos                  (0U)
-#define EXTI_EMR2_EM32_Msk                  (0x1UL << EXTI_EMR2_EM32_Pos)           /*!< 0x00000001 */
-#define EXTI_EMR2_EM32                      EXTI_EMR2_EM32_Msk                      /*!< Event Mask on line 32*/
-#define EXTI_EMR2_EM33_Pos                  (1U)
-#define EXTI_EMR2_EM33_Msk                  (0x1UL << EXTI_EMR2_EM33_Pos)           /*!< 0x00000002 */
-#define EXTI_EMR2_EM33                      EXTI_EMR2_EM33_Msk                      /*!< Event Mask on line 33*/
-#define EXTI_EMR2_EM34_Pos                  (2U)
-#define EXTI_EMR2_EM34_Msk                  (0x1UL << EXTI_EMR2_EM34_Pos)           /*!< 0x00000004 */
-#define EXTI_EMR2_EM34                      EXTI_EMR2_EM34_Msk                      /*!< Event Mask on line 34*/
-#define EXTI_EMR2_EM35_Pos                  (3U)
-#define EXTI_EMR2_EM35_Msk                  (0x1UL << EXTI_EMR2_EM35_Pos)           /*!< 0x00000008 */
-#define EXTI_EMR2_EM35                      EXTI_EMR2_EM35_Msk                      /*!< Event Mask on line 35*/
-#define EXTI_EMR2_EM36_Pos                  (4U)
-#define EXTI_EMR2_EM36_Msk                  (0x1UL << EXTI_EMR2_EM36_Pos)           /*!< 0x00000010 */
-#define EXTI_EMR2_EM36                      EXTI_EMR2_EM36_Msk                      /*!< Event Mask on line 36*/
 #define EXTI_EMR2_EM37_Pos                  (5U)
 #define EXTI_EMR2_EM37_Msk                  (0x1UL << EXTI_EMR2_EM37_Pos)           /*!< 0x00000020 */
 #define EXTI_EMR2_EM37                      EXTI_EMR2_EM37_Msk                      /*!< Event Mask on line 37*/
@@ -9045,15 +6374,6 @@ typedef struct
 #define EXTI_EMR2_EM43_Pos                  (11U)
 #define EXTI_EMR2_EM43_Msk                  (0x1UL << EXTI_EMR2_EM43_Pos)           /*!< 0x00000800 */
 #define EXTI_EMR2_EM43                      EXTI_EMR2_EM43_Msk                      /*!< Event Mask on line 43 */
-#define EXTI_EMR2_EM44_Pos                  (12U)
-#define EXTI_EMR2_EM44_Msk                  (0x1UL << EXTI_EMR2_EM44_Pos)           /*!< 0x00001000 */
-#define EXTI_EMR2_EM44                      EXTI_EMR2_EM44_Msk                      /*!< Event Mask on line 44 */
-#define EXTI_EMR2_EM45_Pos                  (13U)
-#define EXTI_EMR2_EM45_Msk                  (0x1UL << EXTI_EMR2_EM45_Pos)           /*!< 0x00002000 */
-#define EXTI_EMR2_EM45                      EXTI_EMR2_EM45_Msk                      /*!< Event Mask on line 45 */
-#define EXTI_EMR2_EM46_Pos                  (14U)
-#define EXTI_EMR2_EM46_Msk                  (0x1UL << EXTI_EMR2_EM46_Pos)           /*!< 0x00004000 */
-#define EXTI_EMR2_EM46                      EXTI_EMR2_EM46_Msk                      /*!< Event Mask on line 46 */
 #define EXTI_EMR2_EM47_Pos                  (15U)
 #define EXTI_EMR2_EM47_Msk                  (0x1UL << EXTI_EMR2_EM47_Pos)           /*!< 0x00008000 */
 #define EXTI_EMR2_EM47                      EXTI_EMR2_EM47_Msk                      /*!< Event Mask on line 47 */
@@ -9069,24 +6389,12 @@ typedef struct
 #define EXTI_EMR2_EM51_Pos                  (19U)
 #define EXTI_EMR2_EM51_Msk                  (0x1UL << EXTI_EMR2_EM51_Pos)           /*!< 0x00080000 */
 #define EXTI_EMR2_EM51                      EXTI_EMR2_EM51_Msk                      /*!< Event Mask on line 51 */
-#define EXTI_EMR2_EM52_Pos                  (20U)
-#define EXTI_EMR2_EM52_Msk                  (0x1UL << EXTI_EMR2_EM52_Pos)           /*!< 0x00100000 */
-#define EXTI_EMR2_EM52                      EXTI_EMR2_EM52_Msk                      /*!< Event Mask on line 52 */
 #define EXTI_EMR2_EM53_Pos                  (21U)
 #define EXTI_EMR2_EM53_Msk                  (0x1UL << EXTI_EMR2_EM53_Pos)           /*!< 0x00200000 */
 #define EXTI_EMR2_EM53                      EXTI_EMR2_EM53_Msk                      /*!< Event Mask on line 53 */
-#define EXTI_EMR2_EM54_Pos                  (22U)
-#define EXTI_EMR2_EM54_Msk                  (0x1UL << EXTI_EMR2_EM54_Pos)           /*!< 0x00400000 */
-#define EXTI_EMR2_EM54                      EXTI_EMR2_EM54_Msk                      /*!< Event Mask on line 54 */
-#define EXTI_EMR2_EM55_Pos                  (23U)
-#define EXTI_EMR2_EM55_Msk                  (0x1UL << EXTI_EMR2_EM55_Pos)           /*!< 0x00800000 */
-#define EXTI_EMR2_EM55                      EXTI_EMR2_EM55_Msk                      /*!< Event Mask on line 55 */
-#define EXTI_EMR2_EM56_Pos                  (24U)
-#define EXTI_EMR2_EM56_Msk                  (0x1UL << EXTI_EMR2_EM56_Pos)           /*!< 0x01000000 */
-#define EXTI_EMR2_EM56                      EXTI_EMR2_EM56_Msk                      /*!< Event Mask on line 56 */
-#define EXTI_EMR2_EM57_Pos                  (25U)
-#define EXTI_EMR2_EM57_Msk                  (0x1UL << EXTI_EMR2_EM57_Pos)           /*!< 0x02000000 */
-#define EXTI_EMR2_EM57                      EXTI_EMR2_EM57_Msk                      /*!< Event Mask on line 57 */
+#define EXTI_EMR2_EM58_Pos                  (26U)
+#define EXTI_EMR2_EM58_Msk                  (0x1UL << EXTI_EMR2_EM58_Pos)           /*!< 0x04000000 */
+#define EXTI_EMR2_EM58                      EXTI_EMR2_EM58_Msk                      /*!< Event Mask on line 58 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -9810,9 +7118,9 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 #define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /*!< FLASH Three Latency cycle */
-#define FLASH_BLOCKBASED_NB_REG             (4U)                                    /*!< 4 Block-based registers for each Flash bank */
-#define FLASH_SIZE_DEFAULT                  (0x200000U)                             /*!< FLASH Size */
-#define FLASH_SECTOR_NB                     (128U)                                  /*!< Flash Sector number */
+#define FLASH_BLOCKBASED_NB_REG             (1U)                                    /*!< 1 Block-based registers for each Flash bank */
+#define FLASH_SIZE_DEFAULT                  (0x80000U)                              /*!< FLASH Size */
+#define FLASH_SECTOR_NB                     (32U)                                   /*!< Flash Sector number */
 #define FLASH_SIZE                          ((((*((uint16_t *)FLASHSIZE_BASE)) == 0xFFFFU)) ? FLASH_SIZE_DEFAULT : \
                                             ((((*((uint16_t *)FLASHSIZE_BASE)) == 0x0000U)) ? FLASH_SIZE_DEFAULT : \
                                             (((uint32_t)(*((uint16_t *)FLASHSIZE_BASE)) & (0xFFFFU)) << 10U)))
@@ -9937,7 +7245,7 @@ typedef struct
 #define FLASH_CR_START_Msk                  (0x1UL << FLASH_CR_START_Pos)           /*!< 0x00000020 */
 #define FLASH_CR_START                      FLASH_CR_START_Msk                      /*!< Erase start control bit */
 #define FLASH_CR_SNB_Pos                    (6U)
-#define FLASH_CR_SNB_Msk                    (0x7FUL << FLASH_CR_SNB_Pos)            /*!< 0x00001FC0 */
+#define FLASH_CR_SNB_Msk                    (0x1FUL << FLASH_CR_SNB_Pos)            /*!< 0x00001FC0 */
 #define FLASH_CR_SNB                        FLASH_CR_SNB_Msk                        /*!< Sector erase selection number */
 #define FLASH_CR_SNB_0                      (0x01UL << FLASH_CR_SNB_Pos)            /*!< 0x00000040 */
 #define FLASH_CR_SNB_1                      (0x02UL << FLASH_CR_SNB_Pos)            /*!< 0x00000080 */
@@ -10033,10 +7341,10 @@ typedef struct
 
 /******************  Bits definition for FLASH_HDPEXTR register  *****************/
 #define FLASH_HDPEXTR_HDP1_EXT_Pos          (0U)
-#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP1_EXT_Pos)  /*!< 0x0000007F */
+#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x1FUL << FLASH_HDPEXTR_HDP1_EXT_Pos)  /*!< 0x0000001F */
 #define FLASH_HDPEXTR_HDP1_EXT              FLASH_HDPEXTR_HDP1_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 1 */
 #define FLASH_HDPEXTR_HDP2_EXT_Pos          (16U)
-#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP2_EXT_Pos)  /*!< 0x007F0000 */
+#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x1FUL << FLASH_HDPEXTR_HDP2_EXT_Pos)  /*!< 0x001F0000 */
 #define FLASH_HDPEXTR_HDP2_EXT              FLASH_HDPEXTR_HDP2_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 2 */
 
 /*******************  Bits definition for FLASH_OPTSR register  ***************/
@@ -10097,9 +7405,6 @@ typedef struct
 #define FLASH_OPTSR2_BKPRAM_ECC_Pos         (4U)
 #define FLASH_OPTSR2_BKPRAM_ECC_Msk         (0x1UL << FLASH_OPTSR2_BKPRAM_ECC_Pos)  /*!< 0x00000010 */
 #define FLASH_OPTSR2_BKPRAM_ECC             FLASH_OPTSR2_BKPRAM_ECC_Msk             /*!< Backup RAM ECC detection and correction enable */
-#define FLASH_OPTSR2_SRAM3_ECC_Pos          (5U)
-#define FLASH_OPTSR2_SRAM3_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM3_ECC_Pos)   /*!< 0x00000020 */
-#define FLASH_OPTSR2_SRAM3_ECC              FLASH_OPTSR2_SRAM3_ECC_Msk              /*!< SRAM3 ECC detection and correction enable */
 #define FLASH_OPTSR2_SRAM2_ECC_Pos          (6U)
 #define FLASH_OPTSR2_SRAM2_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM2_ECC_Pos)   /*!< 0x00000040 */
 #define FLASH_OPTSR2_SRAM2_ECC              FLASH_OPTSR2_SRAM2_ECC_Msk              /*!< SRAM2 ECC detection and correction disable */
@@ -10125,15 +7430,15 @@ typedef struct
 
 /*****************  Bits definition for FLASH_SECWMR register  ********************/
 #define FLASH_SECWMR_SECWM_STRT_Pos         (0U)
-#define FLASH_SECWMR_SECWM_STRT_Msk         (0x7FUL << FLASH_SECWMR_SECWM_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_SECWMR_SECWM_STRT_Msk         (0x1FUL << FLASH_SECWMR_SECWM_STRT_Pos) /*!< 0x0000001F */
 #define FLASH_SECWMR_SECWM_STRT             FLASH_SECWMR_SECWM_STRT_Msk             /*!< Start sector of secure area */
 #define FLASH_SECWMR_SECWM_END_Pos          (16U)
-#define FLASH_SECWMR_SECWM_END_Msk          (0x7FUL << FLASH_SECWMR_SECWM_END_Pos)  /*!< 0x007F0000 */
+#define FLASH_SECWMR_SECWM_END_Msk          (0x1FUL << FLASH_SECWMR_SECWM_END_Pos)  /*!< 0x001F0000 */
 #define FLASH_SECWMR_SECWM_END              FLASH_SECWMR_SECWM_END_Msk              /*!< End sector of secure area */
 
 /*****************  Bits definition for FLASH_WRPR register  *********************/
 #define FLASH_WRPR_WRPSG_Pos                (0U)
-#define FLASH_WRPR_WRPSG_Msk                (0xFFFFFFFFUL << FLASH_WRPR_WRPSG_Pos) /*!< 0xFFFFFFFF */
+#define FLASH_WRPR_WRPSG_Msk                (0x000000FFUL << FLASH_WRPR_WRPSG_Pos) /*!< 0x000000FF */
 #define FLASH_WRPR_WRPSG                    FLASH_WRPR_WRPSG_Msk  /*!< Sector group protection option status */
 
 /*****************  Bits definition for FLASH_EDATA register  ********************/
@@ -10146,10 +7451,10 @@ typedef struct
 
 /*****************  Bits definition for FLASH_HDPR register  ********************/
 #define FLASH_HDPR_HDP_STRT_Pos             (0U)
-#define FLASH_HDPR_HDP_STRT_Msk             (0x7FUL << FLASH_HDPR_HDP_STRT_Pos)     /*!< 0x0000007F */
+#define FLASH_HDPR_HDP_STRT_Msk             (0x1FUL << FLASH_HDPR_HDP_STRT_Pos)     /*!< 0x0000001F */
 #define FLASH_HDPR_HDP_STRT                 FLASH_HDPR_HDP_STRT_Msk                 /*!< Start sector of hide protection area */
 #define FLASH_HDPR_HDP_END_Pos              (16U)
-#define FLASH_HDPR_HDP_END_Msk              (0x7FUL << FLASH_HDPR_HDP_END_Pos)      /*!< 0x007F0000 */
+#define FLASH_HDPR_HDP_END_Msk              (0x1FUL << FLASH_HDPR_HDP_END_Pos)      /*!< 0x001F0000 */
 #define FLASH_HDPR_HDP_END                  FLASH_HDPR_HDP_END_Msk                  /*!< End sector of hide protection area */
 
 /*******************  Bits definition for FLASH_ECCR register  ***************/
@@ -10185,121 +7490,6 @@ typedef struct
 #define FLASH_ECCDR_FAIL_DATA_Pos           (0U)
 #define FLASH_ECCDR_FAIL_DATA_Msk           (0xFFFFUL << FLASH_ECCDR_FAIL_DATA_Pos) /*!< 0x0000FFFF */
 #define FLASH_ECCDR_FAIL_DATA               FLASH_ECCDR_FAIL_DATA_Msk               /*!< ECC fail data */
-
-/******************************************************************************/
-/*                                                                            */
-/*                Filter Mathematical ACcelerator unit (FMAC)                 */
-/*                                                                            */
-/******************************************************************************/
-/*****************  Bit definition for FMAC_X1BUFCFG register  ****************/
-#define FMAC_X1BUFCFG_X1_BASE_Pos           (0U)
-#define FMAC_X1BUFCFG_X1_BASE_Msk           (0xFFUL << FMAC_X1BUFCFG_X1_BASE_Pos)   /*!< 0x000000FF */
-#define FMAC_X1BUFCFG_X1_BASE               FMAC_X1BUFCFG_X1_BASE_Msk               /*!< Base address of X1 buffer */
-#define FMAC_X1BUFCFG_X1_BUF_SIZE_Pos       (8U)
-#define FMAC_X1BUFCFG_X1_BUF_SIZE_Msk       (0xFFUL << FMAC_X1BUFCFG_X1_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_X1BUFCFG_X1_BUF_SIZE           FMAC_X1BUFCFG_X1_BUF_SIZE_Msk           /*!< Allocated size of X1 buffer in 16-bit words */
-#define FMAC_X1BUFCFG_FULL_WM_Pos           (24U)
-#define FMAC_X1BUFCFG_FULL_WM_Msk           (0x3UL << FMAC_X1BUFCFG_FULL_WM_Pos)    /*!< 0x03000000 */
-#define FMAC_X1BUFCFG_FULL_WM               FMAC_X1BUFCFG_FULL_WM_Msk               /*!< Watermark for buffer full flag */
-
-/*****************  Bit definition for FMAC_X2BUFCFG register  ****************/
-#define FMAC_X2BUFCFG_X2_BASE_Pos           (0U)
-#define FMAC_X2BUFCFG_X2_BASE_Msk           (0xFFUL << FMAC_X2BUFCFG_X2_BASE_Pos)   /*!< 0x000000FF */
-#define FMAC_X2BUFCFG_X2_BASE               FMAC_X2BUFCFG_X2_BASE_Msk               /*!< Base address of X2 buffer */
-#define FMAC_X2BUFCFG_X2_BUF_SIZE_Pos       (8U)
-#define FMAC_X2BUFCFG_X2_BUF_SIZE_Msk       (0xFFUL << FMAC_X2BUFCFG_X2_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_X2BUFCFG_X2_BUF_SIZE           FMAC_X2BUFCFG_X2_BUF_SIZE_Msk           /*!< Size of X2 buffer in 16-bit words */
-
-/*****************  Bit definition for FMAC_YBUFCFG register  *****************/
-#define FMAC_YBUFCFG_Y_BASE_Pos             (0U)
-#define FMAC_YBUFCFG_Y_BASE_Msk             (0xFFUL << FMAC_YBUFCFG_Y_BASE_Pos)     /*!< 0x000000FF */
-#define FMAC_YBUFCFG_Y_BASE                 FMAC_YBUFCFG_Y_BASE_Msk                 /*!< Base address of Y buffer */
-#define FMAC_YBUFCFG_Y_BUF_SIZE_Pos         (8U)
-#define FMAC_YBUFCFG_Y_BUF_SIZE_Msk         (0xFFUL << FMAC_YBUFCFG_Y_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_YBUFCFG_Y_BUF_SIZE             FMAC_YBUFCFG_Y_BUF_SIZE_Msk             /*!< Size of Y buffer in 16-bit words */
-#define FMAC_YBUFCFG_EMPTY_WM_Pos           (24U)
-#define FMAC_YBUFCFG_EMPTY_WM_Msk           (0x3UL << FMAC_YBUFCFG_EMPTY_WM_Pos)    /*!< 0x03000000 */
-#define FMAC_YBUFCFG_EMPTY_WM               FMAC_YBUFCFG_EMPTY_WM_Msk               /*!< Watermark for buffer empty flag */
-
-/******************  Bit definition for FMAC_PARAM register  ******************/
-#define FMAC_PARAM_P_Pos                    (0U)
-#define FMAC_PARAM_P_Msk                    (0xFFUL << FMAC_PARAM_P_Pos)            /*!< 0x000000FF */
-#define FMAC_PARAM_P                        FMAC_PARAM_P_Msk                        /*!< Input parameter P */
-#define FMAC_PARAM_Q_Pos                    (8U)
-#define FMAC_PARAM_Q_Msk                    (0xFFUL << FMAC_PARAM_Q_Pos)            /*!< 0x0000FF00 */
-#define FMAC_PARAM_Q                        FMAC_PARAM_Q_Msk                        /*!< Input parameter Q */
-#define FMAC_PARAM_R_Pos                    (16U)
-#define FMAC_PARAM_R_Msk                    (0xFFUL << FMAC_PARAM_R_Pos)            /*!< 0x00FF0000 */
-#define FMAC_PARAM_R                        FMAC_PARAM_R_Msk                        /*!< Input parameter R */
-#define FMAC_PARAM_FUNC_Pos                 (24U)
-#define FMAC_PARAM_FUNC_Msk                 (0x7FUL << FMAC_PARAM_FUNC_Pos)         /*!< 0x7F000000 */
-#define FMAC_PARAM_FUNC                     FMAC_PARAM_FUNC_Msk                     /*!< Function */
-#define FMAC_PARAM_FUNC_0                   (0x1UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x01000000 */
-#define FMAC_PARAM_FUNC_1                   (0x2UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x02000000 */
-#define FMAC_PARAM_FUNC_2                   (0x4UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x04000000 */
-#define FMAC_PARAM_FUNC_3                   (0x8UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x08000000 */
-#define FMAC_PARAM_FUNC_4                   (0x10UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x10000000 */
-#define FMAC_PARAM_FUNC_5                   (0x20UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x20000000 */
-#define FMAC_PARAM_FUNC_6                   (0x40UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x40000000 */
-#define FMAC_PARAM_START_Pos                (31U)
-#define FMAC_PARAM_START_Msk                (0x1UL << FMAC_PARAM_START_Pos)         /*!< 0x80000000 */
-#define FMAC_PARAM_START                    FMAC_PARAM_START_Msk                    /*!< Enable execution */
-
-/********************  Bit definition for FMAC_CR register  *******************/
-#define FMAC_CR_RIEN_Pos                    (0U)
-#define FMAC_CR_RIEN_Msk                    (0x1UL << FMAC_CR_RIEN_Pos)             /*!< 0x00000001 */
-#define FMAC_CR_RIEN                        FMAC_CR_RIEN_Msk                        /*!< Enable read interrupt */
-#define FMAC_CR_WIEN_Pos                    (1U)
-#define FMAC_CR_WIEN_Msk                    (0x1UL << FMAC_CR_WIEN_Pos)             /*!< 0x00000002 */
-#define FMAC_CR_WIEN                        FMAC_CR_WIEN_Msk                        /*!< Enable write interrupt */
-#define FMAC_CR_OVFLIEN_Pos                 (2U)
-#define FMAC_CR_OVFLIEN_Msk                 (0x1UL << FMAC_CR_OVFLIEN_Pos)          /*!< 0x00000004 */
-#define FMAC_CR_OVFLIEN                     FMAC_CR_OVFLIEN_Msk                     /*!< Enable overflow error interrupts */
-#define FMAC_CR_UNFLIEN_Pos                 (3U)
-#define FMAC_CR_UNFLIEN_Msk                 (0x1UL << FMAC_CR_UNFLIEN_Pos)          /*!< 0x00000008 */
-#define FMAC_CR_UNFLIEN                     FMAC_CR_UNFLIEN_Msk                     /*!< Enable underflow error interrupts */
-#define FMAC_CR_SATIEN_Pos                  (4U)
-#define FMAC_CR_SATIEN_Msk                  (0x1UL << FMAC_CR_SATIEN_Pos)           /*!< 0x00000010 */
-#define FMAC_CR_SATIEN                      FMAC_CR_SATIEN_Msk                      /*!< Enable saturation error interrupts */
-#define FMAC_CR_DMAREN_Pos                  (8U)
-#define FMAC_CR_DMAREN_Msk                  (0x1UL << FMAC_CR_DMAREN_Pos)           /*!< 0x00000100 */
-#define FMAC_CR_DMAREN                      FMAC_CR_DMAREN_Msk                      /*!< Enable DMA read channel requests */
-#define FMAC_CR_DMAWEN_Pos                  (9U)
-#define FMAC_CR_DMAWEN_Msk                  (0x1UL << FMAC_CR_DMAWEN_Pos)           /*!< 0x00000200 */
-#define FMAC_CR_DMAWEN                      FMAC_CR_DMAWEN_Msk                      /*!< Enable DMA write channel requests */
-#define FMAC_CR_CLIPEN_Pos                  (15U)
-#define FMAC_CR_CLIPEN_Msk                  (0x1UL << FMAC_CR_CLIPEN_Pos)           /*!< 0x00008000 */
-#define FMAC_CR_CLIPEN                      FMAC_CR_CLIPEN_Msk                      /*!< Enable clipping */
-#define FMAC_CR_RESET_Pos                   (16U)
-#define FMAC_CR_RESET_Msk                   (0x1UL << FMAC_CR_RESET_Pos)            /*!< 0x00010000 */
-#define FMAC_CR_RESET                       FMAC_CR_RESET_Msk                       /*!< Reset filter mathematical accelerator unit */
-
-/*******************  Bit definition for FMAC_SR register  ********************/
-#define FMAC_SR_YEMPTY_Pos                  (0U)
-#define FMAC_SR_YEMPTY_Msk                  (0x1UL << FMAC_SR_YEMPTY_Pos)           /*!< 0x00000001 */
-#define FMAC_SR_YEMPTY                      FMAC_SR_YEMPTY_Msk                      /*!< Y buffer empty flag */
-#define FMAC_SR_X1FULL_Pos                  (1U)
-#define FMAC_SR_X1FULL_Msk                  (0x1UL << FMAC_SR_X1FULL_Pos)           /*!< 0x00000002 */
-#define FMAC_SR_X1FULL                      FMAC_SR_X1FULL_Msk                      /*!< X1 buffer full flag */
-#define FMAC_SR_OVFL_Pos                    (8U)
-#define FMAC_SR_OVFL_Msk                    (0x1UL << FMAC_SR_OVFL_Pos)             /*!< 0x00000100 */
-#define FMAC_SR_OVFL                        FMAC_SR_OVFL_Msk                        /*!< Overflow error flag */
-#define FMAC_SR_UNFL_Pos                    (9U)
-#define FMAC_SR_UNFL_Msk                    (0x1UL << FMAC_SR_UNFL_Pos)             /*!< 0x00000200 */
-#define FMAC_SR_UNFL                        FMAC_SR_UNFL_Msk                        /*!< Underflow error flag */
-#define FMAC_SR_SAT_Pos                     (10U)
-#define FMAC_SR_SAT_Msk                     (0x1UL << FMAC_SR_SAT_Pos)              /*!< 0x00000400 */
-#define FMAC_SR_SAT                         FMAC_SR_SAT_Msk                         /*!< Saturation error flag */
-
-/******************  Bit definition for FMAC_WDATA register  ******************/
-#define FMAC_WDATA_WDATA_Pos                (0U)
-#define FMAC_WDATA_WDATA_Msk                (0xFFFFUL << FMAC_WDATA_WDATA_Pos)      /*!< 0x0000FFFF */
-#define FMAC_WDATA_WDATA                    FMAC_WDATA_WDATA_Msk                    /*!< Write data */
-
-/******************  Bit definition for FMACX_RDATA register  *****************/
-#define FMAC_RDATA_RDATA_Pos                (0U)
-#define FMAC_RDATA_RDATA_Msk                (0xFFFFUL << FMAC_RDATA_RDATA_Pos)      /*!< 0x0000FFFF */
-#define FMAC_RDATA_RDATA                    FMAC_RDATA_RDATA_Msk                    /*!< Read data */
 
 /******************************************************************************/
 /*                                                                            */
@@ -14511,19 +11701,19 @@ typedef struct
 #define PWR_PMCR_AVD_READY_Pos               (13U)
 #define PWR_PMCR_AVD_READY_Msk               (0x1UL << PWR_PMCR_AVD_READY_Pos)
 #define PWR_PMCR_AVD_READY                   PWR_PMCR_AVD_READY_Msk
-#define PWR_PMCR_ETHERNETSO_Pos              (16U)
-#define PWR_PMCR_ETHERNETSO_Msk              (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
-#define PWR_PMCR_ETHERNETSO                  PWR_PMCR_ETHERNETSO_Msk
 #define PWR_PMCR_SRAM3SO_Pos                 (23U)
 #define PWR_PMCR_SRAM3SO_Msk                 (0x1UL << PWR_PMCR_SRAM3SO_Pos)
 #define PWR_PMCR_SRAM3SO                     PWR_PMCR_SRAM3SO_Msk
-#define PWR_PMCR_SRAM2_16SO_Pos              (24U)
-#define PWR_PMCR_SRAM2_16SO_Msk              (0x1UL << PWR_PMCR_SRAM2_16SO_Pos)
-#define PWR_PMCR_SRAM2_16SO                  PWR_PMCR_SRAM2_16SO_Msk
-#define PWR_PMCR_SRAM2_48SO_Pos              (25U)
+#define PWR_PMCR_SRAM2_16LSO_Pos             (24U)
+#define PWR_PMCR_SRAM2_16LSO_Msk             (0x1UL << PWR_PMCR_SRAM2_16LSO_Pos)
+#define PWR_PMCR_SRAM2_16LSO                 PWR_PMCR_SRAM2_16LSO_Msk
+#define PWR_PMCR_SRAM2_16HSO_Pos             (25U)
+#define PWR_PMCR_SRAM2_16HSO_Msk             (0x1UL << PWR_PMCR_SRAM2_16HSO_Pos)
+#define PWR_PMCR_SRAM2_16HSO                 PWR_PMCR_SRAM2_16HSO_Msk
+#define PWR_PMCR_SRAM2_48SO_Pos              (26U)
 #define PWR_PMCR_SRAM2_48SO_Msk              (0x1UL << PWR_PMCR_SRAM2_48SO_Pos)
 #define PWR_PMCR_SRAM2_48SO                  PWR_PMCR_SRAM2_48SO_Msk
-#define PWR_PMCR_SRAM1SO_Pos                 (26U)
+#define PWR_PMCR_SRAM1SO_Pos                 (27U)
 #define PWR_PMCR_SRAM1SO_Msk                 (0x1UL << PWR_PMCR_SRAM1SO_Pos)
 #define PWR_PMCR_SRAM1SO                     PWR_PMCR_SRAM1SO_Msk
 
@@ -14606,9 +11796,6 @@ typedef struct
 #define PWR_SCCR_LDOEN_Pos                   (8U)
 #define PWR_SCCR_LDOEN_Msk                   (0x1UL << PWR_SCCR_LDOEN_Pos)
 #define PWR_SCCR_LDOEN                       PWR_SCCR_LDOEN_Msk
-#define PWR_SCCR_SMPSEN_Pos                  (9U)
-#define PWR_SCCR_SMPSEN_Msk                  (0x1UL << PWR_SCCR_SMPSEN_Pos)
-#define PWR_SCCR_SMPSEN                      PWR_SCCR_SMPSEN_Msk
 
 /********************  Bit definition for PWR_VMCR register  ******************/
 #define PWR_VMCR_PVDEN_Pos                   (0U)
@@ -15108,6 +12295,55 @@ typedef struct
 #define RAMCFG_WPR2_P63WP_Msk               (0x1UL << RAMCFG_WPR2_P63WP_Pos)        /*!< 0x80000000 */
 #define RAMCFG_WPR2_P63WP                   RAMCFG_WPR2_P63WP_Msk                   /*!< Write Protection Page 63 */
 
+/******************  Bit definition for RAMCFG_WPR3 register  ****************/
+#define RAMCFG_WPR3_P64WP_Pos               (0U)
+#define RAMCFG_WPR3_P64WP_Msk               (0x1UL << RAMCFG_WPR3_P64WP_Pos)        /*!< 0x00000001 */
+#define RAMCFG_WPR3_P64WP                   RAMCFG_WPR3_P64WP_Msk                   /*!< Write Protection Page 64 */
+#define RAMCFG_WPR3_P65WP_Pos               (1U)
+#define RAMCFG_WPR3_P65WP_Msk               (0x1UL << RAMCFG_WPR3_P65WP_Pos)        /*!< 0x00000002 */
+#define RAMCFG_WPR3_P65WP                   RAMCFG_WPR3_P65WP_Msk                   /*!< Write Protection Page 65 */
+#define RAMCFG_WPR3_P66WP_Pos               (2U)
+#define RAMCFG_WPR3_P66WP_Msk               (0x1UL << RAMCFG_WPR3_P66WP_Pos)        /*!< 0x00000004 */
+#define RAMCFG_WPR3_P66WP                   RAMCFG_WPR3_P66WP_Msk                   /*!< Write Protection Page 66 */
+#define RAMCFG_WPR3_P67WP_Pos               (3U)
+#define RAMCFG_WPR3_P67WP_Msk               (0x1UL << RAMCFG_WPR3_P67WP_Pos)        /*!< 0x00000008 */
+#define RAMCFG_WPR3_P67WP                   RAMCFG_WPR3_P67WP_Msk                   /*!< Write Protection Page 67 */
+#define RAMCFG_WPR3_P68WP_Pos               (4U)
+#define RAMCFG_WPR3_P68WP_Msk               (0x1UL << RAMCFG_WPR3_P68WP_Pos)        /*!< 0x00000010 */
+#define RAMCFG_WPR3_P68WP                   RAMCFG_WPR3_P68WP_Msk                   /*!< Write Protection Page 68 */
+#define RAMCFG_WPR3_P69WP_Pos               (5U)
+#define RAMCFG_WPR3_P69WP_Msk               (0x1UL << RAMCFG_WPR3_P69WP_Pos)        /*!< 0x00000020 */
+#define RAMCFG_WPR3_P69WP                   RAMCFG_WPR3_P69WP_Msk                   /*!< Write Protection Page 69 */
+#define RAMCFG_WPR3_P70WP_Pos               (6U)
+#define RAMCFG_WPR3_P70WP_Msk               (0x1UL << RAMCFG_WPR3_P70WP_Pos)        /*!< 0x00000040 */
+#define RAMCFG_WPR3_P70WP                   RAMCFG_WPR3_P70WP_Msk                   /*!< Write Protection Page 70 */
+#define RAMCFG_WPR3_P71WP_Pos               (7U)
+#define RAMCFG_WPR3_P71WP_Msk               (0x1UL << RAMCFG_WPR3_P71WP_Pos)        /*!< 0x00000080 */
+#define RAMCFG_WPR3_P71WP                   RAMCFG_WPR3_P71WP_Msk                   /*!< Write Protection Page 71 */
+#define RAMCFG_WPR3_P72WP_Pos               (8U)
+#define RAMCFG_WPR3_P72WP_Msk               (0x1UL << RAMCFG_WPR3_P72WP_Pos)        /*!< 0x00000100 */
+#define RAMCFG_WPR3_P72WP                   RAMCFG_WPR3_P72WP_Msk                   /*!< Write Protection Page 72 */
+#define RAMCFG_WPR3_P73WP_Pos               (9U)
+#define RAMCFG_WPR3_P73WP_Msk               (0x1UL << RAMCFG_WPR3_P73WP_Pos)        /*!< 0x00000200 */
+#define RAMCFG_WPR3_P73WP                   RAMCFG_WPR3_P73WP_Msk                   /*!< Write Protection Page 73 */
+#define RAMCFG_WPR3_P74WP_Pos               (10U)
+#define RAMCFG_WPR3_P74WP_Msk               (0x1UL << RAMCFG_WPR3_P74WP_Pos)        /*!< 0x00000400 */
+#define RAMCFG_WPR3_P74WP                   RAMCFG_WPR3_P74WP_Msk                   /*!< Write Protection Page 74 */
+#define RAMCFG_WPR3_P75WP_Pos               (11U)
+#define RAMCFG_WPR3_P75WP_Msk               (0x1UL << RAMCFG_WPR3_P75WP_Pos)        /*!< 0x00000800 */
+#define RAMCFG_WPR3_P75WP                   RAMCFG_WPR3_P75WP_Msk                   /*!< Write Protection Page 75 */
+#define RAMCFG_WPR3_P76WP_Pos               (12U)
+#define RAMCFG_WPR3_P76WP_Msk               (0x1UL << RAMCFG_WPR3_P76WP_Pos)        /*!< 0x00001000 */
+#define RAMCFG_WPR3_P76WP                   RAMCFG_WPR3_P76WP_Msk                   /*!< Write Protection Page 76 */
+#define RAMCFG_WPR3_P77WP_Pos               (13U)
+#define RAMCFG_WPR3_P77WP_Msk               (0x1UL << RAMCFG_WPR3_P77WP_Pos)        /*!< 0x00002000 */
+#define RAMCFG_WPR3_P77WP                   RAMCFG_WPR3_P77WP_Msk                   /*!< Write Protection Page 77 */
+#define RAMCFG_WPR3_P78WP_Pos               (14U)
+#define RAMCFG_WPR3_P78WP_Msk               (0x1UL << RAMCFG_WPR3_P78WP_Pos)        /*!< 0x00004000 */
+#define RAMCFG_WPR3_P78WP                   RAMCFG_WPR3_P78WP_Msk                   /*!< Write Protection Page 78 */
+#define RAMCFG_WPR3_P79WP_Pos               (15U)
+#define RAMCFG_WPR3_P79WP_Msk               (0x1UL << RAMCFG_WPR3_P79WP_Pos)        /*!< 0x00008000 */
+#define RAMCFG_WPR3_P79WP                   RAMCFG_WPR3_P79WP_Msk                   /*!< Write Protection Page 79 */
 /*****************  Bit definition for RAMCFG_ECCKEYR register  ***************/
 #define RAMCFG_ECCKEYR_ECCKEY_Pos           (0U)
 #define RAMCFG_ECCKEYR_ECCKEY_Msk           (0xFFUL << RAMCFG_ECCKEYR_ECCKEY_Pos)   /*!< 0x000000FF */
@@ -15782,18 +13018,9 @@ typedef struct
 #define RCC_AHB1RSTR_CRCRST_Pos             (12U)
 #define RCC_AHB1RSTR_CRCRST_Msk             (0x1UL << RCC_AHB1RSTR_CRCRST_Pos)      /*!< 0x00001000 */
 #define RCC_AHB1RSTR_CRCRST                 RCC_AHB1RSTR_CRCRST_Msk
-#define RCC_AHB1RSTR_CORDICRST_Pos          (14U)
-#define RCC_AHB1RSTR_CORDICRST_Msk          (0x1UL << RCC_AHB1RSTR_CORDICRST_Pos)   /*!< 0x00004000 */
-#define RCC_AHB1RSTR_CORDICRST              RCC_AHB1RSTR_CORDICRST_Msk
-#define RCC_AHB1RSTR_FMACRST_Pos            (15U)
-#define RCC_AHB1RSTR_FMACRST_Msk            (0x1UL << RCC_AHB1RSTR_FMACRST_Pos)     /*!< 0x00008000 */
-#define RCC_AHB1RSTR_FMACRST                RCC_AHB1RSTR_FMACRST_Msk
 #define RCC_AHB1RSTR_RAMCFGRST_Pos          (17U)
 #define RCC_AHB1RSTR_RAMCFGRST_Msk          (0x1UL << RCC_AHB1RSTR_RAMCFGRST_Pos)   /*!< 0x00020000 */
 #define RCC_AHB1RSTR_RAMCFGRST              RCC_AHB1RSTR_RAMCFGRST_Msk
-#define RCC_AHB1RSTR_ETHRST_Pos             (19U)
-#define RCC_AHB1RSTR_ETHRST_Msk             (0x1UL << RCC_AHB1RSTR_ETHRST_Pos)      /*!< 0x00080000 */
-#define RCC_AHB1RSTR_ETHRST                 RCC_AHB1RSTR_ETHRST_Msk
 #define RCC_AHB1RSTR_TZSC1RST_Pos           (24U)
 #define RCC_AHB1RSTR_TZSC1RST_Msk           (0x1UL << RCC_AHB1RSTR_TZSC1RST_Pos)    /*!< 0x01000000 */
 #define RCC_AHB1RSTR_TZSC1RST               RCC_AHB1RSTR_TZSC1RST_Msk
@@ -15823,9 +13050,6 @@ typedef struct
 #define RCC_AHB2RSTR_GPIOHRST_Pos           (7U)
 #define RCC_AHB2RSTR_GPIOHRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOHRST_Pos)    /*!< 0x00000080 */
 #define RCC_AHB2RSTR_GPIOHRST               RCC_AHB2RSTR_GPIOHRST_Msk
-#define RCC_AHB2RSTR_GPIOIRST_Pos           (8U)
-#define RCC_AHB2RSTR_GPIOIRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOIRST_Pos)    /*!< 0x00000100 */
-#define RCC_AHB2RSTR_GPIOIRST               RCC_AHB2RSTR_GPIOIRST_Msk
 #define RCC_AHB2RSTR_ADCRST_Pos             (10U)
 #define RCC_AHB2RSTR_ADCRST_Msk             (0x1UL << RCC_AHB2RSTR_ADCRST_Pos)      /*!< 0x00000400 */
 #define RCC_AHB2RSTR_ADCRST                 RCC_AHB2RSTR_ADCRST_Msk
@@ -15849,9 +13073,6 @@ typedef struct
 #define RCC_AHB4RSTR_SDMMC1RST_Pos          (11U)
 #define RCC_AHB4RSTR_SDMMC1RST_Msk          (0x1UL << RCC_AHB4RSTR_SDMMC1RST_Pos)   /*!< 0x00000800 */
 #define RCC_AHB4RSTR_SDMMC1RST              RCC_AHB4RSTR_SDMMC1RST_Msk
-#define RCC_AHB4RSTR_SDMMC2RST_Pos          (12U)
-#define RCC_AHB4RSTR_SDMMC2RST_Msk          (0x1UL << RCC_AHB4RSTR_SDMMC2RST_Pos)   /*!< 0x0001000 */
-#define RCC_AHB4RSTR_SDMMC2RST              RCC_AHB4RSTR_SDMMC2RST_Msk
 #define RCC_AHB4RSTR_FMCRST_Pos             (16U)
 #define RCC_AHB4RSTR_FMCRST_Msk             (0x1UL << RCC_AHB4RSTR_FMCRST_Pos)      /*!< 0x00010000 */
 #define RCC_AHB4RSTR_FMCRST                 RCC_AHB4RSTR_FMCRST_Msk
@@ -15881,12 +13102,6 @@ typedef struct
 #define RCC_APB1LRSTR_TIM12RST_Pos          (6U)
 #define RCC_APB1LRSTR_TIM12RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM12RST_Pos)  /*!< 0x00000040 */
 #define RCC_APB1LRSTR_TIM12RST              RCC_APB1LRSTR_TIM12RST_Msk
-#define RCC_APB1LRSTR_TIM13RST_Pos          (7U)
-#define RCC_APB1LRSTR_TIM13RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM13RST_Pos)  /*!< 0x00000080 */
-#define RCC_APB1LRSTR_TIM13RST              RCC_APB1LRSTR_TIM13RST_Msk
-#define RCC_APB1LRSTR_TIM14RST_Pos          (8U)
-#define RCC_APB1LRSTR_TIM14RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM14RST_Pos)  /*!< 0x00000100 */
-#define RCC_APB1LRSTR_TIM14RST              RCC_APB1LRSTR_TIM14RST_Msk
 #define RCC_APB1LRSTR_SPI2RST_Pos           (14U)
 #define RCC_APB1LRSTR_SPI2RST_Msk           (0x1UL << RCC_APB1LRSTR_SPI2RST_Pos)    /*!< 0x00004000 */
 #define RCC_APB1LRSTR_SPI2RST               RCC_APB1LRSTR_SPI2RST_Msk
@@ -15920,29 +13135,11 @@ typedef struct
 #define RCC_APB1LRSTR_USART6RST_Pos         (25U)
 #define RCC_APB1LRSTR_USART6RST_Msk         (0x1UL << RCC_APB1LRSTR_USART6RST_Pos)  /*!< 0x02000000 */
 #define RCC_APB1LRSTR_USART6RST             RCC_APB1LRSTR_USART6RST_Msk
-#define RCC_APB1LRSTR_USART10RST_Pos        (26U)
-#define RCC_APB1LRSTR_USART10RST_Msk        (0x1UL << RCC_APB1LRSTR_USART10RST_Pos) /*!< 0x04000000 */
-#define RCC_APB1LRSTR_USART10RST            RCC_APB1LRSTR_USART10RST_Msk
-#define RCC_APB1LRSTR_USART11RST_Pos        (27U)
-#define RCC_APB1LRSTR_USART11RST_Msk        (0x1UL << RCC_APB1LRSTR_USART11RST_Pos) /*!< 0x08000000 */
-#define RCC_APB1LRSTR_USART11RST            RCC_APB1LRSTR_USART11RST_Msk
 #define RCC_APB1LRSTR_CECRST_Pos            (28U)
 #define RCC_APB1LRSTR_CECRST_Msk            (0x1UL << RCC_APB1LRSTR_CECRST_Pos)      /*!< 0x10000000 */
 #define RCC_APB1LRSTR_CECRST                RCC_APB1LRSTR_CECRST_Msk
-#define RCC_APB1LRSTR_UART7RST_Pos          (30U)
-#define RCC_APB1LRSTR_UART7RST_Msk          (0x1UL << RCC_APB1LRSTR_UART7RST_Pos)    /*!< 0x40000000 */
-#define RCC_APB1LRSTR_UART7RST              RCC_APB1LRSTR_UART7RST_Msk
-#define RCC_APB1LRSTR_UART8RST_Pos          (31U)
-#define RCC_APB1LRSTR_UART8RST_Msk          (0x1UL << RCC_APB1LRSTR_UART8RST_Pos)    /*!< 0x80000000 */
-#define RCC_APB1LRSTR_UART8RST              RCC_APB1LRSTR_UART8RST_Msk
 
 /********************  Bit definition for RCC_APB1HRSTR register  **************/
-#define RCC_APB1HRSTR_UART9RST_Pos          (0U)
-#define RCC_APB1HRSTR_UART9RST_Msk          (0x1UL << RCC_APB1HRSTR_UART9RST_Pos)    /*!< 0x00000001 */
-#define RCC_APB1HRSTR_UART9RST              RCC_APB1HRSTR_UART9RST_Msk
-#define RCC_APB1HRSTR_UART12RST_Pos         (1U)
-#define RCC_APB1HRSTR_UART12RST_Msk         (0x1UL << RCC_APB1HRSTR_UART12RST_Pos)   /*!< 0x00000002 */
-#define RCC_APB1HRSTR_UART12RST             RCC_APB1HRSTR_UART12RST_Msk
 #define RCC_APB1HRSTR_DTSRST_Pos            (3U)
 #define RCC_APB1HRSTR_DTSRST_Msk            (0x1UL << RCC_APB1HRSTR_DTSRST_Pos)     /*!< 0x00000008 */
 #define RCC_APB1HRSTR_DTSRST                RCC_APB1HRSTR_DTSRST_Msk
@@ -15972,56 +13169,26 @@ typedef struct
 #define RCC_APB2RSTR_TIM15RST_Pos           (16U)
 #define RCC_APB2RSTR_TIM15RST_Msk           (0x1UL << RCC_APB2RSTR_TIM15RST_Pos)    /*!< 0x00010000 */
 #define RCC_APB2RSTR_TIM15RST               RCC_APB2RSTR_TIM15RST_Msk
-#define RCC_APB2RSTR_TIM16RST_Pos           (17U)
-#define RCC_APB2RSTR_TIM16RST_Msk           (0x1UL << RCC_APB2RSTR_TIM16RST_Pos)    /*!< 0x00020000 */
-#define RCC_APB2RSTR_TIM16RST               RCC_APB2RSTR_TIM16RST_Msk
-#define RCC_APB2RSTR_TIM17RST_Pos           (18U)
-#define RCC_APB2RSTR_TIM17RST_Msk           (0x1UL << RCC_APB2RSTR_TIM17RST_Pos)    /*!< 0x00040000 */
-#define RCC_APB2RSTR_TIM17RST               RCC_APB2RSTR_TIM17RST_Msk
 #define RCC_APB2RSTR_SPI4RST_Pos            (19U)
 #define RCC_APB2RSTR_SPI4RST_Msk            (0x1UL << RCC_APB2RSTR_SPI4RST_Pos)     /*!< 0x00080000 */
 #define RCC_APB2RSTR_SPI4RST                RCC_APB2RSTR_SPI4RST_Msk
-#define RCC_APB2RSTR_SPI6RST_Pos            (20U)
-#define RCC_APB2RSTR_SPI6RST_Msk            (0x1UL << RCC_APB2RSTR_SPI6RST_Pos)     /*!< 0x00100000 */
-#define RCC_APB2RSTR_SPI6RST                RCC_APB2RSTR_SPI6RST_Msk
-#define RCC_APB2RSTR_SAI1RST_Pos            (21U)
-#define RCC_APB2RSTR_SAI1RST_Msk            (0x1UL << RCC_APB2RSTR_SAI1RST_Pos)     /*!< 0x00200000 */
-#define RCC_APB2RSTR_SAI1RST                RCC_APB2RSTR_SAI1RST_Msk
-#define RCC_APB2RSTR_SAI2RST_Pos            (22U)
-#define RCC_APB2RSTR_SAI2RST_Msk            (0x1UL << RCC_APB2RSTR_SAI2RST_Pos)     /*!< 0x00400000 */
-#define RCC_APB2RSTR_SAI2RST                RCC_APB2RSTR_SAI2RST_Msk
 #define RCC_APB2RSTR_USBRST_Pos             (24U)
 #define RCC_APB2RSTR_USBRST_Msk             (0x1UL << RCC_APB2RSTR_USBRST_Pos)      /*!< 0x01000000 */
 #define RCC_APB2RSTR_USBRST                 RCC_APB2RSTR_USBRST_Msk
 
 /********************  Bit definition for RCC_APB3RSTR register  **************/
-#define RCC_APB3RSTR_SPI5RST_Pos            (5U)
-#define RCC_APB3RSTR_SPI5RST_Msk            (0x1UL << RCC_APB3RSTR_SPI5RST_Pos)     /*!< 0x00000020 */
-#define RCC_APB3RSTR_SPI5RST                RCC_APB3RSTR_SPI5RST_Msk
 #define RCC_APB3RSTR_LPUART1RST_Pos         (6U)
 #define RCC_APB3RSTR_LPUART1RST_Msk         (0x1UL << RCC_APB3RSTR_LPUART1RST_Pos)  /*!< 0x00000040 */
 #define RCC_APB3RSTR_LPUART1RST             RCC_APB3RSTR_LPUART1RST_Msk
 #define RCC_APB3RSTR_I2C3RST_Pos            (7U)
 #define RCC_APB3RSTR_I2C3RST_Msk            (0x1UL << RCC_APB3RSTR_I2C3RST_Pos)     /*!< 0x00000080 */
 #define RCC_APB3RSTR_I2C3RST                RCC_APB3RSTR_I2C3RST_Msk
-#define RCC_APB3RSTR_I2C4RST_Pos            (8U)
-#define RCC_APB3RSTR_I2C4RST_Msk            (0x1UL << RCC_APB3RSTR_I2C4RST_Pos)     /*!< 0x00000100 */
-#define RCC_APB3RSTR_I2C4RST                RCC_APB3RSTR_I2C4RST_Msk
+#define RCC_APB3RSTR_I3C2RST_Pos            (9U)
+#define RCC_APB3RSTR_I3C2RST_Msk            (0x1UL << RCC_APB3RSTR_I3C2RST_Pos)     /*!< 0x00000200 */
+#define RCC_APB3RSTR_I3C2RST                RCC_APB3RSTR_I3C2RST_Msk
 #define RCC_APB3RSTR_LPTIM1RST_Pos          (11U)
 #define RCC_APB3RSTR_LPTIM1RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM1RST_Pos)   /*!< 0x00000800 */
 #define RCC_APB3RSTR_LPTIM1RST              RCC_APB3RSTR_LPTIM1RST_Msk
-#define RCC_APB3RSTR_LPTIM3RST_Pos          (12U)
-#define RCC_APB3RSTR_LPTIM3RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM3RST_Pos)   /*!< 0x00001000 */
-#define RCC_APB3RSTR_LPTIM3RST              RCC_APB3RSTR_LPTIM3RST_Msk
-#define RCC_APB3RSTR_LPTIM4RST_Pos          (13U)
-#define RCC_APB3RSTR_LPTIM4RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM4RST_Pos)   /*!< 0x00002000 */
-#define RCC_APB3RSTR_LPTIM4RST              RCC_APB3RSTR_LPTIM4RST_Msk
-#define RCC_APB3RSTR_LPTIM5RST_Pos          (14U)
-#define RCC_APB3RSTR_LPTIM5RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM5RST_Pos)   /*!< 0x00004000 */
-#define RCC_APB3RSTR_LPTIM5RST              RCC_APB3RSTR_LPTIM5RST_Msk
-#define RCC_APB3RSTR_LPTIM6RST_Pos          (15U)
-#define RCC_APB3RSTR_LPTIM6RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM6RST_Pos)   /*!< 0x00008000 */
-#define RCC_APB3RSTR_LPTIM6RST              RCC_APB3RSTR_LPTIM6RST_Msk
 #define RCC_APB3RSTR_VREFRST_Pos            (20U)
 #define RCC_APB3RSTR_VREFRST_Msk            (0x1UL << RCC_APB3RSTR_VREFRST_Pos)     /*!< 0x00100000 */
 #define RCC_APB3RSTR_VREFRST                RCC_APB3RSTR_VREFRST_Msk
@@ -16039,24 +13206,9 @@ typedef struct
 #define RCC_AHB1ENR_CRCEN_Pos               (12U)
 #define RCC_AHB1ENR_CRCEN_Msk               (0x1UL << RCC_AHB1ENR_CRCEN_Pos)        /*!< 0x00001000 */
 #define RCC_AHB1ENR_CRCEN                   RCC_AHB1ENR_CRCEN_Msk
-#define RCC_AHB1ENR_CORDICEN_Pos            (14U)
-#define RCC_AHB1ENR_CORDICEN_Msk            (0x1UL << RCC_AHB1ENR_CORDICEN_Pos)     /*!< 0x00004000 */
-#define RCC_AHB1ENR_CORDICEN                RCC_AHB1ENR_CORDICEN_Msk
-#define RCC_AHB1ENR_FMACEN_Pos              (15U)
-#define RCC_AHB1ENR_FMACEN_Msk              (0x1UL << RCC_AHB1ENR_FMACEN_Pos)       /*!< 0x00008000 */
-#define RCC_AHB1ENR_FMACEN                  RCC_AHB1ENR_FMACEN_Msk
 #define RCC_AHB1ENR_RAMCFGEN_Pos            (17U)
 #define RCC_AHB1ENR_RAMCFGEN_Msk            (0x1UL << RCC_AHB1ENR_RAMCFGEN_Pos)     /*!< 0x00020000 */
 #define RCC_AHB1ENR_RAMCFGEN                RCC_AHB1ENR_RAMCFGEN_Msk
-#define RCC_AHB1ENR_ETHEN_Pos               (19U)
-#define RCC_AHB1ENR_ETHEN_Msk               (0x1UL << RCC_AHB1ENR_ETHEN_Pos)        /*!< 0x00080000 */
-#define RCC_AHB1ENR_ETHEN                   RCC_AHB1ENR_ETHEN_Msk
-#define RCC_AHB1ENR_ETHTXEN_Pos             (20U)
-#define RCC_AHB1ENR_ETHTXEN_Msk             (0x1UL << RCC_AHB1ENR_ETHTXEN_Pos)      /*!< 0x00100000 */
-#define RCC_AHB1ENR_ETHTXEN                 RCC_AHB1ENR_ETHTXEN_Msk
-#define RCC_AHB1ENR_ETHRXEN_Pos             (21U)
-#define RCC_AHB1ENR_ETHRXEN_Msk             (0x1UL << RCC_AHB1ENR_ETHRXEN_Pos)      /*!< 0x00200000 */
-#define RCC_AHB1ENR_ETHRXEN                 RCC_AHB1ENR_ETHRXEN_Msk
 #define RCC_AHB1ENR_TZSC1EN_Pos             (24U)
 #define RCC_AHB1ENR_TZSC1EN_Msk             (0x1UL << RCC_AHB1ENR_TZSC1EN_Pos)      /*!< 0x01000000 */
 #define RCC_AHB1ENR_TZSC1EN                 RCC_AHB1ENR_TZSC1EN_Msk
@@ -16095,9 +13247,6 @@ typedef struct
 #define RCC_AHB2ENR_GPIOHEN_Pos             (7U)
 #define RCC_AHB2ENR_GPIOHEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOHEN_Pos)      /*!< 0x00000080 */
 #define RCC_AHB2ENR_GPIOHEN                 RCC_AHB2ENR_GPIOHEN_Msk
-#define RCC_AHB2ENR_GPIOIEN_Pos             (8U)
-#define RCC_AHB2ENR_GPIOIEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOIEN_Pos)      /*!< 0x00000100 */
-#define RCC_AHB2ENR_GPIOIEN                 RCC_AHB2ENR_GPIOIEN_Msk
 #define RCC_AHB2ENR_ADCEN_Pos               (10U)
 #define RCC_AHB2ENR_ADCEN_Msk               (0x1UL << RCC_AHB2ENR_ADCEN_Pos)        /*!< 0x00000400 */
 #define RCC_AHB2ENR_ADCEN                   RCC_AHB2ENR_ADCEN_Msk
@@ -16127,9 +13276,6 @@ typedef struct
 #define RCC_AHB4ENR_SDMMC1EN_Pos            (11U)
 #define RCC_AHB4ENR_SDMMC1EN_Msk            (0x1UL << RCC_AHB4ENR_SDMMC1EN_Pos)     /*!< 0x00000800 */
 #define RCC_AHB4ENR_SDMMC1EN                RCC_AHB4ENR_SDMMC1EN_Msk
-#define RCC_AHB4ENR_SDMMC2EN_Pos            (12U)
-#define RCC_AHB4ENR_SDMMC2EN_Msk            (0x1UL << RCC_AHB4ENR_SDMMC2EN_Pos)     /*!< 0x00000100 */
-#define RCC_AHB4ENR_SDMMC2EN                RCC_AHB4ENR_SDMMC2EN_Msk
 #define RCC_AHB4ENR_FMCEN_Pos               (16U)
 #define RCC_AHB4ENR_FMCEN_Msk               (0x1UL << RCC_AHB4ENR_FMCEN_Pos)        /*!< 0x00010000 */
 #define RCC_AHB4ENR_FMCEN                   RCC_AHB4ENR_FMCEN_Msk
@@ -16159,12 +13305,6 @@ typedef struct
 #define RCC_APB1LENR_TIM12EN_Pos            (6U)
 #define RCC_APB1LENR_TIM12EN_Msk            (0x1UL << RCC_APB1LENR_TIM12EN_Pos)     /*!< 0x00000040 */
 #define RCC_APB1LENR_TIM12EN                RCC_APB1LENR_TIM12EN_Msk
-#define RCC_APB1LENR_TIM13EN_Pos            (7U)
-#define RCC_APB1LENR_TIM13EN_Msk            (0x1UL << RCC_APB1LENR_TIM13EN_Pos)     /*!< 0x00000080 */
-#define RCC_APB1LENR_TIM13EN                RCC_APB1LENR_TIM13EN_Msk
-#define RCC_APB1LENR_TIM14EN_Pos            (8U)
-#define RCC_APB1LENR_TIM14EN_Msk            (0x1UL << RCC_APB1LENR_TIM14EN_Pos)     /*!< 0x00000100 */
-#define RCC_APB1LENR_TIM14EN                RCC_APB1LENR_TIM14EN_Msk
 #define RCC_APB1LENR_WWDGEN_Pos             (11U)
 #define RCC_APB1LENR_WWDGEN_Msk             (0x1UL << RCC_APB1LENR_WWDGEN_Pos)      /*!< 0x00000800 */
 #define RCC_APB1LENR_WWDGEN                 RCC_APB1LENR_WWDGEN_Msk
@@ -16201,29 +13341,11 @@ typedef struct
 #define RCC_APB1LENR_USART6EN_Pos           (25U)
 #define RCC_APB1LENR_USART6EN_Msk           (0x1UL << RCC_APB1LENR_USART6EN_Pos)    /*!< 0x02000000 */
 #define RCC_APB1LENR_USART6EN               RCC_APB1LENR_USART6EN_Msk
-#define RCC_APB1LENR_USART10EN_Pos          (26U)
-#define RCC_APB1LENR_USART10EN_Msk          (0x1UL << RCC_APB1LENR_USART10EN_Pos)   /*!< 0x04000000 */
-#define RCC_APB1LENR_USART10EN              RCC_APB1LENR_USART10EN_Msk
-#define RCC_APB1LENR_USART11EN_Pos          (27U)
-#define RCC_APB1LENR_USART11EN_Msk          (0x1UL << RCC_APB1LENR_USART11EN_Pos)   /*!< 0x08000000 */
-#define RCC_APB1LENR_USART11EN              RCC_APB1LENR_USART11EN_Msk
 #define RCC_APB1LENR_CECEN_Pos              (28U)
 #define RCC_APB1LENR_CECEN_Msk              (0x1UL << RCC_APB1LENR_CECEN_Pos)       /*!< 0x10000000 */
 #define RCC_APB1LENR_CECEN                  RCC_APB1LENR_CECEN_Msk
-#define RCC_APB1LENR_UART7EN_Pos            (30U)
-#define RCC_APB1LENR_UART7EN_Msk            (0x1UL << RCC_APB1LENR_UART7EN_Pos)     /*!< 0x40000000 */
-#define RCC_APB1LENR_UART7EN                RCC_APB1LENR_UART7EN_Msk
-#define RCC_APB1LENR_UART8EN_Pos            (31U)
-#define RCC_APB1LENR_UART8EN_Msk            (0x1UL << RCC_APB1LENR_UART8EN_Pos)     /*!< 0x80000000 */
-#define RCC_APB1LENR_UART8EN                RCC_APB1LENR_UART8EN_Msk
 
 /********************  Bit definition for RCC_APB1HENR register  **************/
-#define RCC_APB1HENR_UART9EN_Pos            (0U)
-#define RCC_APB1HENR_UART9EN_Msk            (0x1UL << RCC_APB1HENR_UART9EN_Pos)     /*!< 0x00000001 */
-#define RCC_APB1HENR_UART9EN                RCC_APB1HENR_UART9EN_Msk
-#define RCC_APB1HENR_UART12EN_Pos           (1U)
-#define RCC_APB1HENR_UART12EN_Msk           (0x1UL << RCC_APB1HENR_UART12EN_Pos)    /*!< 0x00000002 */
-#define RCC_APB1HENR_UART12EN               RCC_APB1HENR_UART12EN_Msk
 #define RCC_APB1HENR_DTSEN_Pos              (3U)
 #define RCC_APB1HENR_DTSEN_Msk              (0x1UL << RCC_APB1HENR_DTSEN_Pos)       /*!< 0x00000008 */
 #define RCC_APB1HENR_DTSEN                  RCC_APB1HENR_DTSEN_Msk
@@ -16253,24 +13375,9 @@ typedef struct
 #define RCC_APB2ENR_TIM15EN_Pos             (16U)
 #define RCC_APB2ENR_TIM15EN_Msk             (0x1UL << RCC_APB2ENR_TIM15EN_Pos)      /*!< 0x00010000 */
 #define RCC_APB2ENR_TIM15EN                 RCC_APB2ENR_TIM15EN_Msk
-#define RCC_APB2ENR_TIM16EN_Pos             (17U)
-#define RCC_APB2ENR_TIM16EN_Msk             (0x1UL << RCC_APB2ENR_TIM16EN_Pos)      /*!< 0x00020000 */
-#define RCC_APB2ENR_TIM16EN                 RCC_APB2ENR_TIM16EN_Msk
-#define RCC_APB2ENR_TIM17EN_Pos             (18U)
-#define RCC_APB2ENR_TIM17EN_Msk             (0x1UL << RCC_APB2ENR_TIM17EN_Pos)      /*!< 0x00040000 */
-#define RCC_APB2ENR_TIM17EN                 RCC_APB2ENR_TIM17EN_Msk
 #define RCC_APB2ENR_SPI4EN_Pos              (19U)
 #define RCC_APB2ENR_SPI4EN_Msk              (0x1UL << RCC_APB2ENR_SPI4EN_Pos)       /*!< 0x00080000 */
 #define RCC_APB2ENR_SPI4EN                  RCC_APB2ENR_SPI4EN_Msk
-#define RCC_APB2ENR_SPI6EN_Pos              (20U)
-#define RCC_APB2ENR_SPI6EN_Msk              (0x1UL << RCC_APB2ENR_SPI6EN_Pos)       /*!< 0x00100000 */
-#define RCC_APB2ENR_SPI6EN                  RCC_APB2ENR_SPI6EN_Msk
-#define RCC_APB2ENR_SAI1EN_Pos              (21U)
-#define RCC_APB2ENR_SAI1EN_Msk              (0x1UL << RCC_APB2ENR_SAI1EN_Pos)       /*!< 0x00200000 */
-#define RCC_APB2ENR_SAI1EN                  RCC_APB2ENR_SAI1EN_Msk
-#define RCC_APB2ENR_SAI2EN_Pos              (22U)
-#define RCC_APB2ENR_SAI2EN_Msk              (0x1UL << RCC_APB2ENR_SAI2EN_Pos)       /*!< 0x00400000 */
-#define RCC_APB2ENR_SAI2EN                  RCC_APB2ENR_SAI2EN_Msk
 #define RCC_APB2ENR_USBEN_Pos               (24U)
 #define RCC_APB2ENR_USBEN_Msk               (0x1UL << RCC_APB2ENR_USBEN_Pos)        /*!< 0x01000000 */
 #define RCC_APB2ENR_USBEN                   RCC_APB2ENR_USBEN_Msk
@@ -16279,33 +13386,18 @@ typedef struct
 #define RCC_APB3ENR_SBSEN_Pos               (1U)
 #define RCC_APB3ENR_SBSEN_Msk               (0x1UL << RCC_APB3ENR_SBSEN_Pos)        /*!< 0x00000002 */
 #define RCC_APB3ENR_SBSEN                   RCC_APB3ENR_SBSEN_Msk
-#define RCC_APB3ENR_SPI5EN_Pos              (5U)
-#define RCC_APB3ENR_SPI5EN_Msk              (0x1UL << RCC_APB3ENR_SPI5EN_Pos)       /*!< 0x00000010 */
-#define RCC_APB3ENR_SPI5EN                  RCC_APB3ENR_SPI5EN_Msk
 #define RCC_APB3ENR_LPUART1EN_Pos           (6U)
 #define RCC_APB3ENR_LPUART1EN_Msk           (0x1UL << RCC_APB3ENR_LPUART1EN_Pos)    /*!< 0x00000040 */
 #define RCC_APB3ENR_LPUART1EN               RCC_APB3ENR_LPUART1EN_Msk
 #define RCC_APB3ENR_I2C3EN_Pos              (7U)
 #define RCC_APB3ENR_I2C3EN_Msk              (0x1UL << RCC_APB3ENR_I2C3EN_Pos)       /*!< 0x00000080 */
 #define RCC_APB3ENR_I2C3EN                  RCC_APB3ENR_I2C3EN_Msk
-#define RCC_APB3ENR_I2C4EN_Pos              (8U)
-#define RCC_APB3ENR_I2C4EN_Msk              (0x1UL << RCC_APB3ENR_I2C4EN_Pos)       /*!< 0x00000100 */
-#define RCC_APB3ENR_I2C4EN                  RCC_APB3ENR_I2C4EN_Msk
+#define RCC_APB3ENR_I3C2EN_Pos              (9U)
+#define RCC_APB3ENR_I3C2EN_Msk              (0x1UL << RCC_APB3ENR_I3C2EN_Pos)       /*!< 0x00000200 */
+#define RCC_APB3ENR_I3C2EN                  RCC_APB3ENR_I3C2EN_Msk
 #define RCC_APB3ENR_LPTIM1EN_Pos            (11U)
 #define RCC_APB3ENR_LPTIM1EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM1EN_Pos)     /*!< 0x00000800 */
 #define RCC_APB3ENR_LPTIM1EN                RCC_APB3ENR_LPTIM1EN_Msk
-#define RCC_APB3ENR_LPTIM3EN_Pos            (12U)
-#define RCC_APB3ENR_LPTIM3EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM3EN_Pos)     /*!< 0x00001000 */
-#define RCC_APB3ENR_LPTIM3EN                RCC_APB3ENR_LPTIM3EN_Msk
-#define RCC_APB3ENR_LPTIM4EN_Pos            (13U)
-#define RCC_APB3ENR_LPTIM4EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM4EN_Pos)     /*!< 0x00002000 */
-#define RCC_APB3ENR_LPTIM4EN                RCC_APB3ENR_LPTIM4EN_Msk
-#define RCC_APB3ENR_LPTIM5EN_Pos            (14U)
-#define RCC_APB3ENR_LPTIM5EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM5EN_Pos)     /*!< 0x00004000 */
-#define RCC_APB3ENR_LPTIM5EN                RCC_APB3ENR_LPTIM5EN_Msk
-#define RCC_APB3ENR_LPTIM6EN_Pos            (15U)
-#define RCC_APB3ENR_LPTIM6EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM6EN_Pos)     /*!< 0x00008000 */
-#define RCC_APB3ENR_LPTIM6EN                RCC_APB3ENR_LPTIM6EN_Msk
 #define RCC_APB3ENR_VREFEN_Pos              (20U)
 #define RCC_APB3ENR_VREFEN_Msk              (0x1UL << RCC_APB3ENR_VREFEN_Pos)       /*!< 0x00100000 */
 #define RCC_APB3ENR_VREFEN                  RCC_APB3ENR_VREFEN_Msk
@@ -16326,24 +13418,9 @@ typedef struct
 #define RCC_AHB1LPENR_CRCLPEN_Pos           (12U)
 #define RCC_AHB1LPENR_CRCLPEN_Msk           (0x1UL << RCC_AHB1LPENR_CRCLPEN_Pos)    /*!< 0x00001000 */
 #define RCC_AHB1LPENR_CRCLPEN               RCC_AHB1LPENR_CRCLPEN_Msk
-#define RCC_AHB1LPENR_CORDICLPEN_Pos        (14U)
-#define RCC_AHB1LPENR_CORDICLPEN_Msk        (0x1UL << RCC_AHB1LPENR_CORDICLPEN_Pos) /*!< 0x00004000*/
-#define RCC_AHB1LPENR_CORDICLPEN            RCC_AHB1LPENR_CORDICLPEN_Msk
-#define RCC_AHB1LPENR_FMACLPEN_Pos          (15U)
-#define RCC_AHB1LPENR_FMACLPEN_Msk          (0x1UL << RCC_AHB1LPENR_FMACLPEN_Pos)   /*!< 0x00008000*/
-#define RCC_AHB1LPENR_FMACLPEN              RCC_AHB1LPENR_FMACLPEN_Msk
 #define RCC_AHB1LPENR_RAMCFGLPEN_Pos        (17U)
 #define RCC_AHB1LPENR_RAMCFGLPEN_Msk        (0x1UL << RCC_AHB1LPENR_RAMCFGLPEN_Pos) /*!< 0x00020000 */
 #define RCC_AHB1LPENR_RAMCFGLPEN            RCC_AHB1LPENR_RAMCFGLPEN_Msk
-#define RCC_AHB1LPENR_ETHLPEN_Pos           (19U)
-#define RCC_AHB1LPENR_ETHLPEN_Msk           (0x1UL << RCC_AHB1LPENR_ETHLPEN_Pos)    /*!< 0x00080000 */
-#define RCC_AHB1LPENR_ETHLPEN               RCC_AHB1LPENR_ETHLPEN_Msk
-#define RCC_AHB1LPENR_ETHTXLPEN_Pos         (20U)
-#define RCC_AHB1LPENR_ETHTXLPEN_Msk         (0x1UL << RCC_AHB1LPENR_ETHTXLPEN_Pos)  /*!< 0x00100000 */
-#define RCC_AHB1LPENR_ETHTXLPEN             RCC_AHB1LPENR_ETHTXLPEN_Msk
-#define RCC_AHB1LPENR_ETHRXLPEN_Pos         (21U)
-#define RCC_AHB1LPENR_ETHRXLPEN_Msk         (0x1UL << RCC_AHB1LPENR_ETHRXLPEN_Pos)  /*!< 0x00200000 */
-#define RCC_AHB1LPENR_ETHRXLPEN             RCC_AHB1LPENR_ETHRXLPEN_Msk
 #define RCC_AHB1LPENR_TZSC1LPEN_Pos         (24U)
 #define RCC_AHB1LPENR_TZSC1LPEN_Msk         (0x1UL << RCC_AHB1LPENR_TZSC1LPEN_Pos)  /*!< 0x01000000 */
 #define RCC_AHB1LPENR_TZSC1LPEN             RCC_AHB1LPENR_TZSC1LPEN_Msk
@@ -16385,9 +13462,6 @@ typedef struct
 #define RCC_AHB2LPENR_GPIOHLPEN_Pos         (7U)
 #define RCC_AHB2LPENR_GPIOHLPEN_Msk         (0x1UL << RCC_AHB2LPENR_GPIOHLPEN_Pos)  /*!< 0x00000080 */
 #define RCC_AHB2LPENR_GPIOHLPEN             RCC_AHB2LPENR_GPIOHLPEN_Msk
-#define RCC_AHB2LPENR_GPIOILPEN_Pos         (8U)
-#define RCC_AHB2LPENR_GPIOILPEN_Msk         (0x1UL << RCC_AHB2LPENR_GPIOILPEN_Pos)  /*!< 0x00000100 */
-#define RCC_AHB2LPENR_GPIOILPEN             RCC_AHB2LPENR_GPIOILPEN_Msk
 #define RCC_AHB2LPENR_ADCLPEN_Pos           (10U)
 #define RCC_AHB2LPENR_ADCLPEN_Msk           (0x1UL << RCC_AHB2LPENR_ADCLPEN_Pos)    /*!< 0x00000400 */
 #define RCC_AHB2LPENR_ADCLPEN               RCC_AHB2LPENR_ADCLPEN_Msk
@@ -16414,9 +13488,6 @@ typedef struct
 #define RCC_AHB4LPENR_SDMMC1LPEN_Pos        (11U)
 #define RCC_AHB4LPENR_SDMMC1LPEN_Msk        (0x1UL << RCC_AHB4LPENR_SDMMC1LPEN_Pos)  /*!< 0x00000800 */
 #define RCC_AHB4LPENR_SDMMC1LPEN            RCC_AHB4LPENR_SDMMC1LPEN_Msk
-#define RCC_AHB4LPENR_SDMMC2LPEN_Pos        (12U)
-#define RCC_AHB4LPENR_SDMMC2LPEN_Msk        (0x1UL << RCC_AHB4LPENR_SDMMC2LPEN_Pos)  /*!< 0x00001000 */
-#define RCC_AHB4LPENR_SDMMC2LPEN            RCC_AHB4LPENR_SDMMC2LPEN_Msk
 #define RCC_AHB4LPENR_FMCLPEN_Pos           (16U)
 #define RCC_AHB4LPENR_FMCLPEN_Msk           (0x1UL << RCC_AHB4LPENR_FMCLPEN_Pos)     /*!< 0x00010000 */
 #define RCC_AHB4LPENR_FMCLPEN               RCC_AHB4LPENR_FMCLPEN_Msk
@@ -16446,12 +13517,6 @@ typedef struct
 #define RCC_APB1LLPENR_TIM12LPEN_Pos        (6U)
 #define RCC_APB1LLPENR_TIM12LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM12LPEN_Pos) /*!< 0x00000040 */
 #define RCC_APB1LLPENR_TIM12LPEN            RCC_APB1LLPENR_TIM12LPEN_Msk
-#define RCC_APB1LLPENR_TIM13LPEN_Pos        (7U)
-#define RCC_APB1LLPENR_TIM13LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM13LPEN_Pos) /*!< 0x00000080 */
-#define RCC_APB1LLPENR_TIM13LPEN            RCC_APB1LLPENR_TIM13LPEN_Msk
-#define RCC_APB1LLPENR_TIM14LPEN_Pos        (8U)
-#define RCC_APB1LLPENR_TIM14LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM14LPEN_Pos) /*!< 0x00000100 */
-#define RCC_APB1LLPENR_TIM14LPEN            RCC_APB1LLPENR_TIM14LPEN_Msk
 #define RCC_APB1LLPENR_WWDGLPEN_Pos         (11U)
 #define RCC_APB1LLPENR_WWDGLPEN_Msk         (0x1UL << RCC_APB1LLPENR_WWDGLPEN_Pos)  /*!< 0x00000800 */
 #define RCC_APB1LLPENR_WWDGLPEN             RCC_APB1LLPENR_WWDGLPEN_Msk
@@ -16488,29 +13553,11 @@ typedef struct
 #define RCC_APB1LLPENR_USART6LPEN_Pos       (25U)
 #define RCC_APB1LLPENR_USART6LPEN_Msk       (0x1UL << RCC_APB1LLPENR_USART6LPEN_Pos) /*!< 0x02000000 */
 #define RCC_APB1LLPENR_USART6LPEN           RCC_APB1LLPENR_USART6LPEN_Msk
-#define RCC_APB1LLPENR_USART10LPEN_Pos      (26U)
-#define RCC_APB1LLPENR_USART10LPEN_Msk      (0x1UL << RCC_APB1LLPENR_USART10LPEN_Pos) /*!< 0x04000000 */
-#define RCC_APB1LLPENR_USART10LPEN          RCC_APB1LLPENR_USART10LPEN_Msk
-#define RCC_APB1LLPENR_USART11LPEN_Pos      (27U)
-#define RCC_APB1LLPENR_USART11LPEN_Msk      (0x1UL << RCC_APB1LLPENR_USART11LPEN_Pos) /*!< 0x08000000 */
-#define RCC_APB1LLPENR_USART11LPEN          RCC_APB1LLPENR_USART11LPEN_Msk
 #define RCC_APB1LLPENR_CECLPEN_Pos          (28U)
 #define RCC_APB1LLPENR_CECLPEN_Msk          (0x1UL << RCC_APB1LLPENR_CECLPEN_Pos)    /*!< 0x10000000 */
 #define RCC_APB1LLPENR_CECLPEN              RCC_APB1LLPENR_CECLPEN_Msk
-#define RCC_APB1LLPENR_UART7LPEN_Pos        (30U)
-#define RCC_APB1LLPENR_UART7LPEN_Msk        (0x1UL << RCC_APB1LLPENR_UART7LPEN_Pos)  /*!< 0x40000000 */
-#define RCC_APB1LLPENR_UART7LPEN            RCC_APB1LLPENR_UART7LPEN_Msk
-#define RCC_APB1LLPENR_UART8LPEN_Pos        (31U)
-#define RCC_APB1LLPENR_UART8LPEN_Msk        (0x1UL << RCC_APB1LLPENR_UART8LPEN_Pos)  /*!< 0x80000000 */
-#define RCC_APB1LLPENR_UART8LPEN            RCC_APB1LLPENR_UART8LPEN_Msk
 
 /********************  Bit definition for RCC_APB1HLPENR register  **************/
-#define RCC_APB1HLPENR_UART9LPEN_Pos        (0U)
-#define RCC_APB1HLPENR_UART9LPEN_Msk        (0x1UL << RCC_APB1HLPENR_UART9LPEN_Pos)  /*!< 0x00000001 */
-#define RCC_APB1HLPENR_UART9LPEN            RCC_APB1HLPENR_UART9LPEN_Msk
-#define RCC_APB1HLPENR_UART12LPEN_Pos       (1U)
-#define RCC_APB1HLPENR_UART12LPEN_Msk       (0x1UL << RCC_APB1HLPENR_UART12LPEN_Pos) /*!< 0x00000002 */
-#define RCC_APB1HLPENR_UART12LPEN           RCC_APB1HLPENR_UART12LPEN_Msk
 #define RCC_APB1HLPENR_DTSLPEN_Pos          (3U)
 #define RCC_APB1HLPENR_DTSLPEN_Msk          (0x1UL << RCC_APB1HLPENR_DTSLPEN_Pos)    /*!< 0x00000008 */
 #define RCC_APB1HLPENR_DTSLPEN              RCC_APB1HLPENR_DTSLPEN_Msk
@@ -16540,24 +13587,9 @@ typedef struct
 #define RCC_APB2LPENR_TIM15LPEN_Pos         (16U)
 #define RCC_APB2LPENR_TIM15LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM15LPEN_Pos)  /*!< 0x00010000 */
 #define RCC_APB2LPENR_TIM15LPEN             RCC_APB2LPENR_TIM15LPEN_Msk
-#define RCC_APB2LPENR_TIM16LPEN_Pos         (17U)
-#define RCC_APB2LPENR_TIM16LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM16LPEN_Pos)  /*!< 0x00020000 */
-#define RCC_APB2LPENR_TIM16LPEN             RCC_APB2LPENR_TIM16LPEN_Msk
-#define RCC_APB2LPENR_TIM17LPEN_Pos         (18U)
-#define RCC_APB2LPENR_TIM17LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM17LPEN_Pos)  /*!< 0x00040000 */
-#define RCC_APB2LPENR_TIM17LPEN             RCC_APB2LPENR_TIM17LPEN_Msk
 #define RCC_APB2LPENR_SPI4LPEN_Pos          (19U)
 #define RCC_APB2LPENR_SPI4LPEN_Msk          (0x1UL << RCC_APB2LPENR_SPI4LPEN_Pos)   /*!< 0x00080000 */
 #define RCC_APB2LPENR_SPI4LPEN              RCC_APB2LPENR_SPI4LPEN_Msk
-#define RCC_APB2LPENR_SPI6LPEN_Pos          (20U)
-#define RCC_APB2LPENR_SPI6LPEN_Msk          (0x1UL << RCC_APB2LPENR_SPI6LPEN_Pos)   /*!< 0x00100000 */
-#define RCC_APB2LPENR_SPI6LPEN              RCC_APB2LPENR_SPI6LPEN_Msk
-#define RCC_APB2LPENR_SAI1LPEN_Pos          (21U)
-#define RCC_APB2LPENR_SAI1LPEN_Msk          (0x1UL << RCC_APB2LPENR_SAI1LPEN_Pos)   /*!< 0x00200000 */
-#define RCC_APB2LPENR_SAI1LPEN              RCC_APB2LPENR_SAI1LPEN_Msk
-#define RCC_APB2LPENR_SAI2LPEN_Pos          (22U)
-#define RCC_APB2LPENR_SAI2LPEN_Msk          (0x1UL << RCC_APB2LPENR_SAI2LPEN_Pos)   /*!< 0x00400000 */
-#define RCC_APB2LPENR_SAI2LPEN              RCC_APB2LPENR_SAI2LPEN_Msk
 #define RCC_APB2LPENR_USBLPEN_Pos           (24U)
 #define RCC_APB2LPENR_USBLPEN_Msk           (0x1UL << RCC_APB2LPENR_USBLPEN_Pos)    /*!< 0x01000000 */
 #define RCC_APB2LPENR_USBLPEN               RCC_APB2LPENR_USBLPEN_Msk
@@ -16566,33 +13598,18 @@ typedef struct
 #define RCC_APB3LPENR_SBSLPEN_Pos           (1U)
 #define RCC_APB3LPENR_SBSLPEN_Msk           (0x1UL << RCC_APB3LPENR_SBSLPEN_Pos)    /*!< 0x00000001 */
 #define RCC_APB3LPENR_SBSLPEN               RCC_APB3LPENR_SBSLPEN_Msk
-#define RCC_APB3LPENR_SPI5LPEN_Pos          (5U)
-#define RCC_APB3LPENR_SPI5LPEN_Msk          (0x1UL << RCC_APB3LPENR_SPI5LPEN_Pos)   /*!< 0x00000010 */
-#define RCC_APB3LPENR_SPI5LPEN              RCC_APB3LPENR_SPI5LPEN_Msk
 #define RCC_APB3LPENR_LPUART1LPEN_Pos       (6U)
 #define RCC_APB3LPENR_LPUART1LPEN_Msk       (0x1UL << RCC_APB3LPENR_LPUART1LPEN_Pos) /*!< 0x00000040 */
 #define RCC_APB3LPENR_LPUART1LPEN           RCC_APB3LPENR_LPUART1LPEN_Msk
 #define RCC_APB3LPENR_I2C3LPEN_Pos          (7U)
 #define RCC_APB3LPENR_I2C3LPEN_Msk          (0x1UL << RCC_APB3LPENR_I2C3LPEN_Pos)   /*!< 0x00000080 */
 #define RCC_APB3LPENR_I2C3LPEN              RCC_APB3LPENR_I2C3LPEN_Msk
-#define RCC_APB3LPENR_I2C4LPEN_Pos          (8U)
-#define RCC_APB3LPENR_I2C4LPEN_Msk          (0x1UL << RCC_APB3LPENR_I2C4LPEN_Pos)   /*!< 0x00000100 */
-#define RCC_APB3LPENR_I2C4LPEN              RCC_APB3LPENR_I2C4LPEN_Msk
+#define RCC_APB3LPENR_I3C2LPEN_Pos          (9U)
+#define RCC_APB3LPENR_I3C2LPEN_Msk          (0x1UL << RCC_APB3LPENR_I3C2LPEN_Pos)   /*!< 0x00000100 */
+#define RCC_APB3LPENR_I3C2LPEN              RCC_APB3LPENR_I3C2LPEN_Msk
 #define RCC_APB3LPENR_LPTIM1LPEN_Pos        (11U)
 #define RCC_APB3LPENR_LPTIM1LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM1LPEN_Pos) /*!< 0x00000800 */
 #define RCC_APB3LPENR_LPTIM1LPEN            RCC_APB3LPENR_LPTIM1LPEN_Msk
-#define RCC_APB3LPENR_LPTIM3LPEN_Pos        (12U)
-#define RCC_APB3LPENR_LPTIM3LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM3LPEN_Pos) /*!< 0x00001000 */
-#define RCC_APB3LPENR_LPTIM3LPEN            RCC_APB3LPENR_LPTIM3LPEN_Msk
-#define RCC_APB3LPENR_LPTIM4LPEN_Pos        (13U)
-#define RCC_APB3LPENR_LPTIM4LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM4LPEN_Pos) /*!< 0x00002000 */
-#define RCC_APB3LPENR_LPTIM4LPEN            RCC_APB3LPENR_LPTIM4LPEN_Msk
-#define RCC_APB3LPENR_LPTIM5LPEN_Pos        (14U)
-#define RCC_APB3LPENR_LPTIM5LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM5LPEN_Pos) /*!< 0x00004000 */
-#define RCC_APB3LPENR_LPTIM5LPEN            RCC_APB3LPENR_LPTIM5LPEN_Msk
-#define RCC_APB3LPENR_LPTIM6LPEN_Pos        (15U)
-#define RCC_APB3LPENR_LPTIM6LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM6LPEN_Pos) /*!< 0x00008000 */
-#define RCC_APB3LPENR_LPTIM6LPEN            RCC_APB3LPENR_LPTIM6LPEN_Msk
 #define RCC_APB3LPENR_VREFLPEN_Pos          (20U)
 #define RCC_APB3LPENR_VREFLPEN_Msk          (0x1UL << RCC_APB3LPENR_VREFLPEN_Pos)   /*!< 0x00100000 */
 #define RCC_APB3LPENR_VREFLPEN              RCC_APB3LPENR_VREFLPEN_Msk
@@ -16642,53 +13659,11 @@ typedef struct
 #define RCC_CCIPR1_USART6SEL_1              (0x2UL << RCC_CCIPR1_USART6SEL_Pos)      /*!< 0x00010000 */
 #define RCC_CCIPR1_USART6SEL_2              (0x4UL << RCC_CCIPR1_USART6SEL_Pos)      /*!< 0x00020000 */
 
-#define RCC_CCIPR1_UART7SEL_Pos             (18U)
-#define RCC_CCIPR1_UART7SEL_Msk             (0x7UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x001C0000 */
-#define RCC_CCIPR1_UART7SEL                 RCC_CCIPR1_UART7SEL_Msk
-#define RCC_CCIPR1_UART7SEL_0               (0x1UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00040000 */
-#define RCC_CCIPR1_UART7SEL_1               (0x2UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00080000 */
-#define RCC_CCIPR1_UART7SEL_2               (0x4UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00100000 */
-
-#define RCC_CCIPR1_UART8SEL_Pos             (21U)
-#define RCC_CCIPR1_UART8SEL_Msk             (0x7UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00E00000 */
-#define RCC_CCIPR1_UART8SEL                 RCC_CCIPR1_UART8SEL_Msk
-#define RCC_CCIPR1_UART8SEL_0               (0x1UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00200000 */
-#define RCC_CCIPR1_UART8SEL_1               (0x2UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00400000 */
-#define RCC_CCIPR1_UART8SEL_2               (0x4UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00800000 */
-
-#define RCC_CCIPR1_UART9SEL_Pos             (24U)
-#define RCC_CCIPR1_UART9SEL_Msk             (0x7UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x07000000 */
-#define RCC_CCIPR1_UART9SEL                 RCC_CCIPR1_UART9SEL_Msk
-#define RCC_CCIPR1_UART9SEL_0               (0x1UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x01000000 */
-#define RCC_CCIPR1_UART9SEL_1               (0x2UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x02000000 */
-#define RCC_CCIPR1_UART9SEL_2               (0x4UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x04000000 */
-
-#define RCC_CCIPR1_USART10SEL_Pos           (27U)
-#define RCC_CCIPR1_USART10SEL_Msk           (0x7UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x38000000 */
-#define RCC_CCIPR1_USART10SEL               RCC_CCIPR1_USART10SEL_Msk
-#define RCC_CCIPR1_USART10SEL_0             (0x1UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x08000000 */
-#define RCC_CCIPR1_USART10SEL_1             (0x2UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x10000000 */
-#define RCC_CCIPR1_USART10SEL_2             (0x4UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x20000000 */
-
 #define RCC_CCIPR1_TIMICSEL_Pos             (31U)
 #define RCC_CCIPR1_TIMICSEL_Msk             (0x1UL << RCC_CCIPR1_TIMICSEL_Pos)      /*!< 0x10000000 */
 #define RCC_CCIPR1_TIMICSEL                 RCC_CCIPR1_TIMICSEL_Msk
 
 /********************  Bit definition for RCC_CCIPR2 register  ******************/
-#define RCC_CCIPR2_USART11SEL_Pos           (0U)
-#define RCC_CCIPR2_USART11SEL_Msk           (0x7UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000007 */
-#define RCC_CCIPR2_USART11SEL               RCC_CCIPR2_USART11SEL_Msk
-#define RCC_CCIPR2_USART11SEL_0             (0x1UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000001 */
-#define RCC_CCIPR2_USART11SEL_1             (0x2UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000002 */
-#define RCC_CCIPR2_USART11SEL_2             (0x4UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000004 */
-
-#define RCC_CCIPR2_UART12SEL_Pos            (4U)
-#define RCC_CCIPR2_UART12SEL_Msk            (0x7UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000070 */
-#define RCC_CCIPR2_UART12SEL                RCC_CCIPR2_UART12SEL_Msk
-#define RCC_CCIPR2_UART12SEL_0              (0x1UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000010 */
-#define RCC_CCIPR2_UART12SEL_1              (0x2UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000020 */
-#define RCC_CCIPR2_UART12SEL_2              (0x4UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000040 */
-
 #define RCC_CCIPR2_LPTIM1SEL_Pos            (8U)
 #define RCC_CCIPR2_LPTIM1SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM1SEL_Pos)     /*!< 0x00000700 */
 #define RCC_CCIPR2_LPTIM1SEL                RCC_CCIPR2_LPTIM1SEL_Msk
@@ -16702,34 +13677,6 @@ typedef struct
 #define RCC_CCIPR2_LPTIM2SEL_0              (0x1UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00001000 */
 #define RCC_CCIPR2_LPTIM2SEL_1              (0x2UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00002000 */
 #define RCC_CCIPR2_LPTIM2SEL_2              (0x4UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00004000 */
-
-#define RCC_CCIPR2_LPTIM3SEL_Pos            (16U)
-#define RCC_CCIPR2_LPTIM3SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00070000 */
-#define RCC_CCIPR2_LPTIM3SEL                RCC_CCIPR2_LPTIM3SEL_Msk
-#define RCC_CCIPR2_LPTIM3SEL_0              (0x1UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00010000 */
-#define RCC_CCIPR2_LPTIM3SEL_1              (0x2UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00020000 */
-#define RCC_CCIPR2_LPTIM3SEL_2              (0x4UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00040000 */
-
-#define RCC_CCIPR2_LPTIM4SEL_Pos            (20U)
-#define RCC_CCIPR2_LPTIM4SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00700000 */
-#define RCC_CCIPR2_LPTIM4SEL                RCC_CCIPR2_LPTIM4SEL_Msk
-#define RCC_CCIPR2_LPTIM4SEL_0              (0x1UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00100000 */
-#define RCC_CCIPR2_LPTIM4SEL_1              (0x2UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00200000 */
-#define RCC_CCIPR2_LPTIM4SEL_2              (0x4UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00400000 */
-
-#define RCC_CCIPR2_LPTIM5SEL_Pos            (24U)
-#define RCC_CCIPR2_LPTIM5SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x07000000 */
-#define RCC_CCIPR2_LPTIM5SEL                RCC_CCIPR2_LPTIM5SEL_Msk
-#define RCC_CCIPR2_LPTIM5SEL_0              (0x1UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x01000000 */
-#define RCC_CCIPR2_LPTIM5SEL_1              (0x2UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x02000000 */
-#define RCC_CCIPR2_LPTIM5SEL_2              (0x4UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x04000000 */
-
-#define RCC_CCIPR2_LPTIM6SEL_Pos            (28U)
-#define RCC_CCIPR2_LPTIM6SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x70000000 */
-#define RCC_CCIPR2_LPTIM6SEL                RCC_CCIPR2_LPTIM6SEL_Msk
-#define RCC_CCIPR2_LPTIM6SEL_0              (0x1UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x10000000 */
-#define RCC_CCIPR2_LPTIM6SEL_1              (0x2UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x20000000 */
-#define RCC_CCIPR2_LPTIM6SEL_2              (0x4UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x40000000 */
 
 /********************  Bit definition for RCC_CCIPR3 register  ***************/
 #define RCC_CCIPR3_SPI1SEL_Pos              (0U)
@@ -16759,20 +13706,6 @@ typedef struct
 #define RCC_CCIPR3_SPI4SEL_0                (0x1UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000200 */
 #define RCC_CCIPR3_SPI4SEL_1                (0x2UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000400 */
 #define RCC_CCIPR3_SPI4SEL_2                (0x4UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000800 */
-
-#define RCC_CCIPR3_SPI5SEL_Pos              (12U)
-#define RCC_CCIPR3_SPI5SEL_Msk              (0x7UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00007000 */
-#define RCC_CCIPR3_SPI5SEL                  RCC_CCIPR3_SPI5SEL_Msk
-#define RCC_CCIPR3_SPI5SEL_0                (0x1UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00001000 */
-#define RCC_CCIPR3_SPI5SEL_1                (0x2UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00002000 */
-#define RCC_CCIPR3_SPI5SEL_2                (0x4UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00004000 */
-
-#define RCC_CCIPR3_SPI6SEL_Pos              (15U)
-#define RCC_CCIPR3_SPI6SEL_Msk              (0x7UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00038000 */
-#define RCC_CCIPR3_SPI6SEL                  RCC_CCIPR3_SPI6SEL_Msk
-#define RCC_CCIPR3_SPI6SEL_0                (0x1UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00008000 */
-#define RCC_CCIPR3_SPI6SEL_1                (0x2UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00010000 */
-#define RCC_CCIPR3_SPI6SEL_2                (0x4UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00020000 */
 
 #define RCC_CCIPR3_LPUART1SEL_Pos           (24U)
 #define RCC_CCIPR3_LPUART1SEL_Msk           (0x7UL << RCC_CCIPR3_LPUART1SEL_Pos)    /*!< 0x07000000 */
@@ -16805,9 +13738,6 @@ typedef struct
 #define RCC_CCIPR4_SDMMC1SEL_Msk            (0x1UL << RCC_CCIPR4_SDMMC1SEL_Pos)     /*!< 0x00000040 */
 #define RCC_CCIPR4_SDMMC1SEL                RCC_CCIPR4_SDMMC1SEL_Msk
 
-#define RCC_CCIPR4_SDMMC2SEL_Pos            (7U)
-#define RCC_CCIPR4_SDMMC2SEL_Msk            (0x1UL << RCC_CCIPR4_SDMMC2SEL_Pos)     /*!< 0x00000080 */
-#define RCC_CCIPR4_SDMMC2SEL                RCC_CCIPR4_SDMMC2SEL_Msk
 
 #define RCC_CCIPR4_I2C1SEL_Pos             (16U)
 #define RCC_CCIPR4_I2C1SEL_Msk             (0x3UL << RCC_CCIPR4_I2C1SEL_Pos)      /*!< 0x00030000 */
@@ -16827,17 +13757,17 @@ typedef struct
 #define RCC_CCIPR4_I2C3SEL_0               (0x1UL << RCC_CCIPR4_I2C3SEL_Pos)      /*!< 0x00100000 */
 #define RCC_CCIPR4_I2C3SEL_1               (0x2UL << RCC_CCIPR4_I2C3SEL_Pos)      /*!< 0x00200000 */
 
-#define RCC_CCIPR4_I2C4SEL_Pos             (22U)
-#define RCC_CCIPR4_I2C4SEL_Msk             (0x3UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00C00000 */
-#define RCC_CCIPR4_I2C4SEL                 RCC_CCIPR4_I2C4SEL_Msk
-#define RCC_CCIPR4_I2C4SEL_0               (0x1UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00400000 */
-#define RCC_CCIPR4_I2C4SEL_1               (0x2UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00800000 */
-
 #define RCC_CCIPR4_I3C1SEL_Pos             (24U)
 #define RCC_CCIPR4_I3C1SEL_Msk             (0x3UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x03000000 */
 #define RCC_CCIPR4_I3C1SEL                 RCC_CCIPR4_I3C1SEL_Msk
 #define RCC_CCIPR4_I3C1SEL_0               (0x1UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x01000000 */
 #define RCC_CCIPR4_I3C1SEL_1               (0x2UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x02000000 */
+
+#define RCC_CCIPR4_I3C2SEL_Pos             (26U)
+#define RCC_CCIPR4_I3C2SEL_Msk             (0x3UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x0C000000 */
+#define RCC_CCIPR4_I3C2SEL                 RCC_CCIPR4_I3C2SEL_Msk
+#define RCC_CCIPR4_I3C2SEL_0               (0x1UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x04000000 */
+#define RCC_CCIPR4_I3C2SEL_1               (0x2UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x08000000 */
 
 /********************  Bit definition for RCC_CCIPR5 register  ***************/
 
@@ -16869,20 +13799,6 @@ typedef struct
 #define RCC_CCIPR5_FDCANSEL                RCC_CCIPR5_FDCANSEL_Msk
 #define RCC_CCIPR5_FDCANSEL_0              (0x1UL << RCC_CCIPR5_FDCANSEL_Pos)     /*!< 0x00000100 */
 #define RCC_CCIPR5_FDCANSEL_1              (0x2UL << RCC_CCIPR5_FDCANSEL_Pos)     /*!< 0x00000200 */
-
-#define RCC_CCIPR5_SAI1SEL_Pos             (16U)
-#define RCC_CCIPR5_SAI1SEL_Msk             (0x7UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00070000 */
-#define RCC_CCIPR5_SAI1SEL                 RCC_CCIPR5_SAI1SEL_Msk
-#define RCC_CCIPR5_SAI1SEL_0               (0x1UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00010000 */
-#define RCC_CCIPR5_SAI1SEL_1               (0x2UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00020000 */
-#define RCC_CCIPR5_SAI1SEL_2               (0x4UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00040000 */
-
-#define RCC_CCIPR5_SAI2SEL_Pos             (19U)
-#define RCC_CCIPR5_SAI2SEL_Msk             (0x7UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00380000 */
-#define RCC_CCIPR5_SAI2SEL                 RCC_CCIPR5_SAI2SEL_Msk
-#define RCC_CCIPR5_SAI2SEL_0               (0x1UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00080000 */
-#define RCC_CCIPR5_SAI2SEL_1               (0x2UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00100000 */
-#define RCC_CCIPR5_SAI2SEL_2               (0x4UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00200000 */
 
 #define RCC_CCIPR5_CKERPSEL_Pos            (30U)
 #define RCC_CCIPR5_CKERPSEL_Msk            (0x3UL << RCC_CCIPR5_CKERPSEL_Pos)     /*!< 0xC0000000 */
@@ -18599,328 +15515,6 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                          Serial Audio Interface                            */
-/*                                                                            */
-/******************************************************************************/
-/********************  Bit definition for SAI_GCR register  *******************/
-#define SAI_GCR_SYNCIN_Pos                  (0U)
-#define SAI_GCR_SYNCIN_Msk                  (0x3UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000003 */
-#define SAI_GCR_SYNCIN                      SAI_GCR_SYNCIN_Msk                      /*!<SYNCIN[1:0] bits (Synchronization Inputs)   */
-#define SAI_GCR_SYNCIN_0                    (0x1UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000001 */
-#define SAI_GCR_SYNCIN_1                    (0x2UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000002 */
-#define SAI_GCR_SYNCOUT_Pos                 (4U)
-#define SAI_GCR_SYNCOUT_Msk                 (0x3UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000030 */
-#define SAI_GCR_SYNCOUT                     SAI_GCR_SYNCOUT_Msk                     /*!<SYNCOUT[1:0] bits (Synchronization Outputs) */
-#define SAI_GCR_SYNCOUT_0                   (0x1UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000010 */
-#define SAI_GCR_SYNCOUT_1                   (0x2UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000020 */
-
-/*******************  Bit definition for SAI_xCR1 register  *******************/
-#define SAI_xCR1_MODE_Pos                   (0U)
-#define SAI_xCR1_MODE_Msk                   (0x3UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000003 */
-#define SAI_xCR1_MODE                       SAI_xCR1_MODE_Msk                       /*!<MODE[1:0] bits (Audio Block Mode)           */
-#define SAI_xCR1_MODE_0                     (0x1UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000001 */
-#define SAI_xCR1_MODE_1                     (0x2UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000002 */
-#define SAI_xCR1_PRTCFG_Pos                 (2U)
-#define SAI_xCR1_PRTCFG_Msk                 (0x3UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x0000000C */
-#define SAI_xCR1_PRTCFG                     SAI_xCR1_PRTCFG_Msk                     /*!<PRTCFG[1:0] bits (Protocol Configuration)   */
-#define SAI_xCR1_PRTCFG_0                   (0x1UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x00000004 */
-#define SAI_xCR1_PRTCFG_1                   (0x2UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x00000008 */
-#define SAI_xCR1_DS_Pos                     (5U)
-#define SAI_xCR1_DS_Msk                     (0x7UL << SAI_xCR1_DS_Pos)              /*!< 0x000000E0 */
-#define SAI_xCR1_DS                         SAI_xCR1_DS_Msk                         /*!<DS[1:0] bits (Data Size) */
-#define SAI_xCR1_DS_0                       (0x1UL << SAI_xCR1_DS_Pos)              /*!< 0x00000020 */
-#define SAI_xCR1_DS_1                       (0x2UL << SAI_xCR1_DS_Pos)              /*!< 0x00000040 */
-#define SAI_xCR1_DS_2                       (0x4UL << SAI_xCR1_DS_Pos)              /*!< 0x00000080 */
-#define SAI_xCR1_LSBFIRST_Pos               (8U)
-#define SAI_xCR1_LSBFIRST_Msk               (0x1UL << SAI_xCR1_LSBFIRST_Pos)        /*!< 0x00000100 */
-#define SAI_xCR1_LSBFIRST                   SAI_xCR1_LSBFIRST_Msk                   /*!<LSB First Configuration  */
-#define SAI_xCR1_CKSTR_Pos                  (9U)
-#define SAI_xCR1_CKSTR_Msk                  (0x1UL << SAI_xCR1_CKSTR_Pos)           /*!< 0x00000200 */
-#define SAI_xCR1_CKSTR                      SAI_xCR1_CKSTR_Msk                      /*!<ClocK STRobing edge      */
-#define SAI_xCR1_SYNCEN_Pos                 (10U)
-#define SAI_xCR1_SYNCEN_Msk                 (0x3UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000C00 */
-#define SAI_xCR1_SYNCEN                     SAI_xCR1_SYNCEN_Msk                     /*!<SYNCEN[1:0](SYNChronization ENable) */
-#define SAI_xCR1_SYNCEN_0                   (0x1UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000400 */
-#define SAI_xCR1_SYNCEN_1                   (0x2UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000800 */
-#define SAI_xCR1_MONO_Pos                   (12U)
-#define SAI_xCR1_MONO_Msk                   (0x1UL << SAI_xCR1_MONO_Pos)            /*!< 0x00001000 */
-#define SAI_xCR1_MONO                       SAI_xCR1_MONO_Msk                       /*!<Mono mode                  */
-#define SAI_xCR1_OUTDRIV_Pos                (13U)
-#define SAI_xCR1_OUTDRIV_Msk                (0x1UL << SAI_xCR1_OUTDRIV_Pos)         /*!< 0x00002000 */
-#define SAI_xCR1_OUTDRIV                    SAI_xCR1_OUTDRIV_Msk                    /*!<Output Drive               */
-#define SAI_xCR1_SAIEN_Pos                  (16U)
-#define SAI_xCR1_SAIEN_Msk                  (0x1UL << SAI_xCR1_SAIEN_Pos)           /*!< 0x00010000 */
-#define SAI_xCR1_SAIEN                      SAI_xCR1_SAIEN_Msk                      /*!<Audio Block enable         */
-#define SAI_xCR1_DMAEN_Pos                  (17U)
-#define SAI_xCR1_DMAEN_Msk                  (0x1UL << SAI_xCR1_DMAEN_Pos)           /*!< 0x00020000 */
-#define SAI_xCR1_DMAEN                      SAI_xCR1_DMAEN_Msk                      /*!<DMA enable                 */
-#define SAI_xCR1_NODIV_Pos                  (19U)
-#define SAI_xCR1_NODIV_Msk                  (0x1UL << SAI_xCR1_NODIV_Pos)           /*!< 0x00080000 */
-#define SAI_xCR1_NODIV                      SAI_xCR1_NODIV_Msk                      /*!<No Divider Configuration   */
-#define SAI_xCR1_MCKDIV_Pos                 (20U)
-#define SAI_xCR1_MCKDIV_Msk                 (0x3FUL << SAI_xCR1_MCKDIV_Pos)         /*!< 0x03F00000 */
-#define SAI_xCR1_MCKDIV                     SAI_xCR1_MCKDIV_Msk                     /*!<MCKDIV[5:0] (Master ClocK Divider)  */
-#define SAI_xCR1_MCKDIV_0                   (0x00100000UL)                          /*!<Bit 0  */
-#define SAI_xCR1_MCKDIV_1                   (0x00200000UL)                          /*!<Bit 1  */
-#define SAI_xCR1_MCKDIV_2                   (0x00400000UL)                          /*!<Bit 2  */
-#define SAI_xCR1_MCKDIV_3                   (0x00800000UL)                          /*!<Bit 3  */
-#define SAI_xCR1_MCKDIV_4                   (0x01000000UL)                          /*!<Bit 4  */
-#define SAI_xCR1_MCKDIV_5                   (0x02000000UL)                          /*!<Bit 5  */
-#define SAI_xCR1_OSR_Pos                    (26U)
-#define SAI_xCR1_OSR_Msk                    (0x1UL << SAI_xCR1_OSR_Pos)             /*!< 0x04000000 */
-#define SAI_xCR1_OSR                        SAI_xCR1_OSR_Msk                        /*!<Oversampling ratio for master clock */
-#define SAI_xCR1_MCKEN_Pos                  (27U)
-#define SAI_xCR1_MCKEN_Msk                  (0x1UL << SAI_xCR1_MCKEN_Pos)           /*!< 0x08000000 */
-#define SAI_xCR1_MCKEN                      SAI_xCR1_MCKEN_Msk                      /*!<Master clock generation enable */
-
-/*******************  Bit definition for SAI_xCR2 register  *******************/
-#define SAI_xCR2_FTH_Pos                    (0U)
-#define SAI_xCR2_FTH_Msk                    (0x7UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000007 */
-#define SAI_xCR2_FTH                        SAI_xCR2_FTH_Msk                        /*!<FTH[2:0](Fifo THreshold)  */
-#define SAI_xCR2_FTH_0                      (0x1UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000001 */
-#define SAI_xCR2_FTH_1                      (0x2UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000002 */
-#define SAI_xCR2_FTH_2                      (0x4UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000004 */
-#define SAI_xCR2_FFLUSH_Pos                 (3U)
-#define SAI_xCR2_FFLUSH_Msk                 (0x1UL << SAI_xCR2_FFLUSH_Pos)          /*!< 0x00000008 */
-#define SAI_xCR2_FFLUSH                     SAI_xCR2_FFLUSH_Msk                     /*!<Fifo FLUSH                       */
-#define SAI_xCR2_TRIS_Pos                   (4U)
-#define SAI_xCR2_TRIS_Msk                   (0x1UL << SAI_xCR2_TRIS_Pos)            /*!< 0x00000010 */
-#define SAI_xCR2_TRIS                       SAI_xCR2_TRIS_Msk                       /*!<TRIState Management on data line */
-#define SAI_xCR2_MUTE_Pos                   (5U)
-#define SAI_xCR2_MUTE_Msk                   (0x1UL << SAI_xCR2_MUTE_Pos)            /*!< 0x00000020 */
-#define SAI_xCR2_MUTE                       SAI_xCR2_MUTE_Msk                       /*!<Mute mode                        */
-#define SAI_xCR2_MUTEVAL_Pos                (6U)
-#define SAI_xCR2_MUTEVAL_Msk                (0x1UL << SAI_xCR2_MUTEVAL_Pos)         /*!< 0x00000040 */
-#define SAI_xCR2_MUTEVAL                    SAI_xCR2_MUTEVAL_Msk                    /*!<Muate value                      */
-#define SAI_xCR2_MUTECNT_Pos                (7U)
-#define SAI_xCR2_MUTECNT_Msk                (0x3FUL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00001F80 */
-#define SAI_xCR2_MUTECNT                    SAI_xCR2_MUTECNT_Msk                    /*!<MUTECNT[5:0] (MUTE counter) */
-#define SAI_xCR2_MUTECNT_0                  (0x01UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000080 */
-#define SAI_xCR2_MUTECNT_1                  (0x02UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000100 */
-#define SAI_xCR2_MUTECNT_2                  (0x04UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000200 */
-#define SAI_xCR2_MUTECNT_3                  (0x08UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000400 */
-#define SAI_xCR2_MUTECNT_4                  (0x10UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000800 */
-#define SAI_xCR2_MUTECNT_5                  (0x20UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00001000 */
-#define SAI_xCR2_CPL_Pos                    (13U)
-#define SAI_xCR2_CPL_Msk                    (0x1UL << SAI_xCR2_CPL_Pos)             /*!< 0x00002000 */
-#define SAI_xCR2_CPL                        SAI_xCR2_CPL_Msk                        /*!<CPL mode                    */
-#define SAI_xCR2_COMP_Pos                   (14U)
-#define SAI_xCR2_COMP_Msk                   (0x3UL << SAI_xCR2_COMP_Pos)            /*!< 0x0000C000 */
-#define SAI_xCR2_COMP                       SAI_xCR2_COMP_Msk                       /*!<COMP[1:0] (Companding mode) */
-#define SAI_xCR2_COMP_0                     (0x1UL << SAI_xCR2_COMP_Pos)            /*!< 0x00004000 */
-#define SAI_xCR2_COMP_1                     (0x2UL << SAI_xCR2_COMP_Pos)            /*!< 0x00008000 */
-
-/******************  Bit definition for SAI_xFRCR register  *******************/
-#define SAI_xFRCR_FRL_Pos                   (0U)
-#define SAI_xFRCR_FRL_Msk                   (0xFFUL << SAI_xFRCR_FRL_Pos)           /*!< 0x000000FF */
-#define SAI_xFRCR_FRL                       SAI_xFRCR_FRL_Msk                       /*!<FRL[7:0](Frame length)  */
-#define SAI_xFRCR_FRL_0                     (0x01UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000001 */
-#define SAI_xFRCR_FRL_1                     (0x02UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000002 */
-#define SAI_xFRCR_FRL_2                     (0x04UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000004 */
-#define SAI_xFRCR_FRL_3                     (0x08UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000008 */
-#define SAI_xFRCR_FRL_4                     (0x10UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000010 */
-#define SAI_xFRCR_FRL_5                     (0x20UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000020 */
-#define SAI_xFRCR_FRL_6                     (0x40UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000040 */
-#define SAI_xFRCR_FRL_7                     (0x80UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000080 */
-#define SAI_xFRCR_FSALL_Pos                 (8U)
-#define SAI_xFRCR_FSALL_Msk                 (0x7FUL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00007F00 */
-#define SAI_xFRCR_FSALL                     SAI_xFRCR_FSALL_Msk                     /*!<FRL[6:0] (Frame synchronization active level length)  */
-#define SAI_xFRCR_FSALL_0                   (0x01UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000100 */
-#define SAI_xFRCR_FSALL_1                   (0x02UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000200 */
-#define SAI_xFRCR_FSALL_2                   (0x04UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000400 */
-#define SAI_xFRCR_FSALL_3                   (0x08UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000800 */
-#define SAI_xFRCR_FSALL_4                   (0x10UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00001000 */
-#define SAI_xFRCR_FSALL_5                   (0x20UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00002000 */
-#define SAI_xFRCR_FSALL_6                   (0x40UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00004000 */
-#define SAI_xFRCR_FSDEF_Pos                 (16U)
-#define SAI_xFRCR_FSDEF_Msk                 (0x1UL << SAI_xFRCR_FSDEF_Pos)          /*!< 0x00010000 */
-#define SAI_xFRCR_FSDEF                     SAI_xFRCR_FSDEF_Msk                     /*!< Frame Synchronization Definition */
-#define SAI_xFRCR_FSPOL_Pos                 (17U)
-#define SAI_xFRCR_FSPOL_Msk                 (0x1UL << SAI_xFRCR_FSPOL_Pos)          /*!< 0x00020000 */
-#define SAI_xFRCR_FSPOL                     SAI_xFRCR_FSPOL_Msk                     /*!<Frame Synchronization POLarity    */
-#define SAI_xFRCR_FSOFF_Pos                 (18U)
-#define SAI_xFRCR_FSOFF_Msk                 (0x1UL << SAI_xFRCR_FSOFF_Pos)          /*!< 0x00040000 */
-#define SAI_xFRCR_FSOFF                     SAI_xFRCR_FSOFF_Msk                     /*!<Frame Synchronization OFFset      */
-
-/******************  Bit definition for SAI_xSLOTR register  *******************/
-#define SAI_xSLOTR_FBOFF_Pos                (0U)
-#define SAI_xSLOTR_FBOFF_Msk                (0x1FUL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x0000001F */
-#define SAI_xSLOTR_FBOFF                    SAI_xSLOTR_FBOFF_Msk                    /*!<FRL[4:0](First Bit Offset)  */
-#define SAI_xSLOTR_FBOFF_0                  (0x01UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000001 */
-#define SAI_xSLOTR_FBOFF_1                  (0x02UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000002 */
-#define SAI_xSLOTR_FBOFF_2                  (0x04UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000004 */
-#define SAI_xSLOTR_FBOFF_3                  (0x08UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000008 */
-#define SAI_xSLOTR_FBOFF_4                  (0x10UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000010 */
-#define SAI_xSLOTR_SLOTSZ_Pos               (6U)
-#define SAI_xSLOTR_SLOTSZ_Msk               (0x3UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x000000C0 */
-#define SAI_xSLOTR_SLOTSZ                   SAI_xSLOTR_SLOTSZ_Msk                   /*!<SLOTSZ[1:0] (Slot size)  */
-#define SAI_xSLOTR_SLOTSZ_0                 (0x1UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x00000040 */
-#define SAI_xSLOTR_SLOTSZ_1                 (0x2UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x00000080 */
-#define SAI_xSLOTR_NBSLOT_Pos               (8U)
-#define SAI_xSLOTR_NBSLOT_Msk               (0xFUL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000F00 */
-#define SAI_xSLOTR_NBSLOT                   SAI_xSLOTR_NBSLOT_Msk                   /*!<NBSLOT[3:0] (Number of Slot in audio Frame)  */
-#define SAI_xSLOTR_NBSLOT_0                 (0x1UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000100 */
-#define SAI_xSLOTR_NBSLOT_1                 (0x2UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000200 */
-#define SAI_xSLOTR_NBSLOT_2                 (0x4UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000400 */
-#define SAI_xSLOTR_NBSLOT_3                 (0x8UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000800 */
-#define SAI_xSLOTR_SLOTEN_Pos               (16U)
-#define SAI_xSLOTR_SLOTEN_Msk               (0xFFFFUL << SAI_xSLOTR_SLOTEN_Pos)     /*!< 0xFFFF0000 */
-#define SAI_xSLOTR_SLOTEN                   SAI_xSLOTR_SLOTEN_Msk                   /*!<SLOTEN[15:0] (Slot Enable)  */
-
-/*******************  Bit definition for SAI_xIMR register  *******************/
-#define SAI_xIMR_OVRUDRIE_Pos               (0U)
-#define SAI_xIMR_OVRUDRIE_Msk               (0x1UL << SAI_xIMR_OVRUDRIE_Pos)        /*!< 0x00000001 */
-#define SAI_xIMR_OVRUDRIE                   SAI_xIMR_OVRUDRIE_Msk                   /*!<Overrun underrun interrupt enable                              */
-#define SAI_xIMR_MUTEDETIE_Pos              (1U)
-#define SAI_xIMR_MUTEDETIE_Msk              (0x1UL << SAI_xIMR_MUTEDETIE_Pos)       /*!< 0x00000002 */
-#define SAI_xIMR_MUTEDETIE                  SAI_xIMR_MUTEDETIE_Msk                  /*!<Mute detection interrupt enable                                */
-#define SAI_xIMR_WCKCFGIE_Pos               (2U)
-#define SAI_xIMR_WCKCFGIE_Msk               (0x1UL << SAI_xIMR_WCKCFGIE_Pos)        /*!< 0x00000004 */
-#define SAI_xIMR_WCKCFGIE                   SAI_xIMR_WCKCFGIE_Msk                   /*!<Wrong Clock Configuration interrupt enable                     */
-#define SAI_xIMR_FREQIE_Pos                 (3U)
-#define SAI_xIMR_FREQIE_Msk                 (0x1UL << SAI_xIMR_FREQIE_Pos)          /*!< 0x00000008 */
-#define SAI_xIMR_FREQIE                     SAI_xIMR_FREQIE_Msk                     /*!<FIFO request interrupt enable                                  */
-#define SAI_xIMR_CNRDYIE_Pos                (4U)
-#define SAI_xIMR_CNRDYIE_Msk                (0x1UL << SAI_xIMR_CNRDYIE_Pos)         /*!< 0x00000010 */
-#define SAI_xIMR_CNRDYIE                    SAI_xIMR_CNRDYIE_Msk                    /*!<Codec not ready interrupt enable                               */
-#define SAI_xIMR_AFSDETIE_Pos               (5U)
-#define SAI_xIMR_AFSDETIE_Msk               (0x1UL << SAI_xIMR_AFSDETIE_Pos)        /*!< 0x00000020 */
-#define SAI_xIMR_AFSDETIE                   SAI_xIMR_AFSDETIE_Msk                   /*!<Anticipated frame synchronization detection interrupt enable   */
-#define SAI_xIMR_LFSDETIE_Pos               (6U)
-#define SAI_xIMR_LFSDETIE_Msk               (0x1UL << SAI_xIMR_LFSDETIE_Pos)        /*!< 0x00000040 */
-#define SAI_xIMR_LFSDETIE                   SAI_xIMR_LFSDETIE_Msk                   /*!<Late frame synchronization detection interrupt enable          */
-
-/********************  Bit definition for SAI_xSR register  *******************/
-#define SAI_xSR_OVRUDR_Pos                  (0U)
-#define SAI_xSR_OVRUDR_Msk                  (0x1UL << SAI_xSR_OVRUDR_Pos)           /*!< 0x00000001 */
-#define SAI_xSR_OVRUDR                      SAI_xSR_OVRUDR_Msk                      /*!<Overrun underrun                               */
-#define SAI_xSR_MUTEDET_Pos                 (1U)
-#define SAI_xSR_MUTEDET_Msk                 (0x1UL << SAI_xSR_MUTEDET_Pos)          /*!< 0x00000002 */
-#define SAI_xSR_MUTEDET                     SAI_xSR_MUTEDET_Msk                     /*!<Mute detection                                 */
-#define SAI_xSR_WCKCFG_Pos                  (2U)
-#define SAI_xSR_WCKCFG_Msk                  (0x1UL << SAI_xSR_WCKCFG_Pos)           /*!< 0x00000004 */
-#define SAI_xSR_WCKCFG                      SAI_xSR_WCKCFG_Msk                      /*!<Wrong Clock Configuration                      */
-#define SAI_xSR_FREQ_Pos                    (3U)
-#define SAI_xSR_FREQ_Msk                    (0x1UL << SAI_xSR_FREQ_Pos)             /*!< 0x00000008 */
-#define SAI_xSR_FREQ                        SAI_xSR_FREQ_Msk                        /*!<FIFO request                                   */
-#define SAI_xSR_CNRDY_Pos                   (4U)
-#define SAI_xSR_CNRDY_Msk                   (0x1UL << SAI_xSR_CNRDY_Pos)            /*!< 0x00000010 */
-#define SAI_xSR_CNRDY                       SAI_xSR_CNRDY_Msk                       /*!<Codec not ready                                */
-#define SAI_xSR_AFSDET_Pos                  (5U)
-#define SAI_xSR_AFSDET_Msk                  (0x1UL << SAI_xSR_AFSDET_Pos)           /*!< 0x00000020 */
-#define SAI_xSR_AFSDET                      SAI_xSR_AFSDET_Msk                      /*!<Anticipated frame synchronization detection    */
-#define SAI_xSR_LFSDET_Pos                  (6U)
-#define SAI_xSR_LFSDET_Msk                  (0x1UL << SAI_xSR_LFSDET_Pos)           /*!< 0x00000040 */
-#define SAI_xSR_LFSDET                      SAI_xSR_LFSDET_Msk                      /*!<Late frame synchronization detection           */
-#define SAI_xSR_FLVL_Pos                    (16U)
-#define SAI_xSR_FLVL_Msk                    (0x7UL << SAI_xSR_FLVL_Pos)             /*!< 0x00070000 */
-#define SAI_xSR_FLVL                        SAI_xSR_FLVL_Msk                        /*!<FLVL[2:0] (FIFO Level Threshold)               */
-#define SAI_xSR_FLVL_0                      (0x1UL << SAI_xSR_FLVL_Pos)             /*!< 0x00010000 */
-#define SAI_xSR_FLVL_1                      (0x2UL << SAI_xSR_FLVL_Pos)             /*!< 0x00020000 */
-#define SAI_xSR_FLVL_2                      (0x4UL << SAI_xSR_FLVL_Pos)             /*!< 0x00040000 */
-
-/******************  Bit definition for SAI_xCLRFR register  ******************/
-#define SAI_xCLRFR_COVRUDR_Pos              (0U)
-#define SAI_xCLRFR_COVRUDR_Msk              (0x1UL << SAI_xCLRFR_COVRUDR_Pos)       /*!< 0x00000001 */
-#define SAI_xCLRFR_COVRUDR                  SAI_xCLRFR_COVRUDR_Msk                  /*!<Clear Overrun underrun                               */
-#define SAI_xCLRFR_CMUTEDET_Pos             (1U)
-#define SAI_xCLRFR_CMUTEDET_Msk             (0x1UL << SAI_xCLRFR_CMUTEDET_Pos)      /*!< 0x00000002 */
-#define SAI_xCLRFR_CMUTEDET                 SAI_xCLRFR_CMUTEDET_Msk                 /*!<Clear Mute detection                                 */
-#define SAI_xCLRFR_CWCKCFG_Pos              (2U)
-#define SAI_xCLRFR_CWCKCFG_Msk              (0x1UL << SAI_xCLRFR_CWCKCFG_Pos)       /*!< 0x00000004 */
-#define SAI_xCLRFR_CWCKCFG                  SAI_xCLRFR_CWCKCFG_Msk                  /*!<Clear Wrong Clock Configuration                      */
-#define SAI_xCLRFR_CFREQ_Pos                (3U)
-#define SAI_xCLRFR_CFREQ_Msk                (0x1UL << SAI_xCLRFR_CFREQ_Pos)         /*!< 0x00000008 */
-#define SAI_xCLRFR_CFREQ                    SAI_xCLRFR_CFREQ_Msk                    /*!<Clear FIFO request                                   */
-#define SAI_xCLRFR_CCNRDY_Pos               (4U)
-#define SAI_xCLRFR_CCNRDY_Msk               (0x1UL << SAI_xCLRFR_CCNRDY_Pos)        /*!< 0x00000010 */
-#define SAI_xCLRFR_CCNRDY                   SAI_xCLRFR_CCNRDY_Msk                   /*!<Clear Codec not ready                                */
-#define SAI_xCLRFR_CAFSDET_Pos              (5U)
-#define SAI_xCLRFR_CAFSDET_Msk              (0x1UL << SAI_xCLRFR_CAFSDET_Pos)       /*!< 0x00000020 */
-#define SAI_xCLRFR_CAFSDET                  SAI_xCLRFR_CAFSDET_Msk                  /*!<Clear Anticipated frame synchronization detection    */
-#define SAI_xCLRFR_CLFSDET_Pos              (6U)
-#define SAI_xCLRFR_CLFSDET_Msk              (0x1UL << SAI_xCLRFR_CLFSDET_Pos)       /*!< 0x00000040 */
-#define SAI_xCLRFR_CLFSDET                  SAI_xCLRFR_CLFSDET_Msk                  /*!<Clear Late frame synchronization detection           */
-
-/******************  Bit definition for SAI_xDR register  ******************/
-#define SAI_xDR_DATA_Pos                    (0U)
-#define SAI_xDR_DATA_Msk                    (0xFFFFFFFFUL << SAI_xDR_DATA_Pos)      /*!< 0xFFFFFFFF */
-#define SAI_xDR_DATA                        SAI_xDR_DATA_Msk
-
-/******************  Bit definition for SAI_PDMCR register  *******************/
-#define SAI_PDMCR_PDMEN_Pos                 (0U)
-#define SAI_PDMCR_PDMEN_Msk                 (0x1UL << SAI_PDMCR_PDMEN_Pos)          /*!< 0x00000001 */
-#define SAI_PDMCR_PDMEN                     SAI_PDMCR_PDMEN_Msk                     /*!<PDM enable */
-#define SAI_PDMCR_MICNBR_Pos                (4U)
-#define SAI_PDMCR_MICNBR_Msk                (0x3UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000030 */
-#define SAI_PDMCR_MICNBR                    SAI_PDMCR_MICNBR_Msk                    /*!<MICNBR[1:0] (Number of microphones) */
-#define SAI_PDMCR_MICNBR_0                  (0x1UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000010 */
-#define SAI_PDMCR_MICNBR_1                  (0x2UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000020 */
-#define SAI_PDMCR_CKEN1_Pos                 (8U)
-#define SAI_PDMCR_CKEN1_Msk                 (0x1UL << SAI_PDMCR_CKEN1_Pos)          /*!< 0x00000100 */
-#define SAI_PDMCR_CKEN1                     SAI_PDMCR_CKEN1_Msk                     /*!<Clock 1 enable */
-#define SAI_PDMCR_CKEN2_Pos                 (9U)
-#define SAI_PDMCR_CKEN2_Msk                 (0x1UL << SAI_PDMCR_CKEN2_Pos)          /*!< 0x00000200 */
-#define SAI_PDMCR_CKEN2                     SAI_PDMCR_CKEN2_Msk                     /*!<Clock 2 enable */
-#define SAI_PDMCR_CKEN3_Pos                 (10U)
-#define SAI_PDMCR_CKEN3_Msk                 (0x1UL << SAI_PDMCR_CKEN3_Pos)          /*!< 0x00000400 */
-#define SAI_PDMCR_CKEN3                     SAI_PDMCR_CKEN3_Msk                     /*!<Clock 3 enable */
-#define SAI_PDMCR_CKEN4_Pos                 (11U)
-#define SAI_PDMCR_CKEN4_Msk                 (0x1UL << SAI_PDMCR_CKEN4_Pos)          /*!< 0x00000800 */
-#define SAI_PDMCR_CKEN4                     SAI_PDMCR_CKEN4_Msk                     /*!<Clock 4 enable */
-
-/******************  Bit definition for SAI_PDMDLY register  ******************/
-#define SAI_PDMDLY_DLYM1L_Pos               (0U)
-#define SAI_PDMDLY_DLYM1L_Msk               (0x7UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000007 */
-#define SAI_PDMDLY_DLYM1L                   SAI_PDMDLY_DLYM1L_Msk                   /*!<DLYM1L[2:0] (Delay line adjust for left microphone of pair 1) */
-#define SAI_PDMDLY_DLYM1L_0                 (0x1UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000001 */
-#define SAI_PDMDLY_DLYM1L_1                 (0x2UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000002 */
-#define SAI_PDMDLY_DLYM1L_2                 (0x4UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000004 */
-#define SAI_PDMDLY_DLYM1R_Pos               (4U)
-#define SAI_PDMDLY_DLYM1R_Msk               (0x7UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000070 */
-#define SAI_PDMDLY_DLYM1R                   SAI_PDMDLY_DLYM1R_Msk                   /*!<DLYM1R[2:0] (Delay line adjust for right microphone of pair 1) */
-#define SAI_PDMDLY_DLYM1R_0                 (0x1UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000010 */
-#define SAI_PDMDLY_DLYM1R_1                 (0x2UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000020 */
-#define SAI_PDMDLY_DLYM1R_2                 (0x4UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000040 */
-#define SAI_PDMDLY_DLYM2L_Pos               (8U)
-#define SAI_PDMDLY_DLYM2L_Msk               (0x7UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000700 */
-#define SAI_PDMDLY_DLYM2L                   SAI_PDMDLY_DLYM2L_Msk                   /*!<DLYM2L[2:0] (Delay line adjust for left microphone of pair 2) */
-#define SAI_PDMDLY_DLYM2L_0                 (0x1UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000100 */
-#define SAI_PDMDLY_DLYM2L_1                 (0x2UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000200 */
-#define SAI_PDMDLY_DLYM2L_2                 (0x4UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000400 */
-#define SAI_PDMDLY_DLYM2R_Pos               (12U)
-#define SAI_PDMDLY_DLYM2R_Msk               (0x7UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00007000 */
-#define SAI_PDMDLY_DLYM2R                   SAI_PDMDLY_DLYM2R_Msk                   /*!<DLYM2R[2:0] (Delay line adjust for right microphone of pair 2) */
-#define SAI_PDMDLY_DLYM2R_0                 (0x1UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00001000 */
-#define SAI_PDMDLY_DLYM2R_1                 (0x2UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00002000 */
-#define SAI_PDMDLY_DLYM2R_2                 (0x4UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00004000 */
-#define SAI_PDMDLY_DLYM3L_Pos               (16U)
-#define SAI_PDMDLY_DLYM3L_Msk               (0x7UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00070000 */
-#define SAI_PDMDLY_DLYM3L                   SAI_PDMDLY_DLYM3L_Msk                   /*!<DLYM3L[2:0] (Delay line adjust for left microphone of pair 3) */
-#define SAI_PDMDLY_DLYM3L_0                 (0x1UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00010000 */
-#define SAI_PDMDLY_DLYM3L_1                 (0x2UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00020000 */
-#define SAI_PDMDLY_DLYM3L_2                 (0x4UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00040000 */
-#define SAI_PDMDLY_DLYM3R_Pos               (20U)
-#define SAI_PDMDLY_DLYM3R_Msk               (0x7UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00700000 */
-#define SAI_PDMDLY_DLYM3R                   SAI_PDMDLY_DLYM3R_Msk                   /*!<DLYM3R[2:0] (Delay line adjust for right microphone of pair 3) */
-#define SAI_PDMDLY_DLYM3R_0                 (0x1UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00100000 */
-#define SAI_PDMDLY_DLYM3R_1                 (0x2UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00200000 */
-#define SAI_PDMDLY_DLYM3R_2                 (0x4UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00400000 */
-#define SAI_PDMDLY_DLYM4L_Pos               (24U)
-#define SAI_PDMDLY_DLYM4L_Msk               (0x7UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x07000000 */
-#define SAI_PDMDLY_DLYM4L                   SAI_PDMDLY_DLYM4L_Msk                   /*!<DLYM4L[2:0] (Delay line adjust for left microphone of pair 4) */
-#define SAI_PDMDLY_DLYM4L_0                 (0x1UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x01000000 */
-#define SAI_PDMDLY_DLYM4L_1                 (0x2UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x02000000 */
-#define SAI_PDMDLY_DLYM4L_2                 (0x4UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x04000000 */
-#define SAI_PDMDLY_DLYM4R_Pos               (28U)
-#define SAI_PDMDLY_DLYM4R_Msk               (0x7UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x70000000 */
-#define SAI_PDMDLY_DLYM4R                   SAI_PDMDLY_DLYM4R_Msk                   /*!<DLYM4R[2:0] (Delay line adjust for right microphone of pair 4) */
-#define SAI_PDMDLY_DLYM4R_0                 (0x1UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x10000000 */
-#define SAI_PDMDLY_DLYM4R_1                 (0x2UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x20000000 */
-#define SAI_PDMDLY_DLYM4R_2                 (0x4UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x40000000 */
-
-/******************************************************************************/
-/*                                                                            */
 /*                                 SBS                                        */
 /*                                                                            */
 /******************************************************************************/
@@ -18988,12 +15582,6 @@ typedef struct
 #define SBS_PMCR_PB9_FMP_Pos              (19U)
 #define SBS_PMCR_PB9_FMP_Msk              (0x1UL << SBS_PMCR_PB9_FMP_Pos)            /*!< 0x00080000 */
 #define SBS_PMCR_PB9_FMP                  SBS_PMCR_PB9_FMP_Msk                       /*!< Fast-mode Plus command on PB(9) */
-#define SBS_PMCR_ETH_SEL_PHY_Pos          (21U)
-#define SBS_PMCR_ETH_SEL_PHY_Msk          (0x7UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00E00000 */
-#define SBS_PMCR_ETH_SEL_PHY              SBS_PMCR_ETH_SEL_PHY_Msk                   /*!< Ethernet PHY Interface Selection */
-#define SBS_PMCR_ETH_SEL_PHY_0            (0x1UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00200000 */
-#define SBS_PMCR_ETH_SEL_PHY_1            (0x2UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00400000 */
-#define SBS_PMCR_ETH_SEL_PHY_2            (0x4UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00800000 */
 
 /******************  Bit definition for SBS_FPUIMR register  ***************/
 #define SBS_FPUIMR_FPU_IE_Pos            (0U)
@@ -19160,10 +15748,6 @@ typedef struct
 #define GTZC_CFGR1_TIM7_Msk                 (0x01UL << GTZC_CFGR1_TIM7_Pos)
 #define GTZC_CFGR1_TIM12_Pos                (6U)
 #define GTZC_CFGR1_TIM12_Msk                (0x01UL << GTZC_CFGR1_TIM12_Pos)
-#define GTZC_CFGR1_TIM13_Pos                (7U)
-#define GTZC_CFGR1_TIM13_Msk                (0x01UL << GTZC_CFGR1_TIM13_Pos)
-#define GTZC_CFGR1_TIM14_Pos                (8U)
-#define GTZC_CFGR1_TIM14_Msk                (0x01UL << GTZC_CFGR1_TIM14_Pos)
 #define GTZC_CFGR1_WWDG_Pos                 (9U)
 #define GTZC_CFGR1_WWDG_Msk                 (0x01UL << GTZC_CFGR1_WWDG_Pos)
 #define GTZC_CFGR1_IWDG_Pos                 (10U)
@@ -19190,22 +15774,10 @@ typedef struct
 #define GTZC_CFGR1_CRS_Msk                  (0x01UL << GTZC_CFGR1_CRS_Pos)
 #define GTZC_CFGR1_USART6_Pos               (21U)
 #define GTZC_CFGR1_USART6_Msk               (0x01UL << GTZC_CFGR1_USART6_Pos)
-#define GTZC_CFGR1_USART10_Pos              (22U)
-#define GTZC_CFGR1_USART10_Msk              (0x01UL << GTZC_CFGR1_USART10_Pos)
-#define GTZC_CFGR1_USART11_Pos              (23U)
-#define GTZC_CFGR1_USART11_Msk              (0x01UL << GTZC_CFGR1_USART11_Pos)
 #define GTZC_CFGR1_HDMICEC_Pos              (24U)
 #define GTZC_CFGR1_HDMICEC_Msk              (0x01UL << GTZC_CFGR1_HDMICEC_Pos)
 #define GTZC_CFGR1_DAC1_Pos                 (25U)
 #define GTZC_CFGR1_DAC1_Msk                 (0x01UL << GTZC_CFGR1_DAC1_Pos)
-#define GTZC_CFGR1_UART7_Pos                (26U)
-#define GTZC_CFGR1_UART7_Msk                (0x01UL << GTZC_CFGR1_UART7_Pos)
-#define GTZC_CFGR1_UART8_Pos                (27U)
-#define GTZC_CFGR1_UART8_Msk                (0x01UL << GTZC_CFGR1_UART8_Pos)
-#define GTZC_CFGR1_UART9_Pos                (28U)
-#define GTZC_CFGR1_UART9_Msk                (0x01UL << GTZC_CFGR1_UART9_Pos)
-#define GTZC_CFGR1_UART12_Pos               (29U)
-#define GTZC_CFGR1_UART12_Msk               (0x01UL << GTZC_CFGR1_UART12_Pos)
 #define GTZC_CFGR1_DTS_Pos                  (30U)
 #define GTZC_CFGR1_DTS_Msk                  (0x01UL << GTZC_CFGR1_DTS_Pos)
 #define GTZC_CFGR1_LPTIM2_Pos               (31U)
@@ -19228,50 +15800,24 @@ typedef struct
 #define GTZC_CFGR2_USART1_Msk               (0x01UL << GTZC_CFGR2_USART1_Pos)
 #define GTZC_CFGR2_TIM15_Pos                (12U)
 #define GTZC_CFGR2_TIM15_Msk                (0x01UL << GTZC_CFGR2_TIM15_Pos)
-#define GTZC_CFGR2_TIM16_Pos                (13U)
-#define GTZC_CFGR2_TIM16_Msk                (0x01UL << GTZC_CFGR2_TIM16_Pos)
-#define GTZC_CFGR2_TIM17_Pos                (14U)
-#define GTZC_CFGR2_TIM17_Msk                (0x01UL << GTZC_CFGR2_TIM17_Pos)
 #define GTZC_CFGR2_SPI4_Pos                 (15U)
 #define GTZC_CFGR2_SPI4_Msk                 (0x01UL << GTZC_CFGR2_SPI4_Pos)
-#define GTZC_CFGR2_SPI6_Pos                 (16U)
-#define GTZC_CFGR2_SPI6_Msk                 (0x01UL << GTZC_CFGR2_SPI6_Pos)
-#define GTZC_CFGR2_SAI1_Pos                 (17U)
-#define GTZC_CFGR2_SAI1_Msk                 (0x01UL << GTZC_CFGR2_SAI1_Pos)
-#define GTZC_CFGR2_SAI2_Pos                 (18U)
-#define GTZC_CFGR2_SAI2_Msk                 (0x01UL << GTZC_CFGR2_SAI2_Pos)
 #define GTZC_CFGR2_USB_Pos                  (19U)
 #define GTZC_CFGR2_USB_Msk                  (0x01UL << GTZC_CFGR2_USB_Pos)
-#define GTZC_CFGR2_SPI5_Pos                 (24U)
-#define GTZC_CFGR2_SPI5_Msk                 (0x01UL << GTZC_CFGR2_SPI5_Pos)
 #define GTZC_CFGR2_LPUART1_Pos              (25U)
 #define GTZC_CFGR2_LPUART1_Msk              (0x01UL << GTZC_CFGR2_LPUART1_Pos)
 #define GTZC_CFGR2_I2C3_Pos                 (26U)
 #define GTZC_CFGR2_I2C3_Msk                 (0x01UL << GTZC_CFGR2_I2C3_Pos)
-#define GTZC_CFGR2_I2C4_Pos                 (27U)
-#define GTZC_CFGR2_I2C4_Msk                 (0x01UL << GTZC_CFGR2_I2C4_Pos)
 #define GTZC_CFGR2_LPTIM1_Pos               (28U)
 #define GTZC_CFGR2_LPTIM1_Msk               (0x01UL << GTZC_CFGR2_LPTIM1_Pos)
-#define GTZC_CFGR2_LPTIM3_Pos               (29U)
-#define GTZC_CFGR2_LPTIM3_Msk               (0x01UL << GTZC_CFGR2_LPTIM3_Pos)
-#define GTZC_CFGR2_LPTIM4_Pos               (30U)
-#define GTZC_CFGR2_LPTIM4_Msk               (0x01UL << GTZC_CFGR2_LPTIM4_Pos)
-#define GTZC_CFGR2_LPTIM5_Pos               (31U)
-#define GTZC_CFGR2_LPTIM5_Msk               (0x01UL << GTZC_CFGR2_LPTIM5_Pos)
 
 /***************  Bits definition for register x=3 (TZSC1) *************/
-#define GTZC_CFGR3_LPTIM6_Pos               (0U)
-#define GTZC_CFGR3_LPTIM6_Msk               (0x01UL << GTZC_CFGR3_LPTIM6_Pos)
 #define GTZC_CFGR3_VREFBUF_Pos              (1U)
 #define GTZC_CFGR3_VREFBUF_Msk              (0x01UL << GTZC_CFGR3_VREFBUF_Pos)
+#define GTZC_CFGR3_I3C2_Pos                 (2U)
+#define GTZC_CFGR3_I3C2_Msk                 (0x01UL << GTZC_CFGR3_I3C2_Pos)
 #define GTZC_CFGR3_CRC_Pos                  (8U)
 #define GTZC_CFGR3_CRC_Msk                  (0x01UL << GTZC_CFGR3_CRC_Pos)
-#define GTZC_CFGR3_CORDIC_Pos               (9U)
-#define GTZC_CFGR3_CORDIC_Msk               (0x01UL << GTZC_CFGR3_CORDIC_Pos)
-#define GTZC_CFGR3_FMAC_Pos                 (10U)
-#define GTZC_CFGR3_FMAC_Msk                 (0x01UL << GTZC_CFGR3_FMAC_Pos)
-#define GTZC_CFGR3_ETHERNET_Pos             (11U)
-#define GTZC_CFGR3_ETHERNET_Msk             (0x01UL << GTZC_CFGR3_ETHERNET_Pos)
 #define GTZC_CFGR3_ICACHE_REG_Pos           (12U)
 #define GTZC_CFGR3_ICACHE_REG_Msk           (0x01UL << GTZC_CFGR3_ICACHE_REG_Pos)
 #define GTZC_CFGR3_DCACHE1_REG_Pos          (13U)
@@ -19286,8 +15832,6 @@ typedef struct
 #define GTZC_CFGR3_RNG_Msk                  (0x01UL << GTZC_CFGR3_RNG_Pos)
 #define GTZC_CFGR3_SDMMC1_Pos               (21U)
 #define GTZC_CFGR3_SDMMC1_Msk               (0x01UL << GTZC_CFGR3_SDMMC1_Pos)
-#define GTZC_CFGR3_SDMMC2_Pos               (22U)
-#define GTZC_CFGR3_SDMMC2_Msk               (0x01UL << GTZC_CFGR3_SDMMC2_Pos)
 #define GTZC_CFGR3_FMC_REG_Pos              (23U)
 #define GTZC_CFGR3_FMC_REG_Msk              (0x01UL << GTZC_CFGR3_FMC_REG_Pos)
 #define GTZC_CFGR3_OCTOSPI1_Pos             (24U)
@@ -19355,10 +15899,6 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZSC1_SECCFGR1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZSC1_SECCFGR1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZSC1_SECCFGR1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZSC1_SECCFGR1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZSC1_SECCFGR1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZSC1_SECCFGR1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZSC1_SECCFGR1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZSC1_SECCFGR1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZSC1_SECCFGR1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -19385,22 +15925,10 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZSC1_SECCFGR1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZSC1_SECCFGR1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZSC1_SECCFGR1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZSC1_SECCFGR1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZSC1_SECCFGR1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZSC1_SECCFGR1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZSC1_SECCFGR1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZSC1_SECCFGR1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZSC1_SECCFGR1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZSC1_SECCFGR1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZSC1_SECCFGR1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZSC1_SECCFGR1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZSC1_SECCFGR1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZSC1_SECCFGR1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZSC1_SECCFGR1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZSC1_SECCFGR1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZSC1_SECCFGR1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZSC1_SECCFGR1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZSC1_SECCFGR1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZSC1_SECCFGR1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -19423,50 +15951,24 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZSC1_SECCFGR2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZSC1_SECCFGR2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZSC1_SECCFGR2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZSC1_SECCFGR2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZSC1_SECCFGR2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZSC1_SECCFGR2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZSC1_SECCFGR2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZSC1_SECCFGR2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZSC1_SECCFGR2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZSC1_SECCFGR2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZSC1_SECCFGR2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZSC1_SECCFGR2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZSC1_SECCFGR2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZSC1_SECCFGR2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZSC1_SECCFGR2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZSC1_SECCFGR2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZSC1_SECCFGR2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZSC1_SECCFGR2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZSC1_SECCFGR2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZSC1_SECCFGR2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZSC1_SECCFGR2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZSC1_SECCFGR2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZSC1_SECCFGR2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZSC1_SECCFGR2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZSC1_SECCFGR2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZSC1_SECCFGR2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZSC_SECCFGR3 register  ***************/
-#define GTZC_TZSC1_SECCFGR3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZSC1_SECCFGR3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZSC1_SECCFGR3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZSC1_SECCFGR3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZSC1_SECCFGR3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZSC1_SECCFGR3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZSC1_SECCFGR3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZSC1_SECCFGR3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZSC1_SECCFGR3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZSC1_SECCFGR3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZSC1_SECCFGR3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZSC1_SECCFGR3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZSC1_SECCFGR3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZSC1_SECCFGR3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZSC1_SECCFGR3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZSC1_SECCFGR3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZSC1_SECCFGR3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19481,8 +15983,6 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR3_RNG_Msk             GTZC_CFGR3_RNG_Msk
 #define GTZC_TZSC1_SECCFGR3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZSC1_SECCFGR3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZSC1_SECCFGR3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZSC1_SECCFGR3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZSC1_SECCFGR3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZSC1_SECCFGR3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZSC1_SECCFGR3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -19506,10 +16006,6 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR1_TIM7_Msk           GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZSC1_PRIVCFGR1_TIM12_Pos          GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZSC1_PRIVCFGR1_TIM12_Msk          GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZSC1_PRIVCFGR1_TIM13_Pos          GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZSC1_PRIVCFGR1_TIM13_Msk          GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZSC1_PRIVCFGR1_TIM14_Pos          GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZSC1_PRIVCFGR1_TIM14_Msk          GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZSC1_PRIVCFGR1_WWDG_Pos           GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZSC1_PRIVCFGR1_WWDG_Msk           GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZSC1_PRIVCFGR1_IWDG_Pos           GTZC_CFGR1_IWDG_Pos
@@ -19536,22 +16032,10 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR1_CRS_Msk            GTZC_CFGR1_CRS_Msk
 #define GTZC_TZSC1_PRIVCFGR1_USART6_Pos         GTZC_CFGR1_USART6_Pos
 #define GTZC_TZSC1_PRIVCFGR1_USART6_Msk         GTZC_CFGR1_USART6_Msk
-#define GTZC_TZSC1_PRIVCFGR1_USART10_Pos        GTZC_CFGR1_USART10_Pos
-#define GTZC_TZSC1_PRIVCFGR1_USART10_Msk        GTZC_CFGR1_USART10_Msk
-#define GTZC_TZSC1_PRIVCFGR1_USART11_Pos        GTZC_CFGR1_USART11_Pos
-#define GTZC_TZSC1_PRIVCFGR1_USART11_Msk        GTZC_CFGR1_USART11_Msk
 #define GTZC_TZSC1_PRIVCFGR1_HDMICEC_Pos        GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZSC1_PRIVCFGR1_HDMICEC_Msk        GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZSC1_PRIVCFGR1_DAC1_Pos           GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZSC1_PRIVCFGR1_DAC1_Msk           GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART7_Pos          GTZC_CFGR1_UART7_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART7_Msk          GTZC_CFGR1_UART7_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART8_Pos          GTZC_CFGR1_UART8_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART8_Msk          GTZC_CFGR1_UART8_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART9_Pos          GTZC_CFGR1_UART9_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART9_Msk          GTZC_CFGR1_UART9_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART12_Pos         GTZC_CFGR1_UART12_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART12Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZSC1_PRIVCFGR1_DTS_Pos            GTZC_CFGR1_DTS_Pos
 #define GTZC_TZSC1_PRIVCFGR1_DTS_Msk            GTZC_CFGR1_DTS_Msk
 #define GTZC_TZSC1_PRIVCFGR1_LPTIM2_Pos         GTZC_CFGR1_LPTIM2_Pos
@@ -19574,50 +16058,24 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR2_USART1_Msk         GTZC_CFGR2_USART1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_TIM15_Pos          GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZSC1_PRIVCFGR2_TIM15_Msk          GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZSC1_PRIVCFGR2_TIM16_Pos          GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZSC1_PRIVCFGR2_TIM16_Msk          GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZSC1_PRIVCFGR2_TIM17_Pos          GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZSC1_PRIVCFGR2_TIM17_Msk          GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZSC1_PRIVCFGR2_SPI4_Pos           GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZSC1_PRIVCFGR2_SPI4_Msk           GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SPI6_Pos           GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SPI6_Msk           GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SAI1_Pos           GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SAI1_Msk           GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SAI2_Pos           GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SAI2_Msk           GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZSC1_PRIVCFGR2_USB_Pos            GTZC_CFGR2_USB_Pos
 #define GTZC_TZSC1_PRIVCFGR2_USB_Msk            GTZC_CFGR2_USB_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SPI5_Pos           GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SPI5_Msk           GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZSC1_PRIVCFGR2_LPUART1_Pos        GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_LPUART1_Msk        GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_I2C3_Pos           GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZSC1_PRIVCFGR2_I2C3_Msk           GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZSC1_PRIVCFGR2_I2C4_Pos           GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZSC1_PRIVCFGR2_I2C4_Msk           GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZSC1_PRIVCFGR2_LPTIM1_Pos         GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_LPTIM1_Msk         GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM3_Pos         GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM3_Msk         GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM4_Pos         GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM4_Msk         GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM5_Pos         GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM5_Msk         GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR3 register  ***************/
-#define GTZC_TZSC1_PRIVCFGR3_LPTIM6_Pos         GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZSC1_PRIVCFGR3_LPTIM6_Msk         GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZSC1_PRIVCFGR3_VREFBUF_Pos        GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZSC1_PRIVCFGR3_VREFBUF_Msk        GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Pos           GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Msk           GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Pos            GTZC_CFGR3_CRC_Pos
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Msk            GTZC_CFGR3_CRC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_CORDIC_Pos         GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZSC1_PRIVCFGR3_CORDIC_Msk         GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_FMAC_Pos           GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZSC1_PRIVCFGR3_FMAC_Msk           GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_ETHERNET_Pos       GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZSC1_PRIVCFGR3_ETHERNET_Msk       GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZSC1_PRIVCFGR3_ICACHE_REG_Pos     GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZSC1_PRIVCFGR3_ICACHE_REG_Msk     GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZSC1_PRIVCFGR3_DCACHE1_REG_Pos    GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19632,8 +16090,6 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR3_RNG_Msk            GTZC_CFGR3_RNG_Msk
 #define GTZC_TZSC1_PRIVCFGR3_SDMMC1_Pos         GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZSC1_PRIVCFGR3_SDMMC1_Msk         GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZSC1_PRIVCFGR3_SDMMC2_Pos         GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZSC1_PRIVCFGR3_SDMMC2_Msk         GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZSC1_PRIVCFGR3_FMC_REG_Pos        GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZSC1_PRIVCFGR3_FMC_REG_Msk        GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZSC1_PRIVCFGR3_OCTOSPI1_Pos       GTZC_CFGR3_OCTOSPI1_Pos
@@ -19656,10 +16112,6 @@ typedef struct
 #define GTZC_TZIC1_IER1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_IER1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_IER1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_IER1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_IER1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_IER1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_IER1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_IER1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_IER1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_IER1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -19686,22 +16138,10 @@ typedef struct
 #define GTZC_TZIC1_IER1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_IER1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_IER1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_IER1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_IER1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_IER1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_IER1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_IER1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_IER1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_IER1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_IER1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_IER1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_IER1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_IER1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_IER1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_IER1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_IER1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_IER1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_IER1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_IER1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_IER1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_IER1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -19724,50 +16164,24 @@ typedef struct
 #define GTZC_TZIC1_IER2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_IER2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_IER2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_IER2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_IER2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_IER2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_IER2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_IER2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_IER2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_IER2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_IER2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_IER2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_IER2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_IER2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_IER2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_IER2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_IER2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_IER2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_IER2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_IER2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_IER2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_IER2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_IER2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_IER2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_IER2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_IER2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_IER2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_IER2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_IER2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_IER2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_IER2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_IER2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_IER2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZIC_IER3 register  ***************/
-#define GTZC_TZIC1_IER3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_IER3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_IER3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_IER3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_IER3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_IER3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_IER3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_IER3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_IER3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_IER3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_IER3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_IER3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_IER3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_IER3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_IER3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_IER3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_IER3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19782,8 +16196,6 @@ typedef struct
 #define GTZC_TZIC1_IER3_RNG_Msk             GTZC_CFGR3_RNG_Msk
 #define GTZC_TZIC1_IER3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_IER3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_IER3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_IER3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_IER3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_IER3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_IER3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -19850,10 +16262,6 @@ typedef struct
 #define GTZC_TZIC1_SR1_TIM7_Msk             GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_SR1_TIM12_Pos            GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_SR1_TIM12_Msk            GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_SR1_TIM13_Pos            GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_SR1_TIM13_Msk            GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_SR1_TIM14_Pos            GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_SR1_TIM14_Msk            GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_SR1_WWDG_Pos             GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_SR1_WWDG_Msk             GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_SR1_IWDG_Pos             GTZC_CFGR1_IWDG_Pos
@@ -19880,22 +16288,10 @@ typedef struct
 #define GTZC_TZIC1_SR1_CRS_Msk              GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_SR1_USART6_Pos           GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_SR1_USART6_Msk           GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_SR1_USART10_Pos          GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_SR1_USART10_Msk          GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_SR1_USART11_Pos          GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_SR1_USART11_Msk          GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_SR1_HDMICEC_Pos          GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_SR1_HDMICEC_Msk          GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_SR1_DAC1_Pos             GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_SR1_DAC1_Msk             GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_SR1_UART7_Pos            GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_SR1_UART7_Msk            GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_SR1_UART8_Pos            GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_SR1_UART8_Msk            GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_SR1_UART9_Pos            GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_SR1_UART9_Msk            GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_SR1_UART12_Pos           GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_SR1_UART12_Msk           GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_SR1_DTS_Pos              GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_SR1_DTS_Msk              GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_SR1_LPTIM2_Pos           GTZC_CFGR1_LPTIM2_Pos
@@ -19918,50 +16314,24 @@ typedef struct
 #define GTZC_TZIC1_SR2_USART1_Msk           GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_SR2_TIM15_Pos            GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_SR2_TIM15_Msk            GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_SR2_TIM16_Pos            GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_SR2_TIM16_Msk            GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_SR2_TIM17_Pos            GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_SR2_TIM17_Msk            GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_SR2_SPI4_Pos             GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_SR2_SPI4_Msk             GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_SR2_SPI6_Pos             GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_SR2_SPI6_Msk             GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_SR2_SAI1_Pos             GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_SR2_SAI1_Msk             GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_SR2_SAI2_Pos             GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_SR2_SAI2_Msk             GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_SR2_USB_Pos              GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_SR2_USB_Msk              GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_SR2_SPI5_Pos             GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_SR2_SPI5_Msk             GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_SR2_LPUART1_Pos          GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_SR2_LPUART1_Msk          GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_SR2_I2C3_Pos             GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_SR2_I2C3_Msk             GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_SR2_I2C4_Pos             GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_SR2_I2C4_Msk             GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_SR2_LPTIM1_Pos           GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_SR2_LPTIM1_Msk           GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_SR2_LPTIM3_Pos           GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_SR2_LPTIM3_Msk           GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_SR2_LPTIM4_Pos           GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_SR2_LPTIM4_Msk           GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_SR2_LPTIM5_Pos           GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_SR2_LPTIM5_Msk           GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZIC_SR3 register  **************/
-#define GTZC_TZIC1_SR3_LPTIM6_Pos           GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_SR3_LPTIM6_Msk           GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_SR3_VREFBUF_Pos          GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_SR3_VREFBUF_Msk          GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_SR3_I3C2_Pos             GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_SR3_I3C2_Msk             GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_SR3_CRC_Pos              GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_SR3_CRC_Msk              GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_SR3_CORDIC_Pos           GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_SR3_CORDIC_Msk           GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_SR3_FMAC_Pos             GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_SR3_FMAC_Msk             GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_SR3_ETHERNET_Pos         GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_SR3_ETHERNET_Msk         GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_SR3_ICACHE_REG_Pos       GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_SR3_ICACHE_REG_Msk       GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_SR3_DCACHE1_REG_Pos      GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19976,8 +16346,6 @@ typedef struct
 #define GTZC_TZIC1_SR3_RNG_Msk              GTZC_CFGR3_RNG_Msk
 #define GTZC_TZIC1_SR3_SDMMC1_Pos           GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_SR3_SDMMC1_Msk           GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_SR3_SDMMC2_Pos           GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_SR3_SDMMC2_Msk           GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_SR3_FMC_REG_Pos          GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_SR3_FMC_REG_Msk          GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_SR3_OCTOSPI1_Pos         GTZC_CFGR3_OCTOSPI1_Pos
@@ -20044,10 +16412,6 @@ typedef struct
 #define GTZC_TZIC1_FCR1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_FCR1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_FCR1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_FCR1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_FCR1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_FCR1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_FCR1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_FCR1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_FCR1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_FCR1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -20074,22 +16438,10 @@ typedef struct
 #define GTZC_TZIC1_FCR1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_FCR1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_FCR1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_FCR1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_FCR1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_FCR1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_FCR1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_FCR1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_FCR1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_FCR1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_FCR1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_FCR1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_FCR1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_FCR1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_FCR1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_FCR1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_FCR1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_FCR1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_FCR1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_FCR1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_FCR1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_FCR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -20112,50 +16464,24 @@ typedef struct
 #define GTZC_TZIC1_FCR2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_FCR2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_FCR2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_FCR2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_FCR2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_FCR2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_FCR2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_FCR2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_FCR2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_FCR2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_FCR2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_FCR2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_FCR2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_FCR2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_FCR2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_FCR2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_FCR2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_FCR2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_FCR2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_FCR2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_FCR2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_FCR2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_FCR2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_FCR2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_FCR2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_FCR2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_FCR2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_FCR2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_FCR2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_FCR2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_FCR2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_FCR2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_FCR2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /******************  Bits definition for GTZC_TZIC_FCR3 register  ****************/
-#define GTZC_TZIC1_FCR3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_FCR3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_FCR3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_FCR3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_FCR3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_FCR3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_FCR3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_FCR3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_FCR3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_FCR3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_FCR3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_FCR3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_FCR3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_FCR3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_FCR3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_FCR3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_FCR3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -20170,8 +16496,6 @@ typedef struct
 #define GTZC_TZIC1_FCR3_RNG_Msk             GTZC_CFGR3_RNG_Msk
 #define GTZC_TZIC1_FCR3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_FCR3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_FCR3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_FCR3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_FCR3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_FCR3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_FCR3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -23218,9 +19542,6 @@ typedef struct
 /******************************* PKA Instances ********************************/
 #define IS_PKA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == PKA_NS) || ((INSTANCE) == PKA_S))
 
-/******************************* CORDIC Instances *****************************/
-#define IS_CORDIC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CORDIC_NS) || ((INSTANCE) == CORDIC_S))
-
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CRC_NS) || ((INSTANCE) == CRC_S))
 
@@ -23232,11 +19553,10 @@ typedef struct
 
 /******************************* DELAYBLOCK Instances *******************************/
 #define IS_DLYB_ALL_INSTANCE(INSTANCE)  (((INSTANCE) == DLYB_SDMMC1_NS)   || \
-                                         ((INSTANCE) == DLYB_SDMMC2_NS)   || \
                                          ((INSTANCE) == DLYB_SDMMC1_S)    || \
-                                         ((INSTANCE) == DLYB_SDMMC2_S)    || \
                                          ((INSTANCE) == DLYB_OCTOSPI1_NS) || \
                                          ((INSTANCE) == DLYB_OCTOSPI1_S ))
+
 /******************************** DMA Instances *******************************/
 #define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPDMA1_Channel0_NS)  || ((INSTANCE) == GPDMA1_Channel0_S)  || \
                                        ((INSTANCE) == GPDMA1_Channel1_NS)  || ((INSTANCE) == GPDMA1_Channel1_S)  || \
@@ -23281,10 +19601,6 @@ typedef struct
 /************************ RAMCFG Write Protection Instances *********************/
 #define IS_RAMCFG_WP_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM2_NS)  || ((INSTANCE) == RAMCFG_SRAM2_S))
 
-
-/******************************** FMAC Instances ******************************/
-#define IS_FMAC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == FMAC_NS) || ((INSTANCE) == FMAC_S))
-
 /******************************* GPIO Instances *******************************/
 #define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA_NS) || ((INSTANCE) == GPIOA_S) || \
                                         ((INSTANCE) == GPIOB_NS) || ((INSTANCE) == GPIOB_S) || \
@@ -23293,8 +19609,7 @@ typedef struct
                                         ((INSTANCE) == GPIOE_NS) || ((INSTANCE) == GPIOE_S) || \
                                         ((INSTANCE) == GPIOF_NS) || ((INSTANCE) == GPIOF_S) || \
                                         ((INSTANCE) == GPIOG_NS) || ((INSTANCE) == GPIOG_S) || \
-                                        ((INSTANCE) == GPIOH_NS) || ((INSTANCE) == GPIOH_S) || \
-                                        ((INSTANCE) == GPIOI_NS) || ((INSTANCE) == GPIOI_S))
+                                        ((INSTANCE) == GPIOH_NS) || ((INSTANCE) == GPIOH_S))
 
 /******************************* DCMI Instances *******************************/
 #define IS_DCMI_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == DCMI_NS) || ((__INSTANCE__) == DCMI_S))
@@ -23316,14 +19631,14 @@ typedef struct
 /******************************** I2C Instances *******************************/
 #define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1_NS) || ((INSTANCE) == I2C1_S) || \
                                        ((INSTANCE) == I2C2_NS) || ((INSTANCE) == I2C2_S) || \
-                                       ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S) || \
-                                       ((INSTANCE) == I2C4_NS) || ((INSTANCE) == I2C4_S))
+                                       ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S))
 
 /****************** I2C Instances : wakeup capability from stop modes *********/
 #define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
 
 /******************************** I3C Instances *******************************/
-#define IS_I3C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I3C1_NS) || ((INSTANCE) == I3C1_S))
+#define IS_I3C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I3C1_NS) || ((INSTANCE) == I3C1_S) || \
+                                       ((INSTANCE) == I3C2_NS) || ((INSTANCE) == I3C2_S))
 
 /******************************* OSPI Instances *******************************/
 #define IS_OSPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == OCTOSPI1_NS) || ((INSTANCE) == OCTOSPI1_S))
@@ -23334,15 +19649,8 @@ typedef struct
 /****************************** RTC Instances *********************************/
 #define IS_RTC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == RTC_NS) || ((INSTANCE) == RTC_S))
 
-/******************************** SAI Instances *******************************/
-#define IS_SAI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SAI1_Block_A_NS) || ((INSTANCE) == SAI1_Block_A_S) || \
-                                       ((INSTANCE) == SAI1_Block_B_NS) || ((INSTANCE) == SAI1_Block_B_S) || \
-                                       ((INSTANCE) == SAI2_Block_A_NS) || ((INSTANCE) == SAI2_Block_A_S) || \
-                                       ((INSTANCE) == SAI2_Block_B_NS) || ((INSTANCE) == SAI2_Block_B_S))
-
 /****************************** SDMMC Instances *******************************/
-#define IS_SDMMC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SDMMC1_NS) || ((INSTANCE) == SDMMC1_S) || \
-                                         ((INSTANCE) == SDMMC2_NS) || ((INSTANCE) == SDMMC2_S))
+#define IS_SDMMC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SDMMC1_NS) || ((INSTANCE) == SDMMC1_S))
 
 /****************************** FDCAN Instances *******************************/
 #define IS_FDCAN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == FDCAN1_NS) || ((INSTANCE) == FDCAN1_S) || \
@@ -23351,20 +19659,15 @@ typedef struct
 /****************************** SMBUS Instances *******************************/
 #define IS_SMBUS_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1_NS) || ((INSTANCE) == I2C1_S) || \
                                          ((INSTANCE) == I2C2_NS) || ((INSTANCE) == I2C2_S) || \
-                                         ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S) || \
-                                         ((INSTANCE) == I2C4_NS) || ((INSTANCE) == I2C4_S))
+                                         ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S))
 
 /******************************** SPI Instances *******************************/
 #define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1_NS) || ((INSTANCE) == SPI1_S) || \
                                        ((INSTANCE) == SPI2_NS) || ((INSTANCE) == SPI2_S) || \
                                        ((INSTANCE) == SPI3_NS) || ((INSTANCE) == SPI3_S) || \
-                                       ((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S) || \
-                                       ((INSTANCE) == SPI5_NS) || ((INSTANCE) == SPI5_S) || \
-                                       ((INSTANCE) == SPI6_NS) || ((INSTANCE) == SPI6_S))
+                                       ((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S))
 
-#define IS_SPI_LIMITED_INSTANCE(INSTANCE) (((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S) || \
-                                           ((INSTANCE) == SPI5_NS) || ((INSTANCE) == SPI5_S) || \
-                                           ((INSTANCE) == SPI6_NS) || ((INSTANCE) == SPI6_S))
+#define IS_SPI_LIMITED_INSTANCE(INSTANCE) (((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S))
 
 #define IS_SPI_FULL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1_NS) || ((INSTANCE) == SPI1_S) || \
                                         ((INSTANCE) == SPI2_NS) || ((INSTANCE) == SPI2_S) || \
@@ -23372,47 +19675,27 @@ typedef struct
 
 /****************** LPTIM Instances : All supported instances *****************/
 #define IS_LPTIM_INSTANCE(INSTANCE)  (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                      ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                      ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                      ((INSTANCE) == LPTIM4_NS) || ((INSTANCE) == LPTIM4_S) ||\
-                                      ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                      ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                      ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : DMA supported instances *****************/
 #define IS_LPTIM_DMA_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /************* LPTIM Instances : at least 1 capture/compare channel ***********/
 #define IS_LPTIM_CC1_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS)  || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS)  || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS)  || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM4_NS)  || ((INSTANCE) == LPTIM4_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS)  || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS)  || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS)  || ((INSTANCE) == LPTIM2_S))
 
 /************* LPTIM Instances : at least 2 capture/compare channel ***********/
 #define IS_LPTIM_CC2_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : supporting encoder interface **************/
 #define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                                       ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                                       ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                                       ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                                       ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                                       ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : supporting Input Capture **************/
 #define IS_LPTIM_INPUT_CAPTURE_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                                   ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                                   ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                                   ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                                   ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                                   ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** TIM Instances : All supported instances *******************/
 #define IS_TIM_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23424,11 +19707,7 @@ typedef struct
                                     ((INSTANCE) == TIM7_NS)  || ((INSTANCE) == TIM7_S)  || \
                                     ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                     ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                    ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                    ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                    ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                    ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting 32 bits counter ****************/
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) (((INSTANCE) == TIM2_NS)  || ((INSTANCE) == TIM2_S)  || \
@@ -23437,16 +19716,12 @@ typedef struct
 /****************** TIM Instances : supporting the break function *************/
 #define IS_TIM_BREAK_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************** TIM Instances : supporting Break source selection *************/
 #define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                               ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                               ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                               ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                               ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting 2 break inputs *****************/
 #define IS_TIM_BKIN2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23460,11 +19735,7 @@ typedef struct
                                          ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                          ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                          ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                         ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                         ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                         ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                         ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************ TIM Instances : at least 2 capture/compare channels *************/
 #define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23509,9 +19780,7 @@ typedef struct
                                             ((INSTANCE) == TIM6_NS)  || ((INSTANCE) == TIM6_S)  || \
                                             ((INSTANCE) == TIM7_NS)  || ((INSTANCE) == TIM7_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
 #define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23520,9 +19789,7 @@ typedef struct
                                             ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                             ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /******************** TIM Instances : DMA burst feature ***********************/
 #define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23531,9 +19798,7 @@ typedef struct
                                             ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                             ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
@@ -23581,21 +19846,9 @@ typedef struct
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
       ((CHANNEL) == TIM_CHANNEL_2)))           \
      ||                                        \
-     ((((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
      ((((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)) && \
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
-      ((CHANNEL) == TIM_CHANNEL_2)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1))))
+      ((CHANNEL) == TIM_CHANNEL_2))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
@@ -23612,12 +19865,6 @@ typedef struct
       ((CHANNEL) == TIM_CHANNEL_4)))            \
     ||                                          \
     ((((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)) && \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    ((((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)) && \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    ((((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S)) && \
      ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
@@ -23628,11 +19875,7 @@ typedef struct
                                                     ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                     ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                                     ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                                    ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                                    ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                    ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                    ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
 #define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23668,8 +19911,6 @@ typedef struct
                                                         ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                         ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                                         ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                                        ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                                        ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
                                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting combined 3-phase PWM mode ******/
@@ -23679,9 +19920,7 @@ typedef struct
 /****************** TIM Instances : supporting commutation event generation ***/
 #define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                      ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                     ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                     ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                     ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                     ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting counting mode selection ********/
 #define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23752,9 +19991,7 @@ typedef struct
                                                        ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                                        ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                        ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                       ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                       ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23767,9 +20004,7 @@ typedef struct
 /****************** TIM Instances : supporting repetition counter *************/
 #define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                        ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                       ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                       ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
@@ -23788,12 +20023,7 @@ typedef struct
 #define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM2_NS)  || ((INSTANCE) == TIM2_S) || \
                                          ((INSTANCE) == TIM3_NS)  || ((INSTANCE) == TIM3_S) || \
                                          ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S)|| \
-                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)|| \
-                                         ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)|| \
-                                         ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
-
-/******************* TIM Instances : supporting bitfield RTCPREEN in OR1 register  ********************/
-#define IS_TIM_RTCPREEN_INSTANCE(INSTANCE) (((INSTANCE) == TIM17_NS)  || ((INSTANCE) == TIM17_S))
+                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : Advanced timer instances *******************/
 #define IS_TIM_ADVANCED_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
@@ -23815,9 +20045,7 @@ typedef struct
 #define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
                                      ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)  || \
                                      ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
-                                     ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                     ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                     ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                     ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** UART Instances : Asynchronous mode **********************/
 #define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23825,13 +20053,7 @@ typedef struct
                                     ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                     ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                     ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                    ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                    ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                    ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                    ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                    ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                    ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /*********************** UART Instances : FIFO mode ***************************/
 #define IS_UART_FIFO_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23840,21 +20062,13 @@ typedef struct
                                          ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                          ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                         ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                         ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                         ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                         ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                         ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                         ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                          ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /*********************** UART Instances : SPI Slave mode **********************/
 #define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)   || \
                                               ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)   || \
                                               ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)   || \
-                                              ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)   || \
-                                              ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S)  || \
-                                              ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                              ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************************** I2S Instances *******************************/
 #define IS_I2S_ALL_INSTANCE(INSTANCE)   (((INSTANCE) == SPI1) || \
@@ -23867,13 +20081,7 @@ typedef struct
                                                             ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                                             ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                             ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                            ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                            ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                            ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                            ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                            ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                            ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /****************** UART Instances : Driver Enable *****************/
 #define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE)     (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23882,12 +20090,6 @@ typedef struct
                                                       ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                       ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                       ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                      ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                      ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                      ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                      ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                      ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                      ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                       ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /******************** UART Instances : Half-Duplex mode **********************/
@@ -23897,12 +20099,6 @@ typedef struct
                                                  ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                  ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                  ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                 ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                 ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                 ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                 ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                 ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                 ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                  ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /****************** UART Instances : Hardware Flow control ********************/
@@ -23912,12 +20108,6 @@ typedef struct
                                            ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                            ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                           ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                           ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                           ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                           ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                           ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                           ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                            ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /******************** UART Instances : LIN mode **********************/
@@ -23926,13 +20116,7 @@ typedef struct
                                           ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                           ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                           ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                          ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                          ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                          ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                          ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                          ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                          ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** UART Instances : Wake-up from Stop mode **********************/
 #define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23941,12 +20125,6 @@ typedef struct
                                                       ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                       ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                       ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                      ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                      ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                      ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                      ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                      ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                      ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                       ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /*********************** UART Instances : IRDA mode ***************************/
@@ -23955,21 +20133,13 @@ typedef struct
                                     ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                     ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                     ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                    ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                    ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                    ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                    ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                    ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                    ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /********************* USART Instances : Smard card mode ***********************/
 #define IS_SMARTCARD_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
                                          ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)  || \
                                          ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
-                                         ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                         ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                         ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                         ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** LPUART Instance *****************************************/
 #define IS_LPUART_INSTANCE(INSTANCE)    (((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
@@ -23994,7 +20164,7 @@ typedef struct
 
 /** @} */ /* End of group STM32H5xx_Peripheral_Exported_macros */
 
-/** @} */ /* End of group STM32H563xx */
+/** @} */ /* End of group STM32H523xx */
 
 /** @} */ /* End of group ST */
 
@@ -24002,4 +20172,4 @@ typedef struct
 }
 #endif
 
-#endif  /* STM32H563xx_H */
+#endif  /* STM32H523xx_H */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h533xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h533xx.h
@@ -1,8 +1,8 @@
 /**
   ******************************************************************************
-  * @file    stm32h563xx.h
+  * @file    stm32h533xx.h
   * @author  MCD Application Team
-  * @brief   CMSIS STM32H563xx Device Peripheral Access Layer Header File.
+  * @brief   CMSIS STM32H533xx Device Peripheral Access Layer Header File.
   *
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
@@ -22,8 +22,8 @@
   ******************************************************************************
   */
 
-#ifndef STM32H563xx_H
-#define STM32H563xx_H
+#ifndef STM32H533xx_H
+#define STM32H533xx_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +34,7 @@ extern "C" {
   */
 
 
-/** @addtogroup STM32H563xx
+/** @addtogroup STM32H533xx
   * @{
   */
 
@@ -65,7 +65,7 @@ typedef enum
   PendSV_IRQn               =  -2,    /*!< -2  Pendable request for system service                           */
   SysTick_IRQn              =  -1,    /*!< -1  System Tick Timer                                             */
 
-/* ===========================================  STM32H563xx Specific Interrupt Numbers  ====================================== */
+/* ===========================================  STM32H533xx Specific Interrupt Numbers  ====================================== */
   WWDG_IRQn                 = 0,      /*!< Window WatchDog interrupt                                         */
   PVD_AVD_IRQn              = 1,      /*!< PVD/AVD through EXTI Line detection Interrupt                     */
   RTC_IRQn                  = 2,      /*!< RTC non-secure interrupt                                          */
@@ -102,6 +102,7 @@ typedef enum
   GPDMA1_Channel6_IRQn      = 33,     /*!< GPDMA1 Channel 6 global interrupt                                 */
   GPDMA1_Channel7_IRQn      = 34,     /*!< GPDMA1 Channel 7 global interrupt                                 */
   IWDG_IRQn                 = 35,     /*!< IWDG global interrupt                                             */
+  SAES_IRQn                 = 36,     /*!< Secure AES global interrupt                                       */
   ADC1_IRQn                 = 37,     /*!< ADC1 global interrupt                                             */
   DAC1_IRQn                 = 38,     /*!< DAC1 global interrupt                                             */
   FDCAN1_IT0_IRQn           = 39,     /*!< FDCAN1 interrupt 0                                                */
@@ -137,8 +138,6 @@ typedef enum
   ADC2_IRQn                 = 69,     /*!< ADC2 global interrupt                                             */
   LPTIM2_IRQn               = 70,     /*!< LPTIM2 global interrupt                                           */
   TIM15_IRQn                = 71,     /*!< TIM15 global interrupt                                            */
-  TIM16_IRQn                = 72,     /*!< TIM16 global interrupt                                            */
-  TIM17_IRQn                = 73,     /*!< TIM17 global interrupt                                            */
   USB_DRD_FS_IRQn           = 74,     /*!< USB FS global interrupt                                           */
   CRS_IRQn                  = 75,     /*!< CRS global interrupt                                              */
   UCPD1_IRQn                = 76,     /*!< UCPD1 global interrupt                                            */
@@ -148,13 +147,7 @@ typedef enum
   I2C3_EV_IRQn              = 80,     /*!< I2C3 event interrupt                                              */
   I2C3_ER_IRQn              = 81,     /*!< I2C3 error interrupt                                              */
   SPI4_IRQn                 = 82,     /*!< SPI4 global interrupt                                             */
-  SPI5_IRQn                 = 83,     /*!< SPI5 global interrupt                                             */
-  SPI6_IRQn                 = 84,     /*!< SPI6 global interrupt                                             */
   USART6_IRQn               = 85,     /*!< USART6 global interrupt                                           */
-  USART10_IRQn              = 86,     /*!< USART10 global interrupt                                          */
-  USART11_IRQn              = 87,     /*!< USART11 global interrupt                                          */
-  SAI1_IRQn                 = 88,     /*!< Serial Audio Interface 1 global interrupt                         */
-  SAI2_IRQn                 = 89,     /*!< Serial Audio Interface 2 global interrupt                         */
   GPDMA2_Channel0_IRQn      = 90,     /*!< GPDMA2 Channel 0 global interrupt                                 */
   GPDMA2_Channel1_IRQn      = 91,     /*!< GPDMA2 Channel 1 global interrupt                                 */
   GPDMA2_Channel2_IRQn      = 92,     /*!< GPDMA2 Channel 2 global interrupt                                 */
@@ -163,37 +156,24 @@ typedef enum
   GPDMA2_Channel5_IRQn      = 95,     /*!< GPDMA2 Channel 5 global interrupt                                 */
   GPDMA2_Channel6_IRQn      = 96,     /*!< GPDMA2 Channel 6 global interrupt                                 */
   GPDMA2_Channel7_IRQn      = 97,     /*!< GPDMA2 Channel 7 global interrupt                                 */
-  UART7_IRQn                = 98,     /*!< UART7 global interrupt                                            */
-  UART8_IRQn                = 99,     /*!< UART8 global interrupt                                            */
-  UART9_IRQn                = 100,    /*!< UART9 global interrupt                                            */
-  UART12_IRQn               = 101,    /*!< UART12 global interrupt                                           */
-  SDMMC2_IRQn               = 102,    /*!< SDMMC2 global interrupt                                           */
   FPU_IRQn                  = 103,    /*!< FPU global interrupt                                              */
   ICACHE_IRQn               = 104,    /*!< Instruction cache global interrupt                                */
   DCACHE1_IRQn              = 105,    /*!< Data cache global interrupt                                       */
-  ETH_IRQn                  = 106,    /*!< Ethernet global interrupt                                         */
-  ETH_WKUP_IRQn             = 107,    /*!< Ethernet Wakeup global interrupt                                  */
   DCMI_PSSI_IRQn            = 108,    /*!< DCMI/PSSI global interrupt                                        */
   FDCAN2_IT0_IRQn           = 109,    /*!< FDCAN2 interrupt 0                                                */
   FDCAN2_IT1_IRQn           = 110,    /*!< FDCAN2 interrupt 1                                                */
-  CORDIC_IRQn               = 111,    /*!< CORDIC global interrupt                                           */
-  FMAC_IRQn                 = 112,    /*!< FMAC global interrupt                                             */
   DTS_IRQn                  = 113,    /*!< DTS global interrupt                                              */
   RNG_IRQn                  = 114,    /*!< RNG global interrupt                                              */
+  OTFDEC1_IRQn              = 115,    /*!< OTFDEC1 global interrupt                                          */
+  AES_IRQn                  = 116,    /*!< AES global interrupt                                              */
   HASH_IRQn                 = 117,    /*!< HASH global interrupt                                             */
   PKA_IRQn                  = 118,    /*!< PKA global interrupt                                              */
   CEC_IRQn                  = 119,    /*!< CEC-HDMI global interrupt                                         */
   TIM12_IRQn                = 120,    /*!< TIM12 global interrupt                                            */
-  TIM13_IRQn                = 121,    /*!< TIM13 global interrupt                                            */
-  TIM14_IRQn                = 122,    /*!< TIM14 global interrupt                                            */
   I3C1_EV_IRQn              = 123,    /*!< I3C1 event interrupt                                              */
   I3C1_ER_IRQn              = 124,    /*!< I3C1 error interrupt                                              */
-  I2C4_EV_IRQn              = 125,    /*!< I2C4 event interrupt                                              */
-  I2C4_ER_IRQn              = 126,    /*!< I2C4 error interrupt                                              */
-  LPTIM3_IRQn               = 127,    /*!< LPTIM3 global interrupt                                           */
-  LPTIM4_IRQn               = 128,    /*!< LPTIM4 global interrupt                                           */
-  LPTIM5_IRQn               = 129,    /*!< LPTIM5 global interrupt                                           */
-  LPTIM6_IRQn               = 130,    /*!< LPTIM6 global interrupt                                           */
+  I3C2_EV_IRQn              = 131,    /*!< I3C2 Event interrupt                                              */
+  I3C2_ER_IRQn              = 132,    /*!< I3C2 Error interrupt                                              */
 } IRQn_Type;
 
 
@@ -224,7 +204,6 @@ typedef enum
   #warning Not supported compiler type
 #endif
 
-#define SMPS       /*!< Switched mode power supply feature */
 
 /* --------  Configuration of the Cortex-M33 Processor and Core Peripherals  ------ */
 #define __CM33_REV                0x0000U   /* Core revision r0p1 */
@@ -370,6 +349,40 @@ __IO uint32_t ISR;           /*!< CRS interrupt and status register,  Address of
 __IO uint32_t ICR;           /*!< CRS interrupt flag clear register,  Address offset: 0x0C */
 } CRS_TypeDef;
 
+/**
+  * @brief AES hardware accelerator
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x5C */
+       uint32_t RESERVED1[168];/*!< Reserved,                                  Address offset: 0x60 -- 0x2FC */
+  __IO uint32_t IER;          /*!< AES Interrupt Enable Register,              Address offset: 0x300 */
+  __IO uint32_t ISR;          /*!< AES Interrupt Status Register,              Address offset: 0x304 */
+  __IO uint32_t ICR;          /*!< AES Interrupt Clear Register,               Address offset: 0x308 */
+} AES_TypeDef;
 
 /**
   * @brief HASH
@@ -402,7 +415,6 @@ typedef struct
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
   __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
-  __IO uint32_t NSCR;  /*!< RNG noise source control register ,     Address offset: 0x0C */
   __IO uint32_t HTCR;  /*!< RNG health test configuration register, Address offset: 0x10 */
 } RNG_TypeDef;
 
@@ -503,179 +515,6 @@ typedef struct
   __IO uint32_t CLLR;         /*!< DMA channel x linked-list address register,      Address offset: 0xCC + (x * 0x80) */
 } DMA_Channel_TypeDef;
 
-/**
-  * @brief Ethernet MAC
-  */
-typedef struct
-{
-  __IO uint32_t MACCR;
-  __IO uint32_t MACECR;
-  __IO uint32_t MACPFR;
-  __IO uint32_t MACWTR;
-  __IO uint32_t MACHT0R;
-  __IO uint32_t MACHT1R;
-  uint32_t      RESERVED1[14];
-  __IO uint32_t MACVTR;
-  uint32_t      RESERVED2;
-  __IO uint32_t MACVHTR;
-  uint32_t      RESERVED3;
-  __IO uint32_t MACVIR;
-  __IO uint32_t MACIVIR;
-  uint32_t      RESERVED4[2];
-  __IO uint32_t MACTFCR;
-  uint32_t      RESERVED5[7];
-  __IO uint32_t MACRFCR;
-  uint32_t      RESERVED6[7];
-  __IO uint32_t MACISR;
-  __IO uint32_t MACIER;
-  __IO uint32_t MACRXTXSR;
-  uint32_t      RESERVED7;
-  __IO uint32_t MACPCSR;
-  __IO uint32_t MACRWKPFR;
-  uint32_t      RESERVED8[2];
-  __IO uint32_t MACLCSR;
-  __IO uint32_t MACLTCR;
-  __IO uint32_t MACLETR;
-  __IO uint32_t MAC1USTCR;
-  uint32_t      RESERVED9[12];
-  __IO uint32_t MACVR;
-  __IO uint32_t MACDR;
-  uint32_t      RESERVED10;
-  __IO uint32_t MACHWF0R;
-  __IO uint32_t MACHWF1R;
-  __IO uint32_t MACHWF2R;
-  uint32_t      RESERVED11[54];
-  __IO uint32_t MACMDIOAR;
-  __IO uint32_t MACMDIODR;
-  uint32_t      RESERVED12[2];
-  __IO uint32_t MACARPAR;
-  uint32_t      RESERVED13[59];
-  __IO uint32_t MACA0HR;
-  __IO uint32_t MACA0LR;
-  __IO uint32_t MACA1HR;
-  __IO uint32_t MACA1LR;
-  __IO uint32_t MACA2HR;
-  __IO uint32_t MACA2LR;
-  __IO uint32_t MACA3HR;
-  __IO uint32_t MACA3LR;
-  uint32_t      RESERVED14[248];
-  __IO uint32_t MMCCR;
-  __IO uint32_t MMCRIR;
-  __IO uint32_t MMCTIR;
-  __IO uint32_t MMCRIMR;
-  __IO uint32_t MMCTIMR;
-  uint32_t      RESERVED15[14];
-  __IO uint32_t MMCTSCGPR;
-  __IO uint32_t MMCTMCGPR;
-  uint32_t      RESERVED16[5];
-  __IO uint32_t MMCTPCGR;
-  uint32_t      RESERVED17[10];
-  __IO uint32_t MMCRCRCEPR;
-  __IO uint32_t MMCRAEPR;
-  uint32_t      RESERVED18[10];
-  __IO uint32_t MMCRUPGR;
-  uint32_t      RESERVED19[9];
-  __IO uint32_t MMCTLPIMSTR;
-  __IO uint32_t MMCTLPITCR;
-  __IO uint32_t MMCRLPIMSTR;
-  __IO uint32_t MMCRLPITCR;
-  uint32_t      RESERVED20[65];
-  __IO uint32_t MACL3L4C0R;
-  __IO uint32_t MACL4A0R;
-  uint32_t      RESERVED21[2];
-  __IO uint32_t MACL3A0R0R;
-  __IO uint32_t MACL3A1R0R;
-  __IO uint32_t MACL3A2R0R;
-  __IO uint32_t MACL3A3R0R;
-  uint32_t      RESERVED22[4];
-  __IO uint32_t MACL3L4C1R;
-  __IO uint32_t MACL4A1R;
-  uint32_t      RESERVED23[2];
-  __IO uint32_t MACL3A0R1R;
-  __IO uint32_t MACL3A1R1R;
-  __IO uint32_t MACL3A2R1R;
-  __IO uint32_t MACL3A3R1R;
-  uint32_t      RESERVED24[108];
-  __IO uint32_t MACTSCR;
-  __IO uint32_t MACSSIR;
-  __IO uint32_t MACSTSR;
-  __IO uint32_t MACSTNR;
-  __IO uint32_t MACSTSUR;
-  __IO uint32_t MACSTNUR;
-  __IO uint32_t MACTSAR;
-  uint32_t      RESERVED25;
-  __IO uint32_t MACTSSR;
-  uint32_t      RESERVED26[3];
-  __IO uint32_t MACTTSSNR;
-  __IO uint32_t MACTTSSSR;
-  uint32_t      RESERVED27[2];
-  __IO uint32_t MACACR;
-  uint32_t      RESERVED28;
-  __IO uint32_t MACATSNR;
-  __IO uint32_t MACATSSR;
-  __IO uint32_t MACTSIACR;
-  __IO uint32_t MACTSEACR;
-  __IO uint32_t MACTSICNR;
-  __IO uint32_t MACTSECNR;
-  uint32_t      RESERVED29[4];
-  __IO uint32_t MACPPSCR;
-  uint32_t      RESERVED30[3];
-  __IO uint32_t MACPPSTTSR;
-  __IO uint32_t MACPPSTTNR;
-  __IO uint32_t MACPPSIR;
-  __IO uint32_t MACPPSWR;
-  uint32_t      RESERVED31[12];
-  __IO uint32_t MACPOCR;
-  __IO uint32_t MACSPI0R;
-  __IO uint32_t MACSPI1R;
-  __IO uint32_t MACSPI2R;
-  __IO uint32_t MACLMIR;
-  uint32_t      RESERVED32[11];
-  __IO uint32_t MTLOMR;
-  uint32_t      RESERVED33[7];
-  __IO uint32_t MTLISR;
-  uint32_t      RESERVED34[55];
-  __IO uint32_t MTLTQOMR;
-  __IO uint32_t MTLTQUR;
-  __IO uint32_t MTLTQDR;
-  uint32_t      RESERVED35[8];
-  __IO uint32_t MTLQICSR;
-  __IO uint32_t MTLRQOMR;
-  __IO uint32_t MTLRQMPOCR;
-  __IO uint32_t MTLRQDR;
-  uint32_t      RESERVED36[177];
-  __IO uint32_t DMAMR;
-  __IO uint32_t DMASBMR;
-  __IO uint32_t DMAISR;
-  __IO uint32_t DMADSR;
-  uint32_t      RESERVED37[60];
-  __IO uint32_t DMACCR;
-  __IO uint32_t DMACTCR;
-  __IO uint32_t DMACRCR;
-  uint32_t      RESERVED38[2];
-  __IO uint32_t DMACTDLAR;
-  uint32_t      RESERVED39;
-  __IO uint32_t DMACRDLAR;
-  __IO uint32_t DMACTDTPR;
-  uint32_t      RESERVED40;
-  __IO uint32_t DMACRDTPR;
-  __IO uint32_t DMACTDRLR;
-  __IO uint32_t DMACRDRLR;
-  __IO uint32_t DMACIER;
-  __IO uint32_t DMACRIWTR;
-  __IO uint32_t DMACSFCSR;
-  uint32_t      RESERVED41;
-  __IO uint32_t DMACCATDR;
-  uint32_t      RESERVED42;
-  __IO uint32_t DMACCARDR;
-  uint32_t      RESERVED43;
-  __IO uint32_t DMACCATBR;
-  uint32_t      RESERVED44;
-  __IO uint32_t DMACCARBR;
-  __IO uint32_t DMACSR;
-  uint32_t      RESERVED45[2];
-  __IO uint32_t DMACMFCR;
-}ETH_TypeDef;
 
 /**
   * @brief Asynch Interrupt/Event Controller (EXTI)
@@ -751,15 +590,9 @@ typedef struct
   __IO uint32_t OTPBLR_PRG;      /*!< FLASH OTP block Lock to program register,                          Address offset: 0x94 */
        uint32_t RESERVED5[2];    /*!< Reserved5,                                                         Address offset: 0x98-0x9C */
   __IO uint32_t SECBB1R1;        /*!< FLASH secure block-based bank 1 register 1,                        Address offset: 0xA0 */
-  __IO uint32_t SECBB1R2;        /*!< FLASH secure block-based bank 1 register 2,                        Address offset: 0xA4 */
-  __IO uint32_t SECBB1R3;        /*!< FLASH secure block-based bank 1 register 3,                        Address offset: 0xA8 */
-  __IO uint32_t SECBB1R4;        /*!< FLASH secure block-based bank 1 register 4,                        Address offset: 0xAC */
-       uint32_t RESERVED6[4];    /*!< Reserved6,                                                         Address offset: 0xB0-0xBC */
+       uint32_t RESERVED6[7];    /*!< Reserved6,                                                         Address offset: 0xA4-0xBF */
   __IO uint32_t PRIVBB1R1;       /*!< FLASH privilege block-based bank 1 register 1,                     Address offset: 0xC0 */
-  __IO uint32_t PRIVBB1R2;       /*!< FLASH privilege block-based bank 1 register 2,                     Address offset: 0xC4 */
-  __IO uint32_t PRIVBB1R3;       /*!< FLASH privilege block-based bank 1 register 3,                     Address offset: 0xC8 */
-  __IO uint32_t PRIVBB1R4;       /*!< FLASH privilege block-based bank 1 register 4,                     Address offset: 0xCC */
-       uint32_t RESERVED7[4];    /*!< Reserved7,                                                         Address offset: 0xD0-0xDC */
+       uint32_t RESERVED7[7];    /*!< Reserved7,                                                         Address offset: 0xC4-0xDC */
   __IO uint32_t SECWM1R_CUR;     /*!< FLASH secure watermark 1 current register,                         Address offset: 0xE0 */
   __IO uint32_t SECWM1R_PRG;     /*!< FLASH secure watermark 1 to program register,                      Address offset: 0xE4 */
   __IO uint32_t WRP1R_CUR;       /*!< FLASH write sector group protection current register for bank1,    Address offset: 0xE8 */
@@ -773,15 +606,9 @@ typedef struct
   __IO uint32_t ECCDR;           /*!< FLASH ECC data register,                                           Address offset: 0x108 */
        uint32_t RESERVED8[37];   /*!< Reserved8,                                                         Address offset: 0x10C-0x19C */
   __IO uint32_t SECBB2R1;        /*!< FLASH secure block-based bank 2 register 1,                        Address offset: 0x1A0 */
-  __IO uint32_t SECBB2R2;        /*!< FLASH secure block-based bank 2 register 2,                        Address offset: 0x1A4 */
-  __IO uint32_t SECBB2R3;        /*!< FLASH secure block-based bank 2 register 3,                        Address offset: 0x1A8 */
-  __IO uint32_t SECBB2R4;        /*!< FLASH secure block-based bank 2 register 4,                        Address offset: 0x1AC */
-       uint32_t RESERVED9[4];    /*!< Reserved9,                                                         Address offset: 0x1B0-0x1BC */
+       uint32_t RESERVED9[7];    /*!< Reserved9,                                                         Address offset: 0x1A4-0x1BF */
   __IO uint32_t PRIVBB2R1;       /*!< FLASH privilege block-based bank 2 register 1,                     Address offset: 0x1C0 */
-  __IO uint32_t PRIVBB2R2;       /*!< FLASH privilege block-based bank 2 register 2,                     Address offset: 0x1C4 */
-  __IO uint32_t PRIVBB2R3;       /*!< FLASH privilege block-based bank 2 register 3,                     Address offset: 0x1C8 */
-  __IO uint32_t PRIVBB2R4;       /*!< FLASH privilege block-based bank 2 register 4,                     Address offset: 0x1CC */
-       uint32_t RESERVED10[4];   /*!< Reserved10,                                                        Address offset: 0x1D0-0x1DC */
+       uint32_t RESERVED10[7];   /*!< Reserved10,                                                        Address offset: 0x1C4-0x1DC */
   __IO uint32_t SECWM2R_CUR;     /*!< FLASH secure watermark 2 current register,                         Address offset: 0x1E0 */
   __IO uint32_t SECWM2R_PRG;     /*!< FLASH secure watermark 2 to program register,                      Address offset: 0x1E4 */
   __IO uint32_t WRP2R_CUR;       /*!< FLASH write sector group protection current register for bank2,    Address offset: 0x1E8 */
@@ -791,21 +618,6 @@ typedef struct
   __IO uint32_t HDP2R_CUR;       /*!< FLASH HDP configuration current register for bank2,                Address offset: 0x1F8 */
   __IO uint32_t HDP2R_PRG;       /*!< FLASH HDP configuration to program register for bank2,             Address offset: 0x1FC */
 } FLASH_TypeDef;
-
-/**
-  * @brief FMAC
-  */
-typedef struct
-{
-  __IO uint32_t X1BUFCFG;        /*!< FMAC X1 Buffer Configuration register, Address offset: 0x00          */
-  __IO uint32_t X2BUFCFG;        /*!< FMAC X2 Buffer Configuration register, Address offset: 0x04          */
-  __IO uint32_t YBUFCFG;         /*!< FMAC Y Buffer Configuration register,  Address offset: 0x08          */
-  __IO uint32_t PARAM;           /*!< FMAC Parameter register,               Address offset: 0x0C          */
-  __IO uint32_t CR;              /*!< FMAC Control register,                 Address offset: 0x10          */
-  __IO uint32_t SR;              /*!< FMAC Status register,                  Address offset: 0x14          */
-  __IO uint32_t WDATA;           /*!< FMAC Write Data register,              Address offset: 0x18          */
-  __IO uint32_t RDATA;           /*!< FMAC Read Data register,               Address offset: 0x1C          */
-} FMAC_TypeDef;
 
 /**
   * @brief General Purpose I/O
@@ -1038,6 +850,33 @@ typedef struct
 } XSPI_TypeDef;
 
 typedef  XSPI_TypeDef OCTOSPI_TypeDef;
+/**
+  * @brief OTFDEC register
+  */
+typedef struct
+{
+  __IO uint32_t REG_CONFIGR;      /*!< OTFDEC Region Configuration register,          Address offset: 0x20 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_START_ADDR;   /*!< OTFDEC Region Start Address register,          Address offset: 0x24 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_END_ADDR;     /*!< OTFDEC Region End Address register,            Address offset: 0x28 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_NONCER0;      /*!< OTFDEC Region Nonce register 0,                Address offset: 0x2C + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_NONCER1;      /*!< OTFDEC Region Nonce register 1,                Address offset: 0x30 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_KEYR0;        /*!< OTFDEC Region Key register 0,                  Address offset: 0x34 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_KEYR1;        /*!< OTFDEC Region Key register 1,                  Address offset: 0x38 + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_KEYR2;        /*!< OTFDEC Region Key register 2,                  Address offset: 0x3C + 0x30 * (x -1) (x = 1 to 4) */
+  __IO uint32_t REG_KEYR3;        /*!< OTFDEC Region Key register 3,                  Address offset: 0x40 + 0x30 * (x -1) (x = 1 to 4) */
+} OTFDEC_Region_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR;               /*!< OTFDEC Control register,                                 Address offset: 0x000 */
+  uint32_t RESERVED1[3];          /*!< Reserved,                                                Address offset: 0x004-0x00C */
+  __IO uint32_t PRIVCFGR;         /*!< OTFDEC Privileged access control Configuration register, Address offset: 0x010 */
+  uint32_t RESERVED2[187];        /*!< Reserved,                                                Address offset: 0x014-0x2FC */
+  __IO uint32_t ISR;              /*!< OTFDEC Interrupt Status register,                        Address offset: 0x300 */
+  __IO uint32_t ICR;              /*!< OTFDEC Interrupt Clear register,                         Address offset: 0x304 */
+  __IO uint32_t IER;              /*!< OTFDEC Interrupt Enable register,                        Address offset: 0x308 */
+} OTFDEC_TypeDef;
+
 
 /**
   * @brief Power Control
@@ -1081,7 +920,7 @@ typedef struct
   __IO uint32_t ICR;      /*!< Interrupt Clear Register,          Address offset: 0x14 */
   __IO uint32_t WPR1;     /*!< SRAM Write Protection Register 1,  Address offset: 0x18 */
   __IO uint32_t WPR2;     /*!< SRAM Write Protection Register 2,  Address offset: 0x1C */
-  uint32_t      RESERVED; /*!< Reserved,                          Address offset: 0x20 */
+  __IO uint32_t WPR3;     /*!< SRAM Write Protection Register 3,  Address offset: 0x20 */
   __IO uint32_t ECCKEY;   /*!< SRAM ECC Key Register,             Address offset: 0x24 */
   __IO uint32_t ERKEYR;   /*!< SRAM Erase Key Register,           Address offset: 0x28 */
 }RAMCFG_TypeDef;
@@ -1288,28 +1127,6 @@ typedef struct
   __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C  */
 } USART_TypeDef;
 
-/**
-  * @brief Serial Audio Interface
-  */
-typedef struct
-{
-  __IO uint32_t GCR;          /*!< SAI global configuration register,        Address offset: 0x00 */
-  uint32_t      RESERVED[16]; /*!< Reserved,                         Address offset: 0x04 to 0x40 */
-  __IO uint32_t PDMCR;        /*!< SAI PDM control register,                 Address offset: 0x44 */
-  __IO uint32_t PDMDLY;       /*!< SAI PDM delay register,                   Address offset: 0x48 */
-} SAI_TypeDef;
-
-typedef struct
-{
-  __IO uint32_t CR1;         /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IO uint32_t CR2;         /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IO uint32_t FRCR;        /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IO uint32_t SLOTR;       /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IO uint32_t IMR;         /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IO uint32_t SR;          /*!< SAI block x status register,              Address offset: 0x18 */
-  __IO uint32_t CLRFR;       /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IO uint32_t DR;          /*!< SAI block x data register,                Address offset: 0x20 */
-} SAI_Block_TypeDef;
 /**
   * @brief System configuration, Boot and Security
   */
@@ -1555,18 +1372,6 @@ typedef struct
 } FMC_Bank3_TypeDef;
 
 /**
-  * @brief Flexible Memory Controller Bank5 and 6
-  */
-typedef struct
-{
-  __IO uint32_t SDCR[2];     /*!< SDRAM Control registers ,       Address offset: 0x140-0x144  */
-  __IO uint32_t SDTR[2];     /*!< SDRAM Timing registers ,        Address offset: 0x148-0x14C  */
-  __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150        */
-  __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154        */
-  __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158        */
-} FMC_Bank5_6_TypeDef;
-
-/**
   * @brief VREFBUF
   */
 typedef struct
@@ -1629,15 +1434,6 @@ typedef struct
   __IO uint32_t CDR;          /*!< ADC common group regular data register Address offset: 0x300 + 0x0C */
 } ADC_Common_TypeDef;
 
-/**
-  * @brief CORDIC
-  */
-typedef struct
-{
-  __IO uint32_t CSR;           /*!< CORDIC control and status register,        Address offset: 0x00 */
-  __IO uint32_t WDATA;         /*!< CORDIC argument register,                  Address offset: 0x04 */
-  __IO uint32_t RDATA;         /*!< CORDIC result register,                    Address offset: 0x08 */
-} CORDIC_TypeDef;
 
 /**
   * @brief IWDG
@@ -1706,7 +1502,7 @@ typedef struct
   __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
-/*@}*/ /* end of group STM32H563xx_Peripherals */
+/*@}*/ /* end of group STM32H533xx_Peripherals */
 
 
 /* --------  End of section using anonymous unions and disabling warnings  -------- */
@@ -1739,16 +1535,17 @@ typedef struct
   */
 
 /* Internal SRAMs size */
-#define SRAM1_SIZE               (0x40000UL)    /*!< SRAM1=256k */
-#define SRAM2_SIZE               (0x10000UL)    /*!< SRAM2=64k  */
-#define SRAM3_SIZE               (0x50000UL)    /*!< SRAM3=320k */
-#define BKPSRAM_SIZE             (0x01000UL)    /*!< BKPSRAM=4k */
+
+#define SRAM1_SIZE               (0x20000UL)    /*!< SRAM1=128k */
+#define SRAM2_SIZE               (0x14000UL)    /*!< SRAM2=80k  */
+#define SRAM3_SIZE               (0x10000UL)    /*!< SRAM3=64k */
+#define BKPSRAM_SIZE             (0x00800UL)    /*!< BKPSRAM=2k */
 
 /* Flash, Peripheral and internal SRAMs base addresses - Non secure */
-#define FLASH_BASE_NS            (0x08000000UL) /*!< FLASH (up to 2 MB) non-secure base address         */
-#define SRAM1_BASE_NS            (0x20000000UL) /*!< SRAM1 (256 KB) non-secure base address             */
-#define SRAM2_BASE_NS            (0x20040000UL) /*!< SRAM2 (64 KB) non-secure base address              */
-#define SRAM3_BASE_NS            (0x20050000UL) /*!< SRAM3 (320 KB) non-secure base address             */
+#define FLASH_BASE_NS            (0x08000000UL) /*!< FLASH (up to 512 KB) non-secure base address       */
+#define SRAM1_BASE_NS            (0x20000000UL) /*!< SRAM1 (128 KB) non-secure base address             */
+#define SRAM2_BASE_NS            (0x20020000UL) /*!< SRAM2 (80 KB) non-secure base address              */
+#define SRAM3_BASE_NS            (0x20034000UL) /*!< SRAM3 (64 KB) non-secure base address              */
 #define PERIPH_BASE_NS           (0x40000000UL) /*!< Peripheral non-secure base address                 */
 
 /* External memories base addresses - Not aliased */
@@ -1782,8 +1579,6 @@ typedef struct
 #define TIM6_BASE_NS             (APB1PERIPH_BASE_NS + 0x1000UL)
 #define TIM7_BASE_NS             (APB1PERIPH_BASE_NS + 0x1400UL)
 #define TIM12_BASE_NS            (APB1PERIPH_BASE_NS + 0x1800UL)
-#define TIM13_BASE_NS            (APB1PERIPH_BASE_NS + 0x1C00UL)
-#define TIM14_BASE_NS            (APB1PERIPH_BASE_NS + 0x2000UL)
 #define WWDG_BASE_NS             (APB1PERIPH_BASE_NS + 0x2C00UL)
 #define IWDG_BASE_NS             (APB1PERIPH_BASE_NS + 0x3000UL)
 #define SPI2_BASE_NS             (APB1PERIPH_BASE_NS + 0x3800UL)
@@ -1797,13 +1592,7 @@ typedef struct
 #define I3C1_BASE_NS             (APB1PERIPH_BASE_NS + 0x5C00UL)
 #define CRS_BASE_NS              (APB1PERIPH_BASE_NS + 0x6000UL)
 #define USART6_BASE_NS           (APB1PERIPH_BASE_NS + 0x6400UL)
-#define USART10_BASE_NS          (APB1PERIPH_BASE_NS + 0x6800UL)
-#define USART11_BASE_NS          (APB1PERIPH_BASE_NS + 0x6C00UL)
 #define CEC_BASE_NS              (APB1PERIPH_BASE_NS + 0x7000UL)
-#define UART7_BASE_NS            (APB1PERIPH_BASE_NS + 0x7800UL)
-#define UART8_BASE_NS            (APB1PERIPH_BASE_NS + 0x7C00UL)
-#define UART9_BASE_NS            (APB1PERIPH_BASE_NS + 0x8000UL)
-#define UART12_BASE_NS           (APB1PERIPH_BASE_NS + 0x8400UL)
 #define DTS_BASE_NS              (APB1PERIPH_BASE_NS + 0x8C00UL)
 #define LPTIM2_BASE_NS           (APB1PERIPH_BASE_NS + 0x9400UL)
 #define FDCAN1_BASE_NS           (APB1PERIPH_BASE_NS + 0xA400UL)
@@ -1818,16 +1607,7 @@ typedef struct
 #define TIM8_BASE_NS             (APB2PERIPH_BASE_NS + 0x3400UL)
 #define USART1_BASE_NS           (APB2PERIPH_BASE_NS + 0x3800UL)
 #define TIM15_BASE_NS            (APB2PERIPH_BASE_NS + 0x4000UL)
-#define TIM16_BASE_NS            (APB2PERIPH_BASE_NS + 0x4400UL)
-#define TIM17_BASE_NS            (APB2PERIPH_BASE_NS + 0x4800UL)
 #define SPI4_BASE_NS             (APB2PERIPH_BASE_NS + 0x4C00UL)
-#define SPI6_BASE_NS             (APB2PERIPH_BASE_NS + 0x5000UL)
-#define SAI1_BASE_NS             (APB2PERIPH_BASE_NS + 0x5400UL)
-#define SAI1_Block_A_BASE_NS     (SAI1_BASE_NS + 0x004UL)
-#define SAI1_Block_B_BASE_NS     (SAI1_BASE_NS + 0x024UL)
-#define SAI2_BASE_NS             (APB2PERIPH_BASE_NS + 0x5800UL)
-#define SAI2_Block_A_BASE_NS     (SAI2_BASE_NS + 0x004UL)
-#define SAI2_Block_B_BASE_NS     (SAI2_BASE_NS + 0x024UL)
 #define USB_DRD_BASE_NS          (APB2PERIPH_BASE_NS + 0x6000UL)
 #define USB_DRD_PMAADDR_NS       (APB2PERIPH_BASE_NS + 0x6400UL)
 
@@ -1836,11 +1616,7 @@ typedef struct
 #define GPDMA2_BASE_NS           (AHB1PERIPH_BASE_NS + 0x01000UL)
 #define FLASH_R_BASE_NS          (AHB1PERIPH_BASE_NS + 0x02000UL)
 #define CRC_BASE_NS              (AHB1PERIPH_BASE_NS + 0x03000UL)
-#define CORDIC_BASE_NS           (AHB1PERIPH_BASE_NS + 0x03800UL)
-#define FMAC_BASE_NS             (AHB1PERIPH_BASE_NS + 0x03C00UL)
 #define RAMCFG_BASE_NS           (AHB1PERIPH_BASE_NS + 0x06000UL)
-#define ETH_BASE_NS              (AHB1PERIPH_BASE_NS + 0x8000UL)
-#define ETH_MAC_BASE_NS          (ETH_BASE)
 #define ICACHE_BASE_NS           (AHB1PERIPH_BASE_NS + 0x10400UL)
 #define DCACHE1_BASE_NS          (AHB1PERIPH_BASE_NS + 0x11400UL)
 #define GTZC_TZSC1_BASE_NS       (AHB1PERIPH_BASE_NS + 0x12400UL)
@@ -1881,30 +1657,26 @@ typedef struct
 #define GPIOF_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01400UL)
 #define GPIOG_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01800UL)
 #define GPIOH_BASE_NS            (AHB2PERIPH_BASE_NS + 0x01C00UL)
-#define GPIOI_BASE_NS            (AHB2PERIPH_BASE_NS + 0x02000UL)
 #define ADC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08000UL)
 #define ADC2_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08100UL)
 #define ADC12_COMMON_BASE_NS     (AHB2PERIPH_BASE_NS + 0x08300UL)
 #define DAC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08400UL)
 #define DCMI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C000UL)
 #define PSSI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C400UL)
+#define AES_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA0000UL)
 #define HASH_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0400UL)
 #define HASH_DIGEST_BASE_NS      (AHB2PERIPH_BASE_NS + 0xA0710UL)
 #define RNG_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA0800UL)
+#define SAES_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0C00UL)
 #define PKA_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA2000UL)
 #define PKA_RAM_BASE_NS          (AHB2PERIPH_BASE_NS + 0xA2400UL)
 
 /*!< APB3 Non secure peripherals */
 #define SBS_BASE_NS              (APB3PERIPH_BASE_NS + 0x0400UL)
-#define SPI5_BASE_NS             (APB3PERIPH_BASE_NS + 0x2000UL)
 #define LPUART1_BASE_NS          (APB3PERIPH_BASE_NS + 0x2400UL)
 #define I2C3_BASE_NS             (APB3PERIPH_BASE_NS + 0x2800UL)
-#define I2C4_BASE_NS             (APB3PERIPH_BASE_NS + 0x2C00UL)
+#define I3C2_BASE_NS             (APB3PERIPH_BASE_NS + 0x3000UL)
 #define LPTIM1_BASE_NS           (APB3PERIPH_BASE_NS + 0x4400UL)
-#define LPTIM3_BASE_NS           (APB3PERIPH_BASE_NS + 0x4800UL)
-#define LPTIM4_BASE_NS           (APB3PERIPH_BASE_NS + 0x4C00UL)
-#define LPTIM5_BASE_NS           (APB3PERIPH_BASE_NS + 0x5000UL)
-#define LPTIM6_BASE_NS           (APB3PERIPH_BASE_NS + 0x5400UL)
 #define VREFBUF_BASE_NS          (APB3PERIPH_BASE_NS + 0x7400UL)
 #define RTC_BASE_NS              (APB3PERIPH_BASE_NS + 0x7800UL)
 #define TAMP_BASE_NS             (APB3PERIPH_BASE_NS + 0x7C00UL)
@@ -1916,10 +1688,13 @@ typedef struct
 #define DEBUG_BASE_NS            (AHB3PERIPH_BASE_NS + 0x4000UL)
 
 /*!< AHB4 Non secure peripherals */
+#define OTFDEC1_BASE_NS          (AHB4PERIPH_BASE_NS + 0x5000UL)
+#define OTFDEC1_REGION1_BASE_NS  (OTFDEC1_BASE_NS + 0x20UL)
+#define OTFDEC1_REGION2_BASE_NS  (OTFDEC1_BASE_NS + 0x50UL)
+#define OTFDEC1_REGION3_BASE_NS  (OTFDEC1_BASE_NS + 0x80UL)
+#define OTFDEC1_REGION4_BASE_NS  (OTFDEC1_BASE_NS + 0xB0UL)
 #define SDMMC1_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8000UL)
 #define DLYB_SDMMC1_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8400UL)
-#define SDMMC2_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8C00UL)
-#define DLYB_SDMMC2_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8800UL)
 #define FMC_R_BASE_NS            (AHB4PERIPH_BASE_NS + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_NS       (AHB4PERIPH_BASE_NS + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_NS    (AHB4PERIPH_BASE_NS + 0x0F000UL)
@@ -1928,13 +1703,12 @@ typedef struct
 #define FMC_Bank1_R_BASE_NS      (FMC_R_BASE_NS + 0x0000UL)
 #define FMC_Bank1E_R_BASE_NS     (FMC_R_BASE_NS + 0x0104UL)
 #define FMC_Bank3_R_BASE_NS      (FMC_R_BASE_NS + 0x0080UL)
-#define FMC_Bank5_6_R_BASE_NS    (FMC_R_BASE_NS + 0x0140UL)
 
 /* Flash, Peripheral and internal SRAMs base addresses - Secure */
-#define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 2 MB) secure base address */
-#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (256 KB) secure base address     */
-#define SRAM2_BASE_S            (0x30040000UL) /*!< SRAM2 (64 KB) secure base address      */
-#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (320 KB) secure base address     */
+#define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 512 KB) secure base address */
+#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (128 KB) secure base address     */
+#define SRAM2_BASE_S            (0x30020000UL) /*!< SRAM2 (80 KB) secure base address      */
+#define SRAM3_BASE_S            (0x30034000UL) /*!< SRAM3 (64 KB) secure base address      */
 #define PERIPH_BASE_S           (0x50000000UL) /*!< Peripheral secure base address         */
 
 /* Peripheral memory map - Secure */
@@ -1954,8 +1728,6 @@ typedef struct
 #define TIM6_BASE_S             (APB1PERIPH_BASE_S + 0x1000UL)
 #define TIM7_BASE_S             (APB1PERIPH_BASE_S + 0x1400UL)
 #define TIM12_BASE_S            (APB1PERIPH_BASE_S + 0x1800UL)
-#define TIM13_BASE_S            (APB1PERIPH_BASE_S + 0x1C00UL)
-#define TIM14_BASE_S            (APB1PERIPH_BASE_S + 0x2000UL)
 #define WWDG_BASE_S             (APB1PERIPH_BASE_S + 0x2C00UL)
 #define IWDG_BASE_S             (APB1PERIPH_BASE_S + 0x3000UL)
 #define SPI2_BASE_S             (APB1PERIPH_BASE_S + 0x3800UL)
@@ -1969,13 +1741,7 @@ typedef struct
 #define I3C1_BASE_S             (APB1PERIPH_BASE_S + 0x5C00UL)
 #define CRS_BASE_S              (APB1PERIPH_BASE_S + 0x6000UL)
 #define USART6_BASE_S           (APB1PERIPH_BASE_S + 0x6400UL)
-#define USART10_BASE_S          (APB1PERIPH_BASE_S + 0x6800UL)
-#define USART11_BASE_S          (APB1PERIPH_BASE_S + 0x6C00UL)
 #define CEC_BASE_S              (APB1PERIPH_BASE_S + 0x7000UL)
-#define UART7_BASE_S            (APB1PERIPH_BASE_S + 0x7800UL)
-#define UART8_BASE_S            (APB1PERIPH_BASE_S + 0x7C00UL)
-#define UART9_BASE_S            (APB1PERIPH_BASE_S + 0x8000UL)
-#define UART12_BASE_S           (APB1PERIPH_BASE_S + 0x8400UL)
 #define DTS_BASE_S              (APB1PERIPH_BASE_S + 0x8C00UL)
 #define LPTIM2_BASE_S           (APB1PERIPH_BASE_S + 0x9400UL)
 #define FDCAN1_BASE_S           (APB1PERIPH_BASE_S + 0xA400UL)
@@ -1990,16 +1756,7 @@ typedef struct
 #define TIM8_BASE_S             (APB2PERIPH_BASE_S + 0x3400UL)
 #define USART1_BASE_S           (APB2PERIPH_BASE_S + 0x3800UL)
 #define TIM15_BASE_S            (APB2PERIPH_BASE_S + 0x4000UL)
-#define TIM16_BASE_S            (APB2PERIPH_BASE_S + 0x4400UL)
-#define TIM17_BASE_S            (APB2PERIPH_BASE_S + 0x4800UL)
 #define SPI4_BASE_S             (APB2PERIPH_BASE_S + 0x4C00UL)
-#define SPI6_BASE_S             (APB2PERIPH_BASE_S + 0x5000UL)
-#define SAI1_BASE_S             (APB2PERIPH_BASE_S + 0x5400UL)
-#define SAI1_Block_A_BASE_S     (SAI1_BASE_S + 0x004UL)
-#define SAI1_Block_B_BASE_S     (SAI1_BASE_S + 0x024UL)
-#define SAI2_BASE_S             (APB2PERIPH_BASE_S + 0x5800UL)
-#define SAI2_Block_A_BASE_S     (SAI2_BASE_S + 0x004UL)
-#define SAI2_Block_B_BASE_S     (SAI2_BASE_S + 0x024UL)
 #define USB_DRD_BASE_S          (APB2PERIPH_BASE_S + 0x6000UL)
 #define USB_DRD_PMAADDR_S       (APB2PERIPH_BASE_S + 0x6400UL)
 
@@ -2008,11 +1765,7 @@ typedef struct
 #define GPDMA2_BASE_S           (AHB1PERIPH_BASE_S + 0x01000UL)
 #define FLASH_R_BASE_S          (AHB1PERIPH_BASE_S + 0x02000UL)
 #define CRC_BASE_S              (AHB1PERIPH_BASE_S + 0x03000UL)
-#define CORDIC_BASE_S           (AHB1PERIPH_BASE_S + 0x03800UL)
-#define FMAC_BASE_S             (AHB1PERIPH_BASE_S + 0x03C00UL)
 #define RAMCFG_BASE_S           (AHB1PERIPH_BASE_S + 0x06000UL)
-#define ETH_BASE_S              (AHB1PERIPH_BASE_S + 0x8000UL)
-#define ETH_MAC_BASE_S          (ETH_BASE_S)
 #define ICACHE_BASE_S           (AHB1PERIPH_BASE_S + 0x10400UL)
 #define DCACHE1_BASE_S          (AHB1PERIPH_BASE_S + 0x11400UL)
 #define GTZC_TZSC1_BASE_S       (AHB1PERIPH_BASE_S + 0x12400UL)
@@ -2051,30 +1804,26 @@ typedef struct
 #define GPIOF_BASE_S            (AHB2PERIPH_BASE_S + 0x01400UL)
 #define GPIOG_BASE_S            (AHB2PERIPH_BASE_S + 0x01800UL)
 #define GPIOH_BASE_S            (AHB2PERIPH_BASE_S + 0x01C00UL)
-#define GPIOI_BASE_S            (AHB2PERIPH_BASE_S + 0x02000UL)
 #define ADC1_BASE_S             (AHB2PERIPH_BASE_S + 0x08000UL)
 #define ADC2_BASE_S             (AHB2PERIPH_BASE_S + 0x08100UL)
 #define ADC12_COMMON_BASE_S     (AHB2PERIPH_BASE_S + 0x08300UL)
 #define DAC1_BASE_S             (AHB2PERIPH_BASE_S + 0x08400UL)
 #define DCMI_BASE_S             (AHB2PERIPH_BASE_S + 0x0C000UL)
 #define PSSI_BASE_S             (AHB2PERIPH_BASE_S + 0x0C400UL)
+#define AES_BASE_S              (AHB2PERIPH_BASE_S + 0xA0000UL)
 #define HASH_BASE_S             (AHB2PERIPH_BASE_S + 0xA0400UL)
 #define HASH_DIGEST_BASE_S      (AHB2PERIPH_BASE_S + 0xA0710UL)
 #define RNG_BASE_S              (AHB2PERIPH_BASE_S + 0xA0800UL)
+#define SAES_BASE_S             (AHB2PERIPH_BASE_S + 0xA0C00UL)
 #define PKA_BASE_S              (AHB2PERIPH_BASE_S + 0xA2000UL)
 #define PKA_RAM_BASE_S          (AHB2PERIPH_BASE_S + 0xA2400UL)
 
 /*!< APB3 secure peripherals */
 #define SBS_BASE_S              (APB3PERIPH_BASE_S + 0x0400UL)
-#define SPI5_BASE_S             (APB3PERIPH_BASE_S + 0x2000UL)
 #define LPUART1_BASE_S          (APB3PERIPH_BASE_S + 0x2400UL)
 #define I2C3_BASE_S             (APB3PERIPH_BASE_S + 0x2800UL)
-#define I2C4_BASE_S             (APB3PERIPH_BASE_S + 0x2C00UL)
+#define I3C2_BASE_S             (APB3PERIPH_BASE_S + 0x3000UL)
 #define LPTIM1_BASE_S           (APB3PERIPH_BASE_S + 0x4400UL)
-#define LPTIM3_BASE_S           (APB3PERIPH_BASE_S + 0x4800UL)
-#define LPTIM4_BASE_S           (APB3PERIPH_BASE_S + 0x4C00UL)
-#define LPTIM5_BASE_S           (APB3PERIPH_BASE_S + 0x5000UL)
-#define LPTIM6_BASE_S           (APB3PERIPH_BASE_S + 0x5400UL)
 #define VREFBUF_BASE_S          (APB3PERIPH_BASE_S + 0x7400UL)
 #define RTC_BASE_S              (APB3PERIPH_BASE_S + 0x7800UL)
 #define TAMP_BASE_S             (APB3PERIPH_BASE_S + 0x7C00UL)
@@ -2086,10 +1835,13 @@ typedef struct
 #define DEBUG_BASE_S            (AHB3PERIPH_BASE_S + 0x4000UL)
 
 /*!< AHB4 secure peripherals */
+#define OTFDEC1_BASE_S          (AHB4PERIPH_BASE_S + 0x5000UL)
+#define OTFDEC1_REGION1_BASE_S  (OTFDEC1_BASE_S + 0x20UL)
+#define OTFDEC1_REGION2_BASE_S  (OTFDEC1_BASE_S + 0x50UL)
+#define OTFDEC1_REGION3_BASE_S  (OTFDEC1_BASE_S + 0x80UL)
+#define OTFDEC1_REGION4_BASE_S  (OTFDEC1_BASE_S + 0xB0UL)
 #define SDMMC1_BASE_S           (AHB4PERIPH_BASE_S + 0x8000UL)
 #define DLYB_SDMMC1_BASE_S      (AHB4PERIPH_BASE_S + 0x8400UL)
-#define SDMMC2_BASE_S           (AHB4PERIPH_BASE_S + 0x8C00UL)
-#define DLYB_SDMMC2_BASE_S      (AHB4PERIPH_BASE_S + 0x8800UL)
 #define FMC_R_BASE_S            (AHB4PERIPH_BASE_S + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_S       (AHB4PERIPH_BASE_S + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_S    (AHB4PERIPH_BASE_S + 0x0F000UL)
@@ -2098,7 +1850,6 @@ typedef struct
 #define FMC_Bank1_R_BASE_S      (FMC_R_BASE_S + 0x0000UL)
 #define FMC_Bank1E_R_BASE_S     (FMC_R_BASE_S + 0x0104UL)
 #define FMC_Bank3_R_BASE_S      (FMC_R_BASE_S + 0x0080UL)
-#define FMC_Bank5_6_R_BASE_S    (FMC_R_BASE_S + 0x0140UL)
 
 /* Debug MCU registers base address */
 #define DBGMCU_BASE             (0x44024000UL)
@@ -2308,6 +2059,30 @@ typedef struct
   __IM NSSLIB_S_JumpHDPlvl3_TypeDef JumpHDPLvl3;
 } NSSLIB_pFunc_TypeDef;
 
+/*
+ * Certificate address description
+ */
+#define CERT_CHIP_PACK1_ADDR (0x0BF9FE00U)
+#define CERT_CHIP_PACK1_SIZE (0x200U)
+#define CERT_CHIP_PACK2_ADDR (0x0BF9FC00U)
+#define CERT_CHIP_PACK2_SIZE (0x200U)
+
+#define CERT_CHIP_PACK_ADDR (CERT_CHIP_PACK2_ADDR)
+#define CERT_CHIP_PACK_SIZE (CERT_CHIP_PACK1_SIZE + CERT_CHIP_PACK2_SIZE)
+
+#define CERT_ST_DUA_INIT_ATTEST_PUB_KEY_OFFSET  (152U)
+#define CERT_ST_DUA_INIT_ATTEST_PUB_KEY_ADDR  (CERT_CHIP_PACK1_ADDR + CERT_ST_DUA_INIT_ATTEST_PUB_KEY_OFFSET)
+#define CERT_ST_DUA_INIT_ATTEST_SIGN_OFFSET   (216U)
+#define CERT_ST_DUA_INIT_ATTEST_SIGN_ADDR     (CERT_CHIP_PACK1_ADDR + CERT_ST_DUA_INIT_ATTEST_SIGN_OFFSET)
+#define CERT_ST_DUA_INIT_ATTEST_SERIAL_OFFSET   (484U)
+#define CERT_ST_DUA_INIT_ATTEST_SERIAL_ADDR   (CERT_CHIP_PACK1_ADDR + CERT_ST_DUA_INIT_ATTEST_SERIAL_OFFSET)
+
+#define CERT_ST_DUA_USER_PUB_KEY_OFFSET     (12U)
+#define CERT_ST_DUA_USER_PUB_KEY_ADDR       (CERT_CHIP_PACK2_ADDR + CERT_ST_DUA_USER_PUB_KEY_OFFSET)
+#define CERT_ST_DUA_USER_SIGN_OFFSET      (76U)
+#define CERT_ST_DUA_USER_SIGN_ADDR        (CERT_CHIP_PACK2_ADDR + CERT_ST_DUA_USER_SIGN_OFFSET)
+#define CERT_ST_DUA_USER_SERIAL_OFFSET      (140U)
+#define CERT_ST_DUA_USER_SERIAL_ADDR      (CERT_CHIP_PACK2_ADDR + CERT_ST_DUA_USER_SERIAL_OFFSET)
 
 /** @} */ /* End of group STM32H5xx_Peripheral_peripheralAddr */
 
@@ -2344,13 +2119,7 @@ typedef struct
 #define I3C1_NS                ((I3C_TypeDef *)I3C1_BASE_NS)
 #define CRS_NS                 ((CRS_TypeDef *)CRS_BASE_NS)
 #define USART6_NS              ((USART_TypeDef *)USART6_BASE_NS)
-#define USART10_NS             ((USART_TypeDef *)USART10_BASE_NS)
-#define USART11_NS             ((USART_TypeDef *)USART11_BASE_NS)
 #define CEC_NS                 ((CEC_TypeDef *)CEC_BASE_NS)
-#define UART7_NS               ((USART_TypeDef *)UART7_BASE_NS)
-#define UART8_NS               ((USART_TypeDef *)UART8_BASE_NS)
-#define UART9_NS               ((USART_TypeDef *)UART9_BASE_NS)
-#define UART12_NS              ((USART_TypeDef *)UART12_BASE_NS)
 #define DTS_NS                 ((DTS_TypeDef *)DTS_BASE_NS)
 #define LPTIM2_NS              ((LPTIM_TypeDef *)LPTIM2_BASE_NS)
 #define FDCAN1_NS              ((FDCAN_GlobalTypeDef *)FDCAN1_BASE_NS)
@@ -2364,16 +2133,7 @@ typedef struct
 #define TIM8_NS                ((TIM_TypeDef *) TIM8_BASE_NS)
 #define USART1_NS              ((USART_TypeDef *) USART1_BASE_NS)
 #define TIM15_NS               ((TIM_TypeDef *) TIM15_BASE_NS)
-#define TIM16_NS               ((TIM_TypeDef *) TIM16_BASE_NS)
-#define TIM17_NS               ((TIM_TypeDef *) TIM17_BASE_NS)
 #define SPI4_NS                ((SPI_TypeDef *) SPI4_BASE_NS)
-#define SPI6_NS                ((SPI_TypeDef *) SPI6_BASE_NS)
-#define SAI1_NS                ((SAI_TypeDef *) SAI1_BASE_NS)
-#define SAI1_Block_A_NS        ((SAI_Block_TypeDef *)SAI1_Block_A_BASE_NS)
-#define SAI1_Block_B_NS        ((SAI_Block_TypeDef *)SAI1_Block_B_BASE_NS)
-#define SAI2_NS                ((SAI_TypeDef *) SAI2_BASE_NS)
-#define SAI2_Block_A_NS        ((SAI_Block_TypeDef *)SAI2_Block_A_BASE_NS)
-#define SAI2_Block_B_NS        ((SAI_Block_TypeDef *)SAI2_Block_B_BASE_NS)
 #define USB_DRD_FS_NS          ((USB_DRD_TypeDef *) USB_DRD_BASE_NS)
 #define USB_DRD_PMA_BUFF_NS    ((USB_DRD_PMABuffDescTypeDef *) USB_DRD_PMAADDR_NS)
 
@@ -2382,14 +2142,10 @@ typedef struct
 #define GPDMA2_NS              ((DMA_TypeDef *) GPDMA2_BASE_NS)
 #define FLASH_NS               ((FLASH_TypeDef *) FLASH_R_BASE_NS)
 #define CRC_NS                 ((CRC_TypeDef *) CRC_BASE_NS)
-#define CORDIC_NS              ((CORDIC_TypeDef *) CORDIC_BASE_NS)
-#define FMAC_NS                ((FMAC_TypeDef *) FMAC_BASE_NS)
 #define RAMCFG_SRAM1_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM1_BASE_NS)
 #define RAMCFG_SRAM2_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM2_BASE_NS)
 #define RAMCFG_SRAM3_NS        ((RAMCFG_TypeDef *) RAMCFG_SRAM3_BASE_NS)
 #define RAMCFG_BKPRAM_NS       ((RAMCFG_TypeDef *) RAMCFG_BKPRAM_BASE_NS)
-#define ETH_NS                 ((ETH_TypeDef *) ETH_BASE_NS)
-#define ETH_MAC_NS             ((ETH_TypeDef *) ETH_MAC_BASE_NS)
 #define ICACHE_NS              ((ICACHE_TypeDef *) ICACHE_BASE_NS)
 #define DCACHE1_NS             ((DCACHE_TypeDef *) DCACHE1_BASE_NS)
 #define GTZC_TZSC1_NS          ((GTZC_TZSC_TypeDef *) GTZC_TZSC1_BASE_NS)
@@ -2423,7 +2179,6 @@ typedef struct
 #define GPIOF_NS               ((GPIO_TypeDef *) GPIOF_BASE_NS)
 #define GPIOG_NS               ((GPIO_TypeDef *) GPIOG_BASE_NS)
 #define GPIOH_NS               ((GPIO_TypeDef *) GPIOH_BASE_NS)
-#define GPIOI_NS               ((GPIO_TypeDef *) GPIOI_BASE_NS)
 #define ADC1_NS                ((ADC_TypeDef *) ADC1_BASE_NS)
 #define ADC2_NS                ((ADC_TypeDef *) ADC2_BASE_NS)
 #define ADC12_COMMON_NS        ((ADC_Common_TypeDef *) ADC12_COMMON_BASE_NS)
@@ -2432,21 +2187,18 @@ typedef struct
 #define PSSI_NS                ((PSSI_TypeDef *) PSSI_BASE_NS)
 #define HASH_NS                ((HASH_TypeDef *) HASH_BASE_NS)
 #define HASH_DIGEST_NS         ((HASH_DIGEST_TypeDef *) HASH_DIGEST_BASE_NS)
+#define AES_NS                 ((AES_TypeDef *) AES_BASE_NS)
 #define RNG_NS                 ((RNG_TypeDef *) RNG_BASE_NS)
+#define SAES_NS                ((AES_TypeDef *) SAES_BASE_NS)
 #define PKA_NS                 ((PKA_TypeDef *) PKA_BASE_NS)
 
 
 /*!< APB3 Non secure peripherals */
 #define SBS_NS                 ((SBS_TypeDef *) SBS_BASE_NS)
-#define SPI5_NS                ((SPI_TypeDef *) SPI5_BASE_NS)
 #define LPUART1_NS             ((USART_TypeDef *) LPUART1_BASE_NS)
 #define I2C3_NS                ((I2C_TypeDef *) I2C3_BASE_NS)
-#define I2C4_NS                ((I2C_TypeDef *) I2C4_BASE_NS)
+#define I3C2_NS                ((I3C_TypeDef *) I3C2_BASE_NS)
 #define LPTIM1_NS              ((LPTIM_TypeDef *) LPTIM1_BASE_NS)
-#define LPTIM3_NS              ((LPTIM_TypeDef *) LPTIM3_BASE_NS)
-#define LPTIM4_NS              ((LPTIM_TypeDef *) LPTIM4_BASE_NS)
-#define LPTIM5_NS              ((LPTIM_TypeDef *) LPTIM5_BASE_NS)
-#define LPTIM6_NS              ((LPTIM_TypeDef *) LPTIM6_BASE_NS)
 #define VREFBUF_NS             ((VREFBUF_TypeDef *) VREFBUF_BASE_NS)
 #define RTC_NS                 ((RTC_TypeDef *) RTC_BASE_NS)
 #define TAMP_NS                ((TAMP_TypeDef *) TAMP_BASE_NS)
@@ -2457,10 +2209,13 @@ typedef struct
 #define EXTI_NS                ((EXTI_TypeDef *) EXTI_BASE_NS)
 
 /*!< AHB4 Non secure peripherals */
+#define OTFDEC1_NS             ((OTFDEC_TypeDef *) OTFDEC1_BASE_NS)
+#define OTFDEC1_REGION1_NS     ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION1_BASE_NS)
+#define OTFDEC1_REGION2_NS     ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION2_BASE_NS)
+#define OTFDEC1_REGION3_NS     ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION3_BASE_NS)
+#define OTFDEC1_REGION4_NS     ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION4_BASE_NS)
 #define SDMMC1_NS              ((SDMMC_TypeDef *) SDMMC1_BASE_NS)
 #define DLYB_SDMMC1_NS         ((DLYB_TypeDef *) DLYB_SDMMC1_BASE_NS)
-#define SDMMC2_NS              ((SDMMC_TypeDef *) SDMMC2_BASE_NS)
-#define DLYB_SDMMC2_NS         ((DLYB_TypeDef *) DLYB_SDMMC2_BASE_NS)
 
 #define OCTOSPI1_NS            ((OCTOSPI_TypeDef *) OCTOSPI1_R_BASE_NS)
 #define DLYB_OCTOSPI1_NS       ((DLYB_TypeDef *) DLYB_OCTOSPI1_BASE_NS)
@@ -2469,7 +2224,6 @@ typedef struct
 #define FMC_Bank1_R_NS         ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE_NS)
 #define FMC_Bank1E_R_NS        ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE_NS)
 #define FMC_Bank3_R_NS         ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE_NS)
-#define FMC_Bank5_6_R_NS       ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE_NS)
 
 /*!< APB1 Secure peripherals */
 #define TIM2_S                 ((TIM_TypeDef *)TIM2_BASE_S)
@@ -2479,8 +2233,6 @@ typedef struct
 #define TIM6_S                 ((TIM_TypeDef *)TIM6_BASE_S)
 #define TIM7_S                 ((TIM_TypeDef *)TIM7_BASE_S)
 #define TIM12_S                ((TIM_TypeDef *)TIM12_BASE_S)
-#define TIM13_S                ((TIM_TypeDef *)TIM13_BASE_S)
-#define TIM14_S                ((TIM_TypeDef *)TIM14_BASE_S)
 #define WWDG_S                 ((WWDG_TypeDef *)WWDG_BASE_S)
 #define IWDG_S                 ((IWDG_TypeDef *)IWDG_BASE_S)
 #define SPI2_S                 ((SPI_TypeDef *)SPI2_BASE_S)
@@ -2494,13 +2246,7 @@ typedef struct
 #define I3C1_S                 ((I3C_TypeDef *)I3C1_BASE_S)
 #define CRS_S                  ((CRS_TypeDef *)CRS_BASE_S)
 #define USART6_S               ((USART_TypeDef *)USART6_BASE_S)
-#define USART10_S              ((USART_TypeDef *)USART10_BASE_S)
-#define USART11_S              ((USART_TypeDef *)USART11_BASE_S)
 #define CEC_S                  ((CEC_TypeDef *)CEC_BASE_S)
-#define UART7_S                ((USART_TypeDef *)UART7_BASE_S)
-#define UART8_S                ((USART_TypeDef *)UART8_BASE_S)
-#define UART9_S                ((USART_TypeDef *)UART9_BASE_S)
-#define UART12_S               ((USART_TypeDef *)UART12_BASE_S)
 #define DTS_S                  ((DTS_TypeDef *)DTS_BASE_S)
 #define LPTIM2_S               ((LPTIM_TypeDef *)LPTIM2_BASE_S)
 #define FDCAN1_S               ((FDCAN_GlobalTypeDef *)FDCAN1_BASE_S)
@@ -2514,16 +2260,7 @@ typedef struct
 #define TIM8_S                 ((TIM_TypeDef *) TIM8_BASE_S)
 #define USART1_S               ((USART_TypeDef *) USART1_BASE_S)
 #define TIM15_S                ((TIM_TypeDef *) TIM15_BASE_S)
-#define TIM16_S                ((TIM_TypeDef *) TIM16_BASE_S)
-#define TIM17_S                ((TIM_TypeDef *) TIM17_BASE_S)
 #define SPI4_S                 ((SPI_TypeDef *) SPI4_BASE_S)
-#define SPI6_S                 ((SPI_TypeDef *) SPI6_BASE_S)
-#define SAI1_S                 ((SAI_TypeDef *) SAI1_BASE_S)
-#define SAI1_Block_A_S         ((SAI_Block_TypeDef *)SAI1_Block_A_BASE_S)
-#define SAI1_Block_B_S         ((SAI_Block_TypeDef *)SAI1_Block_B_BASE_S)
-#define SAI2_S                 ((SAI_TypeDef *) SAI2_BASE_S)
-#define SAI2_Block_A_S         ((SAI_Block_TypeDef *)SAI2_Block_A_BASE_S)
-#define SAI2_Block_B_S         ((SAI_Block_TypeDef *)SAI2_Block_B_BASE_S)
 #define USB_DRD_FS_S           ((USB_DRD_TypeDef *)USB_DRD_BASE_S)
 #define USB_DRD_PMA_BUFF_S     ((USB_DRD_PMABuffDescTypeDef *) USB_DRD_PMAADDR_S)
 
@@ -2532,14 +2269,10 @@ typedef struct
 #define GPDMA2_S               ((DMA_TypeDef *) GPDMA2_BASE_S)
 #define FLASH_S                ((FLASH_TypeDef *) FLASH_R_BASE_S)
 #define CRC_S                  ((CRC_TypeDef *) CRC_BASE_S)
-#define CORDIC_S               ((CORDIC_TypeDef *) CORDIC_BASE_S)
-#define FMAC_S                 ((FMAC_TypeDef *) FMAC_BASE_S)
 #define RAMCFG_SRAM1_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM1_BASE_S)
 #define RAMCFG_SRAM2_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM2_BASE_S)
 #define RAMCFG_SRAM3_S         ((RAMCFG_TypeDef *) RAMCFG_SRAM3_BASE_S)
 #define RAMCFG_BKPRAM_S        ((RAMCFG_TypeDef *) RAMCFG_BKPRAM_BASE_S)
-#define ETH_S                  ((ETH_TypeDef *) ETH_BASE_S)
-#define ETH_MAC_S              ((ETH_TypeDef *) ETH_MAC_BASE_S)
 #define ICACHE_S               ((ICACHE_TypeDef *) ICACHE_BASE_S)
 #define DCACHE1_S              ((DCACHE_TypeDef *) DCACHE1_BASE_S)
 #define GTZC_TZSC1_S           ((GTZC_TZSC_TypeDef *) GTZC_TZSC1_BASE_S)
@@ -2574,7 +2307,6 @@ typedef struct
 #define GPIOF_S                ((GPIO_TypeDef *) GPIOF_BASE_S)
 #define GPIOG_S                ((GPIO_TypeDef *) GPIOG_BASE_S)
 #define GPIOH_S                ((GPIO_TypeDef *) GPIOH_BASE_S)
-#define GPIOI_S                ((GPIO_TypeDef *) GPIOI_BASE_S)
 #define ADC1_S                 ((ADC_TypeDef *) ADC1_BASE_S)
 #define ADC2_S                 ((ADC_TypeDef *) ADC2_BASE_S)
 #define ADC12_COMMON_S         ((ADC_Common_TypeDef *) ADC12_COMMON_BASE_S)
@@ -2583,20 +2315,17 @@ typedef struct
 #define PSSI_S                 ((PSSI_TypeDef *) PSSI_BASE_S)
 #define HASH_S                 ((HASH_TypeDef *) HASH_BASE_S)
 #define HASH_DIGEST_S          ((HASH_DIGEST_TypeDef *) HASH_DIGEST_BASE_S)
+#define AES_S                  ((AES_TypeDef *) AES_BASE_S)
 #define RNG_S                  ((RNG_TypeDef *) RNG_BASE_S)
+#define SAES_S                 ((AES_TypeDef *) SAES_BASE_S)
 #define PKA_S                  ((PKA_TypeDef *) PKA_BASE_S)
 
 /*!< APB3 secure peripherals */
 #define SBS_S                  ((SBS_TypeDef *) SBS_BASE_S)
-#define SPI5_S                 ((SPI_TypeDef *) SPI5_BASE_S)
 #define LPUART1_S              ((USART_TypeDef *) LPUART1_BASE_S)
 #define I2C3_S                 ((I2C_TypeDef *) I2C3_BASE_S)
-#define I2C4_S                 ((I2C_TypeDef *) I2C4_BASE_S)
+#define I3C2_S                 ((I3C_TypeDef *) I3C2_BASE_S)
 #define LPTIM1_S               ((LPTIM_TypeDef *) LPTIM1_BASE_S)
-#define LPTIM3_S               ((LPTIM_TypeDef *) LPTIM3_BASE_S)
-#define LPTIM4_S               ((LPTIM_TypeDef *) LPTIM4_BASE_S)
-#define LPTIM5_S               ((LPTIM_TypeDef *) LPTIM5_BASE_S)
-#define LPTIM6_S               ((LPTIM_TypeDef *) LPTIM6_BASE_S)
 #define VREFBUF_S              ((VREFBUF_TypeDef *) VREFBUF_BASE_S)
 #define RTC_S                  ((RTC_TypeDef *) RTC_BASE_S)
 #define TAMP_S                 ((TAMP_TypeDef *) TAMP_BASE_S)
@@ -2607,15 +2336,17 @@ typedef struct
 #define EXTI_S                 ((EXTI_TypeDef *) EXTI_BASE_S)
 
 /*!< AHB4 secure peripherals */
+#define OTFDEC1_S              ((OTFDEC_TypeDef *) OTFDEC1_BASE_S)
+#define OTFDEC1_REGION1_S      ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION1_BASE_S)
+#define OTFDEC1_REGION2_S      ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION2_BASE_S)
+#define OTFDEC1_REGION3_S      ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION3_BASE_S)
+#define OTFDEC1_REGION4_S      ((OTFDEC_Region_TypeDef *) OTFDEC1_REGION4_BASE_S)
 #define SDMMC1_S               ((SDMMC_TypeDef *) SDMMC1_BASE_S)
 #define DLYB_SDMMC1_S          ((DLYB_TypeDef *) DLYB_SDMMC1_BASE_S)
-#define SDMMC2_S               ((SDMMC_TypeDef *) SDMMC2_BASE_S)
-#define DLYB_SDMMC2_S          ((DLYB_TypeDef *) DLYB_SDMMC2_BASE_S)
 
 #define FMC_Bank1_R_S          ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE_S)
 #define FMC_Bank1E_R_S         ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE_S)
 #define FMC_Bank3_R_S          ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE_S)
-#define FMC_Bank5_6_R_S        ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE_S)
 
 #define OCTOSPI1_S             ((OCTOSPI_TypeDef *) OCTOSPI1_R_BASE_S)
 #define DLYB_OCTOSPI1_S        ((DLYB_TypeDef *) DLYB_OCTOSPI1_BASE_S)
@@ -2645,9 +2376,6 @@ typedef struct
 #define AHB4PERIPH_BASE                AHB4PERIPH_BASE_S
 
 /*!< Instance aliases and base addresses for Secure peripherals */
-#define CORDIC                         CORDIC_S
-#define CORDIC_BASE                    CORDIC_BASE_S
-
 #define RCC                            RCC_S
 #define RCC_BASE                       RCC_BASE_S
 
@@ -2662,9 +2390,6 @@ typedef struct
 
 #define FLASH                          FLASH_S
 #define FLASH_R_BASE                   FLASH_R_BASE_S
-
-#define FMAC                           FMAC_S
-#define FMAC_BASE                      FMAC_BASE_S
 
 #define GPDMA1                         GPDMA1_S
 #define GPDMA1_BASE                    GPDMA1_BASE_S
@@ -2744,9 +2469,6 @@ typedef struct
 #define GPIOH                          GPIOH_S
 #define GPIOH_BASE                     GPIOH_BASE_S
 
-#define GPIOI                          GPIOI_S
-#define GPIOI_BASE                     GPIOI_BASE_S
-
 #define PWR                            PWR_S
 #define PWR_BASE                       PWR_BASE_S
 
@@ -2822,18 +2544,6 @@ typedef struct
 #define TIM12                          TIM12_S
 #define TIM12_BASE                     TIM12_BASE_S
 
-#define TIM13                          TIM13_S
-#define TIM13_BASE                     TIM13_BASE_S
-
-#define TIM14                          TIM14_S
-#define TIM14_BASE                     TIM14_BASE_S
-
-#define TIM16                          TIM16_S
-#define TIM16_BASE                     TIM16_BASE_S
-
-#define TIM17                          TIM17_S
-#define TIM17_BASE                     TIM17_BASE_S
-
 #define WWDG                           WWDG_S
 #define WWDG_BASE                      WWDG_BASE_S
 
@@ -2851,12 +2561,6 @@ typedef struct
 
 #define SPI4                           SPI4_S
 #define SPI4_BASE                      SPI4_BASE_S
-
-#define SPI5                           SPI5_S
-#define SPI5_BASE                      SPI5_BASE_S
-
-#define SPI6                           SPI6_S
-#define SPI6_BASE                      SPI6_BASE_S
 
 #define USART1                         USART1_S
 #define USART1_BASE                    USART1_BASE_S
@@ -2876,24 +2580,6 @@ typedef struct
 #define USART6                         USART6_S
 #define USART6_BASE                    USART6_BASE_S
 
-#define UART7                          UART7_S
-#define UART7_BASE                     UART7_BASE_S
-
-#define UART8                          UART8_S
-#define UART8_BASE                     UART8_BASE_S
-
-#define UART9                          UART9_S
-#define UART9_BASE                     UART9_BASE_S
-
-#define USART10                        USART10_S
-#define USART10_BASE                   USART10_BASE_S
-
-#define USART11                        USART11_S
-#define USART11_BASE                   USART11_BASE_S
-
-#define UART12                         UART12_S
-#define UART12_BASE                    UART12_BASE_S
-
 #define CEC                            CEC_S
 #define CEC_BASE                       CEC_BASE_S
 
@@ -2906,11 +2592,11 @@ typedef struct
 #define I2C3                           I2C3_S
 #define I2C3_BASE                      I2C3_BASE_S
 
-#define I2C4                           I2C4_S
-#define I2C4_BASE                      I2C4_BASE_S
-
 #define I3C1                           I3C1_S
 #define I3C1_BASE                      I3C1_BASE_S
+
+#define I3C2                           I3C2_S
+#define I3C2_BASE                      I3C2_BASE_S
 
 #define CRS                            CRS_S
 #define CRS_BASE                       CRS_BASE_S
@@ -2934,18 +2620,6 @@ typedef struct
 #define LPTIM2                         LPTIM2_S
 #define LPTIM2_BASE                    LPTIM2_BASE_S
 
-#define LPTIM3                         LPTIM3_S
-#define LPTIM3_BASE                    LPTIM3_BASE_S
-
-#define LPTIM4                         LPTIM4_S
-#define LPTIM4_BASE                    LPTIM4_BASE_S
-
-#define LPTIM5                         LPTIM5_S
-#define LPTIM5_BASE                    LPTIM5_BASE_S
-
-#define LPTIM6                         LPTIM6_S
-#define LPTIM6_BASE                    LPTIM6_BASE_S
-
 #define LPUART1                        LPUART1_S
 #define LPUART1_BASE                   LPUART1_BASE_S
 
@@ -2957,24 +2631,6 @@ typedef struct
 
 #define VREFBUF                        VREFBUF_S
 #define VREFBUF_BASE                   VREFBUF_BASE_S
-
-#define SAI1                           SAI1_S
-#define SAI1_BASE                      SAI1_BASE_S
-
-#define SAI1_Block_A                   SAI1_Block_A_S
-#define SAI1_Block_A_BASE              SAI1_Block_A_BASE_S
-
-#define SAI1_Block_B                   SAI1_Block_B_S
-#define SAI1_Block_B_BASE              SAI1_Block_B_BASE_S
-
-#define SAI2                           SAI2_S
-#define SAI2_BASE                      SAI2_BASE_S
-
-#define SAI2_Block_A                   SAI2_Block_A_S
-#define SAI2_Block_A_BASE              SAI2_Block_A_BASE_S
-
-#define SAI2_Block_B                   SAI2_Block_B_S
-#define SAI2_Block_B_BASE              SAI2_Block_B_BASE_S
 
 #define USB_DRD_FS                     USB_DRD_FS_S
 #define USB_DRD_BASE                   USB_DRD_BASE_S
@@ -2999,23 +2655,39 @@ typedef struct
 #define HASH_DIGEST                    HASH_DIGEST_S
 #define HASH_DIGEST_BASE               HASH_DIGEST_BASE_S
 
+#define AES                            AES_S
+#define AES_BASE                       AES_BASE_S
+
 #define RNG                            RNG_S
 #define RNG_BASE                       RNG_BASE_S
+
+#define SAES                           SAES_S
+#define SAES_BASE                      SAES_BASE_S
 
 #define PKA                            PKA_S
 #define PKA_BASE                       PKA_BASE_S
 #define PKA_RAM_BASE                   PKA_RAM_BASE_S
 
-#define ETH                            ETH_S
-#define ETH_BASE                       ETH_BASE_S
-#define ETH_MAC                        ETH_MAC_S
-#define ETH_MAC_BASE                   ETH_MAC_BASE_S
+#define OTFDEC1                        OTFDEC1_S
+#define OTFDEC1_BASE                   OTFDEC1_BASE_S
+
+#define OTFDEC1_REGION1                OTFDEC1_REGION1_S
+#define OTFDEC1_REGION1_BASE           OTFDEC1_REGION1_BASE_S
+
+#define OTFDEC1_REGION2                OTFDEC1_REGION2_S
+#define OTFDEC1_REGION2_BASE           OTFDEC1_REGION2_BASE_S
+
+#define OTFDEC1_REGION3                OTFDEC1_REGION3_S
+#define OTFDEC1_REGION3_BASE           OTFDEC1_REGION3_BASE_S
+
+#define OTFDEC1_REGION4                OTFDEC1_REGION4_S
+#define OTFDEC1_REGION4_BASE           OTFDEC1_REGION4_BASE_S
+
+
 
 #define SDMMC1                         SDMMC1_S
 #define SDMMC1_BASE                    SDMMC1_BASE_S
 
-#define SDMMC2                         SDMMC2_S
-#define SDMMC2_BASE                    SDMMC2_BASE_S
 
 #define FMC_Bank1_R                    FMC_Bank1_R_S
 #define FMC_Bank1_R_BASE               FMC_Bank1_R_BASE_S
@@ -3026,17 +2698,11 @@ typedef struct
 #define FMC_Bank3_R                    FMC_Bank3_R_S
 #define FMC_Bank3_R_BASE               FMC_Bank3_R_BASE_S
 
-#define FMC_Bank5_6_R                  FMC_Bank5_6_R_S
-#define FMC_Bank5_6_R_BASE             FMC_Bank5_6_R_BASE_S
-
 #define OCTOSPI1                       OCTOSPI1_S
 #define OCTOSPI1_R_BASE                OCTOSPI1_R_BASE_S
 
 #define DLYB_SDMMC1                    DLYB_SDMMC1_S
 #define DLYB_SDMMC1_BASE               DLYB_SDMMC1_BASE_S
-
-#define DLYB_SDMMC2                    DLYB_SDMMC2_S
-#define DLYB_SDMMC2_BASE               DLYB_SDMMC2_BASE_S
 
 #define DLYB_OCTOSPI1                  DLYB_OCTOSPI1_S
 #define DLYB_OCTOSPI1_BASE             DLYB_OCTOSPI1_BASE_S
@@ -3065,9 +2731,6 @@ typedef struct
 #define AHB4PERIPH_BASE                AHB4PERIPH_BASE_NS
 
 /*!< Instance aliases and base addresses for Non secure peripherals */
-#define CORDIC                         CORDIC_NS
-#define CORDIC_BASE                    CORDIC_BASE_NS
-
 #define RCC                            RCC_NS
 #define RCC_BASE                       RCC_BASE_NS
 
@@ -3082,9 +2745,6 @@ typedef struct
 
 #define FLASH                          FLASH_NS
 #define FLASH_R_BASE                   FLASH_R_BASE_NS
-
-#define FMAC                           FMAC_NS
-#define FMAC_BASE                      FMAC_BASE_NS
 
 #define GPDMA1                         GPDMA1_NS
 #define GPDMA1_BASE                    GPDMA1_BASE_NS
@@ -3164,9 +2824,6 @@ typedef struct
 #define GPIOH                          GPIOH_NS
 #define GPIOH_BASE                     GPIOH_BASE_NS
 
-#define GPIOI                          GPIOI_NS
-#define GPIOI_BASE                     GPIOI_BASE_NS
-
 #define PWR                            PWR_NS
 #define PWR_BASE                       PWR_BASE_NS
 
@@ -3239,20 +2896,8 @@ typedef struct
 #define TIM12                          TIM12_NS
 #define TIM12_BASE                     TIM12_BASE_NS
 
-#define TIM13                          TIM13_NS
-#define TIM13_BASE                     TIM13_BASE_NS
-
-#define TIM14                          TIM14_NS
-#define TIM14_BASE                     TIM14_BASE_NS
-
 #define TIM15                          TIM15_NS
 #define TIM15_BASE                     TIM15_BASE_NS
-
-#define TIM16                          TIM16_NS
-#define TIM16_BASE                     TIM16_BASE_NS
-
-#define TIM17                          TIM17_NS
-#define TIM17_BASE                     TIM17_BASE_NS
 
 #define WWDG                           WWDG_NS
 #define WWDG_BASE                      WWDG_BASE_NS
@@ -3272,12 +2917,6 @@ typedef struct
 #define SPI4                           SPI4_NS
 #define SPI4_BASE                      SPI4_BASE_NS
 
-#define SPI5                           SPI5_NS
-#define SPI5_BASE                      SPI5_BASE_NS
-
-#define SPI6                           SPI6_NS
-#define SPI6_BASE                      SPI6_BASE_NS
-
 #define USART1                         USART1_NS
 #define USART1_BASE                    USART1_BASE_NS
 
@@ -3296,24 +2935,6 @@ typedef struct
 #define USART6                         USART6_NS
 #define USART6_BASE                    USART6_BASE_NS
 
-#define UART7                          UART7_NS
-#define UART7_BASE                     UART7_BASE_NS
-
-#define UART8                          UART8_NS
-#define UART8_BASE                     UART8_BASE_NS
-
-#define UART9                          UART9_NS
-#define UART9_BASE                     UART9_BASE_NS
-
-#define USART10                        USART10_NS
-#define USART10_BASE                   USART10_BASE_NS
-
-#define USART11                        USART11_NS
-#define USART11_BASE                   USART11_BASE_NS
-
-#define UART12                         UART12_NS
-#define UART12_BASE                    UART12_BASE_NS
-
 #define CEC                            CEC_NS
 #define CEC_BASE                       CEC_BASE_NS
 
@@ -3326,11 +2947,11 @@ typedef struct
 #define I2C3                           I2C3_NS
 #define I2C3_BASE                      I2C3_BASE_NS
 
-#define I2C4                           I2C4_NS
-#define I2C4_BASE                      I2C4_BASE_NS
-
 #define I3C1                           I3C1_NS
 #define I3C1_BASE                      I3C1_BASE_NS
+
+#define I3C2                           I3C2_NS
+#define I3C2_BASE                      I3C2_BASE_NS
 
 #define CRS                            CRS_NS
 #define CRS_BASE                       CRS_BASE_NS
@@ -3354,18 +2975,6 @@ typedef struct
 #define LPTIM2                         LPTIM2_NS
 #define LPTIM2_BASE                    LPTIM2_BASE_NS
 
-#define LPTIM3                         LPTIM3_NS
-#define LPTIM3_BASE                    LPTIM3_BASE_NS
-
-#define LPTIM4                         LPTIM4_NS
-#define LPTIM4_BASE                    LPTIM4_BASE_NS
-
-#define LPTIM5                         LPTIM5_NS
-#define LPTIM5_BASE                    LPTIM5_BASE_NS
-
-#define LPTIM6                         LPTIM6_NS
-#define LPTIM6_BASE                    LPTIM6_BASE_NS
-
 #define LPUART1                        LPUART1_NS
 #define LPUART1_BASE                   LPUART1_BASE_NS
 
@@ -3377,24 +2986,6 @@ typedef struct
 
 #define VREFBUF                        VREFBUF_NS
 #define VREFBUF_BASE                   VREFBUF_BASE_NS
-
-#define SAI1                           SAI1_NS
-#define SAI1_BASE                      SAI1_BASE_NS
-
-#define SAI1_Block_A                   SAI1_Block_A_NS
-#define SAI1_Block_A_BASE              SAI1_Block_A_BASE_NS
-
-#define SAI1_Block_B                   SAI1_Block_B_NS
-#define SAI1_Block_B_BASE              SAI1_Block_B_BASE_NS
-
-#define SAI2                           SAI2_NS
-#define SAI2_BASE                      SAI2_BASE_NS
-
-#define SAI2_Block_A                   SAI2_Block_A_NS
-#define SAI2_Block_A_BASE              SAI2_Block_A_BASE_NS
-
-#define SAI2_Block_B                   SAI2_Block_B_NS
-#define SAI2_Block_B_BASE              SAI2_Block_B_BASE_NS
 
 #define USB_DRD_FS                     USB_DRD_FS_NS
 #define USB_DRD_BASE                   USB_DRD_BASE_NS
@@ -3419,24 +3010,39 @@ typedef struct
 #define HASH_DIGEST                    HASH_DIGEST_NS
 #define HASH_DIGEST_BASE               HASH_DIGEST_BASE_NS
 
+#define AES                            AES_NS
+#define AES_BASE                       AES_BASE_NS
+
 #define RNG                            RNG_NS
 #define RNG_BASE                       RNG_BASE_NS
+
+#define SAES                           SAES_NS
+#define SAES_BASE                      SAES_BASE_NS
 
 #define PKA                            PKA_NS
 #define PKA_BASE                       PKA_BASE_NS
 #define PKA_RAM_BASE                   PKA_RAM_BASE_NS
 
+#define OTFDEC1                        OTFDEC1_NS
+#define OTFDEC1_BASE                   OTFDEC1_BASE_NS
 
-#define ETH                            ETH_NS
-#define ETH_BASE                       ETH_BASE_NS
-#define ETH_MAC                        ETH_MAC_NS
-#define ETH_MAC_BASE                   ETH_MAC_BASE_NS
+#define OTFDEC1_REGION1                OTFDEC1_REGION1_NS
+#define OTFDEC1_REGION1_BASE           OTFDEC1_REGION1_BASE_NS
+
+#define OTFDEC1_REGION2                OTFDEC1_REGION2_NS
+#define OTFDEC1_REGION2_BASE           OTFDEC1_REGION2_BASE_NS
+
+#define OTFDEC1_REGION3                OTFDEC1_REGION3_NS
+#define OTFDEC1_REGION3_BASE           OTFDEC1_REGION3_BASE_NS
+
+#define OTFDEC1_REGION4                OTFDEC1_REGION4_NS
+#define OTFDEC1_REGION4_BASE           OTFDEC1_REGION4_BASE_NS
+
+
 
 #define SDMMC1                         SDMMC1_NS
 #define SDMMC1_BASE                    SDMMC1_BASE_NS
 
-#define SDMMC2                         SDMMC2_NS
-#define SDMMC2_BASE                    SDMMC2_BASE_NS
 
 #define FMC_Bank1_R                    FMC_Bank1_R_NS
 #define FMC_Bank1_R_BASE               FMC_Bank1_R_BASE_NS
@@ -3447,17 +3053,11 @@ typedef struct
 #define FMC_Bank3_R                    FMC_Bank3_R_NS
 #define FMC_Bank3_R_BASE               FMC_Bank3_R_BASE_NS
 
-#define FMC_Bank5_6_R                  FMC_Bank5_6_R_NS
-#define FMC_Bank5_6_R_BASE             FMC_Bank5_6_R_BASE_NS
-
 #define OCTOSPI1                       OCTOSPI1_NS
 #define OCTOSPI1_R_BASE                OCTOSPI1_R_BASE_NS
 
 #define DLYB_SDMMC1                    DLYB_SDMMC1_NS
 #define DLYB_SDMMC1_BASE               DLYB_SDMMC1_BASE_NS
-
-#define DLYB_SDMMC2                    DLYB_SDMMC2_NS
-#define DLYB_SDMMC2_BASE               DLYB_SDMMC2_BASE_NS
 
 #define DLYB_OCTOSPI1                  DLYB_OCTOSPI1_NS
 #define DLYB_OCTOSPI1_BASE             DLYB_OCTOSPI1_BASE_NS
@@ -4455,66 +4055,6 @@ typedef struct
 #define ADC_CDR_RDATA_SLV              ADC_CDR_RDATA_SLV_Msk                   /*!< ADC multimode slave group regular conversion data */
 
 
-/******************************************************************************/
-/*                                                                            */
-/*                          CORDIC calculation unit                           */
-/*                                                                            */
-/******************************************************************************/
-/*******************  Bit definition for CORDIC_CSR register  *****************/
-#define CORDIC_CSR_FUNC_Pos                 (0U)
-#define CORDIC_CSR_FUNC_Msk                 (0xFUL << CORDIC_CSR_FUNC_Pos)          /*!< 0x0000000F */
-#define CORDIC_CSR_FUNC                     CORDIC_CSR_FUNC_Msk                     /*!< Function */
-#define CORDIC_CSR_FUNC_0                   (0x1UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000001 */
-#define CORDIC_CSR_FUNC_1                   (0x2UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000002 */
-#define CORDIC_CSR_FUNC_2                   (0x4UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000004 */
-#define CORDIC_CSR_FUNC_3                   (0x8UL << CORDIC_CSR_FUNC_Pos)          /*!< 0x00000008 */
-#define CORDIC_CSR_PRECISION_Pos            (4U)
-#define CORDIC_CSR_PRECISION_Msk            (0xFUL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x000000F0 */
-#define CORDIC_CSR_PRECISION                CORDIC_CSR_PRECISION_Msk                /*!< Precision */
-#define CORDIC_CSR_PRECISION_0              (0x1UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000010 */
-#define CORDIC_CSR_PRECISION_1              (0x2UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000020 */
-#define CORDIC_CSR_PRECISION_2              (0x4UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000040 */
-#define CORDIC_CSR_PRECISION_3              (0x8UL << CORDIC_CSR_PRECISION_Pos)     /*!< 0x00000080 */
-#define CORDIC_CSR_SCALE_Pos                (8U)
-#define CORDIC_CSR_SCALE_Msk                (0x7UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000700 */
-#define CORDIC_CSR_SCALE                    CORDIC_CSR_SCALE_Msk                    /*!< Scaling factor */
-#define CORDIC_CSR_SCALE_0                  (0x1UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000100 */
-#define CORDIC_CSR_SCALE_1                  (0x2UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000200 */
-#define CORDIC_CSR_SCALE_2                  (0x4UL << CORDIC_CSR_SCALE_Pos)         /*!< 0x00000400 */
-#define CORDIC_CSR_IEN_Pos                  (16U)
-#define CORDIC_CSR_IEN_Msk                  (0x1UL << CORDIC_CSR_IEN_Pos)           /*!< 0x00010000 */
-#define CORDIC_CSR_IEN                      CORDIC_CSR_IEN_Msk                      /*!< Interrupt Enable */
-#define CORDIC_CSR_DMAREN_Pos               (17U)
-#define CORDIC_CSR_DMAREN_Msk               (0x1UL << CORDIC_CSR_DMAREN_Pos)        /*!< 0x00020000 */
-#define CORDIC_CSR_DMAREN                   CORDIC_CSR_DMAREN_Msk                   /*!< DMA Read channel Enable */
-#define CORDIC_CSR_DMAWEN_Pos               (18U)
-#define CORDIC_CSR_DMAWEN_Msk               (0x1UL << CORDIC_CSR_DMAWEN_Pos)        /*!< 0x00040000 */
-#define CORDIC_CSR_DMAWEN                   CORDIC_CSR_DMAWEN_Msk                   /*!< DMA Write channel Enable */
-#define CORDIC_CSR_NRES_Pos                 (19U)
-#define CORDIC_CSR_NRES_Msk                 (0x1UL << CORDIC_CSR_NRES_Pos)          /*!< 0x00080000 */
-#define CORDIC_CSR_NRES                     CORDIC_CSR_NRES_Msk                     /*!< Number of results in WDATA register */
-#define CORDIC_CSR_NARGS_Pos                (20U)
-#define CORDIC_CSR_NARGS_Msk                (0x1UL << CORDIC_CSR_NARGS_Pos)         /*!< 0x00100000 */
-#define CORDIC_CSR_NARGS                    CORDIC_CSR_NARGS_Msk                    /*!< Number of arguments in RDATA register */
-#define CORDIC_CSR_RESSIZE_Pos              (21U)
-#define CORDIC_CSR_RESSIZE_Msk              (0x1UL << CORDIC_CSR_RESSIZE_Pos)       /*!< 0x00200000 */
-#define CORDIC_CSR_RESSIZE                  CORDIC_CSR_RESSIZE_Msk                  /*!< Width of output data */
-#define CORDIC_CSR_ARGSIZE_Pos              (22U)
-#define CORDIC_CSR_ARGSIZE_Msk              (0x1UL << CORDIC_CSR_ARGSIZE_Pos)       /*!< 0x00400000 */
-#define CORDIC_CSR_ARGSIZE                  CORDIC_CSR_ARGSIZE_Msk                  /*!< Width of input data */
-#define CORDIC_CSR_RRDY_Pos                 (31U)
-#define CORDIC_CSR_RRDY_Msk                 (0x1UL << CORDIC_CSR_RRDY_Pos)          /*!< 0x80000000 */
-#define CORDIC_CSR_RRDY                     CORDIC_CSR_RRDY_Msk                     /*!< Result Ready Flag */
-
-/*******************  Bit definition for CORDIC_WDATA register  ***************/
-#define CORDIC_WDATA_ARG_Pos                (0U)
-#define CORDIC_WDATA_ARG_Msk                (0xFFFFFFFFUL << CORDIC_WDATA_ARG_Pos)  /*!< 0xFFFFFFFF */
-#define CORDIC_WDATA_ARG                    CORDIC_WDATA_ARG_Msk                    /*!< Input Argument */
-
-/*******************  Bit definition for CORDIC_RDATA register  ***************/
-#define CORDIC_RDATA_RES_Pos                (0U)
-#define CORDIC_RDATA_RES_Msk                (0xFFFFFFFFUL << CORDIC_RDATA_RES_Pos)  /*!< 0xFFFFFFFF */
-#define CORDIC_RDATA_RES                    CORDIC_RDATA_RES_Msk                    /*!< Output Result */
 
 /******************************************************************************/
 /*                                                                            */
@@ -4717,25 +4257,6 @@ typedef struct
 #define RNG_SR_SEIS_Msk                     (0x1UL << RNG_SR_SEIS_Pos)              /*!< 0x00000040 */
 #define RNG_SR_SEIS                         RNG_SR_SEIS_Msk
 
-/********************  Bits definition for RNG_NSCR register  *******************/
-#define RNG_NSCR_EN_OSC1_Pos                (0U)
-#define RNG_NSCR_EN_OSC1_Msk                (0x7UL << RNG_NSCR_EN_OSC1_Pos)         /*!< 0x00000007 */
-#define RNG_NSCR_EN_OSC1                    RNG_NSCR_EN_OSC1_Msk
-#define RNG_NSCR_EN_OSC2_Pos                (3U)
-#define RNG_NSCR_EN_OSC2_Msk                (0x7UL << RNG_NSCR_EN_OSC2_Pos)         /*!< 0x00000038 */
-#define RNG_NSCR_EN_OSC2                    RNG_NSCR_EN_OSC2_Msk
-#define RNG_NSCR_EN_OSC3_Pos                (6U)
-#define RNG_NSCR_EN_OSC3_Msk                (0x7UL << RNG_NSCR_EN_OSC3_Pos)         /*!< 0x000001C0 */
-#define RNG_NSCR_EN_OSC3                    RNG_NSCR_EN_OSC3_Msk
-#define RNG_NSCR_EN_OSC4_Pos                (9U)
-#define RNG_NSCR_EN_OSC4_Msk                (0x7UL << RNG_NSCR_EN_OSC4_Pos)         /*!< 0x00000E00 */
-#define RNG_NSCR_EN_OSC4                    RNG_NSCR_EN_OSC4_Msk
-#define RNG_NSCR_EN_OSC5_Pos                (12U)
-#define RNG_NSCR_EN_OSC5_Msk                (0x7UL << RNG_NSCR_EN_OSC5_Pos)         /*!< 0x00007000 */
-#define RNG_NSCR_EN_OSC5                    RNG_NSCR_EN_OSC5_Msk
-#define RNG_NSCR_EN_OSC6_Pos                (15U)
-#define RNG_NSCR_EN_OSC6_Msk                (0x7UL << RNG_NSCR_EN_OSC6_Pos)         /*!< 0x00038000 */
-#define RNG_NSCR_EN_OSC6                    RNG_NSCR_EN_OSC6_Msk
 
 /********************  Bits definition for RNG_HTCR register  *******************/
 #define RNG_HTCR_HTCFG_Pos                  (0U)
@@ -4743,9 +4264,8 @@ typedef struct
 #define RNG_HTCR_HTCFG                      RNG_HTCR_HTCFG_Msk
 
 /********************  RNG Nist Compliance Values  ******************************/
-#define RNG_CR_NIST_VALUE                   (0x00F00E00U)
-#define RNG_HTCR_NIST_VALUE                 (0x6A91U)
-#define RNG_NSCR_NIST_VALUE                 (0x3AF66U)
+#define RNG_CR_NIST_VALUE                   (0x00F00D00U)
+#define RNG_HTCR_NIST_VALUE                 (0xAAC7U)
 
 /******************************************************************************/
 /*                                                                            */
@@ -5032,6 +4552,256 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
+/*                       Advanced Encryption Standard (AES)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for AES_CR register  *********************/
+#define AES_CR_EN_Pos                       (0U)
+#define AES_CR_EN_Msk                       (0x1UL << AES_CR_EN_Pos)                /*!< 0x00000001 */
+#define AES_CR_EN                           AES_CR_EN_Msk                           /*!< AES Enable */
+#define AES_CR_DATATYPE_Pos                 (1U)
+#define AES_CR_DATATYPE_Msk                 (0x3UL << AES_CR_DATATYPE_Pos)          /*!< 0x00000006 */
+#define AES_CR_DATATYPE                     AES_CR_DATATYPE_Msk                     /*!< Data type selection */
+#define AES_CR_DATATYPE_0                   (0x1UL << AES_CR_DATATYPE_Pos)          /*!< 0x00000002 */
+#define AES_CR_DATATYPE_1                   (0x2UL << AES_CR_DATATYPE_Pos)          /*!< 0x00000004 */
+#define AES_CR_MODE_Pos                     (3U)
+#define AES_CR_MODE_Msk                     (0x3UL << AES_CR_MODE_Pos)              /*!< 0x00000018 */
+#define AES_CR_MODE                         AES_CR_MODE_Msk                         /*!< AES Mode Of Operation */
+#define AES_CR_MODE_0                       (0x1UL << AES_CR_MODE_Pos)              /*!< 0x00000008 */
+#define AES_CR_MODE_1                       (0x2UL << AES_CR_MODE_Pos)              /*!< 0x00000010 */
+#define AES_CR_CHMOD_Pos                    (5U)
+#define AES_CR_CHMOD_Msk                    (0x803UL << AES_CR_CHMOD_Pos)           /*!< 0x00010060 */
+#define AES_CR_CHMOD                        AES_CR_CHMOD_Msk                        /*!< AES Chaining Mode */
+#define AES_CR_CHMOD_0                      (0x001UL << AES_CR_CHMOD_Pos)           /*!< 0x00000020 */
+#define AES_CR_CHMOD_1                      (0x002UL << AES_CR_CHMOD_Pos)           /*!< 0x00000040 */
+#define AES_CR_CHMOD_2                      (0x800UL << AES_CR_CHMOD_Pos)           /*!< 0x00010000 */
+#define AES_CR_DMAINEN_Pos                  (11U)
+#define AES_CR_DMAINEN_Msk                  (0x1UL << AES_CR_DMAINEN_Pos)           /*!< 0x00000800 */
+#define AES_CR_DMAINEN                      AES_CR_DMAINEN_Msk                      /*!< Enable data input phase DMA management  */
+#define AES_CR_DMAOUTEN_Pos                 (12U)
+#define AES_CR_DMAOUTEN_Msk                 (0x1UL << AES_CR_DMAOUTEN_Pos)          /*!< 0x00001000 */
+#define AES_CR_DMAOUTEN                     AES_CR_DMAOUTEN_Msk                     /*!< Enable data output phase DMA management */
+#define AES_CR_GCMPH_Pos                    (13U)
+#define AES_CR_GCMPH_Msk                    (0x3UL << AES_CR_GCMPH_Pos)             /*!< 0x00006000 */
+#define AES_CR_GCMPH                        AES_CR_GCMPH_Msk                        /*!< GCM Phase */
+#define AES_CR_GCMPH_0                      (0x1UL << AES_CR_GCMPH_Pos)             /*!< 0x00002000 */
+#define AES_CR_GCMPH_1                      (0x2UL << AES_CR_GCMPH_Pos)             /*!< 0x00004000 */
+#define AES_CR_KEYSIZE_Pos                  (18U)
+#define AES_CR_KEYSIZE_Msk                  (0x1UL << AES_CR_KEYSIZE_Pos)           /*!< 0x00040000 */
+#define AES_CR_KEYSIZE                      AES_CR_KEYSIZE_Msk                      /*!< Key size selection */
+#define AES_CR_KEYPROT_Pos                 (19U)
+#define AES_CR_KEYPROT_Msk                 (0x1UL << AES_CR_KEYPROT_Pos)          /*!< 0x00040000 */
+#define AES_CR_KEYPROT                     AES_CR_KEYPROT_Msk                     /*!<  Key protection */
+#define AES_CR_NPBLB_Pos                    (20U)
+#define AES_CR_NPBLB_Msk                    (0xFUL << AES_CR_NPBLB_Pos)             /*!< 0x00F00000 */
+#define AES_CR_NPBLB                        AES_CR_NPBLB_Msk                        /*!< Number of padding bytes in payload last block */
+#define AES_CR_NPBLB_0                      (0x1UL << AES_CR_NPBLB_Pos)             /*!< 0x00100000 */
+#define AES_CR_NPBLB_1                      (0x2UL << AES_CR_NPBLB_Pos)             /*!< 0x00200000 */
+#define AES_CR_NPBLB_2                      (0x4UL << AES_CR_NPBLB_Pos)             /*!< 0x00400000 */
+#define AES_CR_NPBLB_3                      (0x8UL << AES_CR_NPBLB_Pos)             /*!< 0x00800000 */
+#define AES_CR_KMOD_Pos                     (24U)
+#define AES_CR_KMOD_Msk                     (0x3UL << AES_CR_KMOD_Pos)              /*!< 0x00000006 */
+#define AES_CR_KMOD                         AES_CR_KMOD_Msk                         /*!< Key mode selection */
+#define AES_CR_KMOD_0                       (0x1UL << AES_CR_KMOD_Pos)             /*!< 0x01000000 */
+#define AES_CR_KMOD_1                       (0x2UL << AES_CR_KMOD_Pos)              /*!< 0x02000000 */
+#define AES_CR_KSHAREID_Pos                (26U)
+#define AES_CR_KSHAREID_Msk                (0x3UL << AES_CR_KSHAREID_Pos)         /*!< 0x00000006 */
+#define AES_CR_KSHAREID                    AES_CR_KSHAREID_Msk                    /*!< Key Shared ID */
+#define AES_CR_KEYSEL_Pos                  (28U)
+#define AES_CR_KEYSEL_Msk                  (0x7UL << AES_CR_KEYSEL_Pos)           /*!< 0x00000006 */
+#define AES_CR_KEYSEL                      AES_CR_KEYSEL_Msk                      /*!< Key Selection */
+#define AES_CR_KEYSEL_0                    (0x1UL << AES_CR_KEYSEL_Pos)           /*!< 0x02000000 */
+#define AES_CR_KEYSEL_1                    (0x2UL << AES_CR_KEYSEL_Pos)           /*!< 0x02000000 */
+#define AES_CR_KEYSEL_2                    (0x4UL << AES_CR_KEYSEL_Pos)           /*!< 0x02000000 */
+#define AES_CR_IPRST_Pos                    (31U)
+#define AES_CR_IPRST_Msk                    (0x1UL << AES_CR_IPRST_Pos)             /*!< 0x80000001 */
+#define AES_CR_IPRST                        AES_CR_IPRST_Msk                        /*!< AES IP software reset */
+
+/*******************  Bit definition for AES_SR register  *********************/
+#define AES_SR_CCF_Pos                      (0U)
+#define AES_SR_CCF_Msk                      (0x1UL << AES_SR_CCF_Pos)               /*!< 0x00000001 */
+#define AES_SR_CCF                          AES_SR_CCF_Msk                          /*!< Computation Complete Flag */
+#define AES_SR_RDERR_Pos                    (1U)
+#define AES_SR_RDERR_Msk                    (0x1UL << AES_SR_RDERR_Pos)             /*!< 0x00000002 */
+#define AES_SR_RDERR                        AES_SR_RDERR_Msk                        /*!< Read Error Flag */
+#define AES_SR_WRERR_Pos                    (2U)
+#define AES_SR_WRERR_Msk                    (0x1UL << AES_SR_WRERR_Pos)             /*!< 0x00000004 */
+#define AES_SR_WRERR                        AES_SR_WRERR_Msk                        /*!< Write Error Flag */
+#define AES_SR_BUSY_Pos                     (3U)
+#define AES_SR_BUSY_Msk                     (0x1UL << AES_SR_BUSY_Pos)              /*!< 0x00000008 */
+#define AES_SR_BUSY                         AES_SR_BUSY_Msk                         /*!< Busy Flag */
+#define AES_SR_KEYVALID_Pos                 (7U)
+#define AES_SR_KEYVALID_Msk                 (0x1UL << AES_SR_KEYVALID_Pos)          /*!< 0x00000008 */
+#define AES_SR_KEYVALID                     AES_SR_KEYVALID_Msk                     /*!< KEYVALID Flag */
+
+/*******************  Bit definition for AES_DINR register  *******************/
+#define AES_DINR_Pos                        (0U)
+#define AES_DINR_Msk                        (0xFFFFFFFFUL << AES_DINR_Pos)          /*!< 0xFFFFFFFF */
+#define AES_DINR                            AES_DINR_Msk                            /*!< AES Data Input Register */
+
+/*******************  Bit definition for AES_DOUTR register  ******************/
+#define AES_DOUTR_Pos                       (0U)
+#define AES_DOUTR_Msk                       (0xFFFFFFFFUL << AES_DOUTR_Pos)         /*!< 0xFFFFFFFF */
+#define AES_DOUTR                           AES_DOUTR_Msk                           /*!< AES Data Output Register */
+
+/*******************  Bit definition for AES_KEYR0 register  ******************/
+#define AES_KEYR0_Pos                       (0U)
+#define AES_KEYR0_Msk                       (0xFFFFFFFFUL << AES_KEYR0_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR0                           AES_KEYR0_Msk                           /*!< AES Key Register 0 */
+
+/*******************  Bit definition for AES_KEYR1 register  ******************/
+#define AES_KEYR1_Pos                       (0U)
+#define AES_KEYR1_Msk                       (0xFFFFFFFFUL << AES_KEYR1_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR1                           AES_KEYR1_Msk                           /*!< AES Key Register 1 */
+
+/*******************  Bit definition for AES_KEYR2 register  ******************/
+#define AES_KEYR2_Pos                       (0U)
+#define AES_KEYR2_Msk                       (0xFFFFFFFFUL << AES_KEYR2_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR2                           AES_KEYR2_Msk                           /*!< AES Key Register 2 */
+
+/*******************  Bit definition for AES_KEYR3 register  ******************/
+#define AES_KEYR3_Pos                       (0U)
+#define AES_KEYR3_Msk                       (0xFFFFFFFFUL << AES_KEYR3_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR3                           AES_KEYR3_Msk                           /*!< AES Key Register 3 */
+
+/*******************  Bit definition for AES_KEYR4 register  ******************/
+#define AES_KEYR4_Pos                       (0U)
+#define AES_KEYR4_Msk                       (0xFFFFFFFFUL << AES_KEYR4_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR4                           AES_KEYR4_Msk                           /*!< AES Key Register 4 */
+
+/*******************  Bit definition for AES_KEYR5 register  ******************/
+#define AES_KEYR5_Pos                       (0U)
+#define AES_KEYR5_Msk                       (0xFFFFFFFFUL << AES_KEYR5_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR5                           AES_KEYR5_Msk                           /*!< AES Key Register 5 */
+
+/*******************  Bit definition for AES_KEYR6 register  ******************/
+#define AES_KEYR6_Pos                       (0U)
+#define AES_KEYR6_Msk                       (0xFFFFFFFFUL << AES_KEYR6_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR6                           AES_KEYR6_Msk                           /*!< AES Key Register 6 */
+
+/*******************  Bit definition for AES_KEYR7 register  ******************/
+#define AES_KEYR7_Pos                       (0U)
+#define AES_KEYR7_Msk                       (0xFFFFFFFFUL << AES_KEYR7_Pos)         /*!< 0xFFFFFFFF */
+#define AES_KEYR7                           AES_KEYR7_Msk                           /*!< AES Key Register 7 */
+
+/*******************  Bit definition for AES_IVR0 register   ******************/
+#define AES_IVR0_Pos                        (0U)
+#define AES_IVR0_Msk                        (0xFFFFFFFFUL << AES_IVR0_Pos)          /*!< 0xFFFFFFFF */
+#define AES_IVR0                            AES_IVR0_Msk                            /*!< AES Initialization Vector Register 0 */
+
+/*******************  Bit definition for AES_IVR1 register   ******************/
+#define AES_IVR1_Pos                        (0U)
+#define AES_IVR1_Msk                        (0xFFFFFFFFUL << AES_IVR1_Pos)          /*!< 0xFFFFFFFF */
+#define AES_IVR1                            AES_IVR1_Msk                            /*!< AES Initialization Vector Register 1 */
+
+/*******************  Bit definition for AES_IVR2 register   ******************/
+#define AES_IVR2_Pos                        (0U)
+#define AES_IVR2_Msk                        (0xFFFFFFFFUL << AES_IVR2_Pos)          /*!< 0xFFFFFFFF */
+#define AES_IVR2                            AES_IVR2_Msk                            /*!< AES Initialization Vector Register 2 */
+
+/*******************  Bit definition for AES_IVR3 register   ******************/
+#define AES_IVR3_Pos                        (0U)
+#define AES_IVR3_Msk                        (0xFFFFFFFFUL << AES_IVR3_Pos)          /*!< 0xFFFFFFFF */
+#define AES_IVR3                            AES_IVR3_Msk                            /*!< AES Initialization Vector Register 3 */
+
+/*******************  Bit definition for AES_SUSP0R register  ******************/
+#define AES_SUSP0R_Pos                      (0U)
+#define AES_SUSP0R_Msk                      (0xFFFFFFFFUL << AES_SUSP0R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP0R                          AES_SUSP0R_Msk                          /*!< AES Suspend registers 0 */
+
+/*******************  Bit definition for AES_SUSP1R register  ******************/
+#define AES_SUSP1R_Pos                      (0U)
+#define AES_SUSP1R_Msk                      (0xFFFFFFFFUL << AES_SUSP1R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP1R                          AES_SUSP1R_Msk                          /*!< AES Suspend registers 1 */
+
+/*******************  Bit definition for AES_SUSP2R register  ******************/
+#define AES_SUSP2R_Pos                      (0U)
+#define AES_SUSP2R_Msk                      (0xFFFFFFFFUL << AES_SUSP2R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP2R                          AES_SUSP2R_Msk                          /*!< AES Suspend registers 2 */
+
+/*******************  Bit definition for AES_SUSP3R register  ******************/
+#define AES_SUSP3R_Pos                      (0U)
+#define AES_SUSP3R_Msk                      (0xFFFFFFFFUL << AES_SUSP3R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP3R                          AES_SUSP3R_Msk                          /*!< AES Suspend registers 3 */
+
+/*******************  Bit definition for AES_SUSP4R register  ******************/
+#define AES_SUSP4R_Pos                      (0U)
+#define AES_SUSP4R_Msk                      (0xFFFFFFFFUL << AES_SUSP4R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP4R                          AES_SUSP4R_Msk                          /*!< AES Suspend registers 4 */
+
+/*******************  Bit definition for AES_SUSP5R register  ******************/
+#define AES_SUSP5R_Pos                      (0U)
+#define AES_SUSP5R_Msk                      (0xFFFFFFFFUL << AES_SUSP5R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP5R                          AES_SUSP5R_Msk                          /*!< AES Suspend registers 5 */
+
+/*******************  Bit definition for AES_SUSP6R register  ******************/
+#define AES_SUSP6R_Pos                      (0U)
+#define AES_SUSP6R_Msk                      (0xFFFFFFFFUL << AES_SUSP6R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP6R                          AES_SUSP6R_Msk                          /*!< AES Suspend registers 6 */
+
+/*******************  Bit definition for AES_SUSP7R register  ******************/
+#define AES_SUSP7R_Pos                      (0U)
+#define AES_SUSP7R_Msk                      (0xFFFFFFFFUL << AES_SUSP7R_Pos)        /*!< 0xFFFFFFFF */
+#define AES_SUSP7R                          AES_SUSP7R_Msk                          /*!< AES Suspend registers 7 */
+
+/*******************  Bit definition for AES_IER register     ******************/
+#define AES_IER_CCFIE_Pos                   (0U)
+#define AES_IER_CCFIE_Msk                   (0x1UL << AES_IER_CCFIE_Pos)            /*!< 0x00000001 */
+#define AES_IER_CCFIE                       AES_IER_CCFIE_Msk                       /*!< Computation complete flag interrupt enable */
+#define AES_IER_RWEIE_Pos                   (1U)
+#define AES_IER_RWEIE_Msk                   (0x1UL << AES_IER_RWEIE_Pos)            /*!< 0x00000002 */
+#define AES_IER_RWEIE                       AES_IER_RWEIE_Msk                       /*!< Read or write error Interrupt Enable */
+#define AES_IER_KEIE_Pos                    (2U)
+#define AES_IER_KEIE_Msk                    (0x1UL << AES_IER_KEIE_Pos)             /*!< 0x00000004 */
+#define AES_IER_KEIE                        AES_IER_KEIE_Msk                        /*!< Key error interrupt enable */
+#define AES_IER_RNGEIE_Pos                  (3U)
+#define AES_IER_RNGEIE_Msk                  (0x1UL << AES_IER_RNGEIE_Pos)           /*!< 0x00000008 */
+#define AES_IER_RNGEIE                      AES_IER_RNGEIE_Msk                      /*!< Rng error interrupt enable */
+
+/*******************  Bit definition for AES_ISR register     ******************/
+#define AES_ISR_CCF_Pos                     (0U)
+#define AES_ISR_CCF_Msk                     (0x1UL << AES_ISR_CCF_Pos)              /*!< 0x00000001 */
+#define AES_ISR_CCF                         AES_ISR_CCF_Msk                         /*!< Computation complete flag */
+#define AES_ISR_RWEIF_Pos                   (1U)
+#define AES_ISR_RWEIF_Msk                   (0x1UL << AES_ISR_RWEIF_Pos)            /*!< 0x00000002 */
+#define AES_ISR_RWEIF                       AES_ISR_RWEIF_Msk                       /*!< Read or write error Interrupt flag */
+#define AES_ISR_KEIF_Pos                    (2U)
+#define AES_ISR_KEIF_Msk                    (0x1UL << AES_ISR_KEIF_Pos)             /*!< 0x00000004 */
+#define AES_ISR_KEIF                        AES_ISR_KEIF_Msk                        /*!< Key error interrupt flag */
+#define AES_ISR_RNGEIF_Pos                  (3U)
+#define AES_ISR_RNGEIF_Msk                  (0x1UL << AES_ISR_RNGEIF_Pos)           /*!< 0x00000008 */
+#define AES_ISR_RNGEIF                      AES_ISR_RNGEIF_Msk                      /*!< Rng error interrupt flag */
+
+/*******************  Bit definition for AES_ICR register     ******************/
+#define AES_ICR_CCF_Pos                     (0U)
+#define AES_ICR_CCF_Msk                     (0x1UL << AES_ICR_CCF_Pos)              /*!< 0x00000001 */
+#define AES_ICR_CCF                         AES_ICR_CCF_Msk                         /*!< Computation complete flag clear */
+#define AES_ICR_RWEIF_Pos                   (1U)
+#define AES_ICR_RWEIF_Msk                   (0x1UL << AES_ICR_RWEIF_Pos)            /*!< 0x00000002 */
+#define AES_ICR_RWEIF                       AES_ICR_RWEIF_Msk                       /*!< Read or write error Interrupt flag clear */
+#define AES_ICR_KEIF_Pos                    (2U)
+#define AES_ICR_KEIF_Msk                    (0x1UL << AES_ICR_KEIF_Pos)             /*!< 0x00000004 */
+#define AES_ICR_KEIF                        AES_ICR_KEIF_Msk                        /*!< Key error interrupt flag clear */
+#define AES_ICR_RNGEIF_Pos                  (3U)
+#define AES_ICR_RNGEIF_Msk                  (0x1UL << AES_ICR_RNGEIF_Pos)           /*!< 0x00000008 */
+#define AES_ICR_RNGEIF                       AES_ICR_RNGEIF_Msk                     /*!< Rng error interrupt flag clear */
+
+/*******************  Bit definition for AES_DPACFGR register     ******************/
+#define AES_DPACFGR_REDCFG_Pos              (0U)
+#define AES_DPACFGR_REDCFG_Msk              (0x3UL << AES_DPACFGR_REDCFG_Pos)       /*!< 0x00000003 */
+#define AES_DPACFGR_REDCFG                   AES_DPACFGR_REDCFG_Msk                 /*!< Redundancy configuration */
+#define AES_DPACFGR_RESEED_Pos              (2U)
+#define AES_DPACFGR_RESEED_Msk              (0x1UL << AES_DPACFGR_RESEED_Pos)       /*!< 0x00000004 */
+#define AES_DPACFGR_RESEED                   AES_DPACFGR_RESEED_Msk                 /*!< Automatic reseed */
+#define AES_DPACFGR_TRIMCFG_Pos             (3U)
+#define AES_DPACFGR_TRIMCFG_Msk             (0x3UL << AES_DPACFGR_TRIMCFG_Pos)       /*!< 0x00000001 */
+#define AES_DPACFGR_TRIMCFG                  AES_DPACFGR_TRIMCFG_Msk                 /*!< Redundancy configuration */
+#define AES_DPACFGR_CONFIGLOCK_Pos          (31U)
+#define AES_DPACFGR_CONFIGLOCK_Msk          (0x1UL << AES_DPACFGR_CONFIGLOCK_Pos)    /*!< 0x80000000 */
+#define AES_DPACFGR_CONFIGLOCK               AES_DPACFGR_CONFIGLOCK_Msk              /*!< DPA configuration lock */
+
+/******************************************************************************/
+/*                                                                            */
 /*                                    HASH                                    */
 /*                                                                            */
 /******************************************************************************/
@@ -5184,12 +4954,6 @@ typedef struct
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP_Pos  (6U)
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM12_STOP_Pos)
 #define DBGMCU_APB1FZR1_DBG_TIM12_STOP      DBGMCU_APB1FZR1_DBG_TIM12_STOP_Msk
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP_Pos  (7U)
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM13_STOP_Pos)
-#define DBGMCU_APB1FZR1_DBG_TIM13_STOP      DBGMCU_APB1FZR1_DBG_TIM13_STOP_Msk
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP_Pos  (8U)
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP_Msk  (0x1UL << DBGMCU_APB1FZR1_DBG_TIM14_STOP_Pos)
-#define DBGMCU_APB1FZR1_DBG_TIM14_STOP      DBGMCU_APB1FZR1_DBG_TIM14_STOP_Msk
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos   (11U)
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk   (0x1UL << DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos)
 #define DBGMCU_APB1FZR1_DBG_WWDG_STOP       DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk
@@ -5221,35 +4985,17 @@ typedef struct
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP_Pos   (16U)
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM15_STOP_Pos)
 #define DBGMCU_APB2FZR_DBG_TIM15_STOP       DBGMCU_APB2FZR_DBG_TIM15_STOP_Msk
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP_Pos   (17U)
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM16_STOP_Pos)
-#define DBGMCU_APB2FZR_DBG_TIM16_STOP       DBGMCU_APB2FZR_DBG_TIM16_STOP_Msk
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP_Pos   (18U)
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP_Msk   (0x1UL << DBGMCU_APB2FZR_DBG_TIM17_STOP_Pos)
-#define DBGMCU_APB2FZR_DBG_TIM17_STOP       DBGMCU_APB2FZR_DBG_TIM17_STOP_Msk
 
 /********************  Bit definition for DBGMCU_APB3FZR register  ***********/
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP_Pos    (10U)
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I2C3_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_I2C3_STOP        DBGMCU_APB3FZR_DBG_I2C3_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP_Pos    (11U)
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I2C4_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_I2C4_STOP        DBGMCU_APB3FZR_DBG_I2C4_STOP_Msk
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP_Pos    (12U)
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP_Msk    (0x1UL << DBGMCU_APB3FZR_DBG_I3C2_STOP_Pos)
+#define DBGMCU_APB3FZR_DBG_I3C2_STOP        DBGMCU_APB3FZR_DBG_I3C2_STOP_Msk
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Pos  (17U)
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_LPTIM1_STOP      DBGMCU_APB3FZR_DBG_LPTIM1_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Pos  (18U)
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM3_STOP      DBGMCU_APB3FZR_DBG_LPTIM3_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Pos  (19U)
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM4_STOP      DBGMCU_APB3FZR_DBG_LPTIM4_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Pos  (20U)
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM5_STOP      DBGMCU_APB3FZR_DBG_LPTIM5_STOP_Msk
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Pos  (21U)
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Msk  (0x1UL << DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Pos)
-#define DBGMCU_APB3FZR_DBG_LPTIM6_STOP      DBGMCU_APB3FZR_DBG_LPTIM6_STOP_Msk
 #define DBGMCU_APB3FZR_DBG_RTC_STOP_Pos     (30U)
 #define DBGMCU_APB3FZR_DBG_RTC_STOP_Msk     (0x1UL << DBGMCU_APB3FZR_DBG_RTC_STOP_Pos)
 #define DBGMCU_APB3FZR_DBG_RTC_STOP         DBGMCU_APB3FZR_DBG_RTC_STOP_Msk
@@ -5640,1870 +5386,6 @@ typedef struct
 #define DCMI_DR_BYTE3_Pos                   (24U)
 #define DCMI_DR_BYTE3_Msk                   (0xFFUL << DCMI_DR_BYTE3_Pos)           /*!< 0xFF000000 */
 #define DCMI_DR_BYTE3                       DCMI_DR_BYTE3_Msk
-/******************************************************************************/
-/*                                                                            */
-/*                Ethernet MAC Registers bits definitions                     */
-/*                                                                            */
-/******************************************************************************/
-/* Bit definition for Ethernet MAC Configuration Register register */
-#define ETH_MACCR_ARP_Pos                             (31U)
-#define ETH_MACCR_ARP_Msk                             (0x1UL << ETH_MACCR_ARP_Pos) /*!< 0x80000000 */
-#define ETH_MACCR_ARP                                 ETH_MACCR_ARP_Msk        /* ARP Offload Enable */
-#define ETH_MACCR_SARC_Pos                            (28U)
-#define ETH_MACCR_SARC_Msk                            (0x7UL << ETH_MACCR_SARC_Pos) /*!< 0x70000000 */
-#define ETH_MACCR_SARC                                ETH_MACCR_SARC_Msk       /* Source Address Insertion or Replacement Control */
-#define ETH_MACCR_SARC_MTIATI                         ((uint32_t)0x00000000)   /* The mti_sa_ctrl_i and ati_sa_ctrl_i input signals control the SA field generation. */
-#define ETH_MACCR_SARC_INSADDR0_Pos                   (29U)
-#define ETH_MACCR_SARC_INSADDR0_Msk                   (0x1UL << ETH_MACCR_SARC_INSADDR0_Pos) /*!< 0x20000000 */
-#define ETH_MACCR_SARC_INSADDR0                       ETH_MACCR_SARC_INSADDR0_Msk /* Insert MAC Address0 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_INSADDR1_Pos                   (29U)
-#define ETH_MACCR_SARC_INSADDR1_Msk                   (0x3UL << ETH_MACCR_SARC_INSADDR1_Pos) /*!< 0x60000000 */
-#define ETH_MACCR_SARC_INSADDR1                       ETH_MACCR_SARC_INSADDR1_Msk /* Insert MAC Address1 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_REPADDR0_Pos                   (28U)
-#define ETH_MACCR_SARC_REPADDR0_Msk                   (0x3UL << ETH_MACCR_SARC_REPADDR0_Pos) /*!< 0x30000000 */
-#define ETH_MACCR_SARC_REPADDR0                       ETH_MACCR_SARC_REPADDR0_Msk /* Replace MAC Address0 in the SA field of all transmitted packets. */
-#define ETH_MACCR_SARC_REPADDR1_Pos                   (28U)
-#define ETH_MACCR_SARC_REPADDR1_Msk                   (0x7UL << ETH_MACCR_SARC_REPADDR1_Pos) /*!< 0x70000000 */
-#define ETH_MACCR_SARC_REPADDR1                       ETH_MACCR_SARC_REPADDR1_Msk /* Replace MAC Address1 in the SA field of all transmitted packets. */
-#define ETH_MACCR_IPC_Pos                             (27U)
-#define ETH_MACCR_IPC_Msk                             (0x1UL << ETH_MACCR_IPC_Pos) /*!< 0x08000000 */
-#define ETH_MACCR_IPC                                 ETH_MACCR_IPC_Msk        /* Checksum Offload */
-#define ETH_MACCR_IPG_Pos                             (24U)
-#define ETH_MACCR_IPG_Msk                             (0x7UL << ETH_MACCR_IPG_Pos) /*!< 0x07000000 */
-#define ETH_MACCR_IPG                                 ETH_MACCR_IPG_Msk        /* Inter-Packet Gap */
-#define ETH_MACCR_IPG_96BIT                           ((uint32_t)0x00000000)   /* Minimum IFG between Packets during transmission is 96Bit */
-#define ETH_MACCR_IPG_88BIT                           ((uint32_t)0x01000000)   /* Minimum IFG between Packets during transmission is 88Bit */
-#define ETH_MACCR_IPG_80BIT                           ((uint32_t)0x02000000)   /* Minimum IFG between Packets during transmission is 80Bit */
-#define ETH_MACCR_IPG_72BIT                           ((uint32_t)0x03000000)   /* Minimum IFG between Packets during transmission is 72Bit */
-#define ETH_MACCR_IPG_64BIT                           ((uint32_t)0x04000000)   /* Minimum IFG between Packets during transmission is 64Bit */
-#define ETH_MACCR_IPG_56BIT                           ((uint32_t)0x05000000)   /* Minimum IFG between Packets during transmission is 56Bit */
-#define ETH_MACCR_IPG_48BIT                           ((uint32_t)0x06000000)   /* Minimum IFG between Packets during transmission is 48Bit */
-#define ETH_MACCR_IPG_40BIT                           ((uint32_t)0x07000000)   /* Minimum IFG between Packets during transmission is 40Bit */
-#define ETH_MACCR_GPSLCE_Pos                          (23U)
-#define ETH_MACCR_GPSLCE_Msk                          (0x1UL << ETH_MACCR_GPSLCE_Pos) /*!< 0x00800000 */
-#define ETH_MACCR_GPSLCE                              ETH_MACCR_GPSLCE_Msk     /* Giant Packet Size Limit Control Enable */
-#define ETH_MACCR_S2KP_Pos                            (22U)
-#define ETH_MACCR_S2KP_Msk                            (0x1UL << ETH_MACCR_S2KP_Pos) /*!< 0x00400000 */
-#define ETH_MACCR_S2KP                                ETH_MACCR_S2KP_Msk       /* IEEE 802.3as Support for 2K Packets */
-#define ETH_MACCR_CST_Pos                             (21U)
-#define ETH_MACCR_CST_Msk                             (0x1UL << ETH_MACCR_CST_Pos) /*!< 0x00200000 */
-#define ETH_MACCR_CST                                 ETH_MACCR_CST_Msk        /* CRC stripping for Type packets */
-#define ETH_MACCR_ACS_Pos                             (20U)
-#define ETH_MACCR_ACS_Msk                             (0x1UL << ETH_MACCR_ACS_Pos) /*!< 0x00100000 */
-#define ETH_MACCR_ACS                                 ETH_MACCR_ACS_Msk        /* Automatic Pad or CRC Stripping */
-#define ETH_MACCR_WD_Pos                              (19U)
-#define ETH_MACCR_WD_Msk                              (0x1UL << ETH_MACCR_WD_Pos) /*!< 0x00080000 */
-#define ETH_MACCR_WD                                  ETH_MACCR_WD_Msk         /* Watchdog disable */
-#define ETH_MACCR_JD_Pos                              (17U)
-#define ETH_MACCR_JD_Msk                              (0x1UL << ETH_MACCR_JD_Pos) /*!< 0x00020000 */
-#define ETH_MACCR_JD                                  ETH_MACCR_JD_Msk         /* Jabber disable */
-#define ETH_MACCR_JE_Pos                              (16U)
-#define ETH_MACCR_JE_Msk                              (0x1UL << ETH_MACCR_JE_Pos) /*!< 0x00010000 */
-#define ETH_MACCR_JE                                  ETH_MACCR_JE_Msk         /* Jumbo Packet Enable */
-#define ETH_MACCR_FES_Pos                             (14U)
-#define ETH_MACCR_FES_Msk                             (0x1UL << ETH_MACCR_FES_Pos) /*!< 0x00004000 */
-#define ETH_MACCR_FES                                 ETH_MACCR_FES_Msk        /* Fast ethernet speed */
-#define ETH_MACCR_DM_Pos                              (13U)
-#define ETH_MACCR_DM_Msk                              (0x1UL << ETH_MACCR_DM_Pos) /*!< 0x00002000 */
-#define ETH_MACCR_DM                                  ETH_MACCR_DM_Msk         /* Duplex mode */
-#define ETH_MACCR_LM_Pos                              (12U)
-#define ETH_MACCR_LM_Msk                              (0x1UL << ETH_MACCR_LM_Pos) /*!< 0x00001000 */
-#define ETH_MACCR_LM                                  ETH_MACCR_LM_Msk         /* loopback mode */
-#define ETH_MACCR_ECRSFD_Pos                          (11U)
-#define ETH_MACCR_ECRSFD_Msk                          (0x1UL << ETH_MACCR_ECRSFD_Pos) /*!< 0x00000800 */
-#define ETH_MACCR_ECRSFD                              ETH_MACCR_ECRSFD_Msk     /* Enable Carrier Sense Before Transmission in Full-Duplex Mode */
-#define ETH_MACCR_DO_Pos                              (10U)
-#define ETH_MACCR_DO_Msk                              (0x1UL << ETH_MACCR_DO_Pos) /*!< 0x00000400 */
-#define ETH_MACCR_DO                                  ETH_MACCR_DO_Msk         /* Disable Receive own  */
-#define ETH_MACCR_DCRS_Pos                            (9U)
-#define ETH_MACCR_DCRS_Msk                            (0x1UL << ETH_MACCR_DCRS_Pos) /*!< 0x00000200 */
-#define ETH_MACCR_DCRS                                ETH_MACCR_DCRS_Msk       /* Disable Carrier Sense During Transmission */
-#define ETH_MACCR_DR_Pos                              (8U)
-#define ETH_MACCR_DR_Msk                              (0x1UL << ETH_MACCR_DR_Pos) /*!< 0x00000100 */
-#define ETH_MACCR_DR                                  ETH_MACCR_DR_Msk         /* Disable Retry */
-#define ETH_MACCR_BL_Pos                              (5U)
-#define ETH_MACCR_BL_Msk                              (0x3UL << ETH_MACCR_BL_Pos) /*!< 0x00000060 */
-#define ETH_MACCR_BL                                  ETH_MACCR_BL_Msk         /* Back-off limit mask */
-#define ETH_MACCR_BL_10                               (0x0UL << ETH_MACCR_BL_Pos) /*!< 0x00000000 */
-#define ETH_MACCR_BL_8                                (0x1UL << ETH_MACCR_BL_Pos) /*!< 0x00000020 */
-#define ETH_MACCR_BL_4                                (0x2UL << ETH_MACCR_BL_Pos) /*!< 0x00000040 */
-#define ETH_MACCR_BL_1                                (0x3UL << ETH_MACCR_BL_Pos) /*!< 0x00000060 */
-#define ETH_MACCR_DC_Pos                              (4U)
-#define ETH_MACCR_DC_Msk                              (0x1UL << ETH_MACCR_DC_Pos) /*!< 0x00000010 */
-#define ETH_MACCR_DC                                  ETH_MACCR_DC_Msk         /* Defferal check */
-#define ETH_MACCR_PRELEN_Pos                          (2U)
-#define ETH_MACCR_PRELEN_Msk                          (0x3UL << ETH_MACCR_PRELEN_Pos) /*!< 0x0000000C */
-#define ETH_MACCR_PRELEN                              ETH_MACCR_PRELEN_Msk     /* Preamble Length for Transmit packets */
-#define ETH_MACCR_PRELEN_7                            (0x0UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000000 */
-#define ETH_MACCR_PRELEN_5                            (0x1UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000004 */
-#define ETH_MACCR_PRELEN_3                            (0x2UL << ETH_MACCR_PRELEN_Pos) /*!< 0x00000008 */
-#define ETH_MACCR_TE_Pos                              (1U)
-#define ETH_MACCR_TE_Msk                              (0x1UL << ETH_MACCR_TE_Pos) /*!< 0x00000002 */
-#define ETH_MACCR_TE                                  ETH_MACCR_TE_Msk         /* Transmitter enable */
-#define ETH_MACCR_RE_Pos                              (0U)
-#define ETH_MACCR_RE_Msk                              (0x1UL << ETH_MACCR_RE_Pos) /*!< 0x00000001 */
-#define ETH_MACCR_RE                                  ETH_MACCR_RE_Msk         /* Receiver enable */
-
-/* Bit definition for Ethernet MAC Extended Configuration Register register */
-#define ETH_MACECR_EIPG_Pos                           (25U)
-#define ETH_MACECR_EIPG_Msk                           (0x1FUL << ETH_MACECR_EIPG_Pos) /*!< 0x3E000000 */
-#define ETH_MACECR_EIPG                               ETH_MACECR_EIPG_Msk      /* Extended Inter-Packet Gap */
-#define ETH_MACECR_EIPGEN_Pos                         (24U)
-#define ETH_MACECR_EIPGEN_Msk                         (0x1UL << ETH_MACECR_EIPGEN_Pos) /*!< 0x01000000 */
-#define ETH_MACECR_EIPGEN                             ETH_MACECR_EIPGEN_Msk    /* Extended Inter-Packet Gap Enable */
-#define ETH_MACECR_USP_Pos                            (18U)
-#define ETH_MACECR_USP_Msk                            (0x1UL << ETH_MACECR_USP_Pos) /*!< 0x00040000 */
-#define ETH_MACECR_USP                                ETH_MACECR_USP_Msk       /* Unicast Slow Protocol Packet Detect */
-#define ETH_MACECR_SPEN_Pos                           (17U)
-#define ETH_MACECR_SPEN_Msk                           (0x1UL << ETH_MACECR_SPEN_Pos) /*!< 0x00020000 */
-#define ETH_MACECR_SPEN                               ETH_MACECR_SPEN_Msk      /* Slow Protocol Detection Enable */
-#define ETH_MACECR_DCRCC_Pos                          (16U)
-#define ETH_MACECR_DCRCC_Msk                          (0x1UL << ETH_MACECR_DCRCC_Pos) /*!< 0x00010000 */
-#define ETH_MACECR_DCRCC                              ETH_MACECR_DCRCC_Msk     /* Disable CRC Checking for Received Packets */
-#define ETH_MACECR_GPSL_Pos                           (0U)
-#define ETH_MACECR_GPSL_Msk                           (0x3FFFUL << ETH_MACECR_GPSL_Pos) /*!< 0x00003FFF */
-#define ETH_MACECR_GPSL                               ETH_MACECR_GPSL_Msk      /* Giant Packet Size Limit */
-
-/* Bit definition for Ethernet MAC Packet Filter Register */
-#define ETH_MACPFR_RA_Pos                             (31U)
-#define ETH_MACPFR_RA_Msk                             (0x1UL << ETH_MACPFR_RA_Pos) /*!< 0x80000000 */
-#define ETH_MACPFR_RA                                 ETH_MACPFR_RA_Msk        /* Receive all */
-#define ETH_MACPFR_DNTU_Pos                           (21U)
-#define ETH_MACPFR_DNTU_Msk                           (0x1UL << ETH_MACPFR_DNTU_Pos) /*!< 0x00200000 */
-#define ETH_MACPFR_DNTU                               ETH_MACPFR_DNTU_Msk      /* Drop Non-TCP/UDP over IP Packets */
-#define ETH_MACPFR_IPFE_Pos                           (20U)
-#define ETH_MACPFR_IPFE_Msk                           (0x1UL << ETH_MACPFR_IPFE_Pos) /*!< 0x00100000 */
-#define ETH_MACPFR_IPFE                               ETH_MACPFR_IPFE_Msk      /* Layer 3 and Layer 4 Filter Enable */
-#define ETH_MACPFR_VTFE_Pos                           (16U)
-#define ETH_MACPFR_VTFE_Msk                           (0x1UL << ETH_MACPFR_VTFE_Pos) /*!< 0x00010000 */
-#define ETH_MACPFR_VTFE                               ETH_MACPFR_VTFE_Msk      /* VLAN Tag Filter Enable */
-#define ETH_MACPFR_HPF_Pos                            (10U)
-#define ETH_MACPFR_HPF_Msk                            (0x1UL << ETH_MACPFR_HPF_Pos) /*!< 0x00000400 */
-#define ETH_MACPFR_HPF                                ETH_MACPFR_HPF_Msk       /* Hash or perfect filter */
-#define ETH_MACPFR_SAF_Pos                            (9U)
-#define ETH_MACPFR_SAF_Msk                            (0x1UL << ETH_MACPFR_SAF_Pos) /*!< 0x00000200 */
-#define ETH_MACPFR_SAF                                ETH_MACPFR_SAF_Msk       /* Source address filter enable */
-#define ETH_MACPFR_SAIF_Pos                           (8U)
-#define ETH_MACPFR_SAIF_Msk                           (0x1UL << ETH_MACPFR_SAIF_Pos) /*!< 0x00000100 */
-#define ETH_MACPFR_SAIF                               ETH_MACPFR_SAIF_Msk      /* SA inverse filtering */
-#define ETH_MACPFR_PCF_Pos                            (6U)
-#define ETH_MACPFR_PCF_Msk                            (0x3UL << ETH_MACPFR_PCF_Pos) /*!< 0x000000C0 */
-#define ETH_MACPFR_PCF                                ETH_MACPFR_PCF_Msk       /* Pass control frames: 4 cases */
-#define ETH_MACPFR_PCF_BLOCKALL                       ((uint32_t)0x00000000)   /* MAC filters all control frames from reaching the application */
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Pos         (6U)
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Msk         (0x1UL << ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Pos) /*!< 0x00000040 */
-#define ETH_MACPFR_PCF_FORWARDALLEXCEPTPA             ETH_MACPFR_PCF_FORWARDALLEXCEPTPA_Msk /* MAC forwards all control frames except Pause packets to application even if they fail the Address Filter */
-#define ETH_MACPFR_PCF_FORWARDALL_Pos                 (7U)
-#define ETH_MACPFR_PCF_FORWARDALL_Msk                 (0x1UL << ETH_MACPFR_PCF_FORWARDALL_Pos) /*!< 0x00000080 */
-#define ETH_MACPFR_PCF_FORWARDALL                     ETH_MACPFR_PCF_FORWARDALL_Msk /* MAC forwards all control frames to application even if they fail the Address Filter */
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Pos    (6U)
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Msk    (0x3UL << ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Pos) /*!< 0x000000C0 */
-#define ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER        ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER_Msk /* MAC forwards control frames that pass the Address Filter. */
-#define ETH_MACPFR_DBF_Pos                            (5U)
-#define ETH_MACPFR_DBF_Msk                            (0x1UL << ETH_MACPFR_DBF_Pos) /*!< 0x00000020 */
-#define ETH_MACPFR_DBF                                ETH_MACPFR_DBF_Msk       /* Disable Broadcast Packets */
-#define ETH_MACPFR_PM_Pos                             (4U)
-#define ETH_MACPFR_PM_Msk                             (0x1UL << ETH_MACPFR_PM_Pos) /*!< 0x00000010 */
-#define ETH_MACPFR_PM                                 ETH_MACPFR_PM_Msk        /* Pass all mutlicast */
-#define ETH_MACPFR_DAIF_Pos                           (3U)
-#define ETH_MACPFR_DAIF_Msk                           (0x1UL << ETH_MACPFR_DAIF_Pos) /*!< 0x00000008 */
-#define ETH_MACPFR_DAIF                               ETH_MACPFR_DAIF_Msk      /* DA Inverse filtering */
-#define ETH_MACPFR_HMC_Pos                            (2U)
-#define ETH_MACPFR_HMC_Msk                            (0x1UL << ETH_MACPFR_HMC_Pos) /*!< 0x00000004 */
-#define ETH_MACPFR_HMC                                ETH_MACPFR_HMC_Msk       /* Hash multicast */
-#define ETH_MACPFR_HUC_Pos                            (1U)
-#define ETH_MACPFR_HUC_Msk                            (0x1UL << ETH_MACPFR_HUC_Pos) /*!< 0x00000002 */
-#define ETH_MACPFR_HUC                                ETH_MACPFR_HUC_Msk       /* Hash unicast */
-#define ETH_MACPFR_PR_Pos                             (0U)
-#define ETH_MACPFR_PR_Msk                             (0x1UL << ETH_MACPFR_PR_Pos) /*!< 0x00000001 */
-#define ETH_MACPFR_PR                                 ETH_MACPFR_PR_Msk        /* Promiscuous mode */
-
-/* Bit definition for Ethernet MAC Watchdog Timeout Register */
-#define ETH_MACWTR_PWE_Pos                            (8U)
-#define ETH_MACWTR_PWE_Msk                            (0x1UL << ETH_MACWTR_PWE_Pos) /*!< 0x00000100 */
-#define ETH_MACWTR_PWE                                ETH_MACWTR_PWE_Msk       /* Programmable Watchdog Enable */
-#define ETH_MACWTR_WTO_Pos                            (0U)
-#define ETH_MACWTR_WTO_Msk                            (0xFUL << ETH_MACWTR_WTO_Pos) /*!< 0x0000000F */
-#define ETH_MACWTR_WTO                                ETH_MACWTR_WTO_Msk       /* Watchdog Timeout */
-#define ETH_MACWTR_WTO_2KB                            ((uint32_t)0x00000000)   /* Maximum received packet length 2KB*/
-#define ETH_MACWTR_WTO_3KB                            ((uint32_t)0x00000001)   /* Maximum received packet length 3KB */
-#define ETH_MACWTR_WTO_4KB                            ((uint32_t)0x00000002)   /* Maximum received packet length 4KB */
-#define ETH_MACWTR_WTO_5KB                            ((uint32_t)0x00000003)   /* Maximum received packet length 5KB */
-#define ETH_MACWTR_WTO_6KB                            ((uint32_t)0x00000004)   /* Maximum received packet length 6KB */
-#define ETH_MACWTR_WTO_7KB                            ((uint32_t)0x00000005)   /* Maximum received packet length 7KB */
-#define ETH_MACWTR_WTO_8KB                            ((uint32_t)0x00000006)   /* Maximum received packet length 8KB */
-#define ETH_MACWTR_WTO_9KB                            ((uint32_t)0x00000007)   /* Maximum received packet length 9KB */
-#define ETH_MACWTR_WTO_10KB                           ((uint32_t)0x00000008)   /* Maximum received packet length 10KB */
-#define ETH_MACWTR_WTO_11KB                           ((uint32_t)0x00000009)   /* Maximum received packet length 11KB */
-#define ETH_MACWTR_WTO_12KB                           ((uint32_t)0x0000000A)   /* Maximum received packet length 12KB */
-#define ETH_MACWTR_WTO_13KB                           ((uint32_t)0x0000000B)   /* Maximum received packet length 13KB */
-#define ETH_MACWTR_WTO_14KB                           ((uint32_t)0x0000000C)   /* Maximum received packet length 14KB */
-#define ETH_MACWTR_WTO_15KB                           ((uint32_t)0x0000000D)   /* Maximum received packet length 15KB */
-#define ETH_MACWTR_WTO_16KB                           ((uint32_t)0x0000000E)   /* Maximum received packet length 16KB */
-
-/* Bit definition for Ethernet MAC Hash Table High Register */
-#define ETH_MACHTHR_HTH_Pos                           (0U)
-#define ETH_MACHTHR_HTH_Msk                           (0xFFFFFFFFUL << ETH_MACHTHR_HTH_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACHTHR_HTH                               ETH_MACHTHR_HTH_Msk      /* Hash table high */
-
-/* Bit definition for Ethernet MAC Hash Table Low Register */
-#define ETH_MACHTLR_HTL_Pos                           (0U)
-#define ETH_MACHTLR_HTL_Msk                           (0xFFFFFFFFUL << ETH_MACHTLR_HTL_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACHTLR_HTL                               ETH_MACHTLR_HTL_Msk      /* Hash table low */
-
-/* Bit definition for Ethernet MAC VLAN Tag Register */
-#define ETH_MACVTR_EIVLRXS_Pos                        (31U)
-#define ETH_MACVTR_EIVLRXS_Msk                        (0x1UL << ETH_MACVTR_EIVLRXS_Pos) /*!< 0x80000000 */
-#define ETH_MACVTR_EIVLRXS                            ETH_MACVTR_EIVLRXS_Msk   /* Enable Inner VLAN Tag in Rx Status */
-#define ETH_MACVTR_EIVLS_Pos                          (28U)
-#define ETH_MACVTR_EIVLS_Msk                          (0x3UL << ETH_MACVTR_EIVLS_Pos) /*!< 0x30000000 */
-#define ETH_MACVTR_EIVLS                              ETH_MACVTR_EIVLS_Msk     /* Enable Inner VLAN Tag Stripping on Receive */
-#define ETH_MACVTR_EIVLS_DONOTSTRIP                   ((uint32_t)0x00000000)   /* Do not strip */
-#define ETH_MACVTR_EIVLS_STRIPIFPASS_Pos              (28U)
-#define ETH_MACVTR_EIVLS_STRIPIFPASS_Msk              (0x1UL << ETH_MACVTR_EIVLS_STRIPIFPASS_Pos) /*!< 0x10000000 */
-#define ETH_MACVTR_EIVLS_STRIPIFPASS                  ETH_MACVTR_EIVLS_STRIPIFPASS_Msk /* Strip if VLAN filter passes */
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS_Pos             (29U)
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS_Msk             (0x1UL << ETH_MACVTR_EIVLS_STRIPIFFAILS_Pos) /*!< 0x20000000 */
-#define ETH_MACVTR_EIVLS_STRIPIFFAILS                 ETH_MACVTR_EIVLS_STRIPIFFAILS_Msk /* Strip if VLAN filter fails */
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP_Pos              (28U)
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP_Msk              (0x3UL << ETH_MACVTR_EIVLS_ALWAYSSTRIP_Pos) /*!< 0x30000000 */
-#define ETH_MACVTR_EIVLS_ALWAYSSTRIP                  ETH_MACVTR_EIVLS_ALWAYSSTRIP_Msk /* Always strip */
-#define ETH_MACVTR_ERIVLT_Pos                         (27U)
-#define ETH_MACVTR_ERIVLT_Msk                         (0x1UL << ETH_MACVTR_ERIVLT_Pos) /*!< 0x08000000 */
-#define ETH_MACVTR_ERIVLT                             ETH_MACVTR_ERIVLT_Msk    /* Enable Inner VLAN Tag */
-#define ETH_MACVTR_EDVLP_Pos                          (26U)
-#define ETH_MACVTR_EDVLP_Msk                          (0x1UL << ETH_MACVTR_EDVLP_Pos) /*!< 0x04000000 */
-#define ETH_MACVTR_EDVLP                              ETH_MACVTR_EDVLP_Msk     /* Enable Double VLAN Processing */
-#define ETH_MACVTR_VTHM_Pos                           (25U)
-#define ETH_MACVTR_VTHM_Msk                           (0x1UL << ETH_MACVTR_VTHM_Pos) /*!< 0x02000000 */
-#define ETH_MACVTR_VTHM                               ETH_MACVTR_VTHM_Msk      /* VLAN Tag Hash Table Match Enable */
-#define ETH_MACVTR_EVLRXS_Pos                         (24U)
-#define ETH_MACVTR_EVLRXS_Msk                         (0x1UL << ETH_MACVTR_EVLRXS_Pos) /*!< 0x01000000 */
-#define ETH_MACVTR_EVLRXS                             ETH_MACVTR_EVLRXS_Msk    /* Enable VLAN Tag in Rx status */
-#define ETH_MACVTR_EVLS_Pos                           (21U)
-#define ETH_MACVTR_EVLS_Msk                           (0x3UL << ETH_MACVTR_EVLS_Pos) /*!< 0x00600000 */
-#define ETH_MACVTR_EVLS                               ETH_MACVTR_EVLS_Msk      /* Enable VLAN Tag Stripping on Receive */
-#define ETH_MACVTR_EVLS_DONOTSTRIP                    ((uint32_t)0x00000000)   /* Do not strip */
-#define ETH_MACVTR_EVLS_STRIPIFPASS_Pos               (21U)
-#define ETH_MACVTR_EVLS_STRIPIFPASS_Msk               (0x1UL << ETH_MACVTR_EVLS_STRIPIFPASS_Pos) /*!< 0x00200000 */
-#define ETH_MACVTR_EVLS_STRIPIFPASS                   ETH_MACVTR_EVLS_STRIPIFPASS_Msk /* Strip if VLAN filter passes */
-#define ETH_MACVTR_EVLS_STRIPIFFAILS_Pos              (22U)
-#define ETH_MACVTR_EVLS_STRIPIFFAILS_Msk              (0x1UL << ETH_MACVTR_EVLS_STRIPIFFAILS_Pos) /*!< 0x00400000 */
-#define ETH_MACVTR_EVLS_STRIPIFFAILS                  ETH_MACVTR_EVLS_STRIPIFFAILS_Msk /* Strip if VLAN filter fails */
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP_Pos               (21U)
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP_Msk               (0x3UL << ETH_MACVTR_EVLS_ALWAYSSTRIP_Pos) /*!< 0x00600000 */
-#define ETH_MACVTR_EVLS_ALWAYSSTRIP                   ETH_MACVTR_EVLS_ALWAYSSTRIP_Msk /* Always strip */
-#define ETH_MACVTR_DOVLTC_Pos                         (20U)
-#define ETH_MACVTR_DOVLTC_Msk                         (0x1UL << ETH_MACVTR_DOVLTC_Pos) /*!< 0x00100000 */
-#define ETH_MACVTR_DOVLTC                             ETH_MACVTR_DOVLTC_Msk    /* Disable VLAN Type Check */
-#define ETH_MACVTR_ERSVLM_Pos                         (19U)
-#define ETH_MACVTR_ERSVLM_Msk                         (0x1UL << ETH_MACVTR_ERSVLM_Pos) /*!< 0x00080000 */
-#define ETH_MACVTR_ERSVLM                             ETH_MACVTR_ERSVLM_Msk    /* Enable Receive S-VLAN Match */
-#define ETH_MACVTR_ESVL_Pos                           (18U)
-#define ETH_MACVTR_ESVL_Msk                           (0x1UL << ETH_MACVTR_ESVL_Pos) /*!< 0x00040000 */
-#define ETH_MACVTR_ESVL                               ETH_MACVTR_ESVL_Msk      /* Enable S-VLAN */
-#define ETH_MACVTR_VTIM_Pos                           (17U)
-#define ETH_MACVTR_VTIM_Msk                           (0x1UL << ETH_MACVTR_VTIM_Pos) /*!< 0x00020000 */
-#define ETH_MACVTR_VTIM                               ETH_MACVTR_VTIM_Msk      /* VLAN Tag Inverse Match Enable */
-#define ETH_MACVTR_ETV_Pos                            (16U)
-#define ETH_MACVTR_ETV_Msk                            (0x1UL << ETH_MACVTR_ETV_Pos) /*!< 0x00010000 */
-#define ETH_MACVTR_ETV                                ETH_MACVTR_ETV_Msk       /* Enable 12-Bit VLAN Tag Comparison */
-#define ETH_MACVTR_VL_Pos                             (0U)
-#define ETH_MACVTR_VL_Msk                             (0xFFFFUL << ETH_MACVTR_VL_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVTR_VL                                 ETH_MACVTR_VL_Msk        /* VLAN Tag Identifier for Receive Packets */
-#define ETH_MACVTR_VL_UP_Pos                          (13U)
-#define ETH_MACVTR_VL_UP_Msk                          (0x7UL << ETH_MACVTR_VL_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACVTR_VL_UP                              ETH_MACVTR_VL_UP_Msk     /* User Priority */
-#define ETH_MACVTR_VL_CFIDEI_Pos                      (12U)
-#define ETH_MACVTR_VL_CFIDEI_Msk                      (0x1UL << ETH_MACVTR_VL_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACVTR_VL_CFIDEI                          ETH_MACVTR_VL_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACVTR_VL_VID_Pos                         (0U)
-#define ETH_MACVTR_VL_VID_Msk                         (0xFFFUL << ETH_MACVTR_VL_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACVTR_VL_VID                             ETH_MACVTR_VL_VID_Msk    /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC VLAN Hash Table Register */
-#define ETH_MACVHTR_VLHT_Pos                          (0U)
-#define ETH_MACVHTR_VLHT_Msk                          (0xFFFFUL << ETH_MACVHTR_VLHT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVHTR_VLHT                              ETH_MACVHTR_VLHT_Msk     /* VLAN Hash Table */
-
-/* Bit definition for Ethernet MAC VLAN Incl Register */
-#define ETH_MACVIR_VLTI_Pos                           (20U)
-#define ETH_MACVIR_VLTI_Msk                           (0x1UL << ETH_MACVIR_VLTI_Pos) /*!< 0x00100000 */
-#define ETH_MACVIR_VLTI                               ETH_MACVIR_VLTI_Msk      /* VLAN Tag Input */
-#define ETH_MACVIR_CSVL_Pos                           (19U)
-#define ETH_MACVIR_CSVL_Msk                           (0x1UL << ETH_MACVIR_CSVL_Pos) /*!< 0x00080000 */
-#define ETH_MACVIR_CSVL                               ETH_MACVIR_CSVL_Msk      /* C-VLAN or S-VLAN */
-#define ETH_MACVIR_VLP_Pos                            (18U)
-#define ETH_MACVIR_VLP_Msk                            (0x1UL << ETH_MACVIR_VLP_Pos) /*!< 0x00040000 */
-#define ETH_MACVIR_VLP                                ETH_MACVIR_VLP_Msk       /* VLAN Priority Control */
-#define ETH_MACVIR_VLC_Pos                            (16U)
-#define ETH_MACVIR_VLC_Msk                            (0x3UL << ETH_MACVIR_VLC_Pos) /*!< 0x00030000 */
-#define ETH_MACVIR_VLC                                ETH_MACVIR_VLC_Msk       /* VLAN Tag Control in Transmit Packets */
-#define ETH_MACVIR_VLC_NOVLANTAG                      ((uint32_t)0x00000000)   /* No VLAN tag deletion, insertion, or replacement */
-#define ETH_MACVIR_VLC_VLANTAGDELETE_Pos              (16U)
-#define ETH_MACVIR_VLC_VLANTAGDELETE_Msk              (0x1UL << ETH_MACVIR_VLC_VLANTAGDELETE_Pos) /*!< 0x00010000 */
-#define ETH_MACVIR_VLC_VLANTAGDELETE                  ETH_MACVIR_VLC_VLANTAGDELETE_Msk /* VLAN tag deletion */
-#define ETH_MACVIR_VLC_VLANTAGINSERT_Pos              (17U)
-#define ETH_MACVIR_VLC_VLANTAGINSERT_Msk              (0x1UL << ETH_MACVIR_VLC_VLANTAGINSERT_Pos) /*!< 0x00020000 */
-#define ETH_MACVIR_VLC_VLANTAGINSERT                  ETH_MACVIR_VLC_VLANTAGINSERT_Msk /* VLAN tag insertion */
-#define ETH_MACVIR_VLC_VLANTAGREPLACE_Pos             (16U)
-#define ETH_MACVIR_VLC_VLANTAGREPLACE_Msk             (0x3UL << ETH_MACVIR_VLC_VLANTAGREPLACE_Pos) /*!< 0x00030000 */
-#define ETH_MACVIR_VLC_VLANTAGREPLACE                 ETH_MACVIR_VLC_VLANTAGREPLACE_Msk /* VLAN tag replacement */
-#define ETH_MACVIR_VLT_Pos                            (0U)
-#define ETH_MACVIR_VLT_Msk                            (0xFFFFUL << ETH_MACVIR_VLT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACVIR_VLT                                ETH_MACVIR_VLT_Msk       /* VLAN Tag for Transmit Packets */
-#define ETH_MACVIR_VLT_UP_Pos                         (13U)
-#define ETH_MACVIR_VLT_UP_Msk                         (0x7UL << ETH_MACVIR_VLT_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACVIR_VLT_UP                             ETH_MACVIR_VLT_UP_Msk    /* User Priority */
-#define ETH_MACVIR_VLT_CFIDEI_Pos                     (12U)
-#define ETH_MACVIR_VLT_CFIDEI_Msk                     (0x1UL << ETH_MACVIR_VLT_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACVIR_VLT_CFIDEI                         ETH_MACVIR_VLT_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACVIR_VLT_VID_Pos                        (0U)
-#define ETH_MACVIR_VLT_VID_Msk                        (0xFFFUL << ETH_MACVIR_VLT_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACVIR_VLT_VID                            ETH_MACVIR_VLT_VID_Msk   /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC Inner_VLAN Incl Register */
-#define ETH_MACIVIR_VLTI_Pos                          (20U)
-#define ETH_MACIVIR_VLTI_Msk                          (0x1UL << ETH_MACIVIR_VLTI_Pos) /*!< 0x00100000 */
-#define ETH_MACIVIR_VLTI                              ETH_MACIVIR_VLTI_Msk     /* VLAN Tag Input */
-#define ETH_MACIVIR_CSVL_Pos                          (19U)
-#define ETH_MACIVIR_CSVL_Msk                          (0x1UL << ETH_MACIVIR_CSVL_Pos) /*!< 0x00080000 */
-#define ETH_MACIVIR_CSVL                              ETH_MACIVIR_CSVL_Msk     /* C-VLAN or S-VLAN */
-#define ETH_MACIVIR_VLP_Pos                           (18U)
-#define ETH_MACIVIR_VLP_Msk                           (0x1UL << ETH_MACIVIR_VLP_Pos) /*!< 0x00040000 */
-#define ETH_MACIVIR_VLP                               ETH_MACIVIR_VLP_Msk      /* VLAN Priority Control */
-#define ETH_MACIVIR_VLC_Pos                           (16U)
-#define ETH_MACIVIR_VLC_Msk                           (0x3UL << ETH_MACIVIR_VLC_Pos) /*!< 0x00030000 */
-#define ETH_MACIVIR_VLC                               ETH_MACIVIR_VLC_Msk      /* VLAN Tag Control in Transmit Packets */
-#define ETH_MACIVIR_VLC_NOVLANTAG                     ((uint32_t)0x00000000)   /* No VLAN tag deletion, insertion, or replacement */
-#define ETH_MACIVIR_VLC_VLANTAGDELETE_Pos             (16U)
-#define ETH_MACIVIR_VLC_VLANTAGDELETE_Msk             (0x1UL << ETH_MACIVIR_VLC_VLANTAGDELETE_Pos) /*!< 0x00010000 */
-#define ETH_MACIVIR_VLC_VLANTAGDELETE                 ETH_MACIVIR_VLC_VLANTAGDELETE_Msk /* VLAN tag deletion */
-#define ETH_MACIVIR_VLC_VLANTAGINSERT_Pos             (17U)
-#define ETH_MACIVIR_VLC_VLANTAGINSERT_Msk             (0x1UL << ETH_MACIVIR_VLC_VLANTAGINSERT_Pos) /*!< 0x00020000 */
-#define ETH_MACIVIR_VLC_VLANTAGINSERT                 ETH_MACIVIR_VLC_VLANTAGINSERT_Msk /* VLAN tag insertion */
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE_Pos            (16U)
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE_Msk            (0x3UL << ETH_MACIVIR_VLC_VLANTAGREPLACE_Pos) /*!< 0x00030000 */
-#define ETH_MACIVIR_VLC_VLANTAGREPLACE                ETH_MACIVIR_VLC_VLANTAGREPLACE_Msk /* VLAN tag replacement */
-#define ETH_MACIVIR_VLT_Pos                           (0U)
-#define ETH_MACIVIR_VLT_Msk                           (0xFFFFUL << ETH_MACIVIR_VLT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACIVIR_VLT                               ETH_MACIVIR_VLT_Msk      /* VLAN Tag for Transmit Packets */
-#define ETH_MACIVIR_VLT_UP_Pos                        (13U)
-#define ETH_MACIVIR_VLT_UP_Msk                        (0x7UL << ETH_MACIVIR_VLT_UP_Pos) /*!< 0x0000E000 */
-#define ETH_MACIVIR_VLT_UP                            ETH_MACIVIR_VLT_UP_Msk   /* User Priority */
-#define ETH_MACIVIR_VLT_CFIDEI_Pos                    (12U)
-#define ETH_MACIVIR_VLT_CFIDEI_Msk                    (0x1UL << ETH_MACIVIR_VLT_CFIDEI_Pos) /*!< 0x00001000 */
-#define ETH_MACIVIR_VLT_CFIDEI                        ETH_MACIVIR_VLT_CFIDEI_Msk /* Canonical Format Indicator or Drop Eligible Indicator */
-#define ETH_MACIVIR_VLT_VID_Pos                       (0U)
-#define ETH_MACIVIR_VLT_VID_Msk                       (0xFFFUL << ETH_MACIVIR_VLT_VID_Pos) /*!< 0x00000FFF */
-#define ETH_MACIVIR_VLT_VID                           ETH_MACIVIR_VLT_VID_Msk  /* VLAN Identifier field of VLAN tag */
-
-/* Bit definition for Ethernet MAC Tx Flow Ctrl Register */
-#define ETH_MACTFCR_PT_Pos                            (16U)
-#define ETH_MACTFCR_PT_Msk                            (0xFFFFUL << ETH_MACTFCR_PT_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACTFCR_PT                                ETH_MACTFCR_PT_Msk       /* Pause Time */
-#define ETH_MACTFCR_DZPQ_Pos                          (7U)
-#define ETH_MACTFCR_DZPQ_Msk                          (0x1UL << ETH_MACTFCR_DZPQ_Pos) /*!< 0x00000080 */
-#define ETH_MACTFCR_DZPQ                              ETH_MACTFCR_DZPQ_Msk     /* Disable Zero-Quanta Pause */
-#define ETH_MACTFCR_PLT_Pos                           (4U)
-#define ETH_MACTFCR_PLT_Msk                           (0x7UL << ETH_MACTFCR_PLT_Pos) /*!< 0x00000070 */
-#define ETH_MACTFCR_PLT                               ETH_MACTFCR_PLT_Msk      /* Pause Low Threshold */
-#define ETH_MACTFCR_PLT_MINUS4                        ((uint32_t)0x00000000)   /* Pause time minus 4 slot times */
-#define ETH_MACTFCR_PLT_MINUS28_Pos                   (4U)
-#define ETH_MACTFCR_PLT_MINUS28_Msk                   (0x1UL << ETH_MACTFCR_PLT_MINUS28_Pos) /*!< 0x00000010 */
-#define ETH_MACTFCR_PLT_MINUS28                       ETH_MACTFCR_PLT_MINUS28_Msk /* Pause time minus 28 slot times */
-#define ETH_MACTFCR_PLT_MINUS36_Pos                   (5U)
-#define ETH_MACTFCR_PLT_MINUS36_Msk                   (0x1UL << ETH_MACTFCR_PLT_MINUS36_Pos) /*!< 0x00000020 */
-#define ETH_MACTFCR_PLT_MINUS36                       ETH_MACTFCR_PLT_MINUS36_Msk /* Pause time minus 36 slot times */
-#define ETH_MACTFCR_PLT_MINUS144_Pos                  (4U)
-#define ETH_MACTFCR_PLT_MINUS144_Msk                  (0x3UL << ETH_MACTFCR_PLT_MINUS144_Pos) /*!< 0x00000030 */
-#define ETH_MACTFCR_PLT_MINUS144                      ETH_MACTFCR_PLT_MINUS144_Msk /* Pause time minus 144 slot times */
-#define ETH_MACTFCR_PLT_MINUS256_Pos                  (6U)
-#define ETH_MACTFCR_PLT_MINUS256_Msk                  (0x1UL << ETH_MACTFCR_PLT_MINUS256_Pos) /*!< 0x00000040 */
-#define ETH_MACTFCR_PLT_MINUS256                      ETH_MACTFCR_PLT_MINUS256_Msk /* Pause time minus 256 slot times */
-#define ETH_MACTFCR_PLT_MINUS512_Pos                  (4U)
-#define ETH_MACTFCR_PLT_MINUS512_Msk                  (0x5UL << ETH_MACTFCR_PLT_MINUS512_Pos) /*!< 0x00000050 */
-#define ETH_MACTFCR_PLT_MINUS512                      ETH_MACTFCR_PLT_MINUS512_Msk /* Pause time minus 512 slot times */
-#define ETH_MACTFCR_TFE_Pos                           (1U)
-#define ETH_MACTFCR_TFE_Msk                           (0x1UL << ETH_MACTFCR_TFE_Pos) /*!< 0x00000002 */
-#define ETH_MACTFCR_TFE                               ETH_MACTFCR_TFE_Msk      /* Transmit Flow Control Enable */
-#define ETH_MACTFCR_FCB_Pos                           (0U)
-#define ETH_MACTFCR_FCB_Msk                           (0x1UL << ETH_MACTFCR_FCB_Pos) /*!< 0x00000001 */
-#define ETH_MACTFCR_FCB                               ETH_MACTFCR_FCB_Msk      /* Flow Control Busy or Backpressure Activate */
-
-/* Bit definition for Ethernet MAC Rx Flow Ctrl Register */
-#define ETH_MACRFCR_UP_Pos                            (1U)
-#define ETH_MACRFCR_UP_Msk                            (0x1UL << ETH_MACRFCR_UP_Pos) /*!< 0x00000002 */
-#define ETH_MACRFCR_UP                                ETH_MACRFCR_UP_Msk       /* Unicast Pause Packet Detect */
-#define ETH_MACRFCR_RFE_Pos                           (0U)
-#define ETH_MACRFCR_RFE_Msk                           (0x1UL << ETH_MACRFCR_RFE_Pos) /*!< 0x00000001 */
-#define ETH_MACRFCR_RFE                               ETH_MACRFCR_RFE_Msk      /* Receive Flow Control Enable */
-
-/* Bit definition for Ethernet MAC Interrupt Status Register */
-#define ETH_MACISR_RXSTSIS_Pos                        (14U)
-#define ETH_MACISR_RXSTSIS_Msk                        (0x1UL << ETH_MACISR_RXSTSIS_Pos) /*!< 0x00004000 */
-#define ETH_MACISR_RXSTSIS                            ETH_MACISR_RXSTSIS_Msk   /* Receive Status Interrupt */
-#define ETH_MACISR_TXSTSIS_Pos                        (13U)
-#define ETH_MACISR_TXSTSIS_Msk                        (0x1UL << ETH_MACISR_TXSTSIS_Pos) /*!< 0x00002000 */
-#define ETH_MACISR_TXSTSIS                            ETH_MACISR_TXSTSIS_Msk   /* Transmit Status Interrupt */
-#define ETH_MACISR_TSIS_Pos                           (12U)
-#define ETH_MACISR_TSIS_Msk                           (0x1UL << ETH_MACISR_TSIS_Pos) /*!< 0x00001000 */
-#define ETH_MACISR_TSIS                               ETH_MACISR_TSIS_Msk      /* Timestamp Interrupt Status */
-#define ETH_MACISR_MMCTXIS_Pos                        (10U)
-#define ETH_MACISR_MMCTXIS_Msk                        (0x1UL << ETH_MACISR_MMCTXIS_Pos) /*!< 0x00000400 */
-#define ETH_MACISR_MMCTXIS                            ETH_MACISR_MMCTXIS_Msk   /* MMC Transmit Interrupt Status */
-#define ETH_MACISR_MMCRXIS_Pos                        (9U)
-#define ETH_MACISR_MMCRXIS_Msk                        (0x1UL << ETH_MACISR_MMCRXIS_Pos) /*!< 0x00000200 */
-#define ETH_MACISR_MMCRXIS                            ETH_MACISR_MMCRXIS_Msk   /* MMC Receive Interrupt Status */
-#define ETH_MACISR_MMCIS_Pos                          (8U)
-#define ETH_MACISR_MMCIS_Msk                          (0x1UL << ETH_MACISR_MMCIS_Pos) /*!< 0x00000100 */
-#define ETH_MACISR_MMCIS                              ETH_MACISR_MMCIS_Msk     /* MMC Interrupt Status */
-#define ETH_MACISR_LPIIS_Pos                          (5U)
-#define ETH_MACISR_LPIIS_Msk                          (0x1UL << ETH_MACISR_LPIIS_Pos) /*!< 0x00000020 */
-#define ETH_MACISR_LPIIS                              ETH_MACISR_LPIIS_Msk     /* LPI Interrupt Status */
-#define ETH_MACISR_PMTIS_Pos                          (4U)
-#define ETH_MACISR_PMTIS_Msk                          (0x1UL << ETH_MACISR_PMTIS_Pos) /*!< 0x00000010 */
-#define ETH_MACISR_PMTIS                              ETH_MACISR_PMTIS_Msk     /* PMT Interrupt Status */
-#define ETH_MACISR_PHYIS_Pos                          (3U)
-#define ETH_MACISR_PHYIS_Msk                          (0x1UL << ETH_MACISR_PHYIS_Pos) /*!< 0x00000008 */
-#define ETH_MACISR_PHYIS                              ETH_MACISR_PHYIS_Msk     /* PHY Interrupt */
-
-/* Bit definition for Ethernet MAC Interrupt Enable Register */
-#define ETH_MACIER_RXSTSIE_Pos                        (14U)
-#define ETH_MACIER_RXSTSIE_Msk                        (0x1UL << ETH_MACIER_RXSTSIE_Pos) /*!< 0x00004000 */
-#define ETH_MACIER_RXSTSIE                            ETH_MACIER_RXSTSIE_Msk   /* Receive Status Interrupt Enable */
-#define ETH_MACIER_TXSTSIE_Pos                        (13U)
-#define ETH_MACIER_TXSTSIE_Msk                        (0x1UL << ETH_MACIER_TXSTSIE_Pos) /*!< 0x00002000 */
-#define ETH_MACIER_TXSTSIE                            ETH_MACIER_TXSTSIE_Msk   /* Transmit Status Interrupt Enable */
-#define ETH_MACIER_TSIE_Pos                           (12U)
-#define ETH_MACIER_TSIE_Msk                           (0x1UL << ETH_MACIER_TSIE_Pos) /*!< 0x00001000 */
-#define ETH_MACIER_TSIE                               ETH_MACIER_TSIE_Msk      /* Timestamp Interrupt Enable */
-#define ETH_MACIER_LPIIE_Pos                          (5U)
-#define ETH_MACIER_LPIIE_Msk                          (0x1UL << ETH_MACIER_LPIIE_Pos) /*!< 0x00000020 */
-#define ETH_MACIER_LPIIE                              ETH_MACIER_LPIIE_Msk     /* LPI Interrupt Enable */
-#define ETH_MACIER_PMTIE_Pos                          (4U)
-#define ETH_MACIER_PMTIE_Msk                          (0x1UL << ETH_MACIER_PMTIE_Pos) /*!< 0x00000010 */
-#define ETH_MACIER_PMTIE                              ETH_MACIER_PMTIE_Msk     /* PMT Interrupt Enable */
-#define ETH_MACIER_PHYIE_Pos                          (3U)
-#define ETH_MACIER_PHYIE_Msk                          (0x1UL << ETH_MACIER_PHYIE_Pos) /*!< 0x00000008 */
-#define ETH_MACIER_PHYIE                              ETH_MACIER_PHYIE_Msk     /* PHY Interrupt Enable */
-
-/* Bit definition for Ethernet MAC Rx Tx Status Register */
-#define ETH_MACRXTXSR_RWT_Pos                         (8U)
-#define ETH_MACRXTXSR_RWT_Msk                         (0x1UL << ETH_MACRXTXSR_RWT_Pos) /*!< 0x00000100 */
-#define ETH_MACRXTXSR_RWT                             ETH_MACRXTXSR_RWT_Msk    /* Receive Watchdog Timeout */
-#define ETH_MACRXTXSR_EXCOL_Pos                       (5U)
-#define ETH_MACRXTXSR_EXCOL_Msk                       (0x1UL << ETH_MACRXTXSR_EXCOL_Pos) /*!< 0x00000020 */
-#define ETH_MACRXTXSR_EXCOL                           ETH_MACRXTXSR_EXCOL_Msk  /* Excessive Collisions */
-#define ETH_MACRXTXSR_LCOL_Pos                        (4U)
-#define ETH_MACRXTXSR_LCOL_Msk                        (0x1UL << ETH_MACRXTXSR_LCOL_Pos) /*!< 0x00000010 */
-#define ETH_MACRXTXSR_LCOL                            ETH_MACRXTXSR_LCOL_Msk   /* Late Collision */
-#define ETH_MACRXTXSR_EXDEF_Pos                       (3U)
-#define ETH_MACRXTXSR_EXDEF_Msk                       (0x1UL << ETH_MACRXTXSR_EXDEF_Pos) /*!< 0x00000008 */
-#define ETH_MACRXTXSR_EXDEF                           ETH_MACRXTXSR_EXDEF_Msk  /* Excessive Deferral */
-#define ETH_MACRXTXSR_LCARR_Pos                       (2U)
-#define ETH_MACRXTXSR_LCARR_Msk                       (0x1UL << ETH_MACRXTXSR_LCARR_Pos) /*!< 0x00000004 */
-#define ETH_MACRXTXSR_LCARR                           ETH_MACRXTXSR_LCARR_Msk  /* Loss of Carrier */
-#define ETH_MACRXTXSR_NCARR_Pos                       (1U)
-#define ETH_MACRXTXSR_NCARR_Msk                       (0x1UL << ETH_MACRXTXSR_NCARR_Pos) /*!< 0x00000002 */
-#define ETH_MACRXTXSR_NCARR                           ETH_MACRXTXSR_NCARR_Msk  /* No Carrier */
-#define ETH_MACRXTXSR_TJT_Pos                         (0U)
-#define ETH_MACRXTXSR_TJT_Msk                         (0x1UL << ETH_MACRXTXSR_TJT_Pos) /*!< 0x00000001 */
-#define ETH_MACRXTXSR_TJT                             ETH_MACRXTXSR_TJT_Msk    /* Transmit Jabber Timeout */
-
-/* Bit definition for Ethernet MAC PMT Control Status Register */
-#define ETH_MACPCSR_RWKFILTRST_Pos                    (31U)
-#define ETH_MACPCSR_RWKFILTRST_Msk                    (0x1UL << ETH_MACPCSR_RWKFILTRST_Pos) /*!< 0x80000000 */
-#define ETH_MACPCSR_RWKFILTRST                        ETH_MACPCSR_RWKFILTRST_Msk /* Remote Wake-Up Packet Filter Register Pointer Reset */
-#define ETH_MACPCSR_RWKPTR_Pos                        (24U)
-#define ETH_MACPCSR_RWKPTR_Msk                        (0x1FUL << ETH_MACPCSR_RWKPTR_Pos) /*!< 0x1F000000 */
-#define ETH_MACPCSR_RWKPTR                            ETH_MACPCSR_RWKPTR_Msk   /* Remote Wake-up FIFO Pointer */
-#define ETH_MACPCSR_RWKPFE_Pos                        (10U)
-#define ETH_MACPCSR_RWKPFE_Msk                        (0x1UL << ETH_MACPCSR_RWKPFE_Pos) /*!< 0x00000400 */
-#define ETH_MACPCSR_RWKPFE                            ETH_MACPCSR_RWKPFE_Msk   /* Remote Wake-up Packet Forwarding Enable */
-#define ETH_MACPCSR_GLBLUCAST_Pos                     (9U)
-#define ETH_MACPCSR_GLBLUCAST_Msk                     (0x1UL << ETH_MACPCSR_GLBLUCAST_Pos) /*!< 0x00000200 */
-#define ETH_MACPCSR_GLBLUCAST                         ETH_MACPCSR_GLBLUCAST_Msk /* Global Unicast */
-#define ETH_MACPCSR_RWKPRCVD_Pos                      (6U)
-#define ETH_MACPCSR_RWKPRCVD_Msk                      (0x1UL << ETH_MACPCSR_RWKPRCVD_Pos) /*!< 0x00000040 */
-#define ETH_MACPCSR_RWKPRCVD                          ETH_MACPCSR_RWKPRCVD_Msk /* Remote Wake-Up Packet Received */
-#define ETH_MACPCSR_MGKPRCVD_Pos                      (5U)
-#define ETH_MACPCSR_MGKPRCVD_Msk                      (0x1UL << ETH_MACPCSR_MGKPRCVD_Pos) /*!< 0x00000020 */
-#define ETH_MACPCSR_MGKPRCVD                          ETH_MACPCSR_MGKPRCVD_Msk /* Magic Packet Received */
-#define ETH_MACPCSR_RWKPKTEN_Pos                      (2U)
-#define ETH_MACPCSR_RWKPKTEN_Msk                      (0x1UL << ETH_MACPCSR_RWKPKTEN_Pos) /*!< 0x00000004 */
-#define ETH_MACPCSR_RWKPKTEN                          ETH_MACPCSR_RWKPKTEN_Msk /* Remote Wake-Up Packet Enable */
-#define ETH_MACPCSR_MGKPKTEN_Pos                      (1U)
-#define ETH_MACPCSR_MGKPKTEN_Msk                      (0x1UL << ETH_MACPCSR_MGKPKTEN_Pos) /*!< 0x00000002 */
-#define ETH_MACPCSR_MGKPKTEN                          ETH_MACPCSR_MGKPKTEN_Msk /* Magic Packet Enable */
-#define ETH_MACPCSR_PWRDWN_Pos                        (0U)
-#define ETH_MACPCSR_PWRDWN_Msk                        (0x1UL << ETH_MACPCSR_PWRDWN_Pos) /*!< 0x00000001 */
-#define ETH_MACPCSR_PWRDWN                            ETH_MACPCSR_PWRDWN_Msk   /* Power Down */
-
-/* Bit definition for Ethernet MAC Remote Wake-Up Packet Filter Register */
-#define ETH_MACRWUPFR_D_Pos                           (0U)
-#define ETH_MACRWUPFR_D_Msk                           (0xFFFFFFFFUL << ETH_MACRWUPFR_D_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACRWUPFR_D                               ETH_MACRWUPFR_D_Msk      /* Wake-up Packet filter register data */
-
-/* Bit definition for Ethernet MAC LPI Control Status Register */
-#define ETH_MACLCSR_LPITCSE_Pos                       (21U)
-#define ETH_MACLCSR_LPITCSE_Msk                       (0x1UL << ETH_MACLCSR_LPITCSE_Pos) /*!< 0x00200000 */
-#define ETH_MACLCSR_LPITCSE                           ETH_MACLCSR_LPITCSE_Msk  /* LPI Tx Clock Stop Enable */
-#define ETH_MACLCSR_LPITE_Pos                         (20U)
-#define ETH_MACLCSR_LPITE_Msk                         (0x1UL << ETH_MACLCSR_LPITE_Pos) /*!< 0x00100000 */
-#define ETH_MACLCSR_LPITE                             ETH_MACLCSR_LPITE_Msk    /* LPI Timer Enable */
-#define ETH_MACLCSR_LPITXA_Pos                        (19U)
-#define ETH_MACLCSR_LPITXA_Msk                        (0x1UL << ETH_MACLCSR_LPITXA_Pos) /*!< 0x00080000 */
-#define ETH_MACLCSR_LPITXA                            ETH_MACLCSR_LPITXA_Msk   /* LPI Tx Automate */
-#define ETH_MACLCSR_PLS_Pos                           (17U)
-#define ETH_MACLCSR_PLS_Msk                           (0x1UL << ETH_MACLCSR_PLS_Pos) /*!< 0x00020000 */
-#define ETH_MACLCSR_PLS                               ETH_MACLCSR_PLS_Msk      /* PHY Link Status */
-#define ETH_MACLCSR_LPIEN_Pos                         (16U)
-#define ETH_MACLCSR_LPIEN_Msk                         (0x1UL << ETH_MACLCSR_LPIEN_Pos) /*!< 0x00010000 */
-#define ETH_MACLCSR_LPIEN                             ETH_MACLCSR_LPIEN_Msk    /* LPI Enable */
-#define ETH_MACLCSR_RLPIST_Pos                        (9U)
-#define ETH_MACLCSR_RLPIST_Msk                        (0x1UL << ETH_MACLCSR_RLPIST_Pos) /*!< 0x00000200 */
-#define ETH_MACLCSR_RLPIST                            ETH_MACLCSR_RLPIST_Msk   /* Receive LPI State */
-#define ETH_MACLCSR_TLPIST_Pos                        (8U)
-#define ETH_MACLCSR_TLPIST_Msk                        (0x1UL << ETH_MACLCSR_TLPIST_Pos) /*!< 0x00000100 */
-#define ETH_MACLCSR_TLPIST                            ETH_MACLCSR_TLPIST_Msk   /* Transmit LPI State */
-#define ETH_MACLCSR_RLPIEX_Pos                        (3U)
-#define ETH_MACLCSR_RLPIEX_Msk                        (0x1UL << ETH_MACLCSR_RLPIEX_Pos) /*!< 0x00000008 */
-#define ETH_MACLCSR_RLPIEX                            ETH_MACLCSR_RLPIEX_Msk   /* Receive LPI Exit */
-#define ETH_MACLCSR_RLPIEN_Pos                        (2U)
-#define ETH_MACLCSR_RLPIEN_Msk                        (0x1UL << ETH_MACLCSR_RLPIEN_Pos) /*!< 0x00000004 */
-#define ETH_MACLCSR_RLPIEN                            ETH_MACLCSR_RLPIEN_Msk   /* Receive LPI Entry */
-#define ETH_MACLCSR_TLPIEX_Pos                        (1U)
-#define ETH_MACLCSR_TLPIEX_Msk                        (0x1UL << ETH_MACLCSR_TLPIEX_Pos) /*!< 0x00000002 */
-#define ETH_MACLCSR_TLPIEX                            ETH_MACLCSR_TLPIEX_Msk   /* Transmit LPI Exit */
-#define ETH_MACLCSR_TLPIEN_Pos                        (0U)
-#define ETH_MACLCSR_TLPIEN_Msk                        (0x1UL << ETH_MACLCSR_TLPIEN_Pos) /*!< 0x00000001 */
-#define ETH_MACLCSR_TLPIEN                            ETH_MACLCSR_TLPIEN_Msk   /* Transmit LPI Entry */
-
-/* Bit definition for Ethernet MAC LPI Timers Control Register */
-#define ETH_MACLTCR_LST_Pos                           (16U)
-#define ETH_MACLTCR_LST_Msk                           (0x3FFUL << ETH_MACLTCR_LST_Pos) /*!< 0x03FF0000 */
-#define ETH_MACLTCR_LST                               ETH_MACLTCR_LST_Msk      /* LPI LS TIMER */
-#define ETH_MACLTCR_TWT_Pos                           (0U)
-#define ETH_MACLTCR_TWT_Msk                           (0xFFFFUL << ETH_MACLTCR_TWT_Pos) /*!< 0x0000FFFF */
-#define ETH_MACLTCR_TWT                               ETH_MACLTCR_TWT_Msk      /* LPI TW TIMER */
-
-/* Bit definition for Ethernet MAC LPI Entry Timer Register */
-#define ETH_MACLETR_LPIET_Pos                         (0U)
-#define ETH_MACLETR_LPIET_Msk                         (0xFFFFFUL << ETH_MACLETR_LPIET_Pos) /*!< 0x000FFFFF */
-#define ETH_MACLETR_LPIET                             ETH_MACLETR_LPIET_Msk    /* LPI Entry Timer */
-
-/* Bit definition for Ethernet MAC 1US Tic Counter Register */
-#define ETH_MAC1USTCR_TIC1USCNTR_Pos                  (0U)
-#define ETH_MAC1USTCR_TIC1USCNTR_Msk                  (0xFFFUL << ETH_MAC1USTCR_TIC1USCNTR_Pos) /*!< 0x00000FFF */
-#define ETH_MAC1USTCR_TIC1USCNTR                      ETH_MAC1USTCR_TIC1USCNTR_Msk /* 1US TIC Counter */
-
-/* Bit definition for Ethernet MAC Version Register */
-#define ETH_MACVR_USERVER_Pos                         (8U)
-#define ETH_MACVR_USERVER_Msk                         (0xFFUL << ETH_MACVR_USERVER_Pos) /*!< 0x0000FF00 */
-#define ETH_MACVR_USERVER                             ETH_MACVR_USERVER_Msk    /* User-defined Version */
-#define ETH_MACVR_SNPSVER_Pos                         (0U)
-#define ETH_MACVR_SNPSVER_Msk                         (0xFFUL << ETH_MACVR_SNPSVER_Pos) /*!< 0x000000FF */
-#define ETH_MACVR_SNPSVER                             ETH_MACVR_SNPSVER_Msk    /* Synopsys-defined Version */
-
-/* Bit definition for Ethernet MAC Debug Register */
-#define ETH_MACDR_TFCSTS_Pos                          (17U)
-#define ETH_MACDR_TFCSTS_Msk                          (0x3UL << ETH_MACDR_TFCSTS_Pos) /*!< 0x00060000 */
-#define ETH_MACDR_TFCSTS                              ETH_MACDR_TFCSTS_Msk     /* MAC Transmit Packet Controller Status */
-#define ETH_MACDR_TFCSTS_IDLE                         ((uint32_t)0x00000000)   /* Idle state */
-#define ETH_MACDR_TFCSTS_WAIT_Pos                     (17U)
-#define ETH_MACDR_TFCSTS_WAIT_Msk                     (0x1UL << ETH_MACDR_TFCSTS_WAIT_Pos) /*!< 0x00020000 */
-#define ETH_MACDR_TFCSTS_WAIT                         ETH_MACDR_TFCSTS_WAIT_Msk /* Waiting for status of the previous packet, IPG or backoff period to be over */
-#define ETH_MACDR_TFCSTS_GENERATEPCP_Pos              (18U)
-#define ETH_MACDR_TFCSTS_GENERATEPCP_Msk              (0x1UL << ETH_MACDR_TFCSTS_GENERATEPCP_Pos) /*!< 0x00040000 */
-#define ETH_MACDR_TFCSTS_GENERATEPCP                  ETH_MACDR_TFCSTS_GENERATEPCP_Msk /* Generating and transmitting a Pause control packet */
-#define ETH_MACDR_TFCSTS_TRASFERIP_Pos                (17U)
-#define ETH_MACDR_TFCSTS_TRASFERIP_Msk                (0x3UL << ETH_MACDR_TFCSTS_TRASFERIP_Pos) /*!< 0x00060000 */
-#define ETH_MACDR_TFCSTS_TRASFERIP                    ETH_MACDR_TFCSTS_TRASFERIP_Msk /* Transferring input packet for transmission */
-#define ETH_MACDR_TPESTS_Pos                          (16U)
-#define ETH_MACDR_TPESTS_Msk                          (0x1UL << ETH_MACDR_TPESTS_Pos) /*!< 0x00010000 */
-#define ETH_MACDR_TPESTS                              ETH_MACDR_TPESTS_Msk     /* MAC Receive Packet Controller FIFO Status */
-#define ETH_MACDR_RFCFCSTS_Pos                        (1U)
-#define ETH_MACDR_RFCFCSTS_Msk                        (0x3UL << ETH_MACDR_RFCFCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MACDR_RFCFCSTS                            ETH_MACDR_RFCFCSTS_Msk   /* MAC MII Transmit Protocol Engine Status */
-#define ETH_MACDR_RPESTS_Pos                          (0U)
-#define ETH_MACDR_RPESTS_Msk                          (0x1UL << ETH_MACDR_RPESTS_Pos) /*!< 0x00000001 */
-#define ETH_MACDR_RPESTS                              ETH_MACDR_RPESTS_Msk     /* MAC MII Receive Protocol Engine Status */
-
-/* Bit definition for Ethernet MAC HW Feature0 Register */
-#define ETH_MACHWF0R_ACTPHYSEL_Pos                    (28U)
-#define ETH_MACHWF0R_ACTPHYSEL_Msk                    (0x7UL << ETH_MACHWF0R_ACTPHYSEL_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF0R_ACTPHYSEL                        ETH_MACHWF0R_ACTPHYSEL_Msk /* Active PHY Selected */
-#define ETH_MACHWF0R_ACTPHYSEL_MII                    ((uint32_t)0x00000000)   /* MII */
-#define ETH_MACHWF0R_ACTPHYSEL_RMII_Pos               (30U)
-#define ETH_MACHWF0R_ACTPHYSEL_RMII_Msk               (0x1UL << ETH_MACHWF0R_ACTPHYSEL_RMII_Pos) /*!< 0x40000000 */
-#define ETH_MACHWF0R_ACTPHYSEL_RMII                   ETH_MACHWF0R_ACTPHYSEL_RMII_Msk /* RMII */
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII_Pos             (28U)
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII_Msk             (0x7UL << ETH_MACHWF0R_ACTPHYSEL_REVMII_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF0R_ACTPHYSEL_REVMII                 ETH_MACHWF0R_ACTPHYSEL_REVMII_Msk /* RevMII */
-#define ETH_MACHWF0R_SAVLANINS_Pos                    (27U)
-#define ETH_MACHWF0R_SAVLANINS_Msk                    (0x1UL << ETH_MACHWF0R_SAVLANINS_Pos) /*!< 0x08000000 */
-#define ETH_MACHWF0R_SAVLANINS                        ETH_MACHWF0R_SAVLANINS_Msk /* Source Address or VLAN Insertion Enable */
-#define ETH_MACHWF0R_TSSTSSEL_Pos                     (25U)
-#define ETH_MACHWF0R_TSSTSSEL_Msk                     (0x3UL << ETH_MACHWF0R_TSSTSSEL_Pos) /*!< 0x06000000 */
-#define ETH_MACHWF0R_TSSTSSEL                         ETH_MACHWF0R_TSSTSSEL_Msk /* Timestamp System Time Source */
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL_Pos            (25U)
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL_Msk            (0x1UL << ETH_MACHWF0R_TSSTSSEL_INTERNAL_Pos) /*!< 0x02000000 */
-#define ETH_MACHWF0R_TSSTSSEL_INTERNAL                ETH_MACHWF0R_TSSTSSEL_INTERNAL_Msk /* Timestamp System Time Source: Internal */
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Pos            (26U)
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Msk            (0x1UL << ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Pos) /*!< 0x04000000 */
-#define ETH_MACHWF0R_TSSTSSEL_EXTERNAL                ETH_MACHWF0R_TSSTSSEL_EXTERNAL_Msk /* Timestamp System Time Source: External */
-#define ETH_MACHWF0R_TSSTSSEL_BOTH_Pos                (25U)
-#define ETH_MACHWF0R_TSSTSSEL_BOTH_Msk                (0x3UL << ETH_MACHWF0R_TSSTSSEL_BOTH_Pos) /*!< 0x06000000 */
-#define ETH_MACHWF0R_TSSTSSEL_BOTH                    ETH_MACHWF0R_TSSTSSEL_BOTH_Msk /* Timestamp System Time Source: Internal & External */
-#define ETH_MACHWF0R_MACADR64SEL_Pos                  (24U)
-#define ETH_MACHWF0R_MACADR64SEL_Msk                  (0x1UL << ETH_MACHWF0R_MACADR64SEL_Pos) /*!< 0x01000000 */
-#define ETH_MACHWF0R_MACADR64SEL                      ETH_MACHWF0R_MACADR64SEL_Msk /* MAC Addresses 64-127 Selected */
-#define ETH_MACHWF0R_MACADR32SEL_Pos                  (23U)
-#define ETH_MACHWF0R_MACADR32SEL_Msk                  (0x1UL << ETH_MACHWF0R_MACADR32SEL_Pos) /*!< 0x00800000 */
-#define ETH_MACHWF0R_MACADR32SEL                      ETH_MACHWF0R_MACADR32SEL_Msk /* MAC Addresses 32-63 Selected */
-#define ETH_MACHWF0R_ADDMACADRSEL_Pos                 (18U)
-#define ETH_MACHWF0R_ADDMACADRSEL_Msk                 (0x1FUL << ETH_MACHWF0R_ADDMACADRSEL_Pos) /*!< 0x007C0000 */
-#define ETH_MACHWF0R_ADDMACADRSEL                     ETH_MACHWF0R_ADDMACADRSEL_Msk /* MAC Addresses 1- 31 Selected */
-#define ETH_MACHWF0R_RXCOESEL_Pos                     (16U)
-#define ETH_MACHWF0R_RXCOESEL_Msk                     (0x1UL << ETH_MACHWF0R_RXCOESEL_Pos) /*!< 0x00010000 */
-#define ETH_MACHWF0R_RXCOESEL                         ETH_MACHWF0R_RXCOESEL_Msk /* Receive Checksum Offload Enabled */
-#define ETH_MACHWF0R_TXCOESEL_Pos                     (14U)
-#define ETH_MACHWF0R_TXCOESEL_Msk                     (0x1UL << ETH_MACHWF0R_TXCOESEL_Pos) /*!< 0x00004000 */
-#define ETH_MACHWF0R_TXCOESEL                         ETH_MACHWF0R_TXCOESEL_Msk /* Transmit Checksum Offload Enabled */
-#define ETH_MACHWF0R_EEESEL_Pos                       (13U)
-#define ETH_MACHWF0R_EEESEL_Msk                       (0x1UL << ETH_MACHWF0R_EEESEL_Pos) /*!< 0x00002000 */
-#define ETH_MACHWF0R_EEESEL                           ETH_MACHWF0R_EEESEL_Msk  /* Energy Efficient Ethernet Enabled */
-#define ETH_MACHWF0R_TSSEL_Pos                        (12U)
-#define ETH_MACHWF0R_TSSEL_Msk                        (0x1UL << ETH_MACHWF0R_TSSEL_Pos) /*!< 0x00001000 */
-#define ETH_MACHWF0R_TSSEL                            ETH_MACHWF0R_TSSEL_Msk   /* IEEE 1588-2008 Timestamp Enabled */
-#define ETH_MACHWF0R_ARPOFFSEL_Pos                    (9U)
-#define ETH_MACHWF0R_ARPOFFSEL_Msk                    (0x1UL << ETH_MACHWF0R_ARPOFFSEL_Pos) /*!< 0x00000200 */
-#define ETH_MACHWF0R_ARPOFFSEL                        ETH_MACHWF0R_ARPOFFSEL_Msk /* ARP Offload Enabled */
-#define ETH_MACHWF0R_MMCSEL_Pos                       (8U)
-#define ETH_MACHWF0R_MMCSEL_Msk                       (0x1UL << ETH_MACHWF0R_MMCSEL_Pos) /*!< 0x00000100 */
-#define ETH_MACHWF0R_MMCSEL                           ETH_MACHWF0R_MMCSEL_Msk  /* RMON Module Enable */
-#define ETH_MACHWF0R_MGKSEL_Pos                       (7U)
-#define ETH_MACHWF0R_MGKSEL_Msk                       (0x1UL << ETH_MACHWF0R_MGKSEL_Pos) /*!< 0x00000080 */
-#define ETH_MACHWF0R_MGKSEL                           ETH_MACHWF0R_MGKSEL_Msk  /* PMT Magic Packet Enable */
-#define ETH_MACHWF0R_RWKSEL_Pos                       (6U)
-#define ETH_MACHWF0R_RWKSEL_Msk                       (0x1UL << ETH_MACHWF0R_RWKSEL_Pos) /*!< 0x00000040 */
-#define ETH_MACHWF0R_RWKSEL                           ETH_MACHWF0R_RWKSEL_Msk  /* PMT Remote Wake-up Packet Enable */
-#define ETH_MACHWF0R_SMASEL_Pos                       (5U)
-#define ETH_MACHWF0R_SMASEL_Msk                       (0x1UL << ETH_MACHWF0R_SMASEL_Pos) /*!< 0x00000020 */
-#define ETH_MACHWF0R_SMASEL                           ETH_MACHWF0R_SMASEL_Msk  /* SMA (MDIO) Interface */
-#define ETH_MACHWF0R_VLHASH_Pos                       (4U)
-#define ETH_MACHWF0R_VLHASH_Msk                       (0x1UL << ETH_MACHWF0R_VLHASH_Pos) /*!< 0x00000010 */
-#define ETH_MACHWF0R_VLHASH                           ETH_MACHWF0R_VLHASH_Msk  /* VLAN Hash Filter Selected */
-#define ETH_MACHWF0R_PCSSEL_Pos                       (3U)
-#define ETH_MACHWF0R_PCSSEL_Msk                       (0x1UL << ETH_MACHWF0R_PCSSEL_Pos) /*!< 0x00000008 */
-#define ETH_MACHWF0R_PCSSEL                           ETH_MACHWF0R_PCSSEL_Msk  /* PCS Registers (TBI, SGMII, or RTBI PHY interface) */
-#define ETH_MACHWF0R_HDSEL_Pos                        (2U)
-#define ETH_MACHWF0R_HDSEL_Msk                        (0x1UL << ETH_MACHWF0R_HDSEL_Pos) /*!< 0x00000004 */
-#define ETH_MACHWF0R_HDSEL                            ETH_MACHWF0R_HDSEL_Msk   /* Half-duplex Support */
-#define ETH_MACHWF0R_GMIISEL_Pos                      (1U)
-#define ETH_MACHWF0R_GMIISEL_Msk                      (0x1UL << ETH_MACHWF0R_GMIISEL_Pos) /*!< 0x00000002 */
-#define ETH_MACHWF0R_GMIISEL                          ETH_MACHWF0R_GMIISEL_Msk /* 1000 Mbps Support */
-#define ETH_MACHWF0R_MIISEL_Pos                       (0U)
-#define ETH_MACHWF0R_MIISEL_Msk                       (0x1UL << ETH_MACHWF0R_MIISEL_Pos) /*!< 0x00000001 */
-#define ETH_MACHWF0R_MIISEL                           ETH_MACHWF0R_MIISEL_Msk  /* 10 or 100 Mbps Support */
-
-/* Bit definition for Ethernet MAC HW Feature1 Register */
-#define ETH_MACHWF1R_L3L4FNUM_Pos                     (27U)
-#define ETH_MACHWF1R_L3L4FNUM_Msk                     (0xFUL << ETH_MACHWF1R_L3L4FNUM_Pos) /*!< 0x78000000 */
-#define ETH_MACHWF1R_L3L4FNUM                         ETH_MACHWF1R_L3L4FNUM_Msk /* Total number of L3 or L4 Filters */
-#define ETH_MACHWF1R_HASHTBLSZ_Pos                    (24U)
-#define ETH_MACHWF1R_HASHTBLSZ_Msk                    (0x3UL << ETH_MACHWF1R_HASHTBLSZ_Pos) /*!< 0x03000000 */
-#define ETH_MACHWF1R_HASHTBLSZ                        ETH_MACHWF1R_HASHTBLSZ_Msk /* Hash Table Size */
-#define ETH_MACHWF1R_AVSEL_Pos                        (20U)
-#define ETH_MACHWF1R_AVSEL_Msk                        (0x1UL << ETH_MACHWF1R_AVSEL_Pos) /*!< 0x00100000 */
-#define ETH_MACHWF1R_AVSEL                            ETH_MACHWF1R_AVSEL_Msk   /* AV Feature Enabled */
-#define ETH_MACHWF1R_DBGMEMA_Pos                      (19U)
-#define ETH_MACHWF1R_DBGMEMA_Msk                      (0x1UL << ETH_MACHWF1R_DBGMEMA_Pos) /*!< 0x00080000 */
-#define ETH_MACHWF1R_DBGMEMA                          ETH_MACHWF1R_DBGMEMA_Msk /* Debug Memory Interface Enabled */
-#define ETH_MACHWF1R_TSOEN_Pos                        (18U)
-#define ETH_MACHWF1R_TSOEN_Msk                        (0x1UL << ETH_MACHWF1R_TSOEN_Pos) /*!< 0x00040000 */
-#define ETH_MACHWF1R_TSOEN                            ETH_MACHWF1R_TSOEN_Msk   /* TCP Segmentation Offload Enable */
-#define ETH_MACHWF1R_SPHEN_Pos                        (17U)
-#define ETH_MACHWF1R_SPHEN_Msk                        (0x1UL << ETH_MACHWF1R_SPHEN_Pos) /*!< 0x00020000 */
-#define ETH_MACHWF1R_SPHEN                            ETH_MACHWF1R_SPHEN_Msk   /* Split Header Feature Enable */
-#define ETH_MACHWF1R_DCBEN_Pos                        (16U)
-#define ETH_MACHWF1R_DCBEN_Msk                        (0x1UL << ETH_MACHWF1R_DCBEN_Pos) /*!< 0x00010000 */
-#define ETH_MACHWF1R_DCBEN                            ETH_MACHWF1R_DCBEN_Msk   /* DCB Feature Enable */
-#define ETH_MACHWF1R_ADDR64_Pos                       (14U)
-#define ETH_MACHWF1R_ADDR64_Msk                       (0x3UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x0000C000 */
-#define ETH_MACHWF1R_ADDR64                           ETH_MACHWF1R_ADDR64_Msk  /* Address Width */
-#define ETH_MACHWF1R_ADDR64_32                        (0x0UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00000000 */
-#define ETH_MACHWF1R_ADDR64_40                        (0x1UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00004000 */
-#define ETH_MACHWF1R_ADDR64_48                        (0x2UL << ETH_MACHWF1R_ADDR64_Pos) /*!< 0x00008000 */
-#define ETH_MACHWF1R_ADVTHWORD_Pos                    (13U)
-#define ETH_MACHWF1R_ADVTHWORD_Msk                    (0x1UL << ETH_MACHWF1R_ADVTHWORD_Pos) /*!< 0x00002000 */
-#define ETH_MACHWF1R_ADVTHWORD                        ETH_MACHWF1R_ADVTHWORD_Msk /* IEEE 1588 High Word Register Enable */
-#define ETH_MACHWF1R_PTOEN_Pos                        (12U)
-#define ETH_MACHWF1R_PTOEN_Msk                        (0x1UL << ETH_MACHWF1R_PTOEN_Pos) /*!< 0x00001000 */
-#define ETH_MACHWF1R_PTOEN                            ETH_MACHWF1R_PTOEN_Msk   /* PTP Offload Enable */
-#define ETH_MACHWF1R_OSTEN_Pos                        (11U)
-#define ETH_MACHWF1R_OSTEN_Msk                        (0x1UL << ETH_MACHWF1R_OSTEN_Pos) /*!< 0x00000800 */
-#define ETH_MACHWF1R_OSTEN                            ETH_MACHWF1R_OSTEN_Msk   /* One-Step Timestamping Enable */
-#define ETH_MACHWF1R_TXFIFOSIZE_Pos                   (6U)
-#define ETH_MACHWF1R_TXFIFOSIZE_Msk                   (0x1FUL << ETH_MACHWF1R_TXFIFOSIZE_Pos) /*!< 0x000007C0 */
-#define ETH_MACHWF1R_TXFIFOSIZE                       ETH_MACHWF1R_TXFIFOSIZE_Msk /* MTL Transmit FIFO Size */
-#define ETH_MACHWF1R_RXFIFOSIZE_Pos                   (0U)
-#define ETH_MACHWF1R_RXFIFOSIZE_Msk                   (0x1FUL << ETH_MACHWF1R_RXFIFOSIZE_Pos) /*!< 0x0000001F */
-#define ETH_MACHWF1R_RXFIFOSIZE                       ETH_MACHWF1R_RXFIFOSIZE_Msk /* MTL Receive FIFO Size */
-
-/* Bit definition for Ethernet MAC HW Feature2 Register */
-#define ETH_MACHWF2R_AUXSNAPNUM_Pos                   (28U)
-#define ETH_MACHWF2R_AUXSNAPNUM_Msk                   (0x7UL << ETH_MACHWF2R_AUXSNAPNUM_Pos) /*!< 0x70000000 */
-#define ETH_MACHWF2R_AUXSNAPNUM                       ETH_MACHWF2R_AUXSNAPNUM_Msk /* Number of Auxiliary Snapshot Inputs */
-#define ETH_MACHWF2R_PPSOUTNUM_Pos                    (24U)
-#define ETH_MACHWF2R_PPSOUTNUM_Msk                    (0x7UL << ETH_MACHWF2R_PPSOUTNUM_Pos) /*!< 0x07000000 */
-#define ETH_MACHWF2R_PPSOUTNUM                        ETH_MACHWF2R_PPSOUTNUM_Msk /*  Number of PPS Outputs */
-#define ETH_MACHWF2R_TXCHCNT_Pos                      (18U)
-#define ETH_MACHWF2R_TXCHCNT_Msk                      (0xFUL << ETH_MACHWF2R_TXCHCNT_Pos) /*!< 0x003C0000 */
-#define ETH_MACHWF2R_TXCHCNT                          ETH_MACHWF2R_TXCHCNT_Msk /* Number of DMA Transmit Channels */
-#define ETH_MACHWF2R_RXCHCNT_Pos                      (13U)
-#define ETH_MACHWF2R_RXCHCNT_Msk                      (0x7UL << ETH_MACHWF2R_RXCHCNT_Pos) /*!< 0x0000E000 */
-#define ETH_MACHWF2R_RXCHCNT                          ETH_MACHWF2R_RXCHCNT_Msk /* Number of DMA Receive Channels */
-#define ETH_MACHWF2R_TXQCNT_Pos                       (6U)
-#define ETH_MACHWF2R_TXQCNT_Msk                       (0xFUL << ETH_MACHWF2R_TXQCNT_Pos) /*!< 0x000003C0 */
-#define ETH_MACHWF2R_TXQCNT                           ETH_MACHWF2R_TXQCNT_Msk  /* Number of MTL Transmit Queues */
-#define ETH_MACHWF2R_RXQCNT_Pos                       (0U)
-#define ETH_MACHWF2R_RXQCNT_Msk                       (0xFUL << ETH_MACHWF2R_RXQCNT_Pos) /*!< 0x0000000F */
-#define ETH_MACHWF2R_RXQCNT                           ETH_MACHWF2R_RXQCNT_Msk  /* Number of MTL Receive Queues */
-
-/* Bit definition for Ethernet MAC MDIO Address Register */
-#define ETH_MACMDIOAR_PSE_Pos                         (27U)
-#define ETH_MACMDIOAR_PSE_Msk                         (0x1UL << ETH_MACMDIOAR_PSE_Pos) /*!< 0x08000000 */
-#define ETH_MACMDIOAR_PSE                             ETH_MACMDIOAR_PSE_Msk    /* Preamble Suppression Enable */
-#define ETH_MACMDIOAR_BTB_Pos                         (26U)
-#define ETH_MACMDIOAR_BTB_Msk                         (0x1UL << ETH_MACMDIOAR_BTB_Pos) /*!< 0x04000000 */
-#define ETH_MACMDIOAR_BTB                             ETH_MACMDIOAR_BTB_Msk    /* Back to Back transactions */
-#define ETH_MACMDIOAR_PA_Pos                          (21U)
-#define ETH_MACMDIOAR_PA_Msk                          (0x1FUL << ETH_MACMDIOAR_PA_Pos) /*!< 0x03E00000 */
-#define ETH_MACMDIOAR_PA                              ETH_MACMDIOAR_PA_Msk     /* Physical Layer Address */
-#define ETH_MACMDIOAR_RDA_Pos                         (16U)
-#define ETH_MACMDIOAR_RDA_Msk                         (0x1FUL << ETH_MACMDIOAR_RDA_Pos) /*!< 0x001F0000 */
-#define ETH_MACMDIOAR_RDA                             ETH_MACMDIOAR_RDA_Msk    /* Register/Device Address */
-#define ETH_MACMDIOAR_NTC_Pos                         (12U)
-#define ETH_MACMDIOAR_NTC_Msk                         (0x7UL << ETH_MACMDIOAR_NTC_Pos) /*!< 0x00007000 */
-#define ETH_MACMDIOAR_NTC                             ETH_MACMDIOAR_NTC_Msk    /* Number of Trailing Clocks */
-#define ETH_MACMDIOAR_CR_Pos                          (8U)
-#define ETH_MACMDIOAR_CR_Msk                          (0xFUL << ETH_MACMDIOAR_CR_Pos) /*!< 0x00000F00 */
-#define ETH_MACMDIOAR_CR                              ETH_MACMDIOAR_CR_Msk     /* CSR Clock Range */
-#define ETH_MACMDIOAR_CR_DIV42                        ((uint32_t)0x00000000)   /* CSR clock/42 */
-#define ETH_MACMDIOAR_CR_DIV62_Pos                    (8U)
-#define ETH_MACMDIOAR_CR_DIV62_Msk                    (0x1UL << ETH_MACMDIOAR_CR_DIV62_Pos) /*!< 0x00000100 */
-#define ETH_MACMDIOAR_CR_DIV62                        ETH_MACMDIOAR_CR_DIV62_Msk /* CSR clock/62 */
-#define ETH_MACMDIOAR_CR_DIV16_Pos                    (9U)
-#define ETH_MACMDIOAR_CR_DIV16_Msk                    (0x1UL << ETH_MACMDIOAR_CR_DIV16_Pos) /*!< 0x00000200 */
-#define ETH_MACMDIOAR_CR_DIV16                        ETH_MACMDIOAR_CR_DIV16_Msk /* CSR clock/16 */
-#define ETH_MACMDIOAR_CR_DIV26_Pos                    (8U)
-#define ETH_MACMDIOAR_CR_DIV26_Msk                    (0x3UL << ETH_MACMDIOAR_CR_DIV26_Pos) /*!< 0x00000300 */
-#define ETH_MACMDIOAR_CR_DIV26                        ETH_MACMDIOAR_CR_DIV26_Msk /* CSR clock/26 */
-#define ETH_MACMDIOAR_CR_DIV102_Pos                   (10U)
-#define ETH_MACMDIOAR_CR_DIV102_Msk                   (0x1UL << ETH_MACMDIOAR_CR_DIV102_Pos) /*!< 0x00000400 */
-#define ETH_MACMDIOAR_CR_DIV102                       ETH_MACMDIOAR_CR_DIV102_Msk /* CSR clock/102 */
-#define ETH_MACMDIOAR_CR_DIV124_Pos                   (8U)
-#define ETH_MACMDIOAR_CR_DIV124_Msk                   (0x5UL << ETH_MACMDIOAR_CR_DIV124_Pos) /*!< 0x00000500 */
-#define ETH_MACMDIOAR_CR_DIV124                       ETH_MACMDIOAR_CR_DIV124_Msk /* CSR clock/124 */
-#define ETH_MACMDIOAR_CR_DIV4AR_Pos                   (11U)
-#define ETH_MACMDIOAR_CR_DIV4AR_Msk                   (0x1UL << ETH_MACMDIOAR_CR_DIV4AR_Pos) /*!< 0x00000800 */
-#define ETH_MACMDIOAR_CR_DIV4AR                       ETH_MACMDIOAR_CR_DIV4AR_Msk /* CSR clock/4: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV6AR_Pos                   (8U)
-#define ETH_MACMDIOAR_CR_DIV6AR_Msk                   (0x9UL << ETH_MACMDIOAR_CR_DIV6AR_Pos) /*!< 0x00000900 */
-#define ETH_MACMDIOAR_CR_DIV6AR                       ETH_MACMDIOAR_CR_DIV6AR_Msk /* CSR clock/6: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV8AR_Pos                   (9U)
-#define ETH_MACMDIOAR_CR_DIV8AR_Msk                   (0x5UL << ETH_MACMDIOAR_CR_DIV8AR_Pos) /*!< 0x00000A00 */
-#define ETH_MACMDIOAR_CR_DIV8AR                       ETH_MACMDIOAR_CR_DIV8AR_Msk /* CSR clock/8: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV10AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV10AR_Msk                  (0xBUL << ETH_MACMDIOAR_CR_DIV10AR_Pos) /*!< 0x00000B00 */
-#define ETH_MACMDIOAR_CR_DIV10AR                      ETH_MACMDIOAR_CR_DIV10AR_Msk /* CSR clock/10: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV12AR_Pos                  (10U)
-#define ETH_MACMDIOAR_CR_DIV12AR_Msk                  (0x3UL << ETH_MACMDIOAR_CR_DIV12AR_Pos) /*!< 0x00000C00 */
-#define ETH_MACMDIOAR_CR_DIV12AR                      ETH_MACMDIOAR_CR_DIV12AR_Msk /* CSR clock/12: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV14AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV14AR_Msk                  (0xDUL << ETH_MACMDIOAR_CR_DIV14AR_Pos) /*!< 0x00000D00 */
-#define ETH_MACMDIOAR_CR_DIV14AR                      ETH_MACMDIOAR_CR_DIV14AR_Msk /* CSR clock/14: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV16AR_Pos                  (9U)
-#define ETH_MACMDIOAR_CR_DIV16AR_Msk                  (0x7UL << ETH_MACMDIOAR_CR_DIV16AR_Pos) /*!< 0x00000E00 */
-#define ETH_MACMDIOAR_CR_DIV16AR                      ETH_MACMDIOAR_CR_DIV16AR_Msk /* CSR clock/16: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_CR_DIV18AR_Pos                  (8U)
-#define ETH_MACMDIOAR_CR_DIV18AR_Msk                  (0xFUL << ETH_MACMDIOAR_CR_DIV18AR_Pos) /*!< 0x00000F00 */
-#define ETH_MACMDIOAR_CR_DIV18AR                      ETH_MACMDIOAR_CR_DIV18AR_Msk /* CSR clock/18: MDC clock above range specified in IEEE */
-#define ETH_MACMDIOAR_SKAP_Pos                        (4U)
-#define ETH_MACMDIOAR_SKAP_Msk                        (0x1UL << ETH_MACMDIOAR_SKAP_Pos) /*!< 0x00000010 */
-#define ETH_MACMDIOAR_SKAP                            ETH_MACMDIOAR_SKAP_Msk   /* Skip Address Packet */
-#define ETH_MACMDIOAR_MOC_Pos                         (2U)
-#define ETH_MACMDIOAR_MOC_Msk                         (0x3UL << ETH_MACMDIOAR_MOC_Pos) /*!< 0x0000000C */
-#define ETH_MACMDIOAR_MOC                             ETH_MACMDIOAR_MOC_Msk    /* MII Operation Command */
-#define ETH_MACMDIOAR_MOC_WR_Pos                      (2U)
-#define ETH_MACMDIOAR_MOC_WR_Msk                      (0x1UL << ETH_MACMDIOAR_MOC_WR_Pos) /*!< 0x00000004 */
-#define ETH_MACMDIOAR_MOC_WR                          ETH_MACMDIOAR_MOC_WR_Msk /* Write */
-#define ETH_MACMDIOAR_MOC_PRDIA_Pos                   (3U)
-#define ETH_MACMDIOAR_MOC_PRDIA_Msk                   (0x1UL << ETH_MACMDIOAR_MOC_PRDIA_Pos) /*!< 0x00000008 */
-#define ETH_MACMDIOAR_MOC_PRDIA                       ETH_MACMDIOAR_MOC_PRDIA_Msk /* Post Read Increment Address for Clause 45 PHY */
-#define ETH_MACMDIOAR_MOC_RD_Pos                      (2U)
-#define ETH_MACMDIOAR_MOC_RD_Msk                      (0x3UL << ETH_MACMDIOAR_MOC_RD_Pos) /*!< 0x0000000C */
-#define ETH_MACMDIOAR_MOC_RD                          ETH_MACMDIOAR_MOC_RD_Msk /* Read */
-#define ETH_MACMDIOAR_C45E_Pos                        (1U)
-#define ETH_MACMDIOAR_C45E_Msk                        (0x1UL << ETH_MACMDIOAR_C45E_Pos) /*!< 0x00000002 */
-#define ETH_MACMDIOAR_C45E                            ETH_MACMDIOAR_C45E_Msk   /* Clause 45 PHY Enable */
-#define ETH_MACMDIOAR_MB_Pos                          (0U)
-#define ETH_MACMDIOAR_MB_Msk                          (0x1UL << ETH_MACMDIOAR_MB_Pos) /*!< 0x00000001 */
-#define ETH_MACMDIOAR_MB                              ETH_MACMDIOAR_MB_Msk     /* MII Busy */
-
-/* Bit definition for Ethernet MAC MDIO Data Register */
-#define ETH_MACMDIODR_RA_Pos                          (16U)
-#define ETH_MACMDIODR_RA_Msk                          (0xFFFFUL << ETH_MACMDIODR_RA_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACMDIODR_RA                              ETH_MACMDIODR_RA_Msk     /* Register Address */
-#define ETH_MACMDIODR_MD_Pos                          (0U)
-#define ETH_MACMDIODR_MD_Msk                          (0xFFFFUL << ETH_MACMDIODR_MD_Pos) /*!< 0x0000FFFF */
-#define ETH_MACMDIODR_MD                              ETH_MACMDIODR_MD_Msk     /* MII Data */
-
-/* Bit definition for Ethernet ARP Address Register */
-#define ETH_MACARPAR_ARPPA_Pos                         (0U)
-#define ETH_MACARPAR_ARPPA_Msk                         (0xFFFFFFFFUL << ETH_MACARPAR_ARPPA_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACARPAR_ARPPA                             ETH_MACARPAR_ARPPA_Msk     /* ARP Protocol Address */
-
-/* Bit definition for Ethernet MAC Address 0 High Register */
-#define ETH_MACA0HR_AE_Pos                            (31U)
-#define ETH_MACA0HR_AE_Msk                            (0x1UL << ETH_MACA0HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA0HR_AE                                ETH_MACA0HR_AE_Msk /* Address Enable*/
-#define ETH_MACA0HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA0HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA0HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA0HR_ADDRHI                            ETH_MACA0HR_ADDRHI_Msk   /* MAC Address 0*/
-
-/* Bit definition for Ethernet MAC Address 0 Low Register */
-#define ETH_MACA0LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA0LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA0LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA0LR_ADDRLO                            ETH_MACA0LR_ADDRLO_Msk   /* MAC Address 0*/
-
-/* Bit definition for Ethernet MAC Address 1 High Register */
-#define ETH_MACA1HR_AE_Pos                            (31U)
-#define ETH_MACA1HR_AE_Msk                            (0x1UL << ETH_MACA1HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA1HR_AE                                ETH_MACA1HR_AE_Msk /* Address Enable*/
-#define ETH_MACA1HR_SA_Pos                            (30U)
-#define ETH_MACA1HR_SA_Msk                            (0x1UL << ETH_MACA1HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA1HR_SA                                ETH_MACA1HR_SA_Msk /* Source Address */
-#define ETH_MACA1HR_MBC_Pos                           (24U)
-#define ETH_MACA1HR_MBC_Msk                           (0x3FUL << ETH_MACA1HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA1HR_MBC                               ETH_MACA1HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA1HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA1HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA1HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA1HR_ADDRHI                            ETH_MACA1HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 1 Low Register */
-#define ETH_MACA1LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA1LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA1LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA1LR_ADDRLO                            ETH_MACA1LR_ADDRLO_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 2 High Register */
-#define ETH_MACA2HR_AE_Pos                            (31U)
-#define ETH_MACA2HR_AE_Msk                            (0x1UL << ETH_MACA2HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA2HR_AE                                ETH_MACA2HR_AE_Msk /* Address Enable*/
-#define ETH_MACA2HR_SA_Pos                            (30U)
-#define ETH_MACA2HR_SA_Msk                            (0x1UL << ETH_MACA2HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA2HR_SA                                ETH_MACA2HR_SA_Msk /* Source Address */
-#define ETH_MACA2HR_MBC_Pos                           (24U)
-#define ETH_MACA2HR_MBC_Msk                           (0x3FUL << ETH_MACA2HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA2HR_MBC                               ETH_MACA2HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA2HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA2HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA2HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA2HR_ADDRHI                            ETH_MACA2HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 2 Low Register */
-#define ETH_MACA2LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA2LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA2LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA2LR_ADDRLO                            ETH_MACA2LR_ADDRLO_Msk   /* MAC Address 2*/
-
-/* Bit definition for Ethernet MAC Address 3 High Register */
-#define ETH_MACA3HR_AE_Pos                            (31U)
-#define ETH_MACA3HR_AE_Msk                            (0x1UL << ETH_MACA3HR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACA3HR_AE                                ETH_MACA3HR_AE_Msk /* Address Enable*/
-#define ETH_MACA3HR_SA_Pos                            (30U)
-#define ETH_MACA3HR_SA_Msk                            (0x1UL << ETH_MACA3HR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACA3HR_SA                                ETH_MACA3HR_SA_Msk /* Source Address */
-#define ETH_MACA3HR_MBC_Pos                           (24U)
-#define ETH_MACA3HR_MBC_Msk                           (0x3FUL << ETH_MACA3HR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACA3HR_MBC                               ETH_MACA3HR_MBC_Msk /* Mask Byte Control */
-#define ETH_MACA3HR_ADDRHI_Pos                        (0U)
-#define ETH_MACA3HR_ADDRHI_Msk                        (0xFFFFUL << ETH_MACA3HR_ADDRHI_Pos) /*!< 0x0000FFFF */
-#define ETH_MACA3HR_ADDRHI                            ETH_MACA3HR_ADDRHI_Msk   /* MAC Address 1*/
-
-/* Bit definition for Ethernet MAC Address 3 Low Register */
-#define ETH_MACA3LR_ADDRLO_Pos                        (0U)
-#define ETH_MACA3LR_ADDRLO_Msk                        (0xFFFFFFFFUL << ETH_MACA3LR_ADDRLO_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACA3LR_ADDRLO                            ETH_MACA3LR_ADDRLO_Msk   /* MAC Address 3*/
-
-/* Bit definition for Ethernet MAC Address High Register */
-#define ETH_MACAHR_AE_Pos                             (31U)
-#define ETH_MACAHR_AE_Msk                             (0x1UL << ETH_MACAHR_AE_Pos) /*!< 0x80000000 */
-#define ETH_MACAHR_AE                                 ETH_MACAHR_AE_Msk        /* Address enable */
-#define ETH_MACAHR_SA_Pos                             (30U)
-#define ETH_MACAHR_SA_Msk                             (0x1UL << ETH_MACAHR_SA_Pos) /*!< 0x40000000 */
-#define ETH_MACAHR_SA                                 ETH_MACAHR_SA_Msk        /* Source address */
-#define ETH_MACAHR_MBC_Pos                            (24U)
-#define ETH_MACAHR_MBC_Msk                            (0x3FUL << ETH_MACAHR_MBC_Pos) /*!< 0x3F000000 */
-#define ETH_MACAHR_MBC                                ETH_MACAHR_MBC_Msk       /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
-#define ETH_MACAHR_MBC_HBITS15_8                      ((uint32_t)0x20000000)   /* Mask MAC Address high reg bits [15:8] */
-#define ETH_MACAHR_MBC_HBITS7_0                       ((uint32_t)0x10000000)   /* Mask MAC Address high reg bits [7:0] */
-#define ETH_MACAHR_MBC_LBITS31_24                     ((uint32_t)0x08000000)   /* Mask MAC Address low reg bits [31:24] */
-#define ETH_MACAHR_MBC_LBITS23_16                     ((uint32_t)0x04000000)   /* Mask MAC Address low reg bits [23:16] */
-#define ETH_MACAHR_MBC_LBITS15_8                      ((uint32_t)0x02000000)   /* Mask MAC Address low reg bits [15:8] */
-#define ETH_MACAHR_MBC_LBITS7_0                       ((uint32_t)0x01000000)   /* Mask MAC Address low reg bits [7:0] */
-#define ETH_MACAHR_MACAH_Pos                          (0U)
-#define ETH_MACAHR_MACAH_Msk                          (0xFFFFUL << ETH_MACAHR_MACAH_Pos) /*!< 0x0000FFFF */
-#define ETH_MACAHR_MACAH                              ETH_MACAHR_MACAH_Msk     /* MAC address high */
-
-/* Bit definition for Ethernet MAC Address Low Register */
-#define ETH_MACALR_MACAL_Pos                          (0U)
-#define ETH_MACALR_MACAL_Msk                          (0xFFFFFFFFUL << ETH_MACALR_MACAL_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACALR_MACAL                              ETH_MACALR_MACAL_Msk     /* MAC address low */
-
-/* Bit definition for Ethernet MMC Control Register */
-#define ETH_MMCCR_UCDBC_Pos                           (8U)
-#define ETH_MMCCR_UCDBC_Msk                           (0x1UL << ETH_MMCCR_UCDBC_Pos) /*!< 0x00000100 */
-#define ETH_MMCCR_UCDBC                               ETH_MMCCR_UCDBC_Msk  /* Update MMC Counters for Dropped Broadcast Packets */
-#define ETH_MMCCR_CNTPRSTLVL_Pos                      (5U)
-#define ETH_MMCCR_CNTPRSTLVL_Msk                      (0x1UL << ETH_MMCCR_CNTPRSTLVL_Pos) /*!< 0x00000020 */
-#define ETH_MMCCR_CNTPRSTLVL                          ETH_MMCCR_CNTPRSTLVL_Msk  /* Full-Half Preset */
-#define ETH_MMCCR_CNTPRST_Pos                         (4U)
-#define ETH_MMCCR_CNTPRST_Msk                         (0x1UL << ETH_MMCCR_CNTPRST_Pos) /*!< 0x00000010 */
-#define ETH_MMCCR_CNTPRST                             ETH_MMCCR_CNTPRST_Msk  /* Counters Reset */
-#define ETH_MMCCR_CNTFREEZ_Pos                        (3U)
-#define ETH_MMCCR_CNTFREEZ_Msk                        (0x1UL << ETH_MMCCR_CNTFREEZ_Pos) /*!< 0x00000008 */
-#define ETH_MMCCR_CNTFREEZ                            ETH_MMCCR_CNTFREEZ_Msk  /* MMC Counter Freeze */
-#define ETH_MMCCR_RSTONRD_Pos                         (2U)
-#define ETH_MMCCR_RSTONRD_Msk                         (0x1UL << ETH_MMCCR_RSTONRD_Pos) /*!< 0x00000004 */
-#define ETH_MMCCR_RSTONRD                             ETH_MMCCR_RSTONRD_Msk  /* Reset On Read */
-#define ETH_MMCCR_CNTSTOPRO_Pos                       (1U)
-#define ETH_MMCCR_CNTSTOPRO_Msk                       (0x1UL << ETH_MMCCR_CNTSTOPRO_Pos) /*!< 0x00000002 */
-#define ETH_MMCCR_CNTSTOPRO                           ETH_MMCCR_CNTSTOPRO_Msk  /* Counter Stop Rollover */
-#define ETH_MMCCR_CNTRST_Pos                          (0U)
-#define ETH_MMCCR_CNTRST_Msk                          (0x1UL << ETH_MMCCR_CNTRST_Pos) /*!< 0x00000001 */
-#define ETH_MMCCR_CNTRST                              ETH_MMCCR_CNTRST_Msk  /* Counters Reset */
-
-/* Bit definition for Ethernet MMC Rx Interrupt Register */
-#define ETH_MMCRIR_RXLPITRCIS_Pos                     (27U)
-#define ETH_MMCRIR_RXLPITRCIS_Msk                     (0x1UL << ETH_MMCRIR_RXLPITRCIS_Pos) /*!< 0x08000000 */
-#define ETH_MMCRIR_RXLPITRCIS                         ETH_MMCRIR_RXLPITRCIS_Msk  /* MMC Receive LPI transition counter interrupt status */
-#define ETH_MMCRIR_RXLPIUSCIS_Pos                     (26U)
-#define ETH_MMCRIR_RXLPIUSCIS_Msk                     (0x1UL << ETH_MMCRIR_RXLPIUSCIS_Pos) /*!< 0x04000000 */
-#define ETH_MMCRIR_RXLPIUSCIS                         ETH_MMCRIR_RXLPIUSCIS_Msk  /* MMC Receive LPI microsecond counter interrupt status */
-#define ETH_MMCRIR_RXUCGPIS_Pos                       (17U)
-#define ETH_MMCRIR_RXUCGPIS_Msk                       (0x1UL << ETH_MMCRIR_RXUCGPIS_Pos) /*!< 0x00020000 */
-#define ETH_MMCRIR_RXUCGPIS                           ETH_MMCRIR_RXUCGPIS_Msk  /* MMC Receive Unicast Good Packet Counter Interrupt Status */
-#define ETH_MMCRIR_RXALGNERPIS_Pos                    (6U)
-#define ETH_MMCRIR_RXALGNERPIS_Msk                    (0x1UL << ETH_MMCRIR_RXALGNERPIS_Pos) /*!< 0x00000040 */
-#define ETH_MMCRIR_RXALGNERPIS                        ETH_MMCRIR_RXALGNERPIS_Msk  /* MMC Receive Alignment Error Packet Counter Interrupt Status */
-#define ETH_MMCRIR_RXCRCERPIS_Pos                     (5U)
-#define ETH_MMCRIR_RXCRCERPIS_Msk                     (0x1UL << ETH_MMCRIR_RXCRCERPIS_Pos) /*!< 0x00000020 */
-#define ETH_MMCRIR_RXCRCERPIS                         ETH_MMCRIR_RXCRCERPIS_Msk  /* MMC Receive CRC Error Packet Counter Interrupt Status */
-
-/* Bit definition for Ethernet MMC Tx Interrupt Register */
-#define ETH_MMCTIR_TXLPITRCIS_Pos                     (27U)
-#define ETH_MMCTIR_TXLPITRCIS_Msk                     (0x1UL << ETH_MMCTIR_TXLPITRCIS_Pos) /*!< 0x08000000 */
-#define ETH_MMCTIR_TXLPITRCIS                         ETH_MMCTIR_TXLPITRCIS_Msk  /* MMC Transmit LPI transition counter interrupt status */
-#define ETH_MMCTIR_TXLPIUSCIS_Pos                     (26U)
-#define ETH_MMCTIR_TXLPIUSCIS_Msk                     (0x1UL << ETH_MMCTIR_TXLPIUSCIS_Pos) /*!< 0x04000000 */
-#define ETH_MMCTIR_TXLPIUSCIS                         ETH_MMCTIR_TXLPIUSCIS_Msk  /* MMC Transmit LPI microsecond counter interrupt status */
-#define ETH_MMCTIR_TXGPKTIS_Pos                       (21U)
-#define ETH_MMCTIR_TXGPKTIS_Msk                       (0x1UL << ETH_MMCTIR_TXGPKTIS_Pos) /*!< 0x00200000 */
-#define ETH_MMCTIR_TXGPKTIS                           ETH_MMCTIR_TXGPKTIS_Msk  /* MMC Transmit Good Packet Counter Interrupt Status */
-#define ETH_MMCTIR_TXMCOLGPIS_Pos                     (15U)
-#define ETH_MMCTIR_TXMCOLGPIS_Msk                     (0x1UL << ETH_MMCTIR_TXMCOLGPIS_Pos) /*!< 0x00008000 */
-#define ETH_MMCTIR_TXMCOLGPIS                         ETH_MMCTIR_TXMCOLGPIS_Msk  /* MMC Transmit Multiple Collision Good Packet Counter Interrupt Status */
-#define ETH_MMCTIR_TXSCOLGPIS_Pos                     (14U)
-#define ETH_MMCTIR_TXSCOLGPIS_Msk                     (0x1UL << ETH_MMCTIR_TXSCOLGPIS_Pos) /*!< 0x00004000 */
-#define ETH_MMCTIR_TXSCOLGPIS                         ETH_MMCTIR_TXSCOLGPIS_Msk  /* MMC Transmit Single Collision Good Packet Counter Interrupt Status */
-
-/* Bit definition for Ethernet MMC Rx interrupt Mask register */
-#define ETH_MMCRIMR_RXLPITRCIM_Pos                    (27U)
-#define ETH_MMCRIMR_RXLPITRCIM_Msk                    (0x1UL << ETH_MMCRIMR_RXLPITRCIM_Pos) /*!< 0x08000000 */
-#define ETH_MMCRIMR_RXLPITRCIM                        ETH_MMCRIMR_RXLPITRCIM_Msk  /* MMC Receive LPI transition counter interrupt Mask */
-#define ETH_MMCRIMR_RXLPIUSCIM_Pos                    (26U)
-#define ETH_MMCRIMR_RXLPIUSCIM_Msk                    (0x1UL << ETH_MMCRIMR_RXLPIUSCIM_Pos) /*!< 0x04000000 */
-#define ETH_MMCRIMR_RXLPIUSCIM                        ETH_MMCRIMR_RXLPIUSCIM_Msk  /* MMC Receive LPI microsecond counter interrupt Mask */
-#define ETH_MMCRIMR_RXUCGPIM_Pos                      (17U)
-#define ETH_MMCRIMR_RXUCGPIM_Msk                      (0x1UL << ETH_MMCRIMR_RXUCGPIM_Pos) /*!< 0x00020000 */
-#define ETH_MMCRIMR_RXUCGPIM                          ETH_MMCRIMR_RXUCGPIM_Msk  /* MMC Receive Unicast Good Packet Counter Interrupt Mask */
-#define ETH_MMCRIMR_RXALGNERPIM_Pos                   (6U)
-#define ETH_MMCRIMR_RXALGNERPIM_Msk                   (0x1UL << ETH_MMCRIMR_RXALGNERPIM_Pos) /*!< 0x00000040 */
-#define ETH_MMCRIMR_RXALGNERPIM                       ETH_MMCRIMR_RXALGNERPIM_Msk  /* MMC Receive Alignment Error Packet Counter Interrupt Mask */
-#define ETH_MMCRIMR_RXCRCERPIM_Pos                    (5U)
-#define ETH_MMCRIMR_RXCRCERPIM_Msk                    (0x1UL << ETH_MMCRIMR_RXCRCERPIM_Pos) /*!< 0x00000020 */
-#define ETH_MMCRIMR_RXCRCERPIM                        ETH_MMCRIMR_RXCRCERPIM_Msk  /* MMC Receive CRC Error Packet Counter Interrupt Mask */
-
-/* Bit definition for Ethernet MMC Tx Interrupt Mask Register */
-#define ETH_MMCTIMR_TXLPITRCIM_Pos                    (27U)
-#define ETH_MMCTIMR_TXLPITRCIM_Msk                    (0x1UL << ETH_MMCTIMR_TXLPITRCIM_Pos) /*!< 0x08000000 */
-#define ETH_MMCTIMR_TXLPITRCIM                        ETH_MMCTIMR_TXLPITRCIM_Msk  /* MMC Transmit LPI transition counter interrupt Mask*/
-#define ETH_MMCTIMR_TXLPIUSCIM_Pos                    (26U)
-#define ETH_MMCTIMR_TXLPIUSCIM_Msk                    (0x1UL << ETH_MMCTIMR_TXLPIUSCIM_Pos) /*!< 0x04000000 */
-#define ETH_MMCTIMR_TXLPIUSCIM                        ETH_MMCTIMR_TXLPIUSCIM_Msk  /* MMC Transmit LPI microsecond counter interrupt Mask*/
-#define ETH_MMCTIMR_TXGPKTIM_Pos                      (21U)
-#define ETH_MMCTIMR_TXGPKTIM_Msk                      (0x1UL << ETH_MMCTIMR_TXGPKTIM_Pos) /*!< 0x00200000 */
-#define ETH_MMCTIMR_TXGPKTIM                          ETH_MMCTIMR_TXGPKTIM_Msk  /* MMC Transmit Good Packet Counter Interrupt Mask*/
-#define ETH_MMCTIMR_TXMCOLGPIM_Pos                    (15U)
-#define ETH_MMCTIMR_TXMCOLGPIM_Msk                    (0x1UL << ETH_MMCTIMR_TXMCOLGPIM_Pos) /*!< 0x00008000 */
-#define ETH_MMCTIMR_TXMCOLGPIM                        ETH_MMCTIMR_TXMCOLGPIM_Msk  /* MMC Transmit Multiple Collision Good Packet Counter Interrupt Mask */
-#define ETH_MMCTIMR_TXSCOLGPIM_Pos                    (14U)
-#define ETH_MMCTIMR_TXSCOLGPIM_Msk                    (0x1UL << ETH_MMCTIMR_TXSCOLGPIM_Pos) /*!< 0x00004000 */
-#define ETH_MMCTIMR_TXSCOLGPIM                        ETH_MMCTIMR_TXSCOLGPIM_Msk  /* MMC Transmit Single Collision Good Packet Counter Interrupt Mask */
-
-/* Bit definition for Ethernet MMC Tx Single Collision Good Packets Register */
-#define ETH_MMCTSCGPR_TXSNGLCOLG_Pos                  (0U)
-#define ETH_MMCTSCGPR_TXSNGLCOLG_msk                  (0xFFFFFFFFUL <<  ETH_MMCTSCGPR_TXSNGLCOLG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTSCGPR_TXSNGLCOLG                      ETH_MMCTSCGPR_TXSNGLCOLG_msk /* Tx Single Collision Good Packets */
-
-/* Bit definition for Ethernet MMC Tx Multiple Collision Good Packets Register */
-#define ETH_MMCTMCGPR_TXMULTCOLG_Pos                  (0U)
-#define ETH_MMCTMCGPR_TXMULTCOLG_msk                  (0xFFFFFFFFUL <<  ETH_MMCTMCGPR_TXMULTCOLG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTMCGPR_TXMULTCOLG                      ETH_MMCTMCGPR_TXMULTCOLG_msk /* Tx Multiple Collision Good Packets */
-
-/* Bit definition for Ethernet MMC Tx Packet Count Good Register */
-#define ETH_MMCTPCGR_TXPKTG_Pos                       (0U)
-#define ETH_MMCTPCGR_TXPKTG_msk                       (0xFFFFFFFFUL <<  ETH_MMCTPCGR_TXPKTG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTPCGR_TXPKTG                           ETH_MMCTPCGR_TXPKTG_msk /* Tx Packet Count Good */
-
-/* Bit definition for Ethernet MMC Rx CRC Error Packets Register */
-#define ETH_MMCRCRCEPR_RXCRCERR_Pos                   (0U)
-#define ETH_MMCRCRCEPR_RXCRCERR_msk                   (0xFFFFFFFFUL <<  ETH_MMCRCRCEPR_RXCRCERR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRCRCEPR_RXCRCERR                       ETH_MMCRCRCEPR_RXCRCERR_msk /* Rx CRC Error Packets */
-
-/* Bit definition for Ethernet MMC Rx alignment error packets register */
-#define ETH_MMCRAEPR_RXALGNERR_Pos                    (0U)
-#define ETH_MMCRAEPR_RXALGNERR_msk                    (0xFFFFFFFFUL <<  ETH_MMCRAEPR_RXALGNERR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRAEPR_RXALGNERR                        ETH_MMCRAEPR_RXALGNERR_msk /* Rx Alignment Error Packets */
-
-/* Bit definition for Ethernet MMC Rx Unicast Packets Good Register */
-#define ETH_MMCRUPGR_RXUCASTG_Pos                     (0U)
-#define ETH_MMCRUPGR_RXUCASTG_msk                     (0xFFFFFFFFUL <<  ETH_MMCRUPGR_RXUCASTG_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRUPGR_RXUCASTG                         ETH_MMCRUPGR_RXUCASTG_msk /* Rx Unicast Packets Good */
-
-/* Bit definition for Ethernet MMC Tx LPI Microsecond Timer Register */
-#define ETH_MMCTLPIMSTR_TXLPIUSC_Pos                  (0U)
-#define ETH_MMCTLPIMSTR_TXLPIUSC_msk                  (0xFFFFFFFFUL <<  ETH_MMCTLPIMSTR_TXLPIUSC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTLPIMSTR_TXLPIUSC                      ETH_MMCTLPIMSTR_TXLPIUSC_msk /* Tx LPI Microseconds Counter */
-
-/* Bit definition for Ethernet MMC Tx LPI Transition Counter Register */
-#define ETH_MMCTLPITCR_TXLPITRC_Pos                   (0U)
-#define ETH_MMCTLPITCR_TXLPITRC_msk                   (0xFFFFFFFFUL <<  ETH_MMCTLPITCR_TXLPITRC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCTLPITCR_TXLPITRC                       ETH_MMCTLPITCR_TXLPITRC_msk /* Tx LPI Transition counter */
-
-/* Bit definition for Ethernet MMC Rx LPI Microsecond Counter Register */
-#define ETH_MMCRLPIMSTR_RXLPIUSC_Pos                  (0U)
-#define ETH_MMCRLPIMSTR_RXLPIUSC_msk                  (0xFFFFFFFFUL <<  ETH_MMCRLPIMSTR_RXLPIUSC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRLPIMSTR_RXLPIUSC                      ETH_MMCRLPIMSTR_RXLPIUSC_msk /* Rx LPI Microseconds Counter */
-
-/* Bit definition for Ethernet MMC Rx LPI Transition Counter Register */
-#define ETH_MMCRLPITCR_RXLPITRC_Pos                   (0U)
-#define ETH_MMCRLPITCR_RXLPITRC_msk                   (0xFFFFFFFFUL <<  ETH_MMCRLPITCR_RXLPITRC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MMCRLPITCR_RXLPITRC                       ETH_MMCRLPITCR_RXLPITRC_msk /* Rx LPI Transition counter */
-
-/* Bit definition for Ethernet MAC L3 L4 Control Register */
-#define ETH_MACL3L4CR_L4DPIM_Pos                      (21U)
-#define ETH_MACL3L4CR_L4DPIM_Msk                      (0x1UL << ETH_MACL3L4CR_L4DPIM_Pos) /*!< 0x00200000 */
-#define ETH_MACL3L4CR_L4DPIM                          ETH_MACL3L4CR_L4DPIM_Msk /* Layer 4 Destination Port Inverse Match Enable */
-#define ETH_MACL3L4CR_L4DPM_Pos                       (20U)
-#define ETH_MACL3L4CR_L4DPM_Msk                       (0x1UL << ETH_MACL3L4CR_L4DPM_Pos) /*!< 0x00100000 */
-#define ETH_MACL3L4CR_L4DPM                           ETH_MACL3L4CR_L4DPM_Msk  /* Layer 4 Destination Port Match Enable */
-#define ETH_MACL3L4CR_L4SPIM_Pos                      (19U)
-#define ETH_MACL3L4CR_L4SPIM_Msk                      (0x1UL << ETH_MACL3L4CR_L4SPIM_Pos) /*!< 0x00080000 */
-#define ETH_MACL3L4CR_L4SPIM                          ETH_MACL3L4CR_L4SPIM_Msk /* Layer 4 Source Port Inverse Match Enable */
-#define ETH_MACL3L4CR_L4SPM_Pos                       (18U)
-#define ETH_MACL3L4CR_L4SPM_Msk                       (0x1UL << ETH_MACL3L4CR_L4SPM_Pos) /*!< 0x00040000 */
-#define ETH_MACL3L4CR_L4SPM                           ETH_MACL3L4CR_L4SPM_Msk  /* Layer 4 Source Port Match Enable */
-#define ETH_MACL3L4CR_L4PEN_Pos                       (16U)
-#define ETH_MACL3L4CR_L4PEN_Msk                       (0x1UL << ETH_MACL3L4CR_L4PEN_Pos) /*!< 0x00010000 */
-#define ETH_MACL3L4CR_L4PEN                           ETH_MACL3L4CR_L4PEN_Msk  /* Layer 4 Protocol Enable */
-#define ETH_MACL3L4CR_L3HDBM_Pos                      (11U)
-#define ETH_MACL3L4CR_L3HDBM_Msk                      (0x1FUL << ETH_MACL3L4CR_L3HDBM_Pos) /*!< 0x0000F800 */
-#define ETH_MACL3L4CR_L3HDBM                          ETH_MACL3L4CR_L3HDBM_Msk /* Layer 3 IP DA Higher Bits Match */
-#define ETH_MACL3L4CR_L3HSBM_Pos                      (6U)
-#define ETH_MACL3L4CR_L3HSBM_Msk                      (0x1FUL << ETH_MACL3L4CR_L3HSBM_Pos) /*!< 0x000007C0 */
-#define ETH_MACL3L4CR_L3HSBM                          ETH_MACL3L4CR_L3HSBM_Msk /* Layer 3 IP SA Higher Bits Match */
-#define ETH_MACL3L4CR_L3DAIM_Pos                      (5U)
-#define ETH_MACL3L4CR_L3DAIM_Msk                      (0x1UL << ETH_MACL3L4CR_L3DAIM_Pos) /*!< 0x00000020 */
-#define ETH_MACL3L4CR_L3DAIM                          ETH_MACL3L4CR_L3DAIM_Msk /* Layer 3 IP DA Inverse Match Enable */
-#define ETH_MACL3L4CR_L3DAM_Pos                       (4U)
-#define ETH_MACL3L4CR_L3DAM_Msk                       (0x1UL << ETH_MACL3L4CR_L3DAM_Pos) /*!< 0x00000010 */
-#define ETH_MACL3L4CR_L3DAM                           ETH_MACL3L4CR_L3DAM_Msk  /* Layer 3 IP DA Match Enable */
-#define ETH_MACL3L4CR_L3SAIM_Pos                      (3U)
-#define ETH_MACL3L4CR_L3SAIM_Msk                      (0x1UL << ETH_MACL3L4CR_L3SAIM_Pos) /*!< 0x00000008 */
-#define ETH_MACL3L4CR_L3SAIM                          ETH_MACL3L4CR_L3SAIM_Msk /* Layer 3 IP SA Inverse Match Enable */
-#define ETH_MACL3L4CR_L3SAM_Pos                       (2U)
-#define ETH_MACL3L4CR_L3SAM_Msk                       (0x1UL << ETH_MACL3L4CR_L3SAM_Pos) /*!< 0x00000004 */
-#define ETH_MACL3L4CR_L3SAM                           ETH_MACL3L4CR_L3SAM_Msk  /* Layer 3 IP SA Match Enable*/
-#define ETH_MACL3L4CR_L3PEN_Pos                       (0U)
-#define ETH_MACL3L4CR_L3PEN_Msk                       (0x1UL << ETH_MACL3L4CR_L3PEN_Pos) /*!< 0x00000001 */
-#define ETH_MACL3L4CR_L3PEN                           ETH_MACL3L4CR_L3PEN_Msk  /* Layer 3 Protocol Enable */
-
-/* Bit definition for Ethernet MAC L4 Address Register */
-#define ETH_MACL4AR_L4DP_Pos                          (16U)
-#define ETH_MACL4AR_L4DP_Msk                          (0xFFFFUL << ETH_MACL4AR_L4DP_Pos) /*!< 0xFFFF0000 */
-#define ETH_MACL4AR_L4DP                              ETH_MACL4AR_L4DP_Msk     /* Layer 4 Destination Port Number Field */
-#define ETH_MACL4AR_L4SP_Pos                          (0U)
-#define ETH_MACL4AR_L4SP_Msk                          (0xFFFFUL << ETH_MACL4AR_L4SP_Pos) /*!< 0x0000FFFF */
-#define ETH_MACL4AR_L4SP                              ETH_MACL4AR_L4SP_Msk     /* Layer 4 Source Port Number Field */
-
-/* Bit definition for Ethernet MAC L3 Address0 Register */
-#define ETH_MACL3A0R_L3A0_Pos                         (0U)
-#define ETH_MACL3A0R_L3A0_Msk                         (0xFFFFFFFFUL << ETH_MACL3A0R_L3A0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A0R_L3A0                             ETH_MACL3A0R_L3A0_Msk    /* Layer 3 Address 0 Field */
-
-/* Bit definition for Ethernet MAC L4 Address1 Register */
-#define ETH_MACL3A1R_L3A1_Pos                         (0U)
-#define ETH_MACL3A1R_L3A1_Msk                         (0xFFFFFFFFUL << ETH_MACL3A1R_L3A1_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A1R_L3A1                             ETH_MACL3A1R_L3A1_Msk    /* Layer 3 Address 1 Field */
-
-/* Bit definition for Ethernet MAC L4 Address2 Register */
-#define ETH_MACL3A2R_L3A2_Pos                         (0U)
-#define ETH_MACL3A2R_L3A2_Msk                         (0xFFFFFFFFUL << ETH_MACL3A2R_L3A2_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A2R_L3A2                             ETH_MACL3A2R_L3A2_Msk    /* Layer 3 Address 2 Field */
-
-/* Bit definition for Ethernet MAC L4 Address3 Register */
-#define ETH_MACL3A3R_L3A3_Pos                         (0U)
-#define ETH_MACL3A3R_L3A3_Msk                         (0xFFFFFFFFUL << ETH_MACL3A3R_L3A3_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACL3A3R_L3A3                             ETH_MACL3A3R_L3A3_Msk    /* Layer 3 Address 3 Field */
-
-/* Bit definition for Ethernet MAC Timestamp Control Register */
-#define ETH_MACTSCR_TXTSSTSM_Pos                      (24U)
-#define ETH_MACTSCR_TXTSSTSM_Msk                      (0x1UL << ETH_MACTSCR_TXTSSTSM_Pos) /*!< 0x01000000 */
-#define ETH_MACTSCR_TXTSSTSM                          ETH_MACTSCR_TXTSSTSM_Msk  /* Transmit Timestamp Status Mode */
-#define ETH_MACTSCR_CSC_Pos                           (19U)
-#define ETH_MACTSCR_CSC_Msk                           (0x1UL << ETH_MACTSCR_CSC_Pos) /*!< 0x00080000 */
-#define ETH_MACTSCR_CSC                               ETH_MACTSCR_CSC_Msk  /* Enable checksum correction during OST for PTP over UDP/IPv4 packets */
-#define ETH_MACTSCR_TSENMACADDR_Pos                   (18U)
-#define ETH_MACTSCR_TSENMACADDR_Msk                   (0x1UL << ETH_MACTSCR_TSENMACADDR_Pos) /*!< 0x00040000 */
-#define ETH_MACTSCR_TSENMACADDR                       ETH_MACTSCR_TSENMACADDR_Msk  /* Enable MAC Address for PTP Packet Filtering */
-#define ETH_MACTSCR_SNAPTYPSEL_Pos                    (16U)
-#define ETH_MACTSCR_SNAPTYPSEL_Msk                    (0x3UL << ETH_MACTSCR_SNAPTYPSEL_Pos) /*!< 0x00030000 */
-#define ETH_MACTSCR_SNAPTYPSEL                        ETH_MACTSCR_SNAPTYPSEL_Msk  /* Select PTP packets for Taking Snapshots */
-#define ETH_MACTSCR_TSMSTRENA_Pos                     (15U)
-#define ETH_MACTSCR_TSMSTRENA_Msk                     (0x1UL << ETH_MACTSCR_TSMSTRENA_Pos) /*!< 0x00008000 */
-#define ETH_MACTSCR_TSMSTRENA                         ETH_MACTSCR_TSMSTRENA_Msk  /* Enable Snapshot for Messages Relevant to Master */
-#define ETH_MACTSCR_TSEVNTENA_Pos                     (14U)
-#define ETH_MACTSCR_TSEVNTENA_Msk                     (0x1UL << ETH_MACTSCR_TSEVNTENA_Pos) /*!< 0x00004000 */
-#define ETH_MACTSCR_TSEVNTENA                         ETH_MACTSCR_TSEVNTENA_Msk  /* Enable Timestamp Snapshot for Event Messages */
-#define ETH_MACTSCR_TSIPV4ENA_Pos                     (13U)
-#define ETH_MACTSCR_TSIPV4ENA_Msk                     (0x1UL << ETH_MACTSCR_TSIPV4ENA_Pos) /*!< 0x00002000 */
-#define ETH_MACTSCR_TSIPV4ENA                         ETH_MACTSCR_TSIPV4ENA_Msk  /* Enable Processing of PTP Packets Sent over IPv4-UDP */
-#define ETH_MACTSCR_TSIPV6ENA_Pos                     (12U)
-#define ETH_MACTSCR_TSIPV6ENA_Msk                     (0x1UL << ETH_MACTSCR_TSIPV6ENA_Pos) /*!< 0x00001000 */
-#define ETH_MACTSCR_TSIPV6ENA                         ETH_MACTSCR_TSIPV6ENA_Msk  /* Enable Processing of PTP Packets Sent over IPv6-UDP */
-#define ETH_MACTSCR_TSIPENA_Pos                       (11U)
-#define ETH_MACTSCR_TSIPENA_Msk                       (0x1UL << ETH_MACTSCR_TSIPENA_Pos) /*!< 0x00000800 */
-#define ETH_MACTSCR_TSIPENA                           ETH_MACTSCR_TSIPENA_Msk  /* Enable Processing of PTP over Ethernet Packets */
-#define ETH_MACTSCR_TSVER2ENA_Pos                     (10U)
-#define ETH_MACTSCR_TSVER2ENA_Msk                     (0x1UL << ETH_MACTSCR_TSVER2ENA_Pos) /*!< 0x00000400 */
-#define ETH_MACTSCR_TSVER2ENA                         ETH_MACTSCR_TSVER2ENA_Msk  /* Enable PTP Packet Processing for Version 2 Format */
-#define ETH_MACTSCR_TSCTRLSSR_Pos                     (9U)
-#define ETH_MACTSCR_TSCTRLSSR_Msk                     (0x1UL << ETH_MACTSCR_TSCTRLSSR_Pos) /*!< 0x00000200 */
-#define ETH_MACTSCR_TSCTRLSSR                         ETH_MACTSCR_TSCTRLSSR_Msk  /* Timestamp Digital or Binary Rollover Control */
-#define ETH_MACTSCR_TSENALL_Pos                       (8U)
-#define ETH_MACTSCR_TSENALL_Msk                       (0x1UL << ETH_MACTSCR_TSENALL_Pos) /*!< 0x00000100 */
-#define ETH_MACTSCR_TSENALL                           ETH_MACTSCR_TSENALL_Msk  /* Enable Timestamp for All Packets */
-#define ETH_MACTSCR_TSADDREG_Pos                      (5U)
-#define ETH_MACTSCR_TSADDREG_Msk                      (0x1UL << ETH_MACTSCR_TSADDREG_Pos) /*!< 0x00000020 */
-#define ETH_MACTSCR_TSADDREG                          ETH_MACTSCR_TSADDREG_Msk  /* Update Addend Register */
-#define ETH_MACTSCR_TSUPDT_Pos                        (3U)
-#define ETH_MACTSCR_TSUPDT_Msk                        (0x1UL << ETH_MACTSCR_TSUPDT_Pos) /*!< 0x00000008 */
-#define ETH_MACTSCR_TSUPDT                            ETH_MACTSCR_TSUPDT_Msk  /* Update Timestamp */
-#define ETH_MACTSCR_TSINIT_Pos                        (2U)
-#define ETH_MACTSCR_TSINIT_Msk                        (0x1UL << ETH_MACTSCR_TSINIT_Pos) /*!< 0x00000004 */
-#define ETH_MACTSCR_TSINIT                             ETH_MACTSCR_TSINIT_Msk  /* Initialize Timestamp */
-#define ETH_MACTSCR_TSCFUPDT_Pos                      (1U)
-#define ETH_MACTSCR_TSCFUPDT_Msk                      (0x1UL << ETH_MACTSCR_TSCFUPDT_Pos) /*!< 0x00000002 */
-#define ETH_MACTSCR_TSCFUPDT                          ETH_MACTSCR_TSCFUPDT_Msk  /* Fine or Coarse Timestamp Update*/
-#define ETH_MACTSCR_TSENA_Pos                         (0U)
-#define ETH_MACTSCR_TSENA_Msk                         (0x1UL << ETH_MACTSCR_TSENA_Pos) /*!< 0x00000001 */
-#define ETH_MACTSCR_TSENA                             ETH_MACTSCR_TSENA_Msk  /* Enable Timestamp */
-
-/* Bit definition for Ethernet MAC Sub-second Increment Register */
-#define ETH_MACMACSSIR_SSINC_Pos                      (16U)
-#define ETH_MACMACSSIR_SSINC_Msk                      (0xFFUL << ETH_MACMACSSIR_SSINC_Pos) /*!< 0x0000FF00 */
-#define ETH_MACMACSSIR_SSINC                          ETH_MACMACSSIR_SSINC_Msk  /* Sub-second Increment Value */
-#define ETH_MACMACSSIR_SNSINC_Pos                     (8U)
-#define ETH_MACMACSSIR_SNSINC_Msk                     (0xFFUL << ETH_MACMACSSIR_SNSINC_Pos) /*!< 0x000000FF */
-#define ETH_MACMACSSIR_SNSINC                         ETH_MACMACSSIR_SNSINC_Msk  /* Sub-nanosecond Increment Value */
-
-/* Bit definition for Ethernet MAC System Time Seconds Register */
-#define ETH_MACSTSR_TSS_Pos                           (0U)
-#define ETH_MACSTSR_TSS_Msk                           (0xFFFFFFFFUL << ETH_MACSTSR_TSS_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSTSR_TSS                               ETH_MACSTSR_TSS_Msk  /* Timestamp Second */
-
-/* Bit definition for Ethernet MAC System Time Nanoseconds Register */
-#define ETH_MACSTNR_TSSS_Pos                          (0U)
-#define ETH_MACSTNR_TSSS_Msk                          (0x7FFFFFFFUL << ETH_MACSTNR_TSSS_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACSTNR_TSSS                              ETH_MACSTNR_TSSS_Msk  /* Timestamp Sub-seconds */
-
-/* Bit definition for Ethernet MAC System Time Seconds Update Register */
-#define ETH_MACSTSUR_TSS_Pos                          (0U)
-#define ETH_MACSTSUR_TSS_Msk                          (0xFFFFFFFFUL << ETH_MACSTSUR_TSS_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSTSUR_TSS                              ETH_MACSTSUR_TSS_Msk  /* Timestamp Seconds */
-
-/* Bit definition for Ethernet MAC System Time Nanoseconds Update Register */
-#define ETH_MACSTNUR_ADDSUB_Pos                       (31U)
-#define ETH_MACSTNUR_ADDSUB_Msk                       (0x1UL << ETH_MACSTNUR_ADDSUB_Pos) /*!< 0x80000000 */
-#define ETH_MACSTNUR_ADDSUB                           ETH_MACSTNUR_ADDSUB_Msk  /* Add or Subtract Time */
-#define ETH_MACSTNUR_TSSS_Pos                         (0U)
-#define ETH_MACSTNUR_TSSS_Msk                         (0x7FFFFFFFUL << ETH_MACSTNUR_TSSS_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACSTNUR_TSSS                             ETH_MACSTNUR_TSSS_Msk  /* Timestamp Sub-seconds */
-
-/* Bit definition for Ethernet MAC Timestamp Addend Register */
-#define ETH_MACTSAR_TSAR_Pos                          (0U)
-#define ETH_MACTSAR_TSAR_Msk                          (0xFFFFFFFFUL << ETH_MACTSAR_TSAR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSAR_TSAR                              ETH_MACTSAR_TSAR_Msk  /* Timestamp Addend Register */
-
-/* Bit definition for Ethernet MAC Timestamp Status Register */
-#define ETH_MACTSSR_ATSNS_Pos                         (25U)
-#define ETH_MACTSSR_ATSNS_Msk                         (0x1FUL << ETH_MACTSSR_ATSNS_Pos) /*!< 0x3E000000 */
-#define ETH_MACTSSR_ATSNS                             ETH_MACTSSR_ATSNS_Msk  /* Number of Auxiliary Timestamp Snapshots */
-#define ETH_MACTSSR_ATSSTM_Pos                        (24U)
-#define ETH_MACTSSR_ATSSTM_Msk                        (0x1UL << ETH_MACTSSR_ATSSTM_Pos) /*!< 0x01000000 */
-#define ETH_MACTSSR_ATSSTM                            ETH_MACTSSR_ATSSTM_Msk  /* Auxiliary Timestamp Snapshot Trigger Missed */
-#define ETH_MACTSSR_ATSSTN_Pos                        (16U)
-#define ETH_MACTSSR_ATSSTN_Msk                        (0xFUL << ETH_MACTSSR_ATSSTN_Pos) /*!< 0x000F0000 */
-#define ETH_MACTSSR_ATSSTN                            ETH_MACTSSR_ATSSTN_Msk  /* Auxiliary Timestamp Snapshot Trigger Identifier */
-#define ETH_MACTSSR_TXTSSIS_Pos                       (15U)
-#define ETH_MACTSSR_TXTSSIS_Msk                       (0x1UL << ETH_MACTSSR_TXTSSIS_Pos) /*!< 0x00008000 */
-#define ETH_MACTSSR_TXTSSIS                           ETH_MACTSSR_TXTSSIS_Msk  /* Tx Timestamp Status Interrupt Status */
-#define ETH_MACTSSR_TSTRGTERR0_Pos                    (3U)
-#define ETH_MACTSSR_TSTRGTERR0_Msk                    (0x1UL << ETH_MACTSSR_TSTRGTERR0_Pos) /*!< 0x00000008 */
-#define ETH_MACTSSR_TSTRGTERR0                        ETH_MACTSSR_TSTRGTERR0_Msk  /* Timestamp Target Time Error */
-#define ETH_MACTSSR_AUXTSTRIG_Pos                     (2U)
-#define ETH_MACTSSR_AUXTSTRIG_Msk                     (0x1UL << ETH_MACTSSR_AUXTSTRIG_Pos) /*!< 0x00000004 */
-#define ETH_MACTSSR_AUXTSTRIG                         ETH_MACTSSR_AUXTSTRIG_Msk  /* Auxiliary Timestamp Trigger Snapshot*/
-#define ETH_MACTSSR_TSTARGT0_Pos                      (1U)
-#define ETH_MACTSSR_TSTARGT0_Msk                      (0x1UL << ETH_MACTSSR_TSTARGT0_Pos) /*!< 0x00000002 */
-#define ETH_MACTSSR_TSTARGT0                          ETH_MACTSSR_TSTARGT0_Msk  /* Timestamp Target Time Reached */
-#define ETH_MACTSSR_TSSOVF_Pos                        (0U)
-#define ETH_MACTSSR_TSSOVF_Msk                        (0x1UL << ETH_MACTSSR_TSSOVF_Pos) /*!< 0x00000001 */
-#define ETH_MACTSSR_TSSOVF                            ETH_MACTSSR_TSSOVF_Msk  /* Timestamp Seconds Overflow */
-
-/* Bit definition for Ethernet MAC Tx Timestamp Status Nanoseconds Register */
-#define ETH_MACTTSSNR_TXTSSMIS_Pos                    (31U)
-#define ETH_MACTTSSNR_TXTSSMIS_Msk                    (0x1UL << ETH_MACTTSSNR_TXTSSMIS_Pos) /*!< 0x80000000 */
-#define ETH_MACTTSSNR_TXTSSMIS                        ETH_MACTTSSNR_TXTSSMIS_Msk  /* Transmit Timestamp Status Missed */
-#define ETH_MACTTSSNR_TXTSSLO_Pos                     (0U)
-#define ETH_MACTTSSNR_TXTSSLO_Msk                     (0x7FFFFFFFUL << ETH_MACTTSSNR_TXTSSLO_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACTTSSNR_TXTSSLO                         ETH_MACTTSSNR_TXTSSLO_Msk  /* Transmit Timestamp Status Low */
-
-/* Bit definition for Ethernet MAC Tx Timestamp Status Seconds Register */
-#define ETH_MACTTSSSR_TXTSSHI_Pos                     (0U)
-#define ETH_MACTTSSSR_TXTSSHI_Msk                     (0xFFFFFFFFUL << ETH_MACTTSSSR_TXTSSHI_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTTSSSR_TXTSSHI                         ETH_MACTTSSSR_TXTSSHI_Msk  /* Transmit Timestamp Status High */
-
-/* Bit definition for Ethernet MAC Auxiliary Control Register*/
-#define ETH_MACACR_ATSEN3_Pos                         (7U)
-#define ETH_MACACR_ATSEN3_Msk                         (0x1UL << ETH_MACACR_ATSEN3_Pos) /*!< 0x00000080 */
-#define ETH_MACACR_ATSEN3                             ETH_MACACR_ATSEN3_Msk  /* Auxiliary Snapshot 3 Enable */
-#define ETH_MACACR_ATSEN2_Pos                         (6U)
-#define ETH_MACACR_ATSEN2_Msk                         (0x1UL << ETH_MACACR_ATSEN2_Pos) /*!< 0x00000040 */
-#define ETH_MACACR_ATSEN2                             ETH_MACACR_ATSEN2_Msk  /* Auxiliary Snapshot 2 Enable */
-#define ETH_MACACR_ATSEN1_Pos                         (5U)
-#define ETH_MACACR_ATSEN1_Msk                         (0x1UL << ETH_MACACR_ATSEN1_Pos) /*!< 0x00000020 */
-#define ETH_MACACR_ATSEN1                             ETH_MACACR_ATSEN1_Msk  /* Auxiliary Snapshot 1 Enable */
-#define ETH_MACACR_ATSEN0_Pos                         (4U)
-#define ETH_MACACR_ATSEN0_Msk                         (0x1UL << ETH_MACACR_ATSEN0_Pos) /*!< 0x00000010 */
-#define ETH_MACACR_ATSEN0                             ETH_MACACR_ATSEN0_Msk  /* Auxiliary Snapshot 0 Enable */
-#define ETH_MACACR_ATSFC_Pos                          (0U)
-#define ETH_MACACR_ATSFC_Msk                          (0x1UL << ETH_MACACR_ATSFC_Pos) /*!< 0x00000001 */
-#define ETH_MACACR_ATSFC                              ETH_MACACR_ATSFC_Msk  /* Auxiliary Snapshot FIFO Clear */
-
-/* Bit definition for Ethernet MAC Auxiliary Timestamp Nanoseconds Register */
-#define ETH_MACATSNR_AUXTSLO_Pos                      (0U)
-#define ETH_MACATSNR_AUXTSLO_Msk                      (0x7FFFFFFFUL << ETH_MACATSNR_AUXTSLO_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACATSNR_AUXTSLO                          ETH_MACATSNR_AUXTSLO_Msk  /* Auxiliary Timestamp */
-
-/* Bit definition for Ethernet MAC Auxiliary Timestamp Seconds Register */
-#define ETH_MACATSSR_AUXTSHI_Pos                      (0U)
-#define ETH_MACATSSR_AUXTSHI_Msk                      (0xFFFFFFFFUL << ETH_MACATSSR_AUXTSHI_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACATSSR_AUXTSHI                          ETH_MACATSSR_AUXTSHI_Msk  /* Auxiliary Timestamp */
-
-/* Bit definition for Ethernet MAC Timestamp Ingress Asymmetric Correction Register */
-#define ETH_MACTSIACR_OSTIAC_Pos                      (0U)
-#define ETH_MACTSIACR_OSTIAC_Msk                      (0xFFFFFFFFUL << ETH_MACTSIACR_OSTIAC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSIACR_OSTIAC                          ETH_MACTSIACR_OSTIAC_Msk  /* One-Step Timestamp Ingress Asymmetry Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Egress Asymmetric Correction Register */
-#define ETH_MACTSEACR_OSTEAC_Pos                      (0U)
-#define ETH_MACTSEACR_OSTEAC_Msk                      (0xFFFFFFFFUL << ETH_MACTSEACR_OSTEAC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSEACR_OSTEAC                          ETH_MACTSEACR_OSTEAC_Msk  /* One-Step Timestamp Egress Asymmetry Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Ingress Correction Nanosecond Register */
-#define ETH_MACTSICNR_TSIC_Pos                        (0U)
-#define ETH_MACTSICNR_TSIC_Msk                        (0xFFFFFFFFUL << ETH_MACTSICNR_TSIC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSICNR_TSIC                            ETH_MACTSICNR_TSIC_Msk  /* Timestamp Ingress Correction */
-
-/* Bit definition for Ethernet MAC Timestamp Egress correction Nanosecond Register */
-#define ETH_MACTSECNR_TSEC_Pos                        (0U)
-#define ETH_MACTSECNR_TSEC_Msk                        (0xFFFFFFFFUL << ETH_MACTSECNR_TSEC_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACTSECNR_TSEC                            ETH_MACTSECNR_TSEC_Msk  /* Timestamp Egress Correction */
-
-/* Bit definition for Ethernet MAC PPS Control Register */
-#define ETH_MACPPSCR_TRGTMODSEL0_Pos                  (5U)
-#define ETH_MACPPSCR_TRGTMODSEL0_Msk                  (0x3UL << ETH_MACPPSCR_TRGTMODSEL0_Pos) /*!< 0x00000060 */
-#define ETH_MACPPSCR_TRGTMODSEL0                      ETH_MACPPSCR_TRGTMODSEL0_Msk  /* Target Time Register Mode for PPS Output */
-#define ETH_MACPPSCR_PPSEN0_Pos                       (4U)
-#define ETH_MACPPSCR_PPSEN0_Msk                       (0x1UL << ETH_MACPPSCR_PPSEN0_Pos) /*!< 0x00000010 */
-#define ETH_MACPPSCR_PPSEN0                           ETH_MACPPSCR_PPSEN0_Msk  /* Flexible PPS Output Mode Enable */
-#define ETH_MACPPSCR_PPSCTRL_Pos                      (0U)
-#define ETH_MACPPSCR_PPSCTRL_Msk                      (0xFUL << ETH_MACPPSCR_PPSCTRL_Pos) /*!< 0x0000000F */
-#define ETH_MACPPSCR_PPSCTRL                          ETH_MACPPSCR_PPSCTRL_Msk  /* PPS Output Frequency Control */
-
-/* Bit definition for Ethernet MAC PPS Target Time Seconds Register */
-#define ETH_MACPPSTTSR_TSTRH0_Pos                     (0U)
-#define ETH_MACPPSTTSR_TSTRH0_Msk                     (0xFFFFFFFFUL << ETH_MACPPSTTSR_TSTRH0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSTTSR_TSTRH0                         ETH_MACPPSTTSR_TSTRH0_Msk  /* PPS Target Time Seconds Register */
-
-/* Bit definition for Ethernet MAC PPS Target Time Nanoseconds Register */
-#define ETH_MACPPSTTNR_TRGTBUSY0_Pos                  (31U)
-#define ETH_MACPPSTTNR_TRGTBUSY0_Msk                  (0x1UL << ETH_MACPPSTTNR_TRGTBUSY0_Pos) /*!< 0x80000000 */
-#define ETH_MACPPSTTNR_TRGTBUSY0                      ETH_MACPPSTTNR_TRGTBUSY0_Msk  /* PPS Target Time Register Busy */
-#define ETH_MACPPSTTNR_TTSL0_Pos                      (0U)
-#define ETH_MACPPSTTNR_TTSL0_Msk                      (0x7FFFFFFFUL << ETH_MACPPSTTNR_TTSL0_Pos) /*!< 0x7FFFFFFF */
-#define ETH_MACPPSTTNR_TTSL0                          ETH_MACPPSTTNR_TTSL0_Msk  /* Target Time Low for PPS Register */
-
-/* Bit definition for Ethernet MAC PPS Interval Register */
-#define ETH_MACPPSIR_PPSINT0_Pos                      (0U)
-#define ETH_MACPPSIR_PPSINT0_Msk                      (0xFFFFFFFFUL << ETH_MACPPSIR_PPSINT0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSIR_PPSINT0                          ETH_MACPPSIR_PPSINT0_Msk  /* PPS Output Signal Interval */
-
-/* Bit definition for Ethernet MAC PPS Width Register */
-#define ETH_MACPPSWR_PPSWIDTH0_Pos                    (0U)
-#define ETH_MACPPSWR_PPSWIDTH0_Msk                    (0xFFFFFFFFUL << ETH_MACPPSWR_PPSWIDTH0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACPPSWR_PPSWIDTH0                        ETH_MACPPSWR_PPSWIDTH0_Msk  /* PPS Output Signal Width */
-
-/* Bit definition for Ethernet MAC PTP Offload Control Register */
-#define ETH_MACPOCR_DN_Pos                            (8U)
-#define ETH_MACPOCR_DN_Msk                            (0xFFUL << ETH_MACPOCR_DN_Pos) /*!< 0x0000FF00 */
-#define ETH_MACPOCR_DN                                ETH_MACPOCR_DN_Msk  /* Domain Number */
-#define ETH_MACPOCR_DRRDIS_Pos                        (6U)
-#define ETH_MACPOCR_DRRDIS_Msk                        (0x1UL << ETH_MACPOCR_DRRDIS_Pos) /*!< 0x00000040 */
-#define ETH_MACPOCR_DRRDIS                            ETH_MACPOCR_DRRDIS_Msk  /* Disable PTO Delay Request/Response response generation */
-#define ETH_MACPOCR_APDREQTRIG_Pos                    (5U)
-#define ETH_MACPOCR_APDREQTRIG_Msk                    (0x1UL << ETH_MACPOCR_APDREQTRIG_Pos) /*!< 0x00000020 */
-#define ETH_MACPOCR_APDREQTRIG                        ETH_MACPOCR_APDREQTRIG_Msk  /* Automatic PTP Pdelay_Req message Trigger */
-#define ETH_MACPOCR_ASYNCTRIG_Pos                     (4U)
-#define ETH_MACPOCR_ASYNCTRIG_Msk                     (0x1UL << ETH_MACPOCR_ASYNCTRIG_Pos) /*!< 0x00000010 */
-#define ETH_MACPOCR_ASYNCTRIG                         ETH_MACPOCR_ASYNCTRIG_Msk  /* Automatic PTP SYNC message Trigger */
-#define ETH_MACPOCR_APDREQEN_Pos                      (2U)
-#define ETH_MACPOCR_APDREQEN_Msk                      (0x1UL << ETH_MACPOCR_APDREQEN_Pos) /*!< 0x00000004 */
-#define ETH_MACPOCR_APDREQEN                          ETH_MACPOCR_APDREQEN_Msk  /* Automatic PTP Pdelay_Req message Enable */
-#define ETH_MACPOCR_ASYNCEN_Pos                       (1U)
-#define ETH_MACPOCR_ASYNCEN_Msk                       (0x1UL << ETH_MACPOCR_ASYNCEN_Pos) /*!< 0x00000002 */
-#define ETH_MACPOCR_ASYNCEN                           ETH_MACPOCR_ASYNCEN_Msk  /* Automatic PTP SYNC message Enable */
-#define ETH_MACPOCR_PTOEN_Pos                         (0U)
-#define ETH_MACPOCR_PTOEN_Msk                         (0x1UL << ETH_MACPOCR_PTOEN_Pos) /*!< 0x00000001 */
-#define ETH_MACPOCR_PTOEN                             ETH_MACPOCR_PTOEN_Msk  /* PTP Offload Enable */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 0 Register */
-#define ETH_MACSPI0R_SPI0_Pos                         (0U)
-#define ETH_MACSPI0R_SPI0_Msk                         (0xFFFFFFFFUL << ETH_MACSPI0R_SPI0_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSPI0R_SPI0                             ETH_MACSPI0R_SPI0_Msk  /* Source Port Identity 0 */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 1 Register */
-#define ETH_MACSPI1R_SPI1_Pos                         (0U)
-#define ETH_MACSPI1R_SPI1_Msk                         (0xFFFFFFFFUL << ETH_MACSPI1R_SPI1_Pos) /*!< 0xFFFFFFFF */
-#define ETH_MACSPI1R_SPI1                             ETH_MACSPI1R_SPI1_Msk  /* Source Port Identity 1 */
-
-/* Bit definition for Ethernet MAC PTP Source Port Identity 2 Register */
-#define ETH_MACSPI2R_SPI2_Pos                         (0U)
-#define ETH_MACSPI2R_SPI2_Msk                         (0xFFFFUL << ETH_MACSPI2R_SPI2_Pos) /*!< 0x0000FFFF */
-#define ETH_MACSPI2R_SPI2                             ETH_MACSPI2R_SPI2_Msk  /* Source Port Identity 2 */
-
-/* Bit definition for Ethernet MAC Log Message Interval Register */
-#define ETH_MACLMIR_LMPDRI_Pos                        (24U)
-#define ETH_MACLMIR_LMPDRI_Msk                        (0xFFUL << ETH_MACLMIR_LMPDRI_Pos) /*!< 0xFF000000 */
-#define ETH_MACLMIR_LMPDRI                             ETH_MACLMIR_LMPDRI_Msk  /* Log Min Pdelay_Req Interval */
-#define ETH_MACLMIR_DRSYNCR_Pos                       (8U)
-#define ETH_MACLMIR_DRSYNCR_Msk                       (0x7UL << ETH_MACLMIR_DRSYNCR_Pos) /*!< 0x00000700 */
-#define ETH_MACLMIR_DRSYNCR                           ETH_MACLMIR_DRSYNCR_Msk  /* Delay_Req to SYNC Ratio */
-#define ETH_MACLMIR_LSI_Pos                           (0U)
-#define ETH_MACLMIR_LSI_Msk                           (0xFFUL << ETH_MACLMIR_LSI_Pos) /*!< 0x000000FF */
-#define ETH_MACLMIR_LSI                               ETH_MACLMIR_LSI_Msk  /* Log Sync Interval */
-
-/* Bit definition for Ethernet MTL Operation Mode Register */
-#define ETH_MTLOMR_CNTCLR_Pos                         (9U)
-#define ETH_MTLOMR_CNTCLR_Msk                         (0x1UL << ETH_MTLOMR_CNTCLR_Pos) /*!< 0x00000200 */
-#define ETH_MTLOMR_CNTCLR                             ETH_MTLOMR_CNTCLR_Msk    /* Counters Reset */
-#define ETH_MTLOMR_CNTPRST_Pos                        (8U)
-#define ETH_MTLOMR_CNTPRST_Msk                        (0x1UL << ETH_MTLOMR_CNTPRST_Pos) /*!< 0x00000100 */
-#define ETH_MTLOMR_CNTPRST                            ETH_MTLOMR_CNTPRST_Msk   /* Counters Preset */
-#define ETH_MTLOMR_DTXSTS_Pos                         (1U)
-#define ETH_MTLOMR_DTXSTS_Msk                         (0x1UL << ETH_MTLOMR_DTXSTS_Pos) /*!< 0x00000002 */
-#define ETH_MTLOMR_DTXSTS                             ETH_MTLOMR_DTXSTS_Msk  /* Drop Transmit Status */
-
-/* Bit definition for Ethernet MTL Interrupt Status Register */
-#define ETH_MTLISR_MACIS_Pos                          (16U)
-#define ETH_MTLISR_MACIS_Msk                          (0x1UL << ETH_MTLISR_MACIS_Pos) /*!< 0x00010000 */
-#define ETH_MTLISR_MACIS                              ETH_MTLISR_MACIS_Msk     /* MAC Interrupt Status */
-#define ETH_MTLISR_QIS_Pos                            (0U)
-#define ETH_MTLISR_QIS_Msk                            (0x1UL << ETH_MTLISR_QIS_Pos) /*!< 0x00000001 */
-#define ETH_MTLISR_QIS                                ETH_MTLISR_QIS_Msk       /* Queue Interrupt status */
-
-/* Bit definition for Ethernet MTL Tx Queue Operation Mode Register */
-#define ETH_MTLTQOMR_TTC_Pos                          (4U)
-#define ETH_MTLTQOMR_TTC_Msk                          (0x7UL << ETH_MTLTQOMR_TTC_Pos) /*!< 0x00000070 */
-#define ETH_MTLTQOMR_TTC                              ETH_MTLTQOMR_TTC_Msk     /* Transmit Threshold Control */
-#define ETH_MTLTQOMR_TTC_32BITS                       ((uint32_t)0x00000000)   /* 32 bits Threshold */
-#define ETH_MTLTQOMR_TTC_64BITS                       ((uint32_t)0x00000010)   /* 64  bits Threshold */
-#define ETH_MTLTQOMR_TTC_96BITS                       ((uint32_t)0x00000020)   /* 96 bits Threshold */
-#define ETH_MTLTQOMR_TTC_128BITS                      ((uint32_t)0x00000030)   /* 128 bits Threshold */
-#define ETH_MTLTQOMR_TTC_192BITS                      ((uint32_t)0x00000040)   /* 192 bits Threshold */
-#define ETH_MTLTQOMR_TTC_256BITS                      ((uint32_t)0x00000050)   /* 256 bits Threshold */
-#define ETH_MTLTQOMR_TTC_384BITS                      ((uint32_t)0x00000060)   /* 384 bits Threshold */
-#define ETH_MTLTQOMR_TTC_512BITS                      ((uint32_t)0x00000070)   /* 512 bits Threshold */
-#define ETH_MTLTQOMR_TSF_Pos                          (1U)
-#define ETH_MTLTQOMR_TSF_Msk                          (0x1UL << ETH_MTLTQOMR_TSF_Pos) /*!< 0x00000002 */
-#define ETH_MTLTQOMR_TSF                              ETH_MTLTQOMR_TSF_Msk     /* Transmit Store and Forward */
-#define ETH_MTLTQOMR_FTQ_Pos                          (0U)
-#define ETH_MTLTQOMR_FTQ_Msk                          (0x1UL << ETH_MTLTQOMR_FTQ_Pos) /*!< 0x00000001 */
-#define ETH_MTLTQOMR_FTQ                              ETH_MTLTQOMR_FTQ_Msk     /* Flush Transmit Queue */
-
-/* Bit definition for Ethernet MTL Tx Queue Underflow Register */
-#define ETH_MTLTQUR_UFCNTOVF_Pos                      (11U)
-#define ETH_MTLTQUR_UFCNTOVF_Msk                      (0x1UL << ETH_MTLTQUR_UFCNTOVF_Pos) /*!< 0x00000800 */
-#define ETH_MTLTQUR_UFCNTOVF                          ETH_MTLTQUR_UFCNTOVF_Msk /* Overflow Bit for Underflow Packet Counter */
-#define ETH_MTLTQUR_UFPKTCNT_Pos                      (0U)
-#define ETH_MTLTQUR_UFPKTCNT_Msk                      (0x7FFUL << ETH_MTLTQUR_UFPKTCNT_Pos) /*!< 0x000007FF */
-#define ETH_MTLTQUR_UFPKTCNT                          ETH_MTLTQUR_UFPKTCNT_Msk /* Underflow Packet Counter */
-
-/* Bit definition for Ethernet MTL Tx Queue Debug Register */
-#define ETH_MTLTQDR_STXSTSF_Pos                       (20U)
-#define ETH_MTLTQDR_STXSTSF_Msk                       (0x7UL << ETH_MTLTQDR_STXSTSF_Pos) /*!< 0x00700000 */
-#define ETH_MTLTQDR_STXSTSF                           ETH_MTLTQDR_STXSTSF_Msk  /* Number of Status Words in the Tx Status FIFO of Queue */
-#define ETH_MTLTQDR_PTXQ_Pos                          (16U)
-#define ETH_MTLTQDR_PTXQ_Msk                          (0x7UL << ETH_MTLTQDR_PTXQ_Pos) /*!< 0x00070000 */
-#define ETH_MTLTQDR_PTXQ                              ETH_MTLTQDR_PTXQ_Msk     /* Number of Packets in the Transmit Queue */
-#define ETH_MTLTQDR_TXSTSFSTS_Pos                     (5U)
-#define ETH_MTLTQDR_TXSTSFSTS_Msk                     (0x1UL << ETH_MTLTQDR_TXSTSFSTS_Pos) /*!< 0x00000020 */
-#define ETH_MTLTQDR_TXSTSFSTS                         ETH_MTLTQDR_TXSTSFSTS_Msk /* MTL Tx Status FIFO Full Status */
-#define ETH_MTLTQDR_TXQSTS_Pos                        (4U)
-#define ETH_MTLTQDR_TXQSTS_Msk                        (0x1UL << ETH_MTLTQDR_TXQSTS_Pos) /*!< 0x00000010 */
-#define ETH_MTLTQDR_TXQSTS                            ETH_MTLTQDR_TXQSTS_Msk   /* MTL Tx Queue Not Empty Status */
-#define ETH_MTLTQDR_TWCSTS_Pos                        (3U)
-#define ETH_MTLTQDR_TWCSTS_Msk                        (0x1UL << ETH_MTLTQDR_TWCSTS_Pos) /*!< 0x00000008 */
-#define ETH_MTLTQDR_TWCSTS                            ETH_MTLTQDR_TWCSTS_Msk   /* MTL Tx Queue Write Controller Status */
-#define ETH_MTLTQDR_TRCSTS_Pos                        (1U)
-#define ETH_MTLTQDR_TRCSTS_Msk                        (0x3UL << ETH_MTLTQDR_TRCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MTLTQDR_TRCSTS                            ETH_MTLTQDR_TRCSTS_Msk  /* MTL Tx Queue Read Controller Status */
-#define ETH_MTLTQDR_TRCSTS_IDLE                       ((uint32_t)0x00000000)  /* Idle state */
-#define ETH_MTLTQDR_TRCSTS_READ                       ((uint32_t)0x00000002)  /* Read state (transferring data to the MAC transmitter) */
-#define ETH_MTLTQDR_TRCSTS_WAITING                    ((uint32_t)0x00000004)  /* Waiting for pending Tx Status from the MAC transmitter */
-#define ETH_MTLTQDR_TRCSTS_FLUSHING                   ((uint32_t)0x00000006)  /* Flushing the Tx queue because of the Packet Abort request from the MAC */
-#define ETH_MTLTQDR_TXQPAUSED_Pos                     (0U)
-#define ETH_MTLTQDR_TXQPAUSED_Msk                     (0x1UL << ETH_MTLTQDR_TXQPAUSED_Pos) /*!< 0x00000001 */
-#define ETH_MTLTQDR_TXQPAUSED                         ETH_MTLTQDR_TXQPAUSED_Msk /* Transmit Queue in Pause */
-
-/* Bit definition for Ethernet MTL Queue Interrupt Control Status Register */
-#define ETH_MTLQICSR_RXOIE_Pos                        (24U)
-#define ETH_MTLQICSR_RXOIE_Msk                        (0x1UL << ETH_MTLQICSR_RXOIE_Pos) /*!< 0x01000000 */
-#define ETH_MTLQICSR_RXOIE                            ETH_MTLQICSR_RXOIE_Msk   /* Receive Queue Overflow Interrupt Enable */
-#define ETH_MTLQICSR_RXOVFIS_Pos                      (16U)
-#define ETH_MTLQICSR_RXOVFIS_Msk                      (0x1UL << ETH_MTLQICSR_RXOVFIS_Pos) /*!< 0x00010000 */
-#define ETH_MTLQICSR_RXOVFIS                          ETH_MTLQICSR_RXOVFIS_Msk /* Receive Queue Overflow Interrupt Status */
-#define ETH_MTLQICSR_TXUIE_Pos                        (8U)
-#define ETH_MTLQICSR_TXUIE_Msk                        (0x1UL << ETH_MTLQICSR_TXUIE_Pos) /*!< 0x00000100 */
-#define ETH_MTLQICSR_TXUIE                            ETH_MTLQICSR_TXUIE_Msk   /* Transmit Queue Underflow Interrupt Enable */
-#define ETH_MTLQICSR_TXUNFIS_Pos                      (0U)
-#define ETH_MTLQICSR_TXUNFIS_Msk                      (0x1UL << ETH_MTLQICSR_TXUNFIS_Pos) /*!< 0x00000001 */
-#define ETH_MTLQICSR_TXUNFIS                          ETH_MTLQICSR_TXUNFIS_Msk /* Transmit Queue Underflow Interrupt Status */
-
-/* Bit definition for Ethernet MTL Rx Queue Operation Mode Register */
-#define ETH_MTLRQOMR_RQS_Pos                          (20U)
-#define ETH_MTLRQOMR_RQS_Msk                          (0x7UL << ETH_MTLRQOMR_RQS_Pos) /*!< 0x00700000 */
-#define ETH_MTLRQOMR_RQS                              ETH_MTLRQOMR_RQS_Msk /* Receive Queue Size */
-#define ETH_MTLRQOMR_RFD_Pos                          (14U)
-#define ETH_MTLRQOMR_RFD_Msk                          (0x7UL << ETH_MTLRQOMR_RFD_Pos) /*!< 0x0001C000 */
-#define ETH_MTLRQOMR_RFD                              ETH_MTLRQOMR_RFD_Msk /* Threshold for Deactivating Flow Control (in half-duplex and full-duplex modes) */
-#define ETH_MTLRQOMR_RFA_Pos                          (8U)
-#define ETH_MTLRQOMR_RFA_Msk                          (0x7UL << ETH_MTLRQOMR_RFA_Pos) /*!< 0x00000700 */
-#define ETH_MTLRQOMR_RFA                              ETH_MTLRQOMR_RFA_Msk /* Threshold for Activating Flow Control (in half-duplex and full-duplex */
-#define ETH_MTLRQOMR_EHFC_Pos                         (7U)
-#define ETH_MTLRQOMR_EHFC_Msk                         (0x1UL << ETH_MTLRQOMR_EHFC_Pos) /*!< 0x00000080 */
-#define ETH_MTLRQOMR_EHFC                             ETH_MTLRQOMR_EHFC_Msk /* DEnable Hardware Flow Control */
-#define ETH_MTLRQOMR_DISTCPEF_Pos                     (6U)
-#define ETH_MTLRQOMR_DISTCPEF_Msk                     (0x1UL << ETH_MTLRQOMR_DISTCPEF_Pos) /*!< 0x00000040 */
-#define ETH_MTLRQOMR_DISTCPEF                         ETH_MTLRQOMR_DISTCPEF_Msk /* Disable Dropping of TCP/IP Checksum Error Packets */
-#define ETH_MTLRQOMR_RSF_Pos                          (5U)
-#define ETH_MTLRQOMR_RSF_Msk                          (0x1UL << ETH_MTLRQOMR_RSF_Pos) /*!< 0x00000020 */
-#define ETH_MTLRQOMR_RSF                              ETH_MTLRQOMR_RSF_Msk     /* Receive Queue Store and Forward */
-#define ETH_MTLRQOMR_FEP_Pos                          (4U)
-#define ETH_MTLRQOMR_FEP_Msk                          (0x1UL << ETH_MTLRQOMR_FEP_Pos) /*!< 0x00000010 */
-#define ETH_MTLRQOMR_FEP                              ETH_MTLRQOMR_FEP_Msk     /* Forward Error Packets */
-#define ETH_MTLRQOMR_FUP_Pos                          (3U)
-#define ETH_MTLRQOMR_FUP_Msk                          (0x1UL << ETH_MTLRQOMR_FUP_Pos) /*!< 0x00000008 */
-#define ETH_MTLRQOMR_FUP                              ETH_MTLRQOMR_FUP_Msk     /* Forward Undersized Good Packets */
-#define ETH_MTLRQOMR_RTC_Pos                          (0U)
-#define ETH_MTLRQOMR_RTC_Msk                          (0x3UL << ETH_MTLRQOMR_RTC_Pos) /*!< 0x00000003 */
-#define ETH_MTLRQOMR_RTC                              ETH_MTLRQOMR_RTC_Msk     /* Receive Queue Threshold Control */
-#define ETH_MTLRQOMR_RTC_64BITS                       ((uint32_t)0x00000000)   /* 64 bits Threshold */
-#define ETH_MTLRQOMR_RTC_32BITS                       ((uint32_t)0x00000001)   /* 32 bits Threshold */
-#define ETH_MTLRQOMR_RTC_96BITS                       ((uint32_t)0x00000002)   /* 96 bits Threshold */
-#define ETH_MTLRQOMR_RTC_128BITS                      ((uint32_t)0x00000003)   /* 128 bits Threshold */
-
-/* Bit definition for Ethernet MTL Rx Queue Missed Packet Overflow Cnt Register */
-#define ETH_MTLRQMPOCR_MISCNTOVF_Pos                  (27U)
-#define ETH_MTLRQMPOCR_MISCNTOVF_Msk                  (0x1UL << ETH_MTLRQMPOCR_MISCNTOVF_Pos) /*!< 0x08000000 */
-#define ETH_MTLRQMPOCR_MISCNTOVF                      ETH_MTLRQMPOCR_MISCNTOVF_Msk /* Missed Packet Counter Overflow Bit */
-#define ETH_MTLRQMPOCR_MISPKTCNT_Pos                  (16U)
-#define ETH_MTLRQMPOCR_MISPKTCNT_Msk                  (0x7FFUL << ETH_MTLRQMPOCR_MISPKTCNT_Pos) /*!< 0x07FF0000 */
-#define ETH_MTLRQMPOCR_MISPKTCNT                      ETH_MTLRQMPOCR_MISPKTCNT_Msk /* Missed Packet Counter */
-#define ETH_MTLRQMPOCR_OVFCNTOVF_Pos                  (11U)
-#define ETH_MTLRQMPOCR_OVFCNTOVF_Msk                  (0x1UL << ETH_MTLRQMPOCR_OVFCNTOVF_Pos) /*!< 0x00000800 */
-#define ETH_MTLRQMPOCR_OVFCNTOVF                      ETH_MTLRQMPOCR_OVFCNTOVF_Msk /* Overflow Counter Overflow Bit */
-#define ETH_MTLRQMPOCR_OVFPKTCNT_Pos                  (0U)
-#define ETH_MTLRQMPOCR_OVFPKTCNT_Msk                  (0x7FFUL << ETH_MTLRQMPOCR_OVFPKTCNT_Pos) /*!< 0x000007FF */
-#define ETH_MTLRQMPOCR_OVFPKTCNT                      ETH_MTLRQMPOCR_OVFPKTCNT_Msk /* Overflow Packet Counter */
-
-/* Bit definition for Ethernet MTL Rx Queue Debug Register */
-#define ETH_MTLRQDR_PRXQ_Pos                          (16U)
-#define ETH_MTLRQDR_PRXQ_Msk                          (0x3FFFUL << ETH_MTLRQDR_PRXQ_Pos) /*!< 0x3FFF0000 */
-#define ETH_MTLRQDR_PRXQ                              ETH_MTLRQDR_PRXQ_Msk     /* Number of Packets in Receive Queue */
-#define ETH_MTLRQDR_RXQSTS_Pos                        (4U)
-#define ETH_MTLRQDR_RXQSTS_Msk                        (0x3UL << ETH_MTLRQDR_RXQSTS_Pos) /*!< 0x00000030 */
-#define ETH_MTLRQDR_RXQSTS                            ETH_MTLRQDR_RXQSTS_Msk   /* MTL Rx Queue Fill-Level Status */
-#define ETH_MTLRQDR_RXQSTS_EMPTY                      ((uint32_t)0x00000000)   /* Rx Queue empty */
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Pos         (4U)
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Msk         (0x1UL << ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Pos) /*!< 0x00000010 */
-#define ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD             ETH_MTLRQDR_RXQSTS_BELOWTHRESHOLD_Msk /* Rx Queue fill-level below flow-control deactivate threshold */
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Pos         (5U)
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Msk         (0x1UL << ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Pos) /*!< 0x00000020 */
-#define ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD             ETH_MTLRQDR_RXQSTS_ABOVETHRESHOLD_Msk /* Rx Queue fill-level above flow-control activate threshold */
-#define ETH_MTLRQDR_RXQSTS_FULL_Pos                   (4U)
-#define ETH_MTLRQDR_RXQSTS_FULL_Msk                   (0x3UL << ETH_MTLRQDR_RXQSTS_FULL_Pos) /*!< 0x00000030 */
-#define ETH_MTLRQDR_RXQSTS_FULL                       ETH_MTLRQDR_RXQSTS_FULL_Msk /* Rx Queue full */
-#define ETH_MTLRQDR_RRCSTS_Pos                        (1U)
-#define ETH_MTLRQDR_RRCSTS_Msk                        (0x3UL << ETH_MTLRQDR_RRCSTS_Pos) /*!< 0x00000006 */
-#define ETH_MTLRQDR_RRCSTS                            ETH_MTLRQDR_RRCSTS_Msk   /* MTL Rx Queue Read Controller State */
-#define ETH_MTLRQDR_RRCSTS_IDLE                       ((uint32_t)0x00000000)   /* Idle state */
-#define ETH_MTLRQDR_RRCSTS_READINGDATA_Pos            (1U)
-#define ETH_MTLRQDR_RRCSTS_READINGDATA_Msk            (0x1UL << ETH_MTLRQDR_RRCSTS_READINGDATA_Pos) /*!< 0x00000002 */
-#define ETH_MTLRQDR_RRCSTS_READINGDATA                ETH_MTLRQDR_RRCSTS_READINGDATA_Msk /* Reading packet data */
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS_Pos          (2U)
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS_Msk          (0x1UL << ETH_MTLRQDR_RRCSTS_READINGSTATUS_Pos) /*!< 0x00000004 */
-#define ETH_MTLRQDR_RRCSTS_READINGSTATUS              ETH_MTLRQDR_RRCSTS_READINGSTATUS_Msk /* Reading packet status (or timestamp) */
-#define ETH_MTLRQDR_RRCSTS_FLUSHING_Pos               (1U)
-#define ETH_MTLRQDR_RRCSTS_FLUSHING_Msk               (0x3UL << ETH_MTLRQDR_RRCSTS_FLUSHING_Pos) /*!< 0x00000006 */
-#define ETH_MTLRQDR_RRCSTS_FLUSHING                   ETH_MTLRQDR_RRCSTS_FLUSHING_Msk /* Flushing the packet data and status */
-#define ETH_MTLRQDR_RWCSTS_Pos                        (0U)
-#define ETH_MTLRQDR_RWCSTS_Msk                        (0x1UL << ETH_MTLRQDR_RWCSTS_Pos) /*!< 0x00000001 */
-#define ETH_MTLRQDR_RWCSTS                            ETH_MTLRQDR_RWCSTS_Msk   /* MTL Rx Queue Write Controller Active Status */
-
-/* Bit definition for Ethernet MTL Rx Queue Control Register */
-#define ETH_MTLRQCR_RQPA_Pos                          (3U)
-#define ETH_MTLRQCR_RQPA_Msk                          (0x1UL << ETH_MTLRQCR_RQPA_Pos) /*!< 0x00000008 */
-#define ETH_MTLRQCR_RQPA                              ETH_MTLRQCR_RQPA_Msk     /* Receive Queue Packet Arbitration */
-#define ETH_MTLRQCR_RQW_Pos                           (0U)
-#define ETH_MTLRQCR_RQW_Msk                           (0x7UL << ETH_MTLRQCR_RQW_Pos) /*!< 0x00000007 */
-#define ETH_MTLRQCR_RQW                               ETH_MTLRQCR_RQW_Msk      /* Receive Queue Weight */
-
-/* Bit definition for Ethernet DMA Mode Register */
-#define ETH_DMAMR_INTM_Pos                            (16U)
-#define ETH_DMAMR_INTM_Msk                            (0x3UL << ETH_DMAMR_INTM_Pos) /*!< 0x00030000 */
-#define ETH_DMAMR_INTM                                ETH_DMAMR_INTM_Msk       /* This field defines the interrupt mode */
-#define ETH_DMAMR_INTM_0                              (0x0UL << ETH_DMAMR_INTM_Pos) /*!< 0x00000000 */
-#define ETH_DMAMR_INTM_1                              (0x1UL << ETH_DMAMR_INTM_Pos) /*!< 0x00010000 */
-#define ETH_DMAMR_INTM_2                              (0x2UL << ETH_DMAMR_INTM_Pos) /*!< 0x00020000 */
-#define ETH_DMAMR_PR_Pos                              (12U)
-#define ETH_DMAMR_PR_Msk                              (0x7UL << ETH_DMAMR_PR_Pos) /*!< 0x00007000 */
-#define ETH_DMAMR_PR                                  ETH_DMAMR_PR_Msk         /* Priority Ratio */
-#define ETH_DMAMR_PR_1_1                              ((uint32_t)0x00000000)   /* The priority ratio is 1:1 */
-#define ETH_DMAMR_PR_2_1                              ((uint32_t)0x00001000)   /* The priority ratio is 2:1 */
-#define ETH_DMAMR_PR_3_1                              ((uint32_t)0x00002000)   /* The priority ratio is 3:1 */
-#define ETH_DMAMR_PR_4_1                              ((uint32_t)0x00003000)   /* The priority ratio is 4:1 */
-#define ETH_DMAMR_PR_5_1                              ((uint32_t)0x00004000)   /* The priority ratio is 5:1 */
-#define ETH_DMAMR_PR_6_1                              ((uint32_t)0x00005000)   /* The priority ratio is 6:1 */
-#define ETH_DMAMR_PR_7_1                              ((uint32_t)0x00006000)   /* The priority ratio is 7:1 */
-#define ETH_DMAMR_PR_8_1                              ((uint32_t)0x00007000)   /* The priority ratio is 8:1 */
-#define ETH_DMAMR_TXPR_Pos                            (11U)
-#define ETH_DMAMR_TXPR_Msk                            (0x1UL << ETH_DMAMR_TXPR_Pos) /*!< 0x00000800 */
-#define ETH_DMAMR_TXPR                                ETH_DMAMR_TXPR_Msk       /* Transmit Priority */
-#define ETH_DMAMR_DA_Pos                              (1U)
-#define ETH_DMAMR_DA_Msk                              (0x1UL << ETH_DMAMR_DA_Pos) /*!< 0x00000002 */
-#define ETH_DMAMR_DA                                  ETH_DMAMR_DA_Msk         /* DMA Tx or Rx Arbitration Scheme */
-#define ETH_DMAMR_SWR_Pos                             (0U)
-#define ETH_DMAMR_SWR_Msk                             (0x1UL << ETH_DMAMR_SWR_Pos) /*!< 0x00000001 */
-#define ETH_DMAMR_SWR                                 ETH_DMAMR_SWR_Msk        /* Software Reset */
-
-/* Bit definition for Ethernet DMA SysBus Mode Register */
-#define ETH_DMASBMR_RB_Pos                            (15U)
-#define ETH_DMASBMR_RB_Msk                            (0x1UL << ETH_DMASBMR_RB_Pos) /*!< 0x00008000 */
-#define ETH_DMASBMR_RB                                ETH_DMASBMR_RB_Msk       /* Rebuild INCRx Burst */
-#define ETH_DMASBMR_MB_Pos                            (14U)
-#define ETH_DMASBMR_MB_Msk                            (0x1UL << ETH_DMASBMR_MB_Pos) /*!< 0x00004000 */
-#define ETH_DMASBMR_MB                                ETH_DMASBMR_MB_Msk       /* Mixed Burst */
-#define ETH_DMASBMR_AAL_Pos                           (12U)
-#define ETH_DMASBMR_AAL_Msk                           (0x1UL << ETH_DMASBMR_AAL_Pos) /*!< 0x00001000 */
-#define ETH_DMASBMR_AAL                               ETH_DMASBMR_AAL_Msk      /* Address-Aligned Beats */
-#define ETH_DMASBMR_FB_Pos                            (0U)
-#define ETH_DMASBMR_FB_Msk                            (0x1UL << ETH_DMASBMR_FB_Pos) /*!< 0x00000001 */
-#define ETH_DMASBMR_FB                                ETH_DMASBMR_FB_Msk       /* Fixed Burst Length */
-
-/* Bit definition for Ethernet DMA Interrupt Status Register */
-#define ETH_DMAISR_MACIS_Pos                          (17U)
-#define ETH_DMAISR_MACIS_Msk                          (0x1UL << ETH_DMAISR_MACIS_Pos) /*!< 0x00020000 */
-#define ETH_DMAISR_MACIS                              ETH_DMAISR_MACIS_Msk     /* MAC Interrupt Status */
-#define ETH_DMAISR_MTLIS_Pos                          (16U)
-#define ETH_DMAISR_MTLIS_Msk                          (0x1UL << ETH_DMAISR_MTLIS_Pos) /*!< 0x00010000 */
-#define ETH_DMAISR_MTLIS                              ETH_DMAISR_MTLIS_Msk     /* MAC Interrupt Status */
-#define ETH_DMAISR_DMACIS_Pos                         (0U)
-#define ETH_DMAISR_DMACIS_Msk                         (0x1UL << ETH_DMAISR_DMACIS_Pos) /*!< 0x00000001 */
-#define ETH_DMAISR_DMACIS                             ETH_DMAISR_DMACIS_Msk    /* DMA Channel Interrupt Status */
-
-/* Bit definition for Ethernet DMA Debug Status Register */
-#define ETH_DMADSR_TPS_Pos                            (12U)
-#define ETH_DMADSR_TPS_Msk                            (0xFUL << ETH_DMADSR_TPS_Pos) /*!< 0x0000F000 */
-#define ETH_DMADSR_TPS                                ETH_DMADSR_TPS_Msk       /* DMA Channel Transmit Process State */
-#define ETH_DMADSR_TPS_STOPPED                        ((uint32_t)0x00000000)   /* Stopped (Reset or Stop Transmit Command issued) */
-#define ETH_DMADSR_TPS_FETCHING_Pos                   (12U)
-#define ETH_DMADSR_TPS_FETCHING_Msk                   (0x1UL << ETH_DMADSR_TPS_FETCHING_Pos) /*!< 0x00001000 */
-#define ETH_DMADSR_TPS_FETCHING                       ETH_DMADSR_TPS_FETCHING_Msk /* Running (Fetching Tx Transfer Descriptor) */
-#define ETH_DMADSR_TPS_WAITING_Pos                    (13U)
-#define ETH_DMADSR_TPS_WAITING_Msk                    (0x1UL << ETH_DMADSR_TPS_WAITING_Pos) /*!< 0x00002000 */
-#define ETH_DMADSR_TPS_WAITING                        ETH_DMADSR_TPS_WAITING_Msk /* Running (Waiting for status) */
-#define ETH_DMADSR_TPS_READING_Pos                    (12U)
-#define ETH_DMADSR_TPS_READING_Msk                    (0x3UL << ETH_DMADSR_TPS_READING_Pos) /*!< 0x00003000 */
-#define ETH_DMADSR_TPS_READING                        ETH_DMADSR_TPS_READING_Msk /* Running (Reading Data from system memory buffer and queuing it to the Tx buffer (Tx FIFO)) */
-#define ETH_DMADSR_TPS_TIMESTAMP_WR_Pos               (14U)
-#define ETH_DMADSR_TPS_TIMESTAMP_WR_Msk               (0x1UL << ETH_DMADSR_TPS_TIMESTAMP_WR_Pos) /*!< 0x00004000 */
-#define ETH_DMADSR_TPS_TIMESTAMP_WR                   ETH_DMADSR_TPS_TIMESTAMP_WR_Msk /* Timestamp write state */
-#define ETH_DMADSR_TPS_SUSPENDED_Pos                  (13U)
-#define ETH_DMADSR_TPS_SUSPENDED_Msk                  (0x3UL << ETH_DMADSR_TPS_SUSPENDED_Pos) /*!< 0x00006000 */
-#define ETH_DMADSR_TPS_SUSPENDED                      ETH_DMADSR_TPS_SUSPENDED_Msk /* Suspended (Tx Descriptor Unavailable or Tx Buffer Underflow) */
-#define ETH_DMADSR_TPS_CLOSING_Pos                    (12U)
-#define ETH_DMADSR_TPS_CLOSING_Msk                    (0x7UL << ETH_DMADSR_TPS_CLOSING_Pos) /*!< 0x00007000 */
-#define ETH_DMADSR_TPS_CLOSING                        ETH_DMADSR_TPS_CLOSING_Msk /* Running (Closing Tx Descriptor) */
-#define ETH_DMADSR_RPS_Pos                            (8U)
-#define ETH_DMADSR_RPS_Msk                            (0xFUL << ETH_DMADSR_RPS_Pos) /*!< 0x00000F00 */
-#define ETH_DMADSR_RPS                                ETH_DMADSR_RPS_Msk       /* DMA Channel Receive Process State */
-#define ETH_DMADSR_RPS_STOPPED                        ((uint32_t)0x00000000)   /* Stopped (Reset or Stop Receive Command issued) */
-#define ETH_DMADSR_RPS_FETCHING_Pos                   (12U)
-#define ETH_DMADSR_RPS_FETCHING_Msk                   (0x1UL << ETH_DMADSR_RPS_FETCHING_Pos) /*!< 0x00001000 */
-#define ETH_DMADSR_RPS_FETCHING                       ETH_DMADSR_RPS_FETCHING_Msk /* Running (Fetching Rx Transfer Descriptor) */
-#define ETH_DMADSR_RPS_WAITING_Pos                    (12U)
-#define ETH_DMADSR_RPS_WAITING_Msk                    (0x3UL << ETH_DMADSR_RPS_WAITING_Pos) /*!< 0x00003000 */
-#define ETH_DMADSR_RPS_WAITING                        ETH_DMADSR_RPS_WAITING_Msk /* Running (Waiting for status) */
-#define ETH_DMADSR_RPS_SUSPENDED_Pos                  (14U)
-#define ETH_DMADSR_RPS_SUSPENDED_Msk                  (0x1UL << ETH_DMADSR_RPS_SUSPENDED_Pos) /*!< 0x00004000 */
-#define ETH_DMADSR_RPS_SUSPENDED                      ETH_DMADSR_RPS_SUSPENDED_Msk /* Suspended (Rx Descriptor Unavailable) */
-#define ETH_DMADSR_RPS_CLOSING_Pos                    (12U)
-#define ETH_DMADSR_RPS_CLOSING_Msk                    (0x5UL << ETH_DMADSR_RPS_CLOSING_Pos) /*!< 0x00005000 */
-#define ETH_DMADSR_RPS_CLOSING                        ETH_DMADSR_RPS_CLOSING_Msk /* Running (Closing the Rx Descriptor) */
-#define ETH_DMADSR_RPS_TIMESTAMP_WR_Pos               (13U)
-#define ETH_DMADSR_RPS_TIMESTAMP_WR_Msk               (0x3UL << ETH_DMADSR_RPS_TIMESTAMP_WR_Pos) /*!< 0x00006000 */
-#define ETH_DMADSR_RPS_TIMESTAMP_WR                   ETH_DMADSR_RPS_TIMESTAMP_WR_Msk /* Timestamp write state */
-#define ETH_DMADSR_RPS_TRANSFERRING_Pos               (12U)
-#define ETH_DMADSR_RPS_TRANSFERRING_Msk               (0x7UL << ETH_DMADSR_RPS_TRANSFERRING_Pos) /*!< 0x00007000 */
-#define ETH_DMADSR_RPS_TRANSFERRING                   ETH_DMADSR_RPS_TRANSFERRING_Msk /* Running (Transferring the received packet data from the Rx buffer to the system memory) */
-
-/* Bit definition for Ethernet DMA Channel Control Register */
-#define ETH_DMACCR_DSL_Pos                            (18U)
-#define ETH_DMACCR_DSL_Msk                            (0x7UL << ETH_DMACCR_DSL_Pos) /*!< 0x001C0000 */
-#define ETH_DMACCR_DSL                                ETH_DMACCR_DSL_Msk       /* Descriptor Skip Length */
-#define ETH_DMACCR_DSL_0BIT                           ((uint32_t)0x00000000)
-#define ETH_DMACCR_DSL_32BIT                          ((uint32_t)0x00040000)
-#define ETH_DMACCR_DSL_64BIT                          ((uint32_t)0x00080000)
-#define ETH_DMACCR_DSL_128BIT                         ((uint32_t)0x00100000)
-#define ETH_DMACCR_8PBL                               ((uint32_t)0x00010000)   /* 8xPBL mode */
-#define ETH_DMACCR_MSS_Pos                            (0U)
-#define ETH_DMACCR_MSS_Msk                            (0x3FFFUL << ETH_DMACCR_MSS_Pos) /*!< 0x00003FFF */
-#define ETH_DMACCR_MSS                                ETH_DMACCR_MSS_Msk       /* Maximum Segment Size */
-
-/* Bit definition for Ethernet DMA Channel Tx Control Register */
-#define ETH_DMACTCR_TPBL_Pos                          (16U)
-#define ETH_DMACTCR_TPBL_Msk                          (0x3FUL << ETH_DMACTCR_TPBL_Pos) /*!< 0x003F0000 */
-#define ETH_DMACTCR_TPBL                              ETH_DMACTCR_TPBL_Msk     /* Transmit Programmable Burst Length */
-#define ETH_DMACTCR_TPBL_1PBL                         ((uint32_t)0x00010000)   /* Transmit Programmable Burst Length 1 */
-#define ETH_DMACTCR_TPBL_2PBL                         ((uint32_t)0x00020000)   /* Transmit Programmable Burst Length 2 */
-#define ETH_DMACTCR_TPBL_4PBL                         ((uint32_t)0x00040000)   /* Transmit Programmable Burst Length 4 */
-#define ETH_DMACTCR_TPBL_8PBL                         ((uint32_t)0x00080000)   /* Transmit Programmable Burst Length 8 */
-#define ETH_DMACTCR_TPBL_16PBL                        ((uint32_t)0x00100000)   /* Transmit Programmable Burst Length 16 */
-#define ETH_DMACTCR_TPBL_32PBL                        ((uint32_t)0x00200000)   /* Transmit Programmable Burst Length 32 */
-#define ETH_DMACTCR_TSE_Pos                           (12U)
-#define ETH_DMACTCR_TSE_Msk                           (0x1UL << ETH_DMACTCR_TSE_Pos) /*!< 0x00001000 */
-#define ETH_DMACTCR_TSE                               ETH_DMACTCR_TSE_Msk      /* TCP Segmentation Enabled */
-#define ETH_DMACTCR_OSP_Pos                           (4U)
-#define ETH_DMACTCR_OSP_Msk                           (0x1UL << ETH_DMACTCR_OSP_Pos) /*!< 0x00000010 */
-#define ETH_DMACTCR_OSP                               ETH_DMACTCR_OSP_Msk      /* Operate on Second Packet */
-#define ETH_DMACTCR_ST_Pos                            (0U)
-#define ETH_DMACTCR_ST_Msk                            (0x1UL << ETH_DMACTCR_ST_Pos) /*!< 0x00000001 */
-#define ETH_DMACTCR_ST                                ETH_DMACTCR_ST_Msk       /* Start or Stop Transmission Command */
-
-/* Bit definition for Ethernet DMA Channel Rx Control Register */
-#define ETH_DMACRCR_RPF_Pos                           (31U)
-#define ETH_DMACRCR_RPF_Msk                           (0x1UL << ETH_DMACRCR_RPF_Pos) /*!< 0x80000000 */
-#define ETH_DMACRCR_RPF                               ETH_DMACRCR_RPF_Msk      /* Rx Packet Flush */
-#define ETH_DMACRCR_RPBL_Pos                          (16U)
-#define ETH_DMACRCR_RPBL_Msk                          (0x3FUL << ETH_DMACRCR_RPBL_Pos) /*!< 0x003F0000 */
-#define ETH_DMACRCR_RPBL                              ETH_DMACRCR_RPBL_Msk     /* Receive Programmable Burst Length */
-#define ETH_DMACRCR_RPBL_1PBL                         ((uint32_t)0x00010000)   /* Receive Programmable Burst Length 1 */
-#define ETH_DMACRCR_RPBL_2PBL                         ((uint32_t)0x00020000)   /* Receive Programmable Burst Length 2 */
-#define ETH_DMACRCR_RPBL_4PBL                         ((uint32_t)0x00040000)   /* Receive Programmable Burst Length 4 */
-#define ETH_DMACRCR_RPBL_8PBL                         ((uint32_t)0x00080000)   /* Receive Programmable Burst Length 8 */
-#define ETH_DMACRCR_RPBL_16PBL                        ((uint32_t)0x00100000)   /* Receive Programmable Burst Length 16 */
-#define ETH_DMACRCR_RPBL_32PBL                        ((uint32_t)0x00200000)   /* Receive Programmable Burst Length 32 */
-#define ETH_DMACRCR_RBSZ_Pos                          (1U)
-#define ETH_DMACRCR_RBSZ_Msk                          (0x3FFFUL << ETH_DMACRCR_RBSZ_Pos) /*!< 0x00007FFE */
-#define ETH_DMACRCR_RBSZ                              ETH_DMACRCR_RBSZ_Msk     /* Receive Buffer size */
-#define ETH_DMACRCR_SR_Pos                            (0U)
-#define ETH_DMACRCR_SR_Msk                            (0x1UL << ETH_DMACRCR_SR_Pos) /*!< 0x00000001 */
-#define ETH_DMACRCR_SR                                ETH_DMACRCR_SR_Msk       /* Start or Stop Receive */
-
-/* Bit definition for Ethernet DMA CH Tx Desc List Address Register */
-#define ETH_DMACTDLAR_TDESLA_Pos                      (2U)
-#define ETH_DMACTDLAR_TDESLA_Msk                      (0x3FFFFFFFUL << ETH_DMACTDLAR_TDESLA_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACTDLAR_TDESLA                          ETH_DMACTDLAR_TDESLA_Msk /* Start of Transmit List */
-
-/* Bit definition for Ethernet DMA CH Rx Desc List Address Register */
-#define ETH_DMACRDLAR_RDESLA_Pos                      (2U)
-#define ETH_DMACRDLAR_RDESLA_Msk                      (0x3FFFFFFFUL << ETH_DMACRDLAR_RDESLA_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACRDLAR_RDESLA                          ETH_DMACRDLAR_RDESLA_Msk /* Start of Receive List */
-
-/* Bit definition for Ethernet DMA CH Tx Desc Tail Pointer Register */
-#define ETH_DMACTDTPR_TDT_Pos                         (2U)
-#define ETH_DMACTDTPR_TDT_Msk                         (0x3FFFFFFFUL << ETH_DMACTDTPR_TDT_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACTDTPR_TDT                             ETH_DMACTDTPR_TDT_Msk    /* Transmit Descriptor Tail Pointer */
-
-/* Bit definition for Ethernet DMA CH Rx Desc Tail Pointer Register */
-#define ETH_DMACRDTPR_RDT_Pos                         (2U)
-#define ETH_DMACRDTPR_RDT_Msk                         (0x3FFFFFFFUL << ETH_DMACRDTPR_RDT_Pos) /*!< 0xFFFFFFFC */
-#define ETH_DMACRDTPR_RDT                             ETH_DMACRDTPR_RDT_Msk    /* Receive Descriptor Tail Pointer */
-
-/* Bit definition for Ethernet DMA CH Tx Desc Ring Length Register */
-#define ETH_DMACTDRLR_TDRL_Pos                        (0U)
-#define ETH_DMACTDRLR_TDRL_Msk                        (0x3FFUL << ETH_DMACTDRLR_TDRL_Pos) /*!< 0x000003FF */
-#define ETH_DMACTDRLR_TDRL                            ETH_DMACTDRLR_TDRL_Msk   /* Transmit Descriptor Ring Length */
-
-/* Bit definition for Ethernet DMA CH Rx Desc Ring Length Register */
-#define ETH_DMACRDRLR_RDRL_Pos                        (0U)
-#define ETH_DMACRDRLR_RDRL_Msk                        (0x3FFUL << ETH_DMACRDRLR_RDRL_Pos) /*!< 0x000003FF */
-#define ETH_DMACRDRLR_RDRL                            ETH_DMACRDRLR_RDRL_Msk   /* Receive Descriptor Ring Length */
-
-/* Bit definition for Ethernet DMA Channel Interrupt Enable Register */
-#define ETH_DMACIER_NIE_Pos                           (15U)
-#define ETH_DMACIER_NIE_Msk                           (0x1UL << ETH_DMACIER_NIE_Pos) /*!< 0x00008000 */
-#define ETH_DMACIER_NIE                               ETH_DMACIER_NIE_Msk      /* Normal Interrupt Summary Enable */
-#define ETH_DMACIER_AIE_Pos                           (14U)
-#define ETH_DMACIER_AIE_Msk                           (0x1UL << ETH_DMACIER_AIE_Pos) /*!< 0x00004000 */
-#define ETH_DMACIER_AIE                               ETH_DMACIER_AIE_Msk      /* Abnormal Interrupt Summary Enable */
-#define ETH_DMACIER_CDEE_Pos                          (13U)
-#define ETH_DMACIER_CDEE_Msk                          (0x1UL << ETH_DMACIER_CDEE_Pos) /*!< 0x00002000 */
-#define ETH_DMACIER_CDEE                              ETH_DMACIER_CDEE_Msk     /* Context Descriptor Error Enable */
-#define ETH_DMACIER_FBEE_Pos                          (12U)
-#define ETH_DMACIER_FBEE_Msk                          (0x1UL << ETH_DMACIER_FBEE_Pos) /*!< 0x00001000 */
-#define ETH_DMACIER_FBEE                              ETH_DMACIER_FBEE_Msk     /* Fatal Bus Error Enable */
-#define ETH_DMACIER_ERIE_Pos                          (11U)
-#define ETH_DMACIER_ERIE_Msk                          (0x1UL << ETH_DMACIER_ERIE_Pos) /*!< 0x00000800 */
-#define ETH_DMACIER_ERIE                              ETH_DMACIER_ERIE_Msk     /* Early Receive Interrupt Enable */
-#define ETH_DMACIER_ETIE_Pos                          (10U)
-#define ETH_DMACIER_ETIE_Msk                          (0x1UL << ETH_DMACIER_ETIE_Pos) /*!< 0x00000400 */
-#define ETH_DMACIER_ETIE                              ETH_DMACIER_ETIE_Msk     /* Early Transmit Interrupt Enable */
-#define ETH_DMACIER_RWTE_Pos                          (9U)
-#define ETH_DMACIER_RWTE_Msk                          (0x1UL << ETH_DMACIER_RWTE_Pos) /*!< 0x00000200 */
-#define ETH_DMACIER_RWTE                              ETH_DMACIER_RWTE_Msk     /* Receive Watchdog Timeout Enable */
-#define ETH_DMACIER_RSE_Pos                           (8U)
-#define ETH_DMACIER_RSE_Msk                           (0x1UL << ETH_DMACIER_RSE_Pos) /*!< 0x00000100 */
-#define ETH_DMACIER_RSE                               ETH_DMACIER_RSE_Msk      /* Receive Stopped Enable */
-#define ETH_DMACIER_RBUE_Pos                          (7U)
-#define ETH_DMACIER_RBUE_Msk                          (0x1UL << ETH_DMACIER_RBUE_Pos) /*!< 0x00000080 */
-#define ETH_DMACIER_RBUE                              ETH_DMACIER_RBUE_Msk     /* Receive Buffer Unavailable Enable */
-#define ETH_DMACIER_RIE_Pos                           (6U)
-#define ETH_DMACIER_RIE_Msk                           (0x1UL << ETH_DMACIER_RIE_Pos) /*!< 0x00000040 */
-#define ETH_DMACIER_RIE                               ETH_DMACIER_RIE_Msk      /* Receive Interrupt Enable */
-#define ETH_DMACIER_TBUE_Pos                          (2U)
-#define ETH_DMACIER_TBUE_Msk                          (0x1UL << ETH_DMACIER_TBUE_Pos) /*!< 0x00000004 */
-#define ETH_DMACIER_TBUE                              ETH_DMACIER_TBUE_Msk     /* Transmit Buffer Unavailable Enable */
-#define ETH_DMACIER_TXSE_Pos                          (1U)
-#define ETH_DMACIER_TXSE_Msk                          (0x1UL << ETH_DMACIER_TXSE_Pos) /*!< 0x00000002 */
-#define ETH_DMACIER_TXSE                              ETH_DMACIER_TXSE_Msk     /* Transmit Stopped Enable */
-#define ETH_DMACIER_TIE_Pos                           (0U)
-#define ETH_DMACIER_TIE_Msk                           (0x1UL << ETH_DMACIER_TIE_Pos) /*!< 0x00000001 */
-#define ETH_DMACIER_TIE                               ETH_DMACIER_TIE_Msk      /* Transmit Interrupt Enable */
-
-/* Bit definition for Ethernet DMA Channel Rx Interrupt Watchdog Timer Register */
-#define ETH_DMACRIWTR_RWT_Pos                         (0U)
-#define ETH_DMACRIWTR_RWT_Msk                         (0xFFUL << ETH_DMACRIWTR_RWT_Pos) /*!< 0x000000FF */
-#define ETH_DMACRIWTR_RWT                             ETH_DMACRIWTR_RWT_Msk    /* Receive Interrupt Watchdog Timer Count */
-
-/* Bit definition for Ethernet DMA Channel Current App Tx Desc Register */
-#define ETH_DMACCATDR_CURTDESAPTR_Pos                 (0U)
-#define ETH_DMACCATDR_CURTDESAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCATDR_CURTDESAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCATDR_CURTDESAPTR                     ETH_DMACCATDR_CURTDESAPTR_Msk /* Application Transmit Descriptor Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Rx Desc Register */
-#define ETH_DMACCARDR_CURRDESAPTR_Pos                 (0U)
-#define ETH_DMACCARDR_CURRDESAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCARDR_CURRDESAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCARDR_CURRDESAPTR                     ETH_DMACCARDR_CURRDESAPTR_Msk /* Application Receive Descriptor Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Tx Buffer Register */
-#define ETH_DMACCATBR_CURTBUFAPTR_Pos                 (0U)
-#define ETH_DMACCATBR_CURTBUFAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCATBR_CURTBUFAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCATBR_CURTBUFAPTR                     ETH_DMACCATBR_CURTBUFAPTR_Msk /* Application Transmit Buffer Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Current App Rx Buffer Register */
-#define ETH_DMACCARBR_CURRBUFAPTR_Pos                 (0U)
-#define ETH_DMACCARBR_CURRBUFAPTR_Msk                 (0xFFFFFFFFUL << ETH_DMACCARBR_CURRBUFAPTR_Pos) /*!< 0xFFFFFFFF */
-#define ETH_DMACCARBR_CURRBUFAPTR                     ETH_DMACCARBR_CURRBUFAPTR_Msk /* Application Receive Buffer Address Pointer */
-
-/* Bit definition for Ethernet DMA Channel Status Register */
-#define ETH_DMACSR_REB_Pos                            (19U)
-#define ETH_DMACSR_REB_Msk                            (0x7UL << ETH_DMACSR_REB_Pos) /*!< 0x00380000 */
-#define ETH_DMACSR_REB                                ETH_DMACSR_REB_Msk       /* Rx DMA Error Bits */
-#define ETH_DMACSR_TEB_Pos                            (16U)
-#define ETH_DMACSR_TEB_Msk                            (0x7UL << ETH_DMACSR_TEB_Pos) /*!< 0x00070000 */
-#define ETH_DMACSR_TEB                                ETH_DMACSR_TEB_Msk       /* Tx DMA Error Bits */
-#define ETH_DMACSR_NIS_Pos                            (15U)
-#define ETH_DMACSR_NIS_Msk                            (0x1UL << ETH_DMACSR_NIS_Pos) /*!< 0x00008000 */
-#define ETH_DMACSR_NIS                                ETH_DMACSR_NIS_Msk       /* Normal Interrupt Summary */
-#define ETH_DMACSR_AIS_Pos                            (14U)
-#define ETH_DMACSR_AIS_Msk                            (0x1UL << ETH_DMACSR_AIS_Pos) /*!< 0x00004000 */
-#define ETH_DMACSR_AIS                                ETH_DMACSR_AIS_Msk       /* Abnormal Interrupt Summary */
-#define ETH_DMACSR_CDE_Pos                            (13U)
-#define ETH_DMACSR_CDE_Msk                            (0x1UL << ETH_DMACSR_CDE_Pos) /*!< 0x00002000 */
-#define ETH_DMACSR_CDE                                ETH_DMACSR_CDE_Msk       /* Context Descriptor Error */
-#define ETH_DMACSR_FBE_Pos                            (12U)
-#define ETH_DMACSR_FBE_Msk                            (0x1UL << ETH_DMACSR_FBE_Pos) /*!< 0x00001000 */
-#define ETH_DMACSR_FBE                                ETH_DMACSR_FBE_Msk       /* Fatal Bus Error */
-#define ETH_DMACSR_ERI_Pos                            (11U)
-#define ETH_DMACSR_ERI_Msk                            (0x1UL << ETH_DMACSR_ERI_Pos) /*!< 0x00000800 */
-#define ETH_DMACSR_ERI                                ETH_DMACSR_ERI_Msk       /* Early Receive Interrupt */
-#define ETH_DMACSR_ETI_Pos                            (10U)
-#define ETH_DMACSR_ETI_Msk                            (0x1UL << ETH_DMACSR_ETI_Pos) /*!< 0x00000400 */
-#define ETH_DMACSR_ETI                                ETH_DMACSR_ETI_Msk       /* Early Transmit Interrupt */
-#define ETH_DMACSR_RWT_Pos                            (9U)
-#define ETH_DMACSR_RWT_Msk                            (0x1UL << ETH_DMACSR_RWT_Pos) /*!< 0x00000200 */
-#define ETH_DMACSR_RWT                                ETH_DMACSR_RWT_Msk       /* Receive Watchdog Timeout */
-#define ETH_DMACSR_RPS_Pos                            (8U)
-#define ETH_DMACSR_RPS_Msk                            (0x1UL << ETH_DMACSR_RPS_Pos) /*!< 0x00000100 */
-#define ETH_DMACSR_RPS                                ETH_DMACSR_RPS_Msk       /* Receive Process Stopped */
-#define ETH_DMACSR_RBU_Pos                            (7U)
-#define ETH_DMACSR_RBU_Msk                            (0x1UL << ETH_DMACSR_RBU_Pos) /*!< 0x00000080 */
-#define ETH_DMACSR_RBU                                ETH_DMACSR_RBU_Msk       /* Receive Buffer Unavailable */
-#define ETH_DMACSR_RI_Pos                             (6U)
-#define ETH_DMACSR_RI_Msk                             (0x1UL << ETH_DMACSR_RI_Pos) /*!< 0x00000040 */
-#define ETH_DMACSR_RI                                 ETH_DMACSR_RI_Msk        /* Receive Interrupt */
-#define ETH_DMACSR_TBU_Pos                            (2U)
-#define ETH_DMACSR_TBU_Msk                            (0x1UL << ETH_DMACSR_TBU_Pos) /*!< 0x00000004 */
-#define ETH_DMACSR_TBU                                ETH_DMACSR_TBU_Msk       /* Transmit Buffer Unavailable */
-#define ETH_DMACSR_TPS_Pos                            (1U)
-#define ETH_DMACSR_TPS_Msk                            (0x1UL << ETH_DMACSR_TPS_Pos) /*!< 0x00000002 */
-#define ETH_DMACSR_TPS                                ETH_DMACSR_TPS_Msk       /* Transmit Process Stopped */
-#define ETH_DMACSR_TI_Pos                             (0U)
-#define ETH_DMACSR_TI_Msk                             (0x1UL << ETH_DMACSR_TI_Pos) /*!< 0x00000001 */
-#define ETH_DMACSR_TI                                 ETH_DMACSR_TI_Msk        /* Transmit Interrupt */
-
-/* Bit definition for Ethernet DMA Channel missed frame count register */
-#define ETH_DMACMFCR_MFCO_Pos                         (15U)
-#define ETH_DMACMFCR_MFCO_Msk                         (0x1UL << ETH_DMACMFCR_MFCO_Pos) /*!< 0x00008000 */
-#define ETH_DMACMFCR_MFCO                             ETH_DMACMFCR_MFCO_Msk    /* Overflow status of the MFC Counter */
-#define ETH_DMACMFCR_MFC_Pos                          (0U)
-#define ETH_DMACMFCR_MFC_Msk                          (0x7FFUL << ETH_DMACMFCR_MFC_Pos) /*!< 0x000007FF */
-#define ETH_DMACMFCR_MFC                              ETH_DMACMFCR_MFC_Msk     /* The number of packet counters dropped by the DMA */
 /******************************************************************************/
 /*                                                                            */
 /*                           DMA Controller (DMA)                             */
@@ -8264,9 +6146,6 @@ typedef struct
 #define EXTI_SECENR1_SEC30_Pos             (30U)
 #define EXTI_SECENR1_SEC30_Msk             (0x1UL << EXTI_SECENR1_SEC30_Pos)      /*!< 0x40000000 */
 #define EXTI_SECENR1_SEC30                 EXTI_SECENR1_SEC30_Msk                 /*!< Security enable on line 30 */
-#define EXTI_SECENR1_SEC31_Pos             (31U)
-#define EXTI_SECENR1_SEC31_Msk             (0x1UL << EXTI_SECENR1_SEC31_Pos)      /*!< 0x80000000 */
-#define EXTI_SECENR1_SEC31                 EXTI_SECENR1_SEC31_Msk                 /*!< Security enable on line 31 */
 
 
 /*******************  Bit definition for EXTI_PRIVENR1 register  ******************/
@@ -8363,17 +6242,11 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV30_Pos            (30U)
 #define EXTI_PRIVENR1_PRIV30_Msk            (0x1UL << EXTI_PRIVENR1_PRIV30_Pos)      /*!< 0x40000000 */
 #define EXTI_PRIVENR1_PRIV30                EXTI_PRIVENR1_PRIV30_Msk                 /*!< Privilege enable on line 30 */
-#define EXTI_PRIVENR1_PRIV31_Pos            (31U)
-#define EXTI_PRIVENR1_PRIV31_Msk            (0x1UL << EXTI_PRIVENR1_PRIV31_Pos)      /*!< 0x80000000 */
-#define EXTI_PRIVENR1_PRIV31                EXTI_PRIVENR1_PRIV31_Msk                 /*!< Privilege enable on line 31 */
 
 /******************  Bit definition for EXTI_RTSR2 register  *******************/
-#define EXTI_RTSR2_RT_Pos                   (12U)
-#define EXTI_RTSR2_RT_Msk                   (0x244UL << EXTI_RTSR2_RT_Pos)              /*!< 0x00244000 */
+#define EXTI_RTSR2_RT_Pos                   (16U)
+#define EXTI_RTSR2_RT_Msk                   (0x24UL << EXTI_RTSR2_RT_Pos)               /*!< 0x00240000 */
 #define EXTI_RTSR2_RT                       EXTI_RTSR2_RT_Msk                           /*!< Rising trigger event configuration bit */
-#define EXTI_RTSR2_RT46_Pos                 (14U)
-#define EXTI_RTSR2_RT46_Msk                 (0x1UL << EXTI_RTSR2_RT46_Pos)              /*!< 0x00004000 */
-#define EXTI_RTSR2_RT46                     EXTI_RTSR2_RT46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
 #define EXTI_RTSR2_RT50_Pos                 (18U)
 #define EXTI_RTSR2_RT50_Msk                 (0x1UL << EXTI_RTSR2_RT50_Pos)              /*!< 0x00040000 */
 #define EXTI_RTSR2_RT50                     EXTI_RTSR2_RT50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
@@ -8382,12 +6255,9 @@ typedef struct
 #define EXTI_RTSR2_RT53                     EXTI_RTSR2_RT53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FTSR2 register  *******************/
-#define EXTI_FTSR2_FT_Pos                   (12U)
-#define EXTI_FTSR2_FT_Msk                   (0x244 << EXTI_FTSR2_FT_Pos)                /*!< 0x00244000 */
+#define EXTI_FTSR2_FT_Pos                   (16U)
+#define EXTI_FTSR2_FT_Msk                   (0x24 << EXTI_FTSR2_FT_Pos)                 /*!< 0x00240000 */
 #define EXTI_FTSR2_FT                       EXTI_FTSR2_FT_Msk                           /*!< Falling trigger event configuration bit */
-#define EXTI_FTSR2_FT46_Pos                 (14U)
-#define EXTI_FTSR2_FT46_Msk                 (0x1UL << EXTI_FTSR2_FT46_Pos)              /*!< 0x00004000 */
-#define EXTI_FTSR2_FT46                     EXTI_FTSR2_FT46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
 #define EXTI_FTSR2_FT50_Pos                 (18U)
 #define EXTI_FTSR2_FT50_Msk                 (0x1UL << EXTI_FTSR2_FT50_Pos)              /*!< 0x00040000 */
 #define EXTI_FTSR2_FT50                     EXTI_FTSR2_FT50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
@@ -8396,9 +6266,6 @@ typedef struct
 #define EXTI_FTSR2_FT53                     EXTI_FTSR2_FT53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_SWIER2 register  ******************/
-#define EXTI_SWIER2_SWIER46_Pos            (14U)
-#define EXTI_SWIER2_SWIER46_Msk            (0x1UL << EXTI_SWIER2_SWIER46_Pos)          /*!< 0x00004000 */
-#define EXTI_SWIER2_SWIER46                EXTI_SWIER2_SWIER46_Msk                     /*!< Software Interrupt on line 46 */
 #define EXTI_SWIER2_SWIER50_Pos            (18U)
 #define EXTI_SWIER2_SWIER50_Msk            (0x1UL << EXTI_SWIER2_SWIER50_Pos)          /*!< 0x00040000 */
 #define EXTI_SWIER2_SWIER50                EXTI_SWIER2_SWIER50_Msk                     /*!< Software Interrupt on line 50 */
@@ -8407,12 +6274,9 @@ typedef struct
 #define EXTI_SWIER2_SWIER53                EXTI_SWIER2_SWIER53_Msk                     /*!< Software Interrupt on line 53 */
 
 /******************  Bit definition for EXTI_RPR2 register  *******************/
-#define EXTI_RPR2_RPIF_Pos                   (12U)
-#define EXTI_RPR2_RPIF_Msk                   (0x244UL << EXTI_RPR2_RPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_RPR2_RPIF_Pos                   (16U)
+#define EXTI_RPR2_RPIF_Msk                   (0x24UL << EXTI_RPR2_RPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_RPR2_RPIF                       EXTI_RPR2_RPIF_Msk                     /*!< Rising pending edge configuration bits */
-#define EXTI_RPR2_RPIF46_Pos                 (14U)
-#define EXTI_RPR2_RPIF46_Msk                 (0x1UL << EXTI_RPR2_RPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_RPR2_RPIF46                     EXTI_RPR2_RPIF46_Msk                   /*!< Rising pending edge configuration bit of line 46 */
 #define EXTI_RPR2_RPIF50_Pos                 (18U)
 #define EXTI_RPR2_RPIF50_Msk                 (0x1UL << EXTI_RPR2_RPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_RPR2_RPIF50                     EXTI_RPR2_RPIF50_Msk                   /*!< Rising pending edge configuration bit of line 50 */
@@ -8421,12 +6285,9 @@ typedef struct
 #define EXTI_RPR2_RPIF53                     EXTI_RPR2_RPIF53_Msk                   /*!< Rising pending edge configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FPR2 register  *******************/
-#define EXTI_FPR2_FPIF_Pos                   (12U)
-#define EXTI_FPR2_FPIF_Msk                   (0x244UL << EXTI_FPR2_FPIF_Pos)        /*!< 0x00244000 */
+#define EXTI_FPR2_FPIF_Pos                   (16U)
+#define EXTI_FPR2_FPIF_Msk                   (0x24UL << EXTI_FPR2_FPIF_Pos)         /*!< 0x00240000 */
 #define EXTI_FPR2_FPIF                       EXTI_FPR2_FPIF_Msk                     /*!< Rising falling edge configuration bits */
-#define EXTI_FPR2_FPIF46_Pos                 (14U)
-#define EXTI_FPR2_FPIF46_Msk                 (0x1UL << EXTI_FPR2_FPIF46_Pos)        /*!< 0x00004000 */
-#define EXTI_FPR2_FPIF46                     EXTI_FPR2_FPIF46_Msk                   /*!< Rising falling edge configuration bit of line 46 */
 #define EXTI_FPR2_FPIF50_Pos                 (18U)
 #define EXTI_FPR2_FPIF50_Msk                 (0x1UL << EXTI_FPR2_FPIF50_Pos)        /*!< 0x00040000 */
 #define EXTI_FPR2_FPIF50                     EXTI_FPR2_FPIF50_Msk                   /*!< Rising falling edge configuration bit of line 50 */
@@ -8435,21 +6296,6 @@ typedef struct
 #define EXTI_FPR2_FPIF53                     EXTI_FPR2_FPIF53_Msk                   /*!< Rising falling edge configuration bit of line 53 */
 
 /*******************  Bit definition for EXTI_SECENR2 register  ******************/
-#define EXTI_SECENR2_SEC32_Pos              (0U)
-#define EXTI_SECENR2_SEC32_Msk              (0x1UL << EXTI_SECENR2_SEC32_Pos)       /*!< 0x00000001 */
-#define EXTI_SECENR2_SEC32                  EXTI_SECENR2_SEC32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_SECENR2_SEC33_Pos              (1U)
-#define EXTI_SECENR2_SEC33_Msk              (0x1UL << EXTI_SECENR2_SEC33_Pos)       /*!< 0x00000002 */
-#define EXTI_SECENR2_SEC33                  EXTI_SECENR2_SEC33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_SECENR2_SEC34_Pos              (2U)
-#define EXTI_SECENR2_SEC34_Msk              (0x1UL << EXTI_SECENR2_SEC34_Pos)       /*!< 0x00000004 */
-#define EXTI_SECENR2_SEC34                  EXTI_SECENR2_SEC34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_SECENR2_SEC35_Pos              (3U)
-#define EXTI_SECENR2_SEC35_Msk              (0x1UL << EXTI_SECENR2_SEC35_Pos)       /*!< 0x00000008 */
-#define EXTI_SECENR2_SEC35                  EXTI_SECENR2_SEC35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_SECENR2_SEC36_Pos              (4U)
-#define EXTI_SECENR2_SEC36_Msk              (0x1UL << EXTI_SECENR2_SEC36_Pos)       /*!< 0x00000010 */
-#define EXTI_SECENR2_SEC36                  EXTI_SECENR2_SEC36_Msk                  /*!< Security enable on line 4 */
 #define EXTI_SECENR2_SEC37_Pos              (5U)
 #define EXTI_SECENR2_SEC37_Msk              (0x1UL << EXTI_SECENR2_SEC37_Pos)       /*!< 0x00000020 */
 #define EXTI_SECENR2_SEC37                  EXTI_SECENR2_SEC37_Msk                  /*!< Security enable on line 5 */
@@ -8471,15 +6317,6 @@ typedef struct
 #define EXTI_SECENR2_SEC43_Pos             (11U)
 #define EXTI_SECENR2_SEC43_Msk             (0x1UL << EXTI_SECENR2_SEC43_Pos)        /*!< 0x00000800 */
 #define EXTI_SECENR2_SEC43                 EXTI_SECENR2_SEC43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_SECENR2_SEC44_Pos             (12U)
-#define EXTI_SECENR2_SEC44_Msk             (0x1UL << EXTI_SECENR2_SEC44_Pos)        /*!< 0x00001000 */
-#define EXTI_SECENR2_SEC44                 EXTI_SECENR2_SEC44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_SECENR2_SEC45_Pos             (13U)
-#define EXTI_SECENR2_SEC45_Msk             (0x1UL << EXTI_SECENR2_SEC45_Pos)        /*!< 0x00002000 */
-#define EXTI_SECENR2_SEC45                 EXTI_SECENR2_SEC45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_SECENR2_SEC46_Pos             (14U)
-#define EXTI_SECENR2_SEC46_Msk             (0x1UL << EXTI_SECENR2_SEC46_Pos)        /*!< 0x00004000 */
-#define EXTI_SECENR2_SEC46                 EXTI_SECENR2_SEC46_Msk                   /*!< Security enable on line 14 */
 #define EXTI_SECENR2_SEC47_Pos             (15U)
 #define EXTI_SECENR2_SEC47_Msk             (0x1UL << EXTI_SECENR2_SEC47_Pos)        /*!< 0x00008000 */
 #define EXTI_SECENR2_SEC47                 EXTI_SECENR2_SEC47_Msk                   /*!< Security enable on line 15 */
@@ -8501,35 +6338,11 @@ typedef struct
 #define EXTI_SECENR2_SEC53_Pos             (21U)
 #define EXTI_SECENR2_SEC53_Msk             (0x1UL << EXTI_SECENR2_SEC53_Pos)        /*!< 0x00200000 */
 #define EXTI_SECENR2_SEC53                 EXTI_SECENR2_SEC53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_SECENR2_SEC54_Pos             (22U)
-#define EXTI_SECENR2_SEC54_Msk             (0x1UL << EXTI_SECENR2_SEC54_Pos)        /*!< 0x00400000 */
-#define EXTI_SECENR2_SEC54                 EXTI_SECENR2_SEC54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_SECENR2_SEC55_Pos             (23U)
-#define EXTI_SECENR2_SEC55_Msk             (0x1UL << EXTI_SECENR2_SEC55_Pos)        /*!< 0x00800000 */
-#define EXTI_SECENR2_SEC55                 EXTI_SECENR2_SEC55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_SECENR2_SEC56_Pos             (24U)
-#define EXTI_SECENR2_SEC56_Msk             (0x1UL << EXTI_SECENR2_SEC56_Pos)        /*!< 0x01000000 */
-#define EXTI_SECENR2_SEC56                 EXTI_SECENR2_SEC56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_SECENR2_SEC57_Pos             (25U)
-#define EXTI_SECENR2_SEC57_Msk             (0x1UL << EXTI_SECENR2_SEC57_Pos)        /*!< 0x02000000 */
-#define EXTI_SECENR2_SEC57                 EXTI_SECENR2_SEC57_Msk                   /*!< Security enable on line 25 */
+#define EXTI_SECENR2_SEC58_Pos             (26U)
+#define EXTI_SECENR2_SEC58_Msk             (0x1UL << EXTI_SECENR2_SEC58_Pos)        /*!< 0x04000000 */
+#define EXTI_SECENR2_SEC58                 EXTI_SECENR2_SEC58_Msk                   /*!< Security enable on line 26 */
 
 /*******************  Bit definition for EXTI_PRIVENR2 register  ******************/
-#define EXTI_PRIVENR2_PRIV32_Pos              (0U)
-#define EXTI_PRIVENR2_PRIV32_Msk              (0x1UL << EXTI_PRIVENR2_PRIV32_Pos)       /*!< 0x00000001 */
-#define EXTI_PRIVENR2_PRIV32                  EXTI_PRIVENR2_PRIV32_Msk                  /*!< Security enable on line 32 */
-#define EXTI_PRIVENR2_PRIV33_Pos              (1U)
-#define EXTI_PRIVENR2_PRIV33_Msk              (0x1UL << EXTI_PRIVENR2_PRIV33_Pos)       /*!< 0x00000002 */
-#define EXTI_PRIVENR2_PRIV33                  EXTI_PRIVENR2_PRIV33_Msk                  /*!< Security enable on line 33 */
-#define EXTI_PRIVENR2_PRIV34_Pos              (2U)
-#define EXTI_PRIVENR2_PRIV34_Msk              (0x1UL << EXTI_PRIVENR2_PRIV34_Pos)       /*!< 0x00000004 */
-#define EXTI_PRIVENR2_PRIV34                  EXTI_PRIVENR2_PRIV34_Msk                  /*!< Security enable on line 2 */
-#define EXTI_PRIVENR2_PRIV35_Pos              (3U)
-#define EXTI_PRIVENR2_PRIV35_Msk              (0x1UL << EXTI_PRIVENR2_PRIV35_Pos)       /*!< 0x00000008 */
-#define EXTI_PRIVENR2_PRIV35                  EXTI_PRIVENR2_PRIV35_Msk                  /*!< Security enable on line 3 */
-#define EXTI_PRIVENR2_PRIV36_Pos              (4U)
-#define EXTI_PRIVENR2_PRIV36_Msk              (0x1UL << EXTI_PRIVENR2_PRIV36_Pos)       /*!< 0x00000010 */
-#define EXTI_PRIVENR2_PRIV36                  EXTI_PRIVENR2_PRIV36_Msk                  /*!< Security enable on line 4 */
 #define EXTI_PRIVENR2_PRIV37_Pos              (5U)
 #define EXTI_PRIVENR2_PRIV37_Msk              (0x1UL << EXTI_PRIVENR2_PRIV37_Pos)       /*!< 0x00000020 */
 #define EXTI_PRIVENR2_PRIV37                  EXTI_PRIVENR2_PRIV37_Msk                  /*!< Security enable on line 5 */
@@ -8551,15 +6364,6 @@ typedef struct
 #define EXTI_PRIVENR2_PRIV43_Pos             (11U)
 #define EXTI_PRIVENR2_PRIV43_Msk             (0x1UL << EXTI_PRIVENR2_PRIV43_Pos)        /*!< 0x00000800 */
 #define EXTI_PRIVENR2_PRIV43                 EXTI_PRIVENR2_PRIV43_Msk                   /*!< Security enable on line 11 */
-#define EXTI_PRIVENR2_PRIV44_Pos             (12U)
-#define EXTI_PRIVENR2_PRIV44_Msk             (0x1UL << EXTI_PRIVENR2_PRIV44_Pos)        /*!< 0x00001000 */
-#define EXTI_PRIVENR2_PRIV44                 EXTI_PRIVENR2_PRIV44_Msk                   /*!< Security enable on line 12 */
-#define EXTI_PRIVENR2_PRIV45_Pos             (13U)
-#define EXTI_PRIVENR2_PRIV45_Msk             (0x1UL << EXTI_PRIVENR2_PRIV45_Pos)        /*!< 0x00002000 */
-#define EXTI_PRIVENR2_PRIV45                 EXTI_PRIVENR2_PRIV45_Msk                   /*!< Security enable on line 13 */
-#define EXTI_PRIVENR2_PRIV46_Pos             (14U)
-#define EXTI_PRIVENR2_PRIV46_Msk             (0x1UL << EXTI_PRIVENR2_PRIV46_Pos)        /*!< 0x00004000 */
-#define EXTI_PRIVENR2_PRIV46                 EXTI_PRIVENR2_PRIV46_Msk                   /*!< Security enable on line 14 */
 #define EXTI_PRIVENR2_PRIV47_Pos             (15U)
 #define EXTI_PRIVENR2_PRIV47_Msk             (0x1UL << EXTI_PRIVENR2_PRIV47_Pos)        /*!< 0x00008000 */
 #define EXTI_PRIVENR2_PRIV47                 EXTI_PRIVENR2_PRIV47_Msk                   /*!< Security enable on line 15 */
@@ -8581,18 +6385,9 @@ typedef struct
 #define EXTI_PRIVENR2_PRIV53_Pos             (21U)
 #define EXTI_PRIVENR2_PRIV53_Msk             (0x1UL << EXTI_PRIVENR2_PRIV53_Pos)        /*!< 0x00200000 */
 #define EXTI_PRIVENR2_PRIV53                 EXTI_PRIVENR2_PRIV53_Msk                   /*!< Security enable on line 21 */
-#define EXTI_PRIVENR2_PRIV54_Pos             (22U)
-#define EXTI_PRIVENR2_PRIV54_Msk             (0x1UL << EXTI_PRIVENR2_PRIV54_Pos)        /*!< 0x00400000 */
-#define EXTI_PRIVENR2_PRIV54                 EXTI_PRIVENR2_PRIV54_Msk                   /*!< Security enable on line 22 */
-#define EXTI_PRIVENR2_PRIV55_Pos             (23U)
-#define EXTI_PRIVENR2_PRIV55_Msk             (0x1UL << EXTI_PRIVENR2_PRIV55_Pos)        /*!< 0x00800000 */
-#define EXTI_PRIVENR2_PRIV55                 EXTI_PRIVENR2_PRIV55_Msk                   /*!< Security enable on line 23 */
-#define EXTI_PRIVENR2_PRIV56_Pos             (24U)
-#define EXTI_PRIVENR2_PRIV56_Msk             (0x1UL << EXTI_PRIVENR2_PRIV56_Pos)        /*!< 0x01000000 */
-#define EXTI_PRIVENR2_PRIV56                 EXTI_PRIVENR2_PRIV56_Msk                   /*!< Security enable on line 24 */
-#define EXTI_PRIVENR2_PRIV57_Pos             (25U)
-#define EXTI_PRIVENR2_PRIV57_Msk             (0x1UL << EXTI_PRIVENR2_PRIV57_Pos)        /*!< 0x02000000 */
-#define EXTI_PRIVENR2_PRIV57                 EXTI_PRIVENR2_PRIV57_Msk                   /*!< Security enable on line 25 */
+#define EXTI_PRIVENR2_PRIV58_Pos             (26U)
+#define EXTI_PRIVENR2_PRIV58_Msk             (0x1UL << EXTI_PRIVENR2_PRIV58_Pos)        /*!< 0x04000000 */
+#define EXTI_PRIVENR2_PRIV58                 EXTI_PRIVENR2_PRIV58_Msk                   /*!< Security enable on line 26 */
 
 /*****************  Bit definition for EXTI_EXTICR1 register  **************/
 #define EXTI_EXTICR1_EXTI0_Pos              (0U)
@@ -8721,7 +6516,7 @@ typedef struct
 
 /*******************  Bit definition for EXTI_IMR1 register  ******************/
 #define EXTI_IMR1_IM_Pos                    (0U)
-#define EXTI_IMR1_IM_Msk                    (0xFFFFFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM_Msk                    (0x7FFFFFFFUL << EXTI_IMR1_IM_Pos)      /*!< 0x7FFFFFFF */
 #define EXTI_IMR1_IM                        EXTI_IMR1_IM_Msk                        /*!< Interrupt Mask */
 #define EXTI_IMR1_IM0_Pos                   (0U)
 #define EXTI_IMR1_IM0_Msk                   (0x1UL << EXTI_IMR1_IM0_Pos)            /*!< 0x00000001 */
@@ -8816,9 +6611,6 @@ typedef struct
 #define EXTI_IMR1_IM30_Pos                  (30U)
 #define EXTI_IMR1_IM30_Msk                  (0x1UL << EXTI_IMR1_IM30_Pos)           /*!< 0x40000000 */
 #define EXTI_IMR1_IM30                      EXTI_IMR1_IM30_Msk                      /*!< Interrupt Mask on line 30 */
-#define EXTI_IMR1_IM31_Pos                  (31U)
-#define EXTI_IMR1_IM31_Msk                  (0x1UL << EXTI_IMR1_IM31_Pos)           /*!< 0x80000000 */
-#define EXTI_IMR1_IM31                      EXTI_IMR1_IM31_Msk                      /*!< Interrupt Mask on line 31 */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
 #define EXTI_EMR1_EM_Pos                    (0U)
@@ -8917,29 +6709,11 @@ typedef struct
 #define EXTI_EMR1_EM30_Pos                  (30U)
 #define EXTI_EMR1_EM30_Msk                  (0x1UL << EXTI_EMR1_EM30_Pos)           /*!< 0x40000000 */
 #define EXTI_EMR1_EM30                      EXTI_EMR1_EM30_Msk                      /*!< Event Mask on line 30 */
-#define EXTI_EMR1_EM31_Pos                  (31U)
-#define EXTI_EMR1_EM31_Msk                  (0x1UL << EXTI_EMR1_EM31_Pos)           /*!< 0x80000000 */
-#define EXTI_EMR1_EM31                      EXTI_EMR1_EM31_Msk                      /*!< Event Mask on line 31 */
 
 /*******************  Bit definition for EXTI_IMR2 register  *******************/
 #define EXTI_IMR2_IM_Pos                    (0U)
-#define EXTI_IMR2_IM_Msk                    (0x03FFFFFFUL << EXTI_IMR2_IM_Pos)      /*!< 0x03FFFFFF */
+#define EXTI_IMR2_IM_Msk                    (0x042F8FE0UL << EXTI_IMR2_IM_Pos)      /*!< 0x04278FE0 */
 #define EXTI_IMR2_IM                        EXTI_IMR2_IM_Msk                        /*!< Interrupt Mask */
-#define EXTI_IMR2_IM32_Pos                  (0U)
-#define EXTI_IMR2_IM32_Msk                  (0x1UL << EXTI_IMR2_IM32_Pos)           /*!< 0x00000001 */
-#define EXTI_IMR2_IM32                      EXTI_IMR2_IM32_Msk                      /*!< Interrupt Mask on line 32 */
-#define EXTI_IMR2_IM33_Pos                  (1U)
-#define EXTI_IMR2_IM33_Msk                  (0x1UL << EXTI_IMR2_IM33_Pos)           /*!< 0x00000002 */
-#define EXTI_IMR2_IM33                      EXTI_IMR2_IM33_Msk                      /*!< Interrupt Mask on line 33 */
-#define EXTI_IMR2_IM34_Pos                  (2U)
-#define EXTI_IMR2_IM34_Msk                  (0x1UL << EXTI_IMR2_IM34_Pos)           /*!< 0x00000004 */
-#define EXTI_IMR2_IM34                      EXTI_IMR2_IM34_Msk                      /*!< Interrupt Mask on line 34 */
-#define EXTI_IMR2_IM35_Pos                  (3U)
-#define EXTI_IMR2_IM35_Msk                  (0x1UL << EXTI_IMR2_IM35_Pos)           /*!< 0x00000008 */
-#define EXTI_IMR2_IM35                      EXTI_IMR2_IM35_Msk                      /*!< Interrupt Mask on line 35 */
-#define EXTI_IMR2_IM36_Pos                  (4U)
-#define EXTI_IMR2_IM36_Msk                  (0x1UL << EXTI_IMR2_IM36_Pos)           /*!< 0x00000010 */
-#define EXTI_IMR2_IM36                      EXTI_IMR2_IM36_Msk                      /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM37_Pos                  (5U)
 #define EXTI_IMR2_IM37_Msk                  (0x1UL << EXTI_IMR2_IM37_Pos)           /*!< 0x00000020 */
 #define EXTI_IMR2_IM37                      EXTI_IMR2_IM37_Msk                      /*!< Interrupt Mask on line 37 */
@@ -8961,15 +6735,6 @@ typedef struct
 #define EXTI_IMR2_IM43_Pos                  (11U)
 #define EXTI_IMR2_IM43_Msk                  (0x1UL << EXTI_IMR2_IM43_Pos)           /*!< 0x00000800 */
 #define EXTI_IMR2_IM43                      EXTI_IMR2_IM43_Msk                      /*!< Interrupt Mask on line 43 */
-#define EXTI_IMR2_IM44_Pos                  (12U)
-#define EXTI_IMR2_IM44_Msk                  (0x1UL << EXTI_IMR2_IM44_Pos)           /*!< 0x00001000 */
-#define EXTI_IMR2_IM44                      EXTI_IMR2_IM44_Msk                      /*!< Interrupt Mask on line 44 */
-#define EXTI_IMR2_IM45_Pos                  (13U)
-#define EXTI_IMR2_IM45_Msk                  (0x1UL << EXTI_IMR2_IM45_Pos)           /*!< 0x00002000 */
-#define EXTI_IMR2_IM45                      EXTI_IMR2_IM45_Msk                      /*!< Interrupt Mask on line 45 */
-#define EXTI_IMR2_IM46_Pos                  (14U)
-#define EXTI_IMR2_IM46_Msk                  (0x1UL << EXTI_IMR2_IM46_Pos)           /*!< 0x00004000 */
-#define EXTI_IMR2_IM46                      EXTI_IMR2_IM46_Msk                      /*!< Interrupt Mask on line 46 */
 #define EXTI_IMR2_IM47_Pos                  (15U)
 #define EXTI_IMR2_IM47_Msk                  (0x1UL << EXTI_IMR2_IM47_Pos)           /*!< 0x00008000 */
 #define EXTI_IMR2_IM47                      EXTI_IMR2_IM47_Msk                      /*!< Interrupt Mask on line 47 */
@@ -8985,45 +6750,18 @@ typedef struct
 #define EXTI_IMR2_IM51_Pos                  (19U)
 #define EXTI_IMR2_IM51_Msk                  (0x1UL << EXTI_IMR2_IM51_Pos)           /*!< 0x00080000 */
 #define EXTI_IMR2_IM51                      EXTI_IMR2_IM51_Msk                      /*!< Interrupt Mask on line 51 */
-#define EXTI_IMR2_IM52_Pos                  (20U)
-#define EXTI_IMR2_IM52_Msk                  (0x1UL << EXTI_IMR2_IM52_Pos)           /*!< 0x00100000 */
-#define EXTI_IMR2_IM52                      EXTI_IMR2_IM52_Msk                      /*!< Interrupt Mask on line 52 */
 #define EXTI_IMR2_IM53_Pos                  (21U)
 #define EXTI_IMR2_IM53_Msk                  (0x1UL << EXTI_IMR2_IM53_Pos)           /*!< 0x00200000 */
 #define EXTI_IMR2_IM53                      EXTI_IMR2_IM53_Msk                      /*!< Interrupt Mask on line 53 */
-#define EXTI_IMR2_IM54_Pos                  (22U)
-#define EXTI_IMR2_IM54_Msk                  (0x1UL << EXTI_IMR2_IM54_Pos)           /*!< 0x00400000 */
-#define EXTI_IMR2_IM54                      EXTI_IMR2_IM54_Msk                      /*!< Interrupt Mask on line 54 */
-#define EXTI_IMR2_IM55_Pos                  (23U)
-#define EXTI_IMR2_IM55_Msk                  (0x1UL << EXTI_IMR2_IM55_Pos)           /*!< 0x00800000 */
-#define EXTI_IMR2_IM55                      EXTI_IMR2_IM55_Msk                      /*!< Interrupt Mask on line 55 */
-#define EXTI_IMR2_IM56_Pos                  (24U)
-#define EXTI_IMR2_IM56_Msk                  (0x1UL << EXTI_IMR2_IM56_Pos)           /*!< 0x01000000 */
-#define EXTI_IMR2_IM56                      EXTI_IMR2_IM56_Msk                      /*!< Interrupt Mask on line 56 */
-#define EXTI_IMR2_IM57_Pos                  (25U)
-#define EXTI_IMR2_IM57_Msk                  (0x1UL << EXTI_IMR2_IM57_Pos)           /*!< 0x02000000 */
-#define EXTI_IMR2_IM57                      EXTI_IMR2_IM57_Msk                      /*!< Interrupt Mask on line 57 */
+#define EXTI_IMR2_IM58_Pos                  (26U)
+#define EXTI_IMR2_IM58_Msk                  (0x1UL << EXTI_IMR2_IM58_Pos)           /*!< 0x04000000 */
+#define EXTI_IMR2_IM58                      EXTI_IMR2_IM58_Msk                      /*!< Interrupt Mask on line 58 */
 
 
 /*******************  Bit definition for EXTI_EMR2 register  *******************/
 #define EXTI_EMR2_EM_Pos                    (0U)
-#define EXTI_EMR2_EM_Msk                    (0x03FFFFFFUL << EXTI_EMR2_EM_Pos)      /*!< 0x03FFFFFF */
+#define EXTI_EMR2_EM_Msk                    (0x042F8FE0UL << EXTI_EMR2_EM_Pos)      /*!< 0x042F8FE0 */
 #define EXTI_EMR2_EM                        EXTI_EMR2_EM_Msk                        /*!< Event Mask */
-#define EXTI_EMR2_EM32_Pos                  (0U)
-#define EXTI_EMR2_EM32_Msk                  (0x1UL << EXTI_EMR2_EM32_Pos)           /*!< 0x00000001 */
-#define EXTI_EMR2_EM32                      EXTI_EMR2_EM32_Msk                      /*!< Event Mask on line 32*/
-#define EXTI_EMR2_EM33_Pos                  (1U)
-#define EXTI_EMR2_EM33_Msk                  (0x1UL << EXTI_EMR2_EM33_Pos)           /*!< 0x00000002 */
-#define EXTI_EMR2_EM33                      EXTI_EMR2_EM33_Msk                      /*!< Event Mask on line 33*/
-#define EXTI_EMR2_EM34_Pos                  (2U)
-#define EXTI_EMR2_EM34_Msk                  (0x1UL << EXTI_EMR2_EM34_Pos)           /*!< 0x00000004 */
-#define EXTI_EMR2_EM34                      EXTI_EMR2_EM34_Msk                      /*!< Event Mask on line 34*/
-#define EXTI_EMR2_EM35_Pos                  (3U)
-#define EXTI_EMR2_EM35_Msk                  (0x1UL << EXTI_EMR2_EM35_Pos)           /*!< 0x00000008 */
-#define EXTI_EMR2_EM35                      EXTI_EMR2_EM35_Msk                      /*!< Event Mask on line 35*/
-#define EXTI_EMR2_EM36_Pos                  (4U)
-#define EXTI_EMR2_EM36_Msk                  (0x1UL << EXTI_EMR2_EM36_Pos)           /*!< 0x00000010 */
-#define EXTI_EMR2_EM36                      EXTI_EMR2_EM36_Msk                      /*!< Event Mask on line 36*/
 #define EXTI_EMR2_EM37_Pos                  (5U)
 #define EXTI_EMR2_EM37_Msk                  (0x1UL << EXTI_EMR2_EM37_Pos)           /*!< 0x00000020 */
 #define EXTI_EMR2_EM37                      EXTI_EMR2_EM37_Msk                      /*!< Event Mask on line 37*/
@@ -9045,15 +6783,6 @@ typedef struct
 #define EXTI_EMR2_EM43_Pos                  (11U)
 #define EXTI_EMR2_EM43_Msk                  (0x1UL << EXTI_EMR2_EM43_Pos)           /*!< 0x00000800 */
 #define EXTI_EMR2_EM43                      EXTI_EMR2_EM43_Msk                      /*!< Event Mask on line 43 */
-#define EXTI_EMR2_EM44_Pos                  (12U)
-#define EXTI_EMR2_EM44_Msk                  (0x1UL << EXTI_EMR2_EM44_Pos)           /*!< 0x00001000 */
-#define EXTI_EMR2_EM44                      EXTI_EMR2_EM44_Msk                      /*!< Event Mask on line 44 */
-#define EXTI_EMR2_EM45_Pos                  (13U)
-#define EXTI_EMR2_EM45_Msk                  (0x1UL << EXTI_EMR2_EM45_Pos)           /*!< 0x00002000 */
-#define EXTI_EMR2_EM45                      EXTI_EMR2_EM45_Msk                      /*!< Event Mask on line 45 */
-#define EXTI_EMR2_EM46_Pos                  (14U)
-#define EXTI_EMR2_EM46_Msk                  (0x1UL << EXTI_EMR2_EM46_Pos)           /*!< 0x00004000 */
-#define EXTI_EMR2_EM46                      EXTI_EMR2_EM46_Msk                      /*!< Event Mask on line 46 */
 #define EXTI_EMR2_EM47_Pos                  (15U)
 #define EXTI_EMR2_EM47_Msk                  (0x1UL << EXTI_EMR2_EM47_Pos)           /*!< 0x00008000 */
 #define EXTI_EMR2_EM47                      EXTI_EMR2_EM47_Msk                      /*!< Event Mask on line 47 */
@@ -9069,24 +6798,12 @@ typedef struct
 #define EXTI_EMR2_EM51_Pos                  (19U)
 #define EXTI_EMR2_EM51_Msk                  (0x1UL << EXTI_EMR2_EM51_Pos)           /*!< 0x00080000 */
 #define EXTI_EMR2_EM51                      EXTI_EMR2_EM51_Msk                      /*!< Event Mask on line 51 */
-#define EXTI_EMR2_EM52_Pos                  (20U)
-#define EXTI_EMR2_EM52_Msk                  (0x1UL << EXTI_EMR2_EM52_Pos)           /*!< 0x00100000 */
-#define EXTI_EMR2_EM52                      EXTI_EMR2_EM52_Msk                      /*!< Event Mask on line 52 */
 #define EXTI_EMR2_EM53_Pos                  (21U)
 #define EXTI_EMR2_EM53_Msk                  (0x1UL << EXTI_EMR2_EM53_Pos)           /*!< 0x00200000 */
 #define EXTI_EMR2_EM53                      EXTI_EMR2_EM53_Msk                      /*!< Event Mask on line 53 */
-#define EXTI_EMR2_EM54_Pos                  (22U)
-#define EXTI_EMR2_EM54_Msk                  (0x1UL << EXTI_EMR2_EM54_Pos)           /*!< 0x00400000 */
-#define EXTI_EMR2_EM54                      EXTI_EMR2_EM54_Msk                      /*!< Event Mask on line 54 */
-#define EXTI_EMR2_EM55_Pos                  (23U)
-#define EXTI_EMR2_EM55_Msk                  (0x1UL << EXTI_EMR2_EM55_Pos)           /*!< 0x00800000 */
-#define EXTI_EMR2_EM55                      EXTI_EMR2_EM55_Msk                      /*!< Event Mask on line 55 */
-#define EXTI_EMR2_EM56_Pos                  (24U)
-#define EXTI_EMR2_EM56_Msk                  (0x1UL << EXTI_EMR2_EM56_Pos)           /*!< 0x01000000 */
-#define EXTI_EMR2_EM56                      EXTI_EMR2_EM56_Msk                      /*!< Event Mask on line 56 */
-#define EXTI_EMR2_EM57_Pos                  (25U)
-#define EXTI_EMR2_EM57_Msk                  (0x1UL << EXTI_EMR2_EM57_Pos)           /*!< 0x02000000 */
-#define EXTI_EMR2_EM57                      EXTI_EMR2_EM57_Msk                      /*!< Event Mask on line 57 */
+#define EXTI_EMR2_EM58_Pos                  (26U)
+#define EXTI_EMR2_EM58_Msk                  (0x1UL << EXTI_EMR2_EM58_Pos)           /*!< 0x04000000 */
+#define EXTI_EMR2_EM58                      EXTI_EMR2_EM58_Msk                      /*!< Event Mask on line 58 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -9810,9 +7527,9 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 #define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /*!< FLASH Three Latency cycle */
-#define FLASH_BLOCKBASED_NB_REG             (4U)                                    /*!< 4 Block-based registers for each Flash bank */
-#define FLASH_SIZE_DEFAULT                  (0x200000U)                             /*!< FLASH Size */
-#define FLASH_SECTOR_NB                     (128U)                                  /*!< Flash Sector number */
+#define FLASH_BLOCKBASED_NB_REG             (1U)                                    /*!< 1 Block-based registers for each Flash bank */
+#define FLASH_SIZE_DEFAULT                  (0x80000U)                              /*!< FLASH Size */
+#define FLASH_SECTOR_NB                     (32U)                                   /*!< Flash Sector number */
 #define FLASH_SIZE                          ((((*((uint16_t *)FLASHSIZE_BASE)) == 0xFFFFU)) ? FLASH_SIZE_DEFAULT : \
                                             ((((*((uint16_t *)FLASHSIZE_BASE)) == 0x0000U)) ? FLASH_SIZE_DEFAULT : \
                                             (((uint32_t)(*((uint16_t *)FLASHSIZE_BASE)) & (0xFFFFU)) << 10U)))
@@ -9937,7 +7654,7 @@ typedef struct
 #define FLASH_CR_START_Msk                  (0x1UL << FLASH_CR_START_Pos)           /*!< 0x00000020 */
 #define FLASH_CR_START                      FLASH_CR_START_Msk                      /*!< Erase start control bit */
 #define FLASH_CR_SNB_Pos                    (6U)
-#define FLASH_CR_SNB_Msk                    (0x7FUL << FLASH_CR_SNB_Pos)            /*!< 0x00001FC0 */
+#define FLASH_CR_SNB_Msk                    (0x1FUL << FLASH_CR_SNB_Pos)            /*!< 0x00001FC0 */
 #define FLASH_CR_SNB                        FLASH_CR_SNB_Msk                        /*!< Sector erase selection number */
 #define FLASH_CR_SNB_0                      (0x01UL << FLASH_CR_SNB_Pos)            /*!< 0x00000040 */
 #define FLASH_CR_SNB_1                      (0x02UL << FLASH_CR_SNB_Pos)            /*!< 0x00000080 */
@@ -10033,10 +7750,10 @@ typedef struct
 
 /******************  Bits definition for FLASH_HDPEXTR register  *****************/
 #define FLASH_HDPEXTR_HDP1_EXT_Pos          (0U)
-#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP1_EXT_Pos)  /*!< 0x0000007F */
+#define FLASH_HDPEXTR_HDP1_EXT_Msk          (0x1FUL << FLASH_HDPEXTR_HDP1_EXT_Pos)  /*!< 0x0000001F */
 #define FLASH_HDPEXTR_HDP1_EXT              FLASH_HDPEXTR_HDP1_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 1 */
 #define FLASH_HDPEXTR_HDP2_EXT_Pos          (16U)
-#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x7FUL << FLASH_HDPEXTR_HDP2_EXT_Pos)  /*!< 0x007F0000 */
+#define FLASH_HDPEXTR_HDP2_EXT_Msk          (0x1FUL << FLASH_HDPEXTR_HDP2_EXT_Pos)  /*!< 0x001F0000 */
 #define FLASH_HDPEXTR_HDP2_EXT              FLASH_HDPEXTR_HDP2_EXT_Msk              /*!< HDP area extension in 8kB sectors in bank 2 */
 
 /*******************  Bits definition for FLASH_OPTSR register  ***************/
@@ -10097,9 +7814,6 @@ typedef struct
 #define FLASH_OPTSR2_BKPRAM_ECC_Pos         (4U)
 #define FLASH_OPTSR2_BKPRAM_ECC_Msk         (0x1UL << FLASH_OPTSR2_BKPRAM_ECC_Pos)  /*!< 0x00000010 */
 #define FLASH_OPTSR2_BKPRAM_ECC             FLASH_OPTSR2_BKPRAM_ECC_Msk             /*!< Backup RAM ECC detection and correction enable */
-#define FLASH_OPTSR2_SRAM3_ECC_Pos          (5U)
-#define FLASH_OPTSR2_SRAM3_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM3_ECC_Pos)   /*!< 0x00000020 */
-#define FLASH_OPTSR2_SRAM3_ECC              FLASH_OPTSR2_SRAM3_ECC_Msk              /*!< SRAM3 ECC detection and correction enable */
 #define FLASH_OPTSR2_SRAM2_ECC_Pos          (6U)
 #define FLASH_OPTSR2_SRAM2_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM2_ECC_Pos)   /*!< 0x00000040 */
 #define FLASH_OPTSR2_SRAM2_ECC              FLASH_OPTSR2_SRAM2_ECC_Msk              /*!< SRAM2 ECC detection and correction disable */
@@ -10125,15 +7839,15 @@ typedef struct
 
 /*****************  Bits definition for FLASH_SECWMR register  ********************/
 #define FLASH_SECWMR_SECWM_STRT_Pos         (0U)
-#define FLASH_SECWMR_SECWM_STRT_Msk         (0x7FUL << FLASH_SECWMR_SECWM_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_SECWMR_SECWM_STRT_Msk         (0x1FUL << FLASH_SECWMR_SECWM_STRT_Pos) /*!< 0x0000001F */
 #define FLASH_SECWMR_SECWM_STRT             FLASH_SECWMR_SECWM_STRT_Msk             /*!< Start sector of secure area */
 #define FLASH_SECWMR_SECWM_END_Pos          (16U)
-#define FLASH_SECWMR_SECWM_END_Msk          (0x7FUL << FLASH_SECWMR_SECWM_END_Pos)  /*!< 0x007F0000 */
+#define FLASH_SECWMR_SECWM_END_Msk          (0x1FUL << FLASH_SECWMR_SECWM_END_Pos)  /*!< 0x001F0000 */
 #define FLASH_SECWMR_SECWM_END              FLASH_SECWMR_SECWM_END_Msk              /*!< End sector of secure area */
 
 /*****************  Bits definition for FLASH_WRPR register  *********************/
 #define FLASH_WRPR_WRPSG_Pos                (0U)
-#define FLASH_WRPR_WRPSG_Msk                (0xFFFFFFFFUL << FLASH_WRPR_WRPSG_Pos) /*!< 0xFFFFFFFF */
+#define FLASH_WRPR_WRPSG_Msk                (0x000000FFUL << FLASH_WRPR_WRPSG_Pos) /*!< 0x000000FF */
 #define FLASH_WRPR_WRPSG                    FLASH_WRPR_WRPSG_Msk  /*!< Sector group protection option status */
 
 /*****************  Bits definition for FLASH_EDATA register  ********************/
@@ -10146,10 +7860,10 @@ typedef struct
 
 /*****************  Bits definition for FLASH_HDPR register  ********************/
 #define FLASH_HDPR_HDP_STRT_Pos             (0U)
-#define FLASH_HDPR_HDP_STRT_Msk             (0x7FUL << FLASH_HDPR_HDP_STRT_Pos)     /*!< 0x0000007F */
+#define FLASH_HDPR_HDP_STRT_Msk             (0x1FUL << FLASH_HDPR_HDP_STRT_Pos)     /*!< 0x0000001F */
 #define FLASH_HDPR_HDP_STRT                 FLASH_HDPR_HDP_STRT_Msk                 /*!< Start sector of hide protection area */
 #define FLASH_HDPR_HDP_END_Pos              (16U)
-#define FLASH_HDPR_HDP_END_Msk              (0x7FUL << FLASH_HDPR_HDP_END_Pos)      /*!< 0x007F0000 */
+#define FLASH_HDPR_HDP_END_Msk              (0x1FUL << FLASH_HDPR_HDP_END_Pos)      /*!< 0x001F0000 */
 #define FLASH_HDPR_HDP_END                  FLASH_HDPR_HDP_END_Msk                  /*!< End sector of hide protection area */
 
 /*******************  Bits definition for FLASH_ECCR register  ***************/
@@ -10185,121 +7899,6 @@ typedef struct
 #define FLASH_ECCDR_FAIL_DATA_Pos           (0U)
 #define FLASH_ECCDR_FAIL_DATA_Msk           (0xFFFFUL << FLASH_ECCDR_FAIL_DATA_Pos) /*!< 0x0000FFFF */
 #define FLASH_ECCDR_FAIL_DATA               FLASH_ECCDR_FAIL_DATA_Msk               /*!< ECC fail data */
-
-/******************************************************************************/
-/*                                                                            */
-/*                Filter Mathematical ACcelerator unit (FMAC)                 */
-/*                                                                            */
-/******************************************************************************/
-/*****************  Bit definition for FMAC_X1BUFCFG register  ****************/
-#define FMAC_X1BUFCFG_X1_BASE_Pos           (0U)
-#define FMAC_X1BUFCFG_X1_BASE_Msk           (0xFFUL << FMAC_X1BUFCFG_X1_BASE_Pos)   /*!< 0x000000FF */
-#define FMAC_X1BUFCFG_X1_BASE               FMAC_X1BUFCFG_X1_BASE_Msk               /*!< Base address of X1 buffer */
-#define FMAC_X1BUFCFG_X1_BUF_SIZE_Pos       (8U)
-#define FMAC_X1BUFCFG_X1_BUF_SIZE_Msk       (0xFFUL << FMAC_X1BUFCFG_X1_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_X1BUFCFG_X1_BUF_SIZE           FMAC_X1BUFCFG_X1_BUF_SIZE_Msk           /*!< Allocated size of X1 buffer in 16-bit words */
-#define FMAC_X1BUFCFG_FULL_WM_Pos           (24U)
-#define FMAC_X1BUFCFG_FULL_WM_Msk           (0x3UL << FMAC_X1BUFCFG_FULL_WM_Pos)    /*!< 0x03000000 */
-#define FMAC_X1BUFCFG_FULL_WM               FMAC_X1BUFCFG_FULL_WM_Msk               /*!< Watermark for buffer full flag */
-
-/*****************  Bit definition for FMAC_X2BUFCFG register  ****************/
-#define FMAC_X2BUFCFG_X2_BASE_Pos           (0U)
-#define FMAC_X2BUFCFG_X2_BASE_Msk           (0xFFUL << FMAC_X2BUFCFG_X2_BASE_Pos)   /*!< 0x000000FF */
-#define FMAC_X2BUFCFG_X2_BASE               FMAC_X2BUFCFG_X2_BASE_Msk               /*!< Base address of X2 buffer */
-#define FMAC_X2BUFCFG_X2_BUF_SIZE_Pos       (8U)
-#define FMAC_X2BUFCFG_X2_BUF_SIZE_Msk       (0xFFUL << FMAC_X2BUFCFG_X2_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_X2BUFCFG_X2_BUF_SIZE           FMAC_X2BUFCFG_X2_BUF_SIZE_Msk           /*!< Size of X2 buffer in 16-bit words */
-
-/*****************  Bit definition for FMAC_YBUFCFG register  *****************/
-#define FMAC_YBUFCFG_Y_BASE_Pos             (0U)
-#define FMAC_YBUFCFG_Y_BASE_Msk             (0xFFUL << FMAC_YBUFCFG_Y_BASE_Pos)     /*!< 0x000000FF */
-#define FMAC_YBUFCFG_Y_BASE                 FMAC_YBUFCFG_Y_BASE_Msk                 /*!< Base address of Y buffer */
-#define FMAC_YBUFCFG_Y_BUF_SIZE_Pos         (8U)
-#define FMAC_YBUFCFG_Y_BUF_SIZE_Msk         (0xFFUL << FMAC_YBUFCFG_Y_BUF_SIZE_Pos) /*!< 0x0000FF00 */
-#define FMAC_YBUFCFG_Y_BUF_SIZE             FMAC_YBUFCFG_Y_BUF_SIZE_Msk             /*!< Size of Y buffer in 16-bit words */
-#define FMAC_YBUFCFG_EMPTY_WM_Pos           (24U)
-#define FMAC_YBUFCFG_EMPTY_WM_Msk           (0x3UL << FMAC_YBUFCFG_EMPTY_WM_Pos)    /*!< 0x03000000 */
-#define FMAC_YBUFCFG_EMPTY_WM               FMAC_YBUFCFG_EMPTY_WM_Msk               /*!< Watermark for buffer empty flag */
-
-/******************  Bit definition for FMAC_PARAM register  ******************/
-#define FMAC_PARAM_P_Pos                    (0U)
-#define FMAC_PARAM_P_Msk                    (0xFFUL << FMAC_PARAM_P_Pos)            /*!< 0x000000FF */
-#define FMAC_PARAM_P                        FMAC_PARAM_P_Msk                        /*!< Input parameter P */
-#define FMAC_PARAM_Q_Pos                    (8U)
-#define FMAC_PARAM_Q_Msk                    (0xFFUL << FMAC_PARAM_Q_Pos)            /*!< 0x0000FF00 */
-#define FMAC_PARAM_Q                        FMAC_PARAM_Q_Msk                        /*!< Input parameter Q */
-#define FMAC_PARAM_R_Pos                    (16U)
-#define FMAC_PARAM_R_Msk                    (0xFFUL << FMAC_PARAM_R_Pos)            /*!< 0x00FF0000 */
-#define FMAC_PARAM_R                        FMAC_PARAM_R_Msk                        /*!< Input parameter R */
-#define FMAC_PARAM_FUNC_Pos                 (24U)
-#define FMAC_PARAM_FUNC_Msk                 (0x7FUL << FMAC_PARAM_FUNC_Pos)         /*!< 0x7F000000 */
-#define FMAC_PARAM_FUNC                     FMAC_PARAM_FUNC_Msk                     /*!< Function */
-#define FMAC_PARAM_FUNC_0                   (0x1UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x01000000 */
-#define FMAC_PARAM_FUNC_1                   (0x2UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x02000000 */
-#define FMAC_PARAM_FUNC_2                   (0x4UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x04000000 */
-#define FMAC_PARAM_FUNC_3                   (0x8UL << FMAC_PARAM_FUNC_Pos)          /*!< 0x08000000 */
-#define FMAC_PARAM_FUNC_4                   (0x10UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x10000000 */
-#define FMAC_PARAM_FUNC_5                   (0x20UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x20000000 */
-#define FMAC_PARAM_FUNC_6                   (0x40UL << FMAC_PARAM_FUNC_Pos)         /*!< 0x40000000 */
-#define FMAC_PARAM_START_Pos                (31U)
-#define FMAC_PARAM_START_Msk                (0x1UL << FMAC_PARAM_START_Pos)         /*!< 0x80000000 */
-#define FMAC_PARAM_START                    FMAC_PARAM_START_Msk                    /*!< Enable execution */
-
-/********************  Bit definition for FMAC_CR register  *******************/
-#define FMAC_CR_RIEN_Pos                    (0U)
-#define FMAC_CR_RIEN_Msk                    (0x1UL << FMAC_CR_RIEN_Pos)             /*!< 0x00000001 */
-#define FMAC_CR_RIEN                        FMAC_CR_RIEN_Msk                        /*!< Enable read interrupt */
-#define FMAC_CR_WIEN_Pos                    (1U)
-#define FMAC_CR_WIEN_Msk                    (0x1UL << FMAC_CR_WIEN_Pos)             /*!< 0x00000002 */
-#define FMAC_CR_WIEN                        FMAC_CR_WIEN_Msk                        /*!< Enable write interrupt */
-#define FMAC_CR_OVFLIEN_Pos                 (2U)
-#define FMAC_CR_OVFLIEN_Msk                 (0x1UL << FMAC_CR_OVFLIEN_Pos)          /*!< 0x00000004 */
-#define FMAC_CR_OVFLIEN                     FMAC_CR_OVFLIEN_Msk                     /*!< Enable overflow error interrupts */
-#define FMAC_CR_UNFLIEN_Pos                 (3U)
-#define FMAC_CR_UNFLIEN_Msk                 (0x1UL << FMAC_CR_UNFLIEN_Pos)          /*!< 0x00000008 */
-#define FMAC_CR_UNFLIEN                     FMAC_CR_UNFLIEN_Msk                     /*!< Enable underflow error interrupts */
-#define FMAC_CR_SATIEN_Pos                  (4U)
-#define FMAC_CR_SATIEN_Msk                  (0x1UL << FMAC_CR_SATIEN_Pos)           /*!< 0x00000010 */
-#define FMAC_CR_SATIEN                      FMAC_CR_SATIEN_Msk                      /*!< Enable saturation error interrupts */
-#define FMAC_CR_DMAREN_Pos                  (8U)
-#define FMAC_CR_DMAREN_Msk                  (0x1UL << FMAC_CR_DMAREN_Pos)           /*!< 0x00000100 */
-#define FMAC_CR_DMAREN                      FMAC_CR_DMAREN_Msk                      /*!< Enable DMA read channel requests */
-#define FMAC_CR_DMAWEN_Pos                  (9U)
-#define FMAC_CR_DMAWEN_Msk                  (0x1UL << FMAC_CR_DMAWEN_Pos)           /*!< 0x00000200 */
-#define FMAC_CR_DMAWEN                      FMAC_CR_DMAWEN_Msk                      /*!< Enable DMA write channel requests */
-#define FMAC_CR_CLIPEN_Pos                  (15U)
-#define FMAC_CR_CLIPEN_Msk                  (0x1UL << FMAC_CR_CLIPEN_Pos)           /*!< 0x00008000 */
-#define FMAC_CR_CLIPEN                      FMAC_CR_CLIPEN_Msk                      /*!< Enable clipping */
-#define FMAC_CR_RESET_Pos                   (16U)
-#define FMAC_CR_RESET_Msk                   (0x1UL << FMAC_CR_RESET_Pos)            /*!< 0x00010000 */
-#define FMAC_CR_RESET                       FMAC_CR_RESET_Msk                       /*!< Reset filter mathematical accelerator unit */
-
-/*******************  Bit definition for FMAC_SR register  ********************/
-#define FMAC_SR_YEMPTY_Pos                  (0U)
-#define FMAC_SR_YEMPTY_Msk                  (0x1UL << FMAC_SR_YEMPTY_Pos)           /*!< 0x00000001 */
-#define FMAC_SR_YEMPTY                      FMAC_SR_YEMPTY_Msk                      /*!< Y buffer empty flag */
-#define FMAC_SR_X1FULL_Pos                  (1U)
-#define FMAC_SR_X1FULL_Msk                  (0x1UL << FMAC_SR_X1FULL_Pos)           /*!< 0x00000002 */
-#define FMAC_SR_X1FULL                      FMAC_SR_X1FULL_Msk                      /*!< X1 buffer full flag */
-#define FMAC_SR_OVFL_Pos                    (8U)
-#define FMAC_SR_OVFL_Msk                    (0x1UL << FMAC_SR_OVFL_Pos)             /*!< 0x00000100 */
-#define FMAC_SR_OVFL                        FMAC_SR_OVFL_Msk                        /*!< Overflow error flag */
-#define FMAC_SR_UNFL_Pos                    (9U)
-#define FMAC_SR_UNFL_Msk                    (0x1UL << FMAC_SR_UNFL_Pos)             /*!< 0x00000200 */
-#define FMAC_SR_UNFL                        FMAC_SR_UNFL_Msk                        /*!< Underflow error flag */
-#define FMAC_SR_SAT_Pos                     (10U)
-#define FMAC_SR_SAT_Msk                     (0x1UL << FMAC_SR_SAT_Pos)              /*!< 0x00000400 */
-#define FMAC_SR_SAT                         FMAC_SR_SAT_Msk                         /*!< Saturation error flag */
-
-/******************  Bit definition for FMAC_WDATA register  ******************/
-#define FMAC_WDATA_WDATA_Pos                (0U)
-#define FMAC_WDATA_WDATA_Msk                (0xFFFFUL << FMAC_WDATA_WDATA_Pos)      /*!< 0x0000FFFF */
-#define FMAC_WDATA_WDATA                    FMAC_WDATA_WDATA_Msk                    /*!< Write data */
-
-/******************  Bit definition for FMACX_RDATA register  *****************/
-#define FMAC_RDATA_RDATA_Pos                (0U)
-#define FMAC_RDATA_RDATA_Msk                (0xFFFFUL << FMAC_RDATA_RDATA_Pos)      /*!< 0x0000FFFF */
-#define FMAC_RDATA_RDATA                    FMAC_RDATA_RDATA_Msk                    /*!< Read data */
 
 /******************************************************************************/
 /*                                                                            */
@@ -14487,6 +12086,116 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
+/*                              On The Fly Decryption                         */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for OTFDEC_CR register  ******************/
+#define OTFDEC_CR_ENC_Pos                   (0U)
+#define OTFDEC_CR_ENC_Msk                   (0x1UL << OTFDEC_CR_ENC_Pos)            /*!< 0x00000001 */
+#define OTFDEC_CR_ENC                       OTFDEC_CR_ENC_Msk                       /*!< Encryption mode bit */
+
+/******************  Bit definition for OTFDEC_PRIVCFGR register  ************/
+#define OTFDEC_PRIVCFGR_PRIV_Pos            (0U)
+#define OTFDEC_PRIVCFGR_PRIV_Msk            (0x1UL << OTFDEC_PRIVCFGR_PRIV_Pos)     /*!< 0x00000001 */
+#define OTFDEC_PRIVCFGR_PRIV                OTFDEC_PRIVCFGR_PRIV_Msk                /*!< Privileged access protection */
+
+/******************  Bit definition for OTFDEC_REG_CONFIGR register  *********/
+#define OTFDEC_REG_CONFIGR_REG_EN_Pos       (0U)
+#define OTFDEC_REG_CONFIGR_REG_EN_Msk       (0x1UL << OTFDEC_REG_CONFIGR_REG_EN_Pos) /*!< 0x00000001 */
+#define OTFDEC_REG_CONFIGR_REG_EN           OTFDEC_REG_CONFIGR_REG_EN_Msk           /*!< Region on-the-fly decryption enable */
+#define OTFDEC_REG_CONFIGR_CONFIGLOCK_Pos   (1U)
+#define OTFDEC_REG_CONFIGR_CONFIGLOCK_Msk   (0x1UL << OTFDEC_REG_CONFIGR_CONFIGLOCK_Pos) /*!< 0x00000002 */
+#define OTFDEC_REG_CONFIGR_CONFIGLOCK       OTFDEC_REG_CONFIGR_CONFIGLOCK_Msk       /*!< Region config lock */
+#define OTFDEC_REG_CONFIGR_KEYLOCK_Pos      (2U)
+#define OTFDEC_REG_CONFIGR_KEYLOCK_Msk      (0x1UL << OTFDEC_REG_CONFIGR_KEYLOCK_Pos) /*!< 0x00000004 */
+#define OTFDEC_REG_CONFIGR_KEYLOCK          OTFDEC_REG_CONFIGR_KEYLOCK_Msk          /*!< Region key lock */
+#define OTFDEC_REG_CONFIGR_MODE_Pos         (4U)
+#define OTFDEC_REG_CONFIGR_MODE_Msk         (0x3UL << OTFDEC_REG_CONFIGR_MODE_Pos)  /*!< 0x00000030 */
+#define OTFDEC_REG_CONFIGR_MODE             OTFDEC_REG_CONFIGR_MODE_Msk             /*!< Region operating mode */
+#define OTFDEC_REG_CONFIGR_MODE_0           (0x1UL << OTFDEC_REG_CONFIGR_MODE_Pos)  /*!< 0x00000010 */
+#define OTFDEC_REG_CONFIGR_MODE_1           (0x2UL << OTFDEC_REG_CONFIGR_MODE_Pos)  /*!< 0x00000020 */
+#define OTFDEC_REG_CONFIGR_KEYCRC_Pos       (8U)
+#define OTFDEC_REG_CONFIGR_KEYCRC_Msk       (0xFFUL << OTFDEC_REG_CONFIGR_KEYCRC_Pos) /*!< 0x0000FF00 */
+#define OTFDEC_REG_CONFIGR_KEYCRC           OTFDEC_REG_CONFIGR_KEYCRC_Msk           /*!< Region key 8-bit CRC */
+#define OTFDEC_REG_CONFIGR_VERSION_Pos      (16U)
+#define OTFDEC_REG_CONFIGR_VERSION_Msk      (0xFFFFUL << OTFDEC_REG_CONFIGR_VERSION_Pos) /*!< 0xFFFF0000 */
+#define OTFDEC_REG_CONFIGR_VERSION          OTFDEC_REG_CONFIGR_VERSION_Msk          /*!< Region firmware version */
+
+/******************  Bit definition for OTFDEC_REG_START_ADDR register  ******/
+#define OTFDEC_REG_START_ADDR_Pos           (0U)
+#define OTFDEC_REG_START_ADDR_Msk           (0xFFFFFFFFUL << OTFDEC_REG_START_ADDR_Pos) /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_START_ADDR               OTFDEC_REG_START_ADDR_Msk               /*!< Region AHB start address */
+
+/******************  Bit definition for OTFDEC_REG_END_ADDR register  ********/
+#define OTFDEC_REG_END_ADDR_Pos             (0U)
+#define OTFDEC_REG_END_ADDR_Msk             (0xFFFFFFFFUL << OTFDEC_REG_END_ADDR_Pos) /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_END_ADDR                 OTFDEC_REG_END_ADDR_Msk                 /*!< Region AHB end address */
+
+/******************  Bit definition for OTFDEC_REG_NONCER0 register  *********/
+#define OTFDEC_REG_NONCER0_Pos              (0U)
+#define OTFDEC_REG_NONCER0_Msk              (0xFFFFFFFFUL << OTFDEC_REG_NONCER0_Pos) /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_NONCER0                  OTFDEC_REG_NONCER0_Msk                  /*!< Region Nonce Register (LSB nonce[31:0]) */
+
+/******************  Bit definition for OTFDEC_REG_NONCER1 register  *********/
+#define OTFDEC_REG_NONCER1_Pos              (0U)
+#define OTFDEC_REG_NONCER1_Msk              (0xFFFFFFFFUL << OTFDEC_REG_NONCER1_Pos) /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_NONCER1                  OTFDEC_REG_NONCER1_Msk                  /*!< Region Nonce Register (MSB nonce[63:32]) */
+
+/******************  Bit definition for OTFDEC_REG_KEYR0 register  ***********/
+#define OTFDEC_REG_KEYR0_Pos                (0U)
+#define OTFDEC_REG_KEYR0_Msk                (0xFFFFFFFFUL << OTFDEC_REG_KEYR0_Pos)  /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_KEYR0                    OTFDEC_REG_KEYR0_Msk                    /*!< Region Key Register (LSB key[31:0]) */
+
+/******************  Bit definition for OTFDEC_REG_KEYR1 register  ***********/
+#define OTFDEC_REG_KEYR1_Pos                (0U)
+#define OTFDEC_REG_KEYR1_Msk                (0xFFFFFFFFUL << OTFDEC_REG_KEYR1_Pos)  /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_KEYR1                    OTFDEC_REG_KEYR1_Msk                    /*!< Region Key Register (key[63:32]) */
+
+/******************  Bit definition for OTFDEC_REG_KEYR2 register  ***********/
+#define OTFDEC_REG_KEYR2_Pos                (0U)
+#define OTFDEC_REG_KEYR2_Msk                (0xFFFFFFFFUL << OTFDEC_REG_KEYR2_Pos)  /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_KEYR2                    OTFDEC_REG_KEYR2_Msk                    /*!< Region Key Register (key[95:64]) */
+
+/******************  Bit definition for OTFDEC_REG_KEYR3 register  ***********/
+#define OTFDEC_REG_KEYR3_Pos                (0U)
+#define OTFDEC_REG_KEYR3_Msk                (0xFFFFFFFFUL << OTFDEC_REG_KEYR3_Pos)  /*!< 0xFFFFFFFF */
+#define OTFDEC_REG_KEYR3                    OTFDEC_REG_KEYR3_Msk                    /*!< Region Key Register (key[127:96]) */
+
+/******************  Bit definition for OTFDEC_ISR register  *****************/
+#define OTFDEC_ISR_SEIF_Pos                 (0U)
+#define OTFDEC_ISR_SEIF_Msk                 (0x1UL << OTFDEC_ISR_SEIF_Pos)          /*!< 0x00000001 */
+#define OTFDEC_ISR_SEIF                     OTFDEC_ISR_SEIF_Msk                     /*!< Security Error Interrupt Flag status bit before enable (mask) */
+#define OTFDEC_ISR_XONEIF_Pos               (1U)
+#define OTFDEC_ISR_XONEIF_Msk               (0x1UL << OTFDEC_ISR_XONEIF_Pos)        /*!< 0x00000002 */
+#define OTFDEC_ISR_XONEIF                   OTFDEC_ISR_XONEIF_Msk                   /*!< Execute-only Error Interrupt Flag status bit before enable (mask) */
+#define OTFDEC_ISR_KEIF_Pos                 (2U)
+#define OTFDEC_ISR_KEIF_Msk                 (0x1UL << OTFDEC_ISR_KEIF_Pos)          /*!< 0x00000004 */
+#define OTFDEC_ISR_KEIF                     OTFDEC_ISR_KEIF_Msk                     /*!< Key Error Interrupt Flag status bit before enable (mask) */
+
+/******************  Bit definition  for OTFDEC_ICR register  *****************/
+#define OTFDEC_ICR_SEIF_Pos                 (0U)
+#define OTFDEC_ICR_SEIF_Msk                 (0x1UL << OTFDEC_ICR_SEIF_Pos)          /*!< 0x00000001 */
+#define OTFDEC_ICR_SEIF                     OTFDEC_ICR_SEIF_Msk                     /*!< Security Error Interrupt Flag clear bit */
+#define OTFDEC_ICR_XONEIF_Pos               (1U)
+#define OTFDEC_ICR_XONEIF_Msk               (0x1UL << OTFDEC_ICR_XONEIF_Pos)        /*!< 0x00000002 */
+#define OTFDEC_ICR_XONEIF                   OTFDEC_ICR_XONEIF_Msk                   /*!< Execute-only Error Interrupt Flag clear bit */
+#define OTFDEC_ICR_KEIF_Pos                 (2U)
+#define OTFDEC_ICR_KEIF_Msk                 (0x1UL << OTFDEC_ICR_KEIF_Pos)          /*!< 0x00000004 */
+#define OTFDEC_ICR_KEIF                     OTFDEC_ICR_KEIF_Msk                     /*!< Key Error Interrupt Flag clear bit */
+
+/******************  Bit definition for OTFDEC_IER register  *****************/
+#define OTFDEC_IER_SEIE_Pos                 (0U)
+#define OTFDEC_IER_SEIE_Msk                 (0x1UL << OTFDEC_IER_SEIE_Pos)          /*!< 0x00000001 */
+#define OTFDEC_IER_SEIE                     OTFDEC_IER_SEIE_Msk                     /*!< Security Error Interrupt Enable bit */
+#define OTFDEC_IER_XONEIE_Pos               (1U)
+#define OTFDEC_IER_XONEIE_Msk               (0x1UL << OTFDEC_IER_XONEIE_Pos)        /*!< 0x00000002 */
+#define OTFDEC_IER_XONEIE                   OTFDEC_IER_XONEIE_Msk                   /*!< Execute-only Error Interrupt Enable bit */
+#define OTFDEC_IER_KEIE_Pos                 (2U)
+#define OTFDEC_IER_KEIE_Msk                 (0x1UL << OTFDEC_IER_KEIE_Pos)          /*!< 0x00000004 */
+#define OTFDEC_IER_KEIE                     OTFDEC_IER_KEIE_Msk
+
+/******************************************************************************/
+/*                                                                            */
 /*                             Power Control                                  */
 /*                                                                            */
 /******************************************************************************/
@@ -14511,19 +12220,19 @@ typedef struct
 #define PWR_PMCR_AVD_READY_Pos               (13U)
 #define PWR_PMCR_AVD_READY_Msk               (0x1UL << PWR_PMCR_AVD_READY_Pos)
 #define PWR_PMCR_AVD_READY                   PWR_PMCR_AVD_READY_Msk
-#define PWR_PMCR_ETHERNETSO_Pos              (16U)
-#define PWR_PMCR_ETHERNETSO_Msk              (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
-#define PWR_PMCR_ETHERNETSO                  PWR_PMCR_ETHERNETSO_Msk
 #define PWR_PMCR_SRAM3SO_Pos                 (23U)
 #define PWR_PMCR_SRAM3SO_Msk                 (0x1UL << PWR_PMCR_SRAM3SO_Pos)
 #define PWR_PMCR_SRAM3SO                     PWR_PMCR_SRAM3SO_Msk
-#define PWR_PMCR_SRAM2_16SO_Pos              (24U)
-#define PWR_PMCR_SRAM2_16SO_Msk              (0x1UL << PWR_PMCR_SRAM2_16SO_Pos)
-#define PWR_PMCR_SRAM2_16SO                  PWR_PMCR_SRAM2_16SO_Msk
-#define PWR_PMCR_SRAM2_48SO_Pos              (25U)
+#define PWR_PMCR_SRAM2_16LSO_Pos             (24U)
+#define PWR_PMCR_SRAM2_16LSO_Msk             (0x1UL << PWR_PMCR_SRAM2_16LSO_Pos)
+#define PWR_PMCR_SRAM2_16LSO                 PWR_PMCR_SRAM2_16LSO_Msk
+#define PWR_PMCR_SRAM2_16HSO_Pos             (25U)
+#define PWR_PMCR_SRAM2_16HSO_Msk             (0x1UL << PWR_PMCR_SRAM2_16HSO_Pos)
+#define PWR_PMCR_SRAM2_16HSO                 PWR_PMCR_SRAM2_16HSO_Msk
+#define PWR_PMCR_SRAM2_48SO_Pos              (26U)
 #define PWR_PMCR_SRAM2_48SO_Msk              (0x1UL << PWR_PMCR_SRAM2_48SO_Pos)
 #define PWR_PMCR_SRAM2_48SO                  PWR_PMCR_SRAM2_48SO_Msk
-#define PWR_PMCR_SRAM1SO_Pos                 (26U)
+#define PWR_PMCR_SRAM1SO_Pos                 (27U)
 #define PWR_PMCR_SRAM1SO_Msk                 (0x1UL << PWR_PMCR_SRAM1SO_Pos)
 #define PWR_PMCR_SRAM1SO                     PWR_PMCR_SRAM1SO_Msk
 
@@ -14606,9 +12315,6 @@ typedef struct
 #define PWR_SCCR_LDOEN_Pos                   (8U)
 #define PWR_SCCR_LDOEN_Msk                   (0x1UL << PWR_SCCR_LDOEN_Pos)
 #define PWR_SCCR_LDOEN                       PWR_SCCR_LDOEN_Msk
-#define PWR_SCCR_SMPSEN_Pos                  (9U)
-#define PWR_SCCR_SMPSEN_Msk                  (0x1UL << PWR_SCCR_SMPSEN_Pos)
-#define PWR_SCCR_SMPSEN                      PWR_SCCR_SMPSEN_Msk
 
 /********************  Bit definition for PWR_VMCR register  ******************/
 #define PWR_VMCR_PVDEN_Pos                   (0U)
@@ -15108,6 +12814,55 @@ typedef struct
 #define RAMCFG_WPR2_P63WP_Msk               (0x1UL << RAMCFG_WPR2_P63WP_Pos)        /*!< 0x80000000 */
 #define RAMCFG_WPR2_P63WP                   RAMCFG_WPR2_P63WP_Msk                   /*!< Write Protection Page 63 */
 
+/******************  Bit definition for RAMCFG_WPR3 register  ****************/
+#define RAMCFG_WPR3_P64WP_Pos               (0U)
+#define RAMCFG_WPR3_P64WP_Msk               (0x1UL << RAMCFG_WPR3_P64WP_Pos)        /*!< 0x00000001 */
+#define RAMCFG_WPR3_P64WP                   RAMCFG_WPR3_P64WP_Msk                   /*!< Write Protection Page 64 */
+#define RAMCFG_WPR3_P65WP_Pos               (1U)
+#define RAMCFG_WPR3_P65WP_Msk               (0x1UL << RAMCFG_WPR3_P65WP_Pos)        /*!< 0x00000002 */
+#define RAMCFG_WPR3_P65WP                   RAMCFG_WPR3_P65WP_Msk                   /*!< Write Protection Page 65 */
+#define RAMCFG_WPR3_P66WP_Pos               (2U)
+#define RAMCFG_WPR3_P66WP_Msk               (0x1UL << RAMCFG_WPR3_P66WP_Pos)        /*!< 0x00000004 */
+#define RAMCFG_WPR3_P66WP                   RAMCFG_WPR3_P66WP_Msk                   /*!< Write Protection Page 66 */
+#define RAMCFG_WPR3_P67WP_Pos               (3U)
+#define RAMCFG_WPR3_P67WP_Msk               (0x1UL << RAMCFG_WPR3_P67WP_Pos)        /*!< 0x00000008 */
+#define RAMCFG_WPR3_P67WP                   RAMCFG_WPR3_P67WP_Msk                   /*!< Write Protection Page 67 */
+#define RAMCFG_WPR3_P68WP_Pos               (4U)
+#define RAMCFG_WPR3_P68WP_Msk               (0x1UL << RAMCFG_WPR3_P68WP_Pos)        /*!< 0x00000010 */
+#define RAMCFG_WPR3_P68WP                   RAMCFG_WPR3_P68WP_Msk                   /*!< Write Protection Page 68 */
+#define RAMCFG_WPR3_P69WP_Pos               (5U)
+#define RAMCFG_WPR3_P69WP_Msk               (0x1UL << RAMCFG_WPR3_P69WP_Pos)        /*!< 0x00000020 */
+#define RAMCFG_WPR3_P69WP                   RAMCFG_WPR3_P69WP_Msk                   /*!< Write Protection Page 69 */
+#define RAMCFG_WPR3_P70WP_Pos               (6U)
+#define RAMCFG_WPR3_P70WP_Msk               (0x1UL << RAMCFG_WPR3_P70WP_Pos)        /*!< 0x00000040 */
+#define RAMCFG_WPR3_P70WP                   RAMCFG_WPR3_P70WP_Msk                   /*!< Write Protection Page 70 */
+#define RAMCFG_WPR3_P71WP_Pos               (7U)
+#define RAMCFG_WPR3_P71WP_Msk               (0x1UL << RAMCFG_WPR3_P71WP_Pos)        /*!< 0x00000080 */
+#define RAMCFG_WPR3_P71WP                   RAMCFG_WPR3_P71WP_Msk                   /*!< Write Protection Page 71 */
+#define RAMCFG_WPR3_P72WP_Pos               (8U)
+#define RAMCFG_WPR3_P72WP_Msk               (0x1UL << RAMCFG_WPR3_P72WP_Pos)        /*!< 0x00000100 */
+#define RAMCFG_WPR3_P72WP                   RAMCFG_WPR3_P72WP_Msk                   /*!< Write Protection Page 72 */
+#define RAMCFG_WPR3_P73WP_Pos               (9U)
+#define RAMCFG_WPR3_P73WP_Msk               (0x1UL << RAMCFG_WPR3_P73WP_Pos)        /*!< 0x00000200 */
+#define RAMCFG_WPR3_P73WP                   RAMCFG_WPR3_P73WP_Msk                   /*!< Write Protection Page 73 */
+#define RAMCFG_WPR3_P74WP_Pos               (10U)
+#define RAMCFG_WPR3_P74WP_Msk               (0x1UL << RAMCFG_WPR3_P74WP_Pos)        /*!< 0x00000400 */
+#define RAMCFG_WPR3_P74WP                   RAMCFG_WPR3_P74WP_Msk                   /*!< Write Protection Page 74 */
+#define RAMCFG_WPR3_P75WP_Pos               (11U)
+#define RAMCFG_WPR3_P75WP_Msk               (0x1UL << RAMCFG_WPR3_P75WP_Pos)        /*!< 0x00000800 */
+#define RAMCFG_WPR3_P75WP                   RAMCFG_WPR3_P75WP_Msk                   /*!< Write Protection Page 75 */
+#define RAMCFG_WPR3_P76WP_Pos               (12U)
+#define RAMCFG_WPR3_P76WP_Msk               (0x1UL << RAMCFG_WPR3_P76WP_Pos)        /*!< 0x00001000 */
+#define RAMCFG_WPR3_P76WP                   RAMCFG_WPR3_P76WP_Msk                   /*!< Write Protection Page 76 */
+#define RAMCFG_WPR3_P77WP_Pos               (13U)
+#define RAMCFG_WPR3_P77WP_Msk               (0x1UL << RAMCFG_WPR3_P77WP_Pos)        /*!< 0x00002000 */
+#define RAMCFG_WPR3_P77WP                   RAMCFG_WPR3_P77WP_Msk                   /*!< Write Protection Page 77 */
+#define RAMCFG_WPR3_P78WP_Pos               (14U)
+#define RAMCFG_WPR3_P78WP_Msk               (0x1UL << RAMCFG_WPR3_P78WP_Pos)        /*!< 0x00004000 */
+#define RAMCFG_WPR3_P78WP                   RAMCFG_WPR3_P78WP_Msk                   /*!< Write Protection Page 78 */
+#define RAMCFG_WPR3_P79WP_Pos               (15U)
+#define RAMCFG_WPR3_P79WP_Msk               (0x1UL << RAMCFG_WPR3_P79WP_Pos)        /*!< 0x00008000 */
+#define RAMCFG_WPR3_P79WP                   RAMCFG_WPR3_P79WP_Msk                   /*!< Write Protection Page 79 */
 /*****************  Bit definition for RAMCFG_ECCKEYR register  ***************/
 #define RAMCFG_ECCKEYR_ECCKEY_Pos           (0U)
 #define RAMCFG_ECCKEYR_ECCKEY_Msk           (0xFFUL << RAMCFG_ECCKEYR_ECCKEY_Pos)   /*!< 0x000000FF */
@@ -15782,18 +13537,9 @@ typedef struct
 #define RCC_AHB1RSTR_CRCRST_Pos             (12U)
 #define RCC_AHB1RSTR_CRCRST_Msk             (0x1UL << RCC_AHB1RSTR_CRCRST_Pos)      /*!< 0x00001000 */
 #define RCC_AHB1RSTR_CRCRST                 RCC_AHB1RSTR_CRCRST_Msk
-#define RCC_AHB1RSTR_CORDICRST_Pos          (14U)
-#define RCC_AHB1RSTR_CORDICRST_Msk          (0x1UL << RCC_AHB1RSTR_CORDICRST_Pos)   /*!< 0x00004000 */
-#define RCC_AHB1RSTR_CORDICRST              RCC_AHB1RSTR_CORDICRST_Msk
-#define RCC_AHB1RSTR_FMACRST_Pos            (15U)
-#define RCC_AHB1RSTR_FMACRST_Msk            (0x1UL << RCC_AHB1RSTR_FMACRST_Pos)     /*!< 0x00008000 */
-#define RCC_AHB1RSTR_FMACRST                RCC_AHB1RSTR_FMACRST_Msk
 #define RCC_AHB1RSTR_RAMCFGRST_Pos          (17U)
 #define RCC_AHB1RSTR_RAMCFGRST_Msk          (0x1UL << RCC_AHB1RSTR_RAMCFGRST_Pos)   /*!< 0x00020000 */
 #define RCC_AHB1RSTR_RAMCFGRST              RCC_AHB1RSTR_RAMCFGRST_Msk
-#define RCC_AHB1RSTR_ETHRST_Pos             (19U)
-#define RCC_AHB1RSTR_ETHRST_Msk             (0x1UL << RCC_AHB1RSTR_ETHRST_Pos)      /*!< 0x00080000 */
-#define RCC_AHB1RSTR_ETHRST                 RCC_AHB1RSTR_ETHRST_Msk
 #define RCC_AHB1RSTR_TZSC1RST_Pos           (24U)
 #define RCC_AHB1RSTR_TZSC1RST_Msk           (0x1UL << RCC_AHB1RSTR_TZSC1RST_Pos)    /*!< 0x01000000 */
 #define RCC_AHB1RSTR_TZSC1RST               RCC_AHB1RSTR_TZSC1RST_Msk
@@ -15823,9 +13569,6 @@ typedef struct
 #define RCC_AHB2RSTR_GPIOHRST_Pos           (7U)
 #define RCC_AHB2RSTR_GPIOHRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOHRST_Pos)    /*!< 0x00000080 */
 #define RCC_AHB2RSTR_GPIOHRST               RCC_AHB2RSTR_GPIOHRST_Msk
-#define RCC_AHB2RSTR_GPIOIRST_Pos           (8U)
-#define RCC_AHB2RSTR_GPIOIRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOIRST_Pos)    /*!< 0x00000100 */
-#define RCC_AHB2RSTR_GPIOIRST               RCC_AHB2RSTR_GPIOIRST_Msk
 #define RCC_AHB2RSTR_ADCRST_Pos             (10U)
 #define RCC_AHB2RSTR_ADCRST_Msk             (0x1UL << RCC_AHB2RSTR_ADCRST_Pos)      /*!< 0x00000400 */
 #define RCC_AHB2RSTR_ADCRST                 RCC_AHB2RSTR_ADCRST_Msk
@@ -15835,6 +13578,9 @@ typedef struct
 #define RCC_AHB2RSTR_DCMI_PSSIRST_Pos       (12U)
 #define RCC_AHB2RSTR_DCMI_PSSIRST_Msk       (0x1UL << RCC_AHB2RSTR_DCMI_PSSIRST_Pos) /*!< 0x00001000 */
 #define RCC_AHB2RSTR_DCMI_PSSIRST           RCC_AHB2RSTR_DCMI_PSSIRST_Msk
+#define RCC_AHB2RSTR_AESRST_Pos             (16U)
+#define RCC_AHB2RSTR_AESRST_Msk             (0x1UL << RCC_AHB2RSTR_AESRST_Pos)    /*!< 0x00010000 */
+#define RCC_AHB2RSTR_AESRST                 RCC_AHB2RSTR_AESRST_Msk
 #define RCC_AHB2RSTR_HASHRST_Pos            (17U)
 #define RCC_AHB2RSTR_HASHRST_Msk            (0x1UL << RCC_AHB2RSTR_HASHRST_Pos)     /*!< 0x00020000 */
 #define RCC_AHB2RSTR_HASHRST                RCC_AHB2RSTR_HASHRST_Msk
@@ -15844,14 +13590,17 @@ typedef struct
 #define RCC_AHB2RSTR_PKARST_Pos             (19U)
 #define RCC_AHB2RSTR_PKARST_Msk             (0x1UL << RCC_AHB2RSTR_PKARST_Pos)      /*!< 0x00080000 */
 #define RCC_AHB2RSTR_PKARST                 RCC_AHB2RSTR_PKARST_Msk
+#define RCC_AHB2RSTR_SAESRST_Pos            (20U)
+#define RCC_AHB2RSTR_SAESRST_Msk            (0x1UL << RCC_AHB2RSTR_SAESRST_Pos)   /*!< 0x00100000 */
+#define RCC_AHB2RSTR_SAESRST                RCC_AHB2RSTR_SAESRST_Msk
 
 /********************  Bit definition for RCC_AHB4RSTR register  **************/
+#define RCC_AHB4RSTR_OTFDEC1RST_Pos         (7U)
+#define RCC_AHB4RSTR_OTFDEC1RST_Msk         (0x1UL << RCC_AHB4RSTR_OTFDEC1RST_Pos)  /*!< 0x00000080 */
+#define RCC_AHB4RSTR_OTFDEC1RST             RCC_AHB4RSTR_OTFDEC1RST_Msk
 #define RCC_AHB4RSTR_SDMMC1RST_Pos          (11U)
 #define RCC_AHB4RSTR_SDMMC1RST_Msk          (0x1UL << RCC_AHB4RSTR_SDMMC1RST_Pos)   /*!< 0x00000800 */
 #define RCC_AHB4RSTR_SDMMC1RST              RCC_AHB4RSTR_SDMMC1RST_Msk
-#define RCC_AHB4RSTR_SDMMC2RST_Pos          (12U)
-#define RCC_AHB4RSTR_SDMMC2RST_Msk          (0x1UL << RCC_AHB4RSTR_SDMMC2RST_Pos)   /*!< 0x0001000 */
-#define RCC_AHB4RSTR_SDMMC2RST              RCC_AHB4RSTR_SDMMC2RST_Msk
 #define RCC_AHB4RSTR_FMCRST_Pos             (16U)
 #define RCC_AHB4RSTR_FMCRST_Msk             (0x1UL << RCC_AHB4RSTR_FMCRST_Pos)      /*!< 0x00010000 */
 #define RCC_AHB4RSTR_FMCRST                 RCC_AHB4RSTR_FMCRST_Msk
@@ -15881,12 +13630,6 @@ typedef struct
 #define RCC_APB1LRSTR_TIM12RST_Pos          (6U)
 #define RCC_APB1LRSTR_TIM12RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM12RST_Pos)  /*!< 0x00000040 */
 #define RCC_APB1LRSTR_TIM12RST              RCC_APB1LRSTR_TIM12RST_Msk
-#define RCC_APB1LRSTR_TIM13RST_Pos          (7U)
-#define RCC_APB1LRSTR_TIM13RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM13RST_Pos)  /*!< 0x00000080 */
-#define RCC_APB1LRSTR_TIM13RST              RCC_APB1LRSTR_TIM13RST_Msk
-#define RCC_APB1LRSTR_TIM14RST_Pos          (8U)
-#define RCC_APB1LRSTR_TIM14RST_Msk          (0x1UL << RCC_APB1LRSTR_TIM14RST_Pos)  /*!< 0x00000100 */
-#define RCC_APB1LRSTR_TIM14RST              RCC_APB1LRSTR_TIM14RST_Msk
 #define RCC_APB1LRSTR_SPI2RST_Pos           (14U)
 #define RCC_APB1LRSTR_SPI2RST_Msk           (0x1UL << RCC_APB1LRSTR_SPI2RST_Pos)    /*!< 0x00004000 */
 #define RCC_APB1LRSTR_SPI2RST               RCC_APB1LRSTR_SPI2RST_Msk
@@ -15920,29 +13663,11 @@ typedef struct
 #define RCC_APB1LRSTR_USART6RST_Pos         (25U)
 #define RCC_APB1LRSTR_USART6RST_Msk         (0x1UL << RCC_APB1LRSTR_USART6RST_Pos)  /*!< 0x02000000 */
 #define RCC_APB1LRSTR_USART6RST             RCC_APB1LRSTR_USART6RST_Msk
-#define RCC_APB1LRSTR_USART10RST_Pos        (26U)
-#define RCC_APB1LRSTR_USART10RST_Msk        (0x1UL << RCC_APB1LRSTR_USART10RST_Pos) /*!< 0x04000000 */
-#define RCC_APB1LRSTR_USART10RST            RCC_APB1LRSTR_USART10RST_Msk
-#define RCC_APB1LRSTR_USART11RST_Pos        (27U)
-#define RCC_APB1LRSTR_USART11RST_Msk        (0x1UL << RCC_APB1LRSTR_USART11RST_Pos) /*!< 0x08000000 */
-#define RCC_APB1LRSTR_USART11RST            RCC_APB1LRSTR_USART11RST_Msk
 #define RCC_APB1LRSTR_CECRST_Pos            (28U)
 #define RCC_APB1LRSTR_CECRST_Msk            (0x1UL << RCC_APB1LRSTR_CECRST_Pos)      /*!< 0x10000000 */
 #define RCC_APB1LRSTR_CECRST                RCC_APB1LRSTR_CECRST_Msk
-#define RCC_APB1LRSTR_UART7RST_Pos          (30U)
-#define RCC_APB1LRSTR_UART7RST_Msk          (0x1UL << RCC_APB1LRSTR_UART7RST_Pos)    /*!< 0x40000000 */
-#define RCC_APB1LRSTR_UART7RST              RCC_APB1LRSTR_UART7RST_Msk
-#define RCC_APB1LRSTR_UART8RST_Pos          (31U)
-#define RCC_APB1LRSTR_UART8RST_Msk          (0x1UL << RCC_APB1LRSTR_UART8RST_Pos)    /*!< 0x80000000 */
-#define RCC_APB1LRSTR_UART8RST              RCC_APB1LRSTR_UART8RST_Msk
 
 /********************  Bit definition for RCC_APB1HRSTR register  **************/
-#define RCC_APB1HRSTR_UART9RST_Pos          (0U)
-#define RCC_APB1HRSTR_UART9RST_Msk          (0x1UL << RCC_APB1HRSTR_UART9RST_Pos)    /*!< 0x00000001 */
-#define RCC_APB1HRSTR_UART9RST              RCC_APB1HRSTR_UART9RST_Msk
-#define RCC_APB1HRSTR_UART12RST_Pos         (1U)
-#define RCC_APB1HRSTR_UART12RST_Msk         (0x1UL << RCC_APB1HRSTR_UART12RST_Pos)   /*!< 0x00000002 */
-#define RCC_APB1HRSTR_UART12RST             RCC_APB1HRSTR_UART12RST_Msk
 #define RCC_APB1HRSTR_DTSRST_Pos            (3U)
 #define RCC_APB1HRSTR_DTSRST_Msk            (0x1UL << RCC_APB1HRSTR_DTSRST_Pos)     /*!< 0x00000008 */
 #define RCC_APB1HRSTR_DTSRST                RCC_APB1HRSTR_DTSRST_Msk
@@ -15972,56 +13697,26 @@ typedef struct
 #define RCC_APB2RSTR_TIM15RST_Pos           (16U)
 #define RCC_APB2RSTR_TIM15RST_Msk           (0x1UL << RCC_APB2RSTR_TIM15RST_Pos)    /*!< 0x00010000 */
 #define RCC_APB2RSTR_TIM15RST               RCC_APB2RSTR_TIM15RST_Msk
-#define RCC_APB2RSTR_TIM16RST_Pos           (17U)
-#define RCC_APB2RSTR_TIM16RST_Msk           (0x1UL << RCC_APB2RSTR_TIM16RST_Pos)    /*!< 0x00020000 */
-#define RCC_APB2RSTR_TIM16RST               RCC_APB2RSTR_TIM16RST_Msk
-#define RCC_APB2RSTR_TIM17RST_Pos           (18U)
-#define RCC_APB2RSTR_TIM17RST_Msk           (0x1UL << RCC_APB2RSTR_TIM17RST_Pos)    /*!< 0x00040000 */
-#define RCC_APB2RSTR_TIM17RST               RCC_APB2RSTR_TIM17RST_Msk
 #define RCC_APB2RSTR_SPI4RST_Pos            (19U)
 #define RCC_APB2RSTR_SPI4RST_Msk            (0x1UL << RCC_APB2RSTR_SPI4RST_Pos)     /*!< 0x00080000 */
 #define RCC_APB2RSTR_SPI4RST                RCC_APB2RSTR_SPI4RST_Msk
-#define RCC_APB2RSTR_SPI6RST_Pos            (20U)
-#define RCC_APB2RSTR_SPI6RST_Msk            (0x1UL << RCC_APB2RSTR_SPI6RST_Pos)     /*!< 0x00100000 */
-#define RCC_APB2RSTR_SPI6RST                RCC_APB2RSTR_SPI6RST_Msk
-#define RCC_APB2RSTR_SAI1RST_Pos            (21U)
-#define RCC_APB2RSTR_SAI1RST_Msk            (0x1UL << RCC_APB2RSTR_SAI1RST_Pos)     /*!< 0x00200000 */
-#define RCC_APB2RSTR_SAI1RST                RCC_APB2RSTR_SAI1RST_Msk
-#define RCC_APB2RSTR_SAI2RST_Pos            (22U)
-#define RCC_APB2RSTR_SAI2RST_Msk            (0x1UL << RCC_APB2RSTR_SAI2RST_Pos)     /*!< 0x00400000 */
-#define RCC_APB2RSTR_SAI2RST                RCC_APB2RSTR_SAI2RST_Msk
 #define RCC_APB2RSTR_USBRST_Pos             (24U)
 #define RCC_APB2RSTR_USBRST_Msk             (0x1UL << RCC_APB2RSTR_USBRST_Pos)      /*!< 0x01000000 */
 #define RCC_APB2RSTR_USBRST                 RCC_APB2RSTR_USBRST_Msk
 
 /********************  Bit definition for RCC_APB3RSTR register  **************/
-#define RCC_APB3RSTR_SPI5RST_Pos            (5U)
-#define RCC_APB3RSTR_SPI5RST_Msk            (0x1UL << RCC_APB3RSTR_SPI5RST_Pos)     /*!< 0x00000020 */
-#define RCC_APB3RSTR_SPI5RST                RCC_APB3RSTR_SPI5RST_Msk
 #define RCC_APB3RSTR_LPUART1RST_Pos         (6U)
 #define RCC_APB3RSTR_LPUART1RST_Msk         (0x1UL << RCC_APB3RSTR_LPUART1RST_Pos)  /*!< 0x00000040 */
 #define RCC_APB3RSTR_LPUART1RST             RCC_APB3RSTR_LPUART1RST_Msk
 #define RCC_APB3RSTR_I2C3RST_Pos            (7U)
 #define RCC_APB3RSTR_I2C3RST_Msk            (0x1UL << RCC_APB3RSTR_I2C3RST_Pos)     /*!< 0x00000080 */
 #define RCC_APB3RSTR_I2C3RST                RCC_APB3RSTR_I2C3RST_Msk
-#define RCC_APB3RSTR_I2C4RST_Pos            (8U)
-#define RCC_APB3RSTR_I2C4RST_Msk            (0x1UL << RCC_APB3RSTR_I2C4RST_Pos)     /*!< 0x00000100 */
-#define RCC_APB3RSTR_I2C4RST                RCC_APB3RSTR_I2C4RST_Msk
+#define RCC_APB3RSTR_I3C2RST_Pos            (9U)
+#define RCC_APB3RSTR_I3C2RST_Msk            (0x1UL << RCC_APB3RSTR_I3C2RST_Pos)     /*!< 0x00000200 */
+#define RCC_APB3RSTR_I3C2RST                RCC_APB3RSTR_I3C2RST_Msk
 #define RCC_APB3RSTR_LPTIM1RST_Pos          (11U)
 #define RCC_APB3RSTR_LPTIM1RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM1RST_Pos)   /*!< 0x00000800 */
 #define RCC_APB3RSTR_LPTIM1RST              RCC_APB3RSTR_LPTIM1RST_Msk
-#define RCC_APB3RSTR_LPTIM3RST_Pos          (12U)
-#define RCC_APB3RSTR_LPTIM3RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM3RST_Pos)   /*!< 0x00001000 */
-#define RCC_APB3RSTR_LPTIM3RST              RCC_APB3RSTR_LPTIM3RST_Msk
-#define RCC_APB3RSTR_LPTIM4RST_Pos          (13U)
-#define RCC_APB3RSTR_LPTIM4RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM4RST_Pos)   /*!< 0x00002000 */
-#define RCC_APB3RSTR_LPTIM4RST              RCC_APB3RSTR_LPTIM4RST_Msk
-#define RCC_APB3RSTR_LPTIM5RST_Pos          (14U)
-#define RCC_APB3RSTR_LPTIM5RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM5RST_Pos)   /*!< 0x00004000 */
-#define RCC_APB3RSTR_LPTIM5RST              RCC_APB3RSTR_LPTIM5RST_Msk
-#define RCC_APB3RSTR_LPTIM6RST_Pos          (15U)
-#define RCC_APB3RSTR_LPTIM6RST_Msk          (0x1UL << RCC_APB3RSTR_LPTIM6RST_Pos)   /*!< 0x00008000 */
-#define RCC_APB3RSTR_LPTIM6RST              RCC_APB3RSTR_LPTIM6RST_Msk
 #define RCC_APB3RSTR_VREFRST_Pos            (20U)
 #define RCC_APB3RSTR_VREFRST_Msk            (0x1UL << RCC_APB3RSTR_VREFRST_Pos)     /*!< 0x00100000 */
 #define RCC_APB3RSTR_VREFRST                RCC_APB3RSTR_VREFRST_Msk
@@ -16039,24 +13734,9 @@ typedef struct
 #define RCC_AHB1ENR_CRCEN_Pos               (12U)
 #define RCC_AHB1ENR_CRCEN_Msk               (0x1UL << RCC_AHB1ENR_CRCEN_Pos)        /*!< 0x00001000 */
 #define RCC_AHB1ENR_CRCEN                   RCC_AHB1ENR_CRCEN_Msk
-#define RCC_AHB1ENR_CORDICEN_Pos            (14U)
-#define RCC_AHB1ENR_CORDICEN_Msk            (0x1UL << RCC_AHB1ENR_CORDICEN_Pos)     /*!< 0x00004000 */
-#define RCC_AHB1ENR_CORDICEN                RCC_AHB1ENR_CORDICEN_Msk
-#define RCC_AHB1ENR_FMACEN_Pos              (15U)
-#define RCC_AHB1ENR_FMACEN_Msk              (0x1UL << RCC_AHB1ENR_FMACEN_Pos)       /*!< 0x00008000 */
-#define RCC_AHB1ENR_FMACEN                  RCC_AHB1ENR_FMACEN_Msk
 #define RCC_AHB1ENR_RAMCFGEN_Pos            (17U)
 #define RCC_AHB1ENR_RAMCFGEN_Msk            (0x1UL << RCC_AHB1ENR_RAMCFGEN_Pos)     /*!< 0x00020000 */
 #define RCC_AHB1ENR_RAMCFGEN                RCC_AHB1ENR_RAMCFGEN_Msk
-#define RCC_AHB1ENR_ETHEN_Pos               (19U)
-#define RCC_AHB1ENR_ETHEN_Msk               (0x1UL << RCC_AHB1ENR_ETHEN_Pos)        /*!< 0x00080000 */
-#define RCC_AHB1ENR_ETHEN                   RCC_AHB1ENR_ETHEN_Msk
-#define RCC_AHB1ENR_ETHTXEN_Pos             (20U)
-#define RCC_AHB1ENR_ETHTXEN_Msk             (0x1UL << RCC_AHB1ENR_ETHTXEN_Pos)      /*!< 0x00100000 */
-#define RCC_AHB1ENR_ETHTXEN                 RCC_AHB1ENR_ETHTXEN_Msk
-#define RCC_AHB1ENR_ETHRXEN_Pos             (21U)
-#define RCC_AHB1ENR_ETHRXEN_Msk             (0x1UL << RCC_AHB1ENR_ETHRXEN_Pos)      /*!< 0x00200000 */
-#define RCC_AHB1ENR_ETHRXEN                 RCC_AHB1ENR_ETHRXEN_Msk
 #define RCC_AHB1ENR_TZSC1EN_Pos             (24U)
 #define RCC_AHB1ENR_TZSC1EN_Msk             (0x1UL << RCC_AHB1ENR_TZSC1EN_Pos)      /*!< 0x01000000 */
 #define RCC_AHB1ENR_TZSC1EN                 RCC_AHB1ENR_TZSC1EN_Msk
@@ -16095,9 +13775,6 @@ typedef struct
 #define RCC_AHB2ENR_GPIOHEN_Pos             (7U)
 #define RCC_AHB2ENR_GPIOHEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOHEN_Pos)      /*!< 0x00000080 */
 #define RCC_AHB2ENR_GPIOHEN                 RCC_AHB2ENR_GPIOHEN_Msk
-#define RCC_AHB2ENR_GPIOIEN_Pos             (8U)
-#define RCC_AHB2ENR_GPIOIEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOIEN_Pos)      /*!< 0x00000100 */
-#define RCC_AHB2ENR_GPIOIEN                 RCC_AHB2ENR_GPIOIEN_Msk
 #define RCC_AHB2ENR_ADCEN_Pos               (10U)
 #define RCC_AHB2ENR_ADCEN_Msk               (0x1UL << RCC_AHB2ENR_ADCEN_Pos)        /*!< 0x00000400 */
 #define RCC_AHB2ENR_ADCEN                   RCC_AHB2ENR_ADCEN_Msk
@@ -16107,6 +13784,9 @@ typedef struct
 #define RCC_AHB2ENR_DCMI_PSSIEN_Pos         (12U)
 #define RCC_AHB2ENR_DCMI_PSSIEN_Msk         (0x1UL << RCC_AHB2ENR_DCMI_PSSIEN_Pos)  /*!< 0x00001000 */
 #define RCC_AHB2ENR_DCMI_PSSIEN             RCC_AHB2ENR_DCMI_PSSIEN_Msk
+#define RCC_AHB2ENR_AESEN_Pos               (16U)
+#define RCC_AHB2ENR_AESEN_Msk               (0x1UL << RCC_AHB2ENR_AESEN_Pos)        /*!< 0x00010000 */
+#define RCC_AHB2ENR_AESEN                   RCC_AHB2ENR_AESEN_Msk
 #define RCC_AHB2ENR_HASHEN_Pos              (17U)
 #define RCC_AHB2ENR_HASHEN_Msk              (0x1UL << RCC_AHB2ENR_HASHEN_Pos)       /*!< 0x00020000 */
 #define RCC_AHB2ENR_HASHEN                  RCC_AHB2ENR_HASHEN_Msk
@@ -16116,6 +13796,9 @@ typedef struct
 #define RCC_AHB2ENR_PKAEN_Pos               (19U)
 #define RCC_AHB2ENR_PKAEN_Msk               (0x1UL << RCC_AHB2ENR_PKAEN_Pos)        /*!< 0x00080000 */
 #define RCC_AHB2ENR_PKAEN                   RCC_AHB2ENR_PKAEN_Msk
+#define RCC_AHB2ENR_SAESEN_Pos              (20U)
+#define RCC_AHB2ENR_SAESEN_Msk              (0x1UL << RCC_AHB2ENR_SAESEN_Pos)       /*!< 0x00100000 */
+#define RCC_AHB2ENR_SAESEN                  RCC_AHB2ENR_SAESEN_Msk
 #define RCC_AHB2ENR_SRAM2EN_Pos             (30U)
 #define RCC_AHB2ENR_SRAM2EN_Msk             (0x1UL << RCC_AHB2ENR_SRAM2EN_Pos)      /*!< 0x40000000 */
 #define RCC_AHB2ENR_SRAM2EN                 RCC_AHB2ENR_SRAM2EN_Msk
@@ -16124,12 +13807,12 @@ typedef struct
 #define RCC_AHB2ENR_SRAM3EN                 RCC_AHB2ENR_SRAM3EN_Msk
 
 /********************  Bit definition for RCC_AHB4ENR register  **************/
+#define RCC_AHB4ENR_OTFDEC1EN_Pos           (7U)
+#define RCC_AHB4ENR_OTFDEC1EN_Msk           (0x1UL << RCC_AHB4ENR_OTFDEC1EN_Pos)    /*!< 0x00000080 */
+#define RCC_AHB4ENR_OTFDEC1EN               RCC_AHB4ENR_OTFDEC1EN_Msk
 #define RCC_AHB4ENR_SDMMC1EN_Pos            (11U)
 #define RCC_AHB4ENR_SDMMC1EN_Msk            (0x1UL << RCC_AHB4ENR_SDMMC1EN_Pos)     /*!< 0x00000800 */
 #define RCC_AHB4ENR_SDMMC1EN                RCC_AHB4ENR_SDMMC1EN_Msk
-#define RCC_AHB4ENR_SDMMC2EN_Pos            (12U)
-#define RCC_AHB4ENR_SDMMC2EN_Msk            (0x1UL << RCC_AHB4ENR_SDMMC2EN_Pos)     /*!< 0x00000100 */
-#define RCC_AHB4ENR_SDMMC2EN                RCC_AHB4ENR_SDMMC2EN_Msk
 #define RCC_AHB4ENR_FMCEN_Pos               (16U)
 #define RCC_AHB4ENR_FMCEN_Msk               (0x1UL << RCC_AHB4ENR_FMCEN_Pos)        /*!< 0x00010000 */
 #define RCC_AHB4ENR_FMCEN                   RCC_AHB4ENR_FMCEN_Msk
@@ -16159,12 +13842,6 @@ typedef struct
 #define RCC_APB1LENR_TIM12EN_Pos            (6U)
 #define RCC_APB1LENR_TIM12EN_Msk            (0x1UL << RCC_APB1LENR_TIM12EN_Pos)     /*!< 0x00000040 */
 #define RCC_APB1LENR_TIM12EN                RCC_APB1LENR_TIM12EN_Msk
-#define RCC_APB1LENR_TIM13EN_Pos            (7U)
-#define RCC_APB1LENR_TIM13EN_Msk            (0x1UL << RCC_APB1LENR_TIM13EN_Pos)     /*!< 0x00000080 */
-#define RCC_APB1LENR_TIM13EN                RCC_APB1LENR_TIM13EN_Msk
-#define RCC_APB1LENR_TIM14EN_Pos            (8U)
-#define RCC_APB1LENR_TIM14EN_Msk            (0x1UL << RCC_APB1LENR_TIM14EN_Pos)     /*!< 0x00000100 */
-#define RCC_APB1LENR_TIM14EN                RCC_APB1LENR_TIM14EN_Msk
 #define RCC_APB1LENR_WWDGEN_Pos             (11U)
 #define RCC_APB1LENR_WWDGEN_Msk             (0x1UL << RCC_APB1LENR_WWDGEN_Pos)      /*!< 0x00000800 */
 #define RCC_APB1LENR_WWDGEN                 RCC_APB1LENR_WWDGEN_Msk
@@ -16201,29 +13878,11 @@ typedef struct
 #define RCC_APB1LENR_USART6EN_Pos           (25U)
 #define RCC_APB1LENR_USART6EN_Msk           (0x1UL << RCC_APB1LENR_USART6EN_Pos)    /*!< 0x02000000 */
 #define RCC_APB1LENR_USART6EN               RCC_APB1LENR_USART6EN_Msk
-#define RCC_APB1LENR_USART10EN_Pos          (26U)
-#define RCC_APB1LENR_USART10EN_Msk          (0x1UL << RCC_APB1LENR_USART10EN_Pos)   /*!< 0x04000000 */
-#define RCC_APB1LENR_USART10EN              RCC_APB1LENR_USART10EN_Msk
-#define RCC_APB1LENR_USART11EN_Pos          (27U)
-#define RCC_APB1LENR_USART11EN_Msk          (0x1UL << RCC_APB1LENR_USART11EN_Pos)   /*!< 0x08000000 */
-#define RCC_APB1LENR_USART11EN              RCC_APB1LENR_USART11EN_Msk
 #define RCC_APB1LENR_CECEN_Pos              (28U)
 #define RCC_APB1LENR_CECEN_Msk              (0x1UL << RCC_APB1LENR_CECEN_Pos)       /*!< 0x10000000 */
 #define RCC_APB1LENR_CECEN                  RCC_APB1LENR_CECEN_Msk
-#define RCC_APB1LENR_UART7EN_Pos            (30U)
-#define RCC_APB1LENR_UART7EN_Msk            (0x1UL << RCC_APB1LENR_UART7EN_Pos)     /*!< 0x40000000 */
-#define RCC_APB1LENR_UART7EN                RCC_APB1LENR_UART7EN_Msk
-#define RCC_APB1LENR_UART8EN_Pos            (31U)
-#define RCC_APB1LENR_UART8EN_Msk            (0x1UL << RCC_APB1LENR_UART8EN_Pos)     /*!< 0x80000000 */
-#define RCC_APB1LENR_UART8EN                RCC_APB1LENR_UART8EN_Msk
 
 /********************  Bit definition for RCC_APB1HENR register  **************/
-#define RCC_APB1HENR_UART9EN_Pos            (0U)
-#define RCC_APB1HENR_UART9EN_Msk            (0x1UL << RCC_APB1HENR_UART9EN_Pos)     /*!< 0x00000001 */
-#define RCC_APB1HENR_UART9EN                RCC_APB1HENR_UART9EN_Msk
-#define RCC_APB1HENR_UART12EN_Pos           (1U)
-#define RCC_APB1HENR_UART12EN_Msk           (0x1UL << RCC_APB1HENR_UART12EN_Pos)    /*!< 0x00000002 */
-#define RCC_APB1HENR_UART12EN               RCC_APB1HENR_UART12EN_Msk
 #define RCC_APB1HENR_DTSEN_Pos              (3U)
 #define RCC_APB1HENR_DTSEN_Msk              (0x1UL << RCC_APB1HENR_DTSEN_Pos)       /*!< 0x00000008 */
 #define RCC_APB1HENR_DTSEN                  RCC_APB1HENR_DTSEN_Msk
@@ -16253,24 +13912,9 @@ typedef struct
 #define RCC_APB2ENR_TIM15EN_Pos             (16U)
 #define RCC_APB2ENR_TIM15EN_Msk             (0x1UL << RCC_APB2ENR_TIM15EN_Pos)      /*!< 0x00010000 */
 #define RCC_APB2ENR_TIM15EN                 RCC_APB2ENR_TIM15EN_Msk
-#define RCC_APB2ENR_TIM16EN_Pos             (17U)
-#define RCC_APB2ENR_TIM16EN_Msk             (0x1UL << RCC_APB2ENR_TIM16EN_Pos)      /*!< 0x00020000 */
-#define RCC_APB2ENR_TIM16EN                 RCC_APB2ENR_TIM16EN_Msk
-#define RCC_APB2ENR_TIM17EN_Pos             (18U)
-#define RCC_APB2ENR_TIM17EN_Msk             (0x1UL << RCC_APB2ENR_TIM17EN_Pos)      /*!< 0x00040000 */
-#define RCC_APB2ENR_TIM17EN                 RCC_APB2ENR_TIM17EN_Msk
 #define RCC_APB2ENR_SPI4EN_Pos              (19U)
 #define RCC_APB2ENR_SPI4EN_Msk              (0x1UL << RCC_APB2ENR_SPI4EN_Pos)       /*!< 0x00080000 */
 #define RCC_APB2ENR_SPI4EN                  RCC_APB2ENR_SPI4EN_Msk
-#define RCC_APB2ENR_SPI6EN_Pos              (20U)
-#define RCC_APB2ENR_SPI6EN_Msk              (0x1UL << RCC_APB2ENR_SPI6EN_Pos)       /*!< 0x00100000 */
-#define RCC_APB2ENR_SPI6EN                  RCC_APB2ENR_SPI6EN_Msk
-#define RCC_APB2ENR_SAI1EN_Pos              (21U)
-#define RCC_APB2ENR_SAI1EN_Msk              (0x1UL << RCC_APB2ENR_SAI1EN_Pos)       /*!< 0x00200000 */
-#define RCC_APB2ENR_SAI1EN                  RCC_APB2ENR_SAI1EN_Msk
-#define RCC_APB2ENR_SAI2EN_Pos              (22U)
-#define RCC_APB2ENR_SAI2EN_Msk              (0x1UL << RCC_APB2ENR_SAI2EN_Pos)       /*!< 0x00400000 */
-#define RCC_APB2ENR_SAI2EN                  RCC_APB2ENR_SAI2EN_Msk
 #define RCC_APB2ENR_USBEN_Pos               (24U)
 #define RCC_APB2ENR_USBEN_Msk               (0x1UL << RCC_APB2ENR_USBEN_Pos)        /*!< 0x01000000 */
 #define RCC_APB2ENR_USBEN                   RCC_APB2ENR_USBEN_Msk
@@ -16279,33 +13923,18 @@ typedef struct
 #define RCC_APB3ENR_SBSEN_Pos               (1U)
 #define RCC_APB3ENR_SBSEN_Msk               (0x1UL << RCC_APB3ENR_SBSEN_Pos)        /*!< 0x00000002 */
 #define RCC_APB3ENR_SBSEN                   RCC_APB3ENR_SBSEN_Msk
-#define RCC_APB3ENR_SPI5EN_Pos              (5U)
-#define RCC_APB3ENR_SPI5EN_Msk              (0x1UL << RCC_APB3ENR_SPI5EN_Pos)       /*!< 0x00000010 */
-#define RCC_APB3ENR_SPI5EN                  RCC_APB3ENR_SPI5EN_Msk
 #define RCC_APB3ENR_LPUART1EN_Pos           (6U)
 #define RCC_APB3ENR_LPUART1EN_Msk           (0x1UL << RCC_APB3ENR_LPUART1EN_Pos)    /*!< 0x00000040 */
 #define RCC_APB3ENR_LPUART1EN               RCC_APB3ENR_LPUART1EN_Msk
 #define RCC_APB3ENR_I2C3EN_Pos              (7U)
 #define RCC_APB3ENR_I2C3EN_Msk              (0x1UL << RCC_APB3ENR_I2C3EN_Pos)       /*!< 0x00000080 */
 #define RCC_APB3ENR_I2C3EN                  RCC_APB3ENR_I2C3EN_Msk
-#define RCC_APB3ENR_I2C4EN_Pos              (8U)
-#define RCC_APB3ENR_I2C4EN_Msk              (0x1UL << RCC_APB3ENR_I2C4EN_Pos)       /*!< 0x00000100 */
-#define RCC_APB3ENR_I2C4EN                  RCC_APB3ENR_I2C4EN_Msk
+#define RCC_APB3ENR_I3C2EN_Pos              (9U)
+#define RCC_APB3ENR_I3C2EN_Msk              (0x1UL << RCC_APB3ENR_I3C2EN_Pos)       /*!< 0x00000200 */
+#define RCC_APB3ENR_I3C2EN                  RCC_APB3ENR_I3C2EN_Msk
 #define RCC_APB3ENR_LPTIM1EN_Pos            (11U)
 #define RCC_APB3ENR_LPTIM1EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM1EN_Pos)     /*!< 0x00000800 */
 #define RCC_APB3ENR_LPTIM1EN                RCC_APB3ENR_LPTIM1EN_Msk
-#define RCC_APB3ENR_LPTIM3EN_Pos            (12U)
-#define RCC_APB3ENR_LPTIM3EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM3EN_Pos)     /*!< 0x00001000 */
-#define RCC_APB3ENR_LPTIM3EN                RCC_APB3ENR_LPTIM3EN_Msk
-#define RCC_APB3ENR_LPTIM4EN_Pos            (13U)
-#define RCC_APB3ENR_LPTIM4EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM4EN_Pos)     /*!< 0x00002000 */
-#define RCC_APB3ENR_LPTIM4EN                RCC_APB3ENR_LPTIM4EN_Msk
-#define RCC_APB3ENR_LPTIM5EN_Pos            (14U)
-#define RCC_APB3ENR_LPTIM5EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM5EN_Pos)     /*!< 0x00004000 */
-#define RCC_APB3ENR_LPTIM5EN                RCC_APB3ENR_LPTIM5EN_Msk
-#define RCC_APB3ENR_LPTIM6EN_Pos            (15U)
-#define RCC_APB3ENR_LPTIM6EN_Msk            (0x1UL << RCC_APB3ENR_LPTIM6EN_Pos)     /*!< 0x00008000 */
-#define RCC_APB3ENR_LPTIM6EN                RCC_APB3ENR_LPTIM6EN_Msk
 #define RCC_APB3ENR_VREFEN_Pos              (20U)
 #define RCC_APB3ENR_VREFEN_Msk              (0x1UL << RCC_APB3ENR_VREFEN_Pos)       /*!< 0x00100000 */
 #define RCC_APB3ENR_VREFEN                  RCC_APB3ENR_VREFEN_Msk
@@ -16326,24 +13955,9 @@ typedef struct
 #define RCC_AHB1LPENR_CRCLPEN_Pos           (12U)
 #define RCC_AHB1LPENR_CRCLPEN_Msk           (0x1UL << RCC_AHB1LPENR_CRCLPEN_Pos)    /*!< 0x00001000 */
 #define RCC_AHB1LPENR_CRCLPEN               RCC_AHB1LPENR_CRCLPEN_Msk
-#define RCC_AHB1LPENR_CORDICLPEN_Pos        (14U)
-#define RCC_AHB1LPENR_CORDICLPEN_Msk        (0x1UL << RCC_AHB1LPENR_CORDICLPEN_Pos) /*!< 0x00004000*/
-#define RCC_AHB1LPENR_CORDICLPEN            RCC_AHB1LPENR_CORDICLPEN_Msk
-#define RCC_AHB1LPENR_FMACLPEN_Pos          (15U)
-#define RCC_AHB1LPENR_FMACLPEN_Msk          (0x1UL << RCC_AHB1LPENR_FMACLPEN_Pos)   /*!< 0x00008000*/
-#define RCC_AHB1LPENR_FMACLPEN              RCC_AHB1LPENR_FMACLPEN_Msk
 #define RCC_AHB1LPENR_RAMCFGLPEN_Pos        (17U)
 #define RCC_AHB1LPENR_RAMCFGLPEN_Msk        (0x1UL << RCC_AHB1LPENR_RAMCFGLPEN_Pos) /*!< 0x00020000 */
 #define RCC_AHB1LPENR_RAMCFGLPEN            RCC_AHB1LPENR_RAMCFGLPEN_Msk
-#define RCC_AHB1LPENR_ETHLPEN_Pos           (19U)
-#define RCC_AHB1LPENR_ETHLPEN_Msk           (0x1UL << RCC_AHB1LPENR_ETHLPEN_Pos)    /*!< 0x00080000 */
-#define RCC_AHB1LPENR_ETHLPEN               RCC_AHB1LPENR_ETHLPEN_Msk
-#define RCC_AHB1LPENR_ETHTXLPEN_Pos         (20U)
-#define RCC_AHB1LPENR_ETHTXLPEN_Msk         (0x1UL << RCC_AHB1LPENR_ETHTXLPEN_Pos)  /*!< 0x00100000 */
-#define RCC_AHB1LPENR_ETHTXLPEN             RCC_AHB1LPENR_ETHTXLPEN_Msk
-#define RCC_AHB1LPENR_ETHRXLPEN_Pos         (21U)
-#define RCC_AHB1LPENR_ETHRXLPEN_Msk         (0x1UL << RCC_AHB1LPENR_ETHRXLPEN_Pos)  /*!< 0x00200000 */
-#define RCC_AHB1LPENR_ETHRXLPEN             RCC_AHB1LPENR_ETHRXLPEN_Msk
 #define RCC_AHB1LPENR_TZSC1LPEN_Pos         (24U)
 #define RCC_AHB1LPENR_TZSC1LPEN_Msk         (0x1UL << RCC_AHB1LPENR_TZSC1LPEN_Pos)  /*!< 0x01000000 */
 #define RCC_AHB1LPENR_TZSC1LPEN             RCC_AHB1LPENR_TZSC1LPEN_Msk
@@ -16385,9 +13999,6 @@ typedef struct
 #define RCC_AHB2LPENR_GPIOHLPEN_Pos         (7U)
 #define RCC_AHB2LPENR_GPIOHLPEN_Msk         (0x1UL << RCC_AHB2LPENR_GPIOHLPEN_Pos)  /*!< 0x00000080 */
 #define RCC_AHB2LPENR_GPIOHLPEN             RCC_AHB2LPENR_GPIOHLPEN_Msk
-#define RCC_AHB2LPENR_GPIOILPEN_Pos         (8U)
-#define RCC_AHB2LPENR_GPIOILPEN_Msk         (0x1UL << RCC_AHB2LPENR_GPIOILPEN_Pos)  /*!< 0x00000100 */
-#define RCC_AHB2LPENR_GPIOILPEN             RCC_AHB2LPENR_GPIOILPEN_Msk
 #define RCC_AHB2LPENR_ADCLPEN_Pos           (10U)
 #define RCC_AHB2LPENR_ADCLPEN_Msk           (0x1UL << RCC_AHB2LPENR_ADCLPEN_Pos)    /*!< 0x00000400 */
 #define RCC_AHB2LPENR_ADCLPEN               RCC_AHB2LPENR_ADCLPEN_Msk
@@ -16397,12 +14008,21 @@ typedef struct
 #define RCC_AHB2LPENR_DCMI_PSSILPEN_Pos     (12U)
 #define RCC_AHB2LPENR_DCMI_PSSILPEN_Msk     (0x1UL << RCC_AHB2LPENR_DCMI_PSSILPEN_Pos) /*!< 0x00001000 */
 #define RCC_AHB2LPENR_DCMI_PSSILPEN         RCC_AHB2LPENR_DCMI_PSSILPEN_Msk
+#define RCC_AHB2LPENR_AESLPEN_Pos           (16U)
+#define RCC_AHB2LPENR_AESLPEN_Msk           (0x1UL << RCC_AHB2LPENR_AESLPEN_Pos)  /*!< 0x00010000 */
+#define RCC_AHB2LPENR_AESLPEN               RCC_AHB2LPENR_AESLPEN_Msk
 #define RCC_AHB2LPENR_HASHLPEN_Pos          (17U)
 #define RCC_AHB2LPENR_HASHLPEN_Msk          (0x1UL << RCC_AHB2LPENR_HASHLPEN_Pos)   /*!< 0x00020000 */
 #define RCC_AHB2LPENR_HASHLPEN              RCC_AHB2LPENR_HASHLPEN_Msk
 #define RCC_AHB2LPENR_RNGLPEN_Pos           (18U)
 #define RCC_AHB2LPENR_RNGLPEN_Msk           (0x1UL << RCC_AHB2LPENR_RNGLPEN_Pos)    /*!< 0x00040000 */
 #define RCC_AHB2LPENR_RNGLPEN               RCC_AHB2LPENR_RNGLPEN_Msk
+#define RCC_AHB2LPENR_PKALPEN_Pos           (19U)
+#define RCC_AHB2LPENR_PKALPEN_Msk           (0x1UL << RCC_AHB2LPENR_PKALPEN_Pos)    /*!< 0x00080000 */
+#define RCC_AHB2LPENR_PKALPEN               RCC_AHB2LPENR_PKALPEN_Msk
+#define RCC_AHB2LPENR_SAESLPEN_Pos          (20U)
+#define RCC_AHB2LPENR_SAESLPEN_Msk          (0x1UL << RCC_AHB2LPENR_SAESLPEN_Pos)   /*!< 0x00100000 */
+#define RCC_AHB2LPENR_SAESLPEN              RCC_AHB2LPENR_SAESLPEN_Msk
 #define RCC_AHB2LPENR_SRAM2LPEN_Pos         (30U)
 #define RCC_AHB2LPENR_SRAM2LPEN_Msk         (0x1UL << RCC_AHB2LPENR_SRAM2LPEN_Pos)  /*!< 0x40000000 */
 #define RCC_AHB2LPENR_SRAM2LPEN             RCC_AHB2LPENR_SRAM2LPEN_Msk
@@ -16411,12 +14031,12 @@ typedef struct
 #define RCC_AHB2LPENR_SRAM3LPEN             RCC_AHB2LPENR_SRAM3LPEN_Msk
 
 /********************  Bit definition for RCC_AHB4LPENR register  **************/
+#define RCC_AHB4LPENR_OTFDEC1LPEN_Pos       (7U)
+#define RCC_AHB4LPENR_OTFDEC1LPEN_Msk       (0x1UL << RCC_AHB4LPENR_OTFDEC1LPEN_Pos) /*!< 0x00000008 */
+#define RCC_AHB4LPENR_OTFDEC1LPEN           RCC_AHB4LPENR_OTFDEC1LPEN_Msk
 #define RCC_AHB4LPENR_SDMMC1LPEN_Pos        (11U)
 #define RCC_AHB4LPENR_SDMMC1LPEN_Msk        (0x1UL << RCC_AHB4LPENR_SDMMC1LPEN_Pos)  /*!< 0x00000800 */
 #define RCC_AHB4LPENR_SDMMC1LPEN            RCC_AHB4LPENR_SDMMC1LPEN_Msk
-#define RCC_AHB4LPENR_SDMMC2LPEN_Pos        (12U)
-#define RCC_AHB4LPENR_SDMMC2LPEN_Msk        (0x1UL << RCC_AHB4LPENR_SDMMC2LPEN_Pos)  /*!< 0x00001000 */
-#define RCC_AHB4LPENR_SDMMC2LPEN            RCC_AHB4LPENR_SDMMC2LPEN_Msk
 #define RCC_AHB4LPENR_FMCLPEN_Pos           (16U)
 #define RCC_AHB4LPENR_FMCLPEN_Msk           (0x1UL << RCC_AHB4LPENR_FMCLPEN_Pos)     /*!< 0x00010000 */
 #define RCC_AHB4LPENR_FMCLPEN               RCC_AHB4LPENR_FMCLPEN_Msk
@@ -16446,12 +14066,6 @@ typedef struct
 #define RCC_APB1LLPENR_TIM12LPEN_Pos        (6U)
 #define RCC_APB1LLPENR_TIM12LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM12LPEN_Pos) /*!< 0x00000040 */
 #define RCC_APB1LLPENR_TIM12LPEN            RCC_APB1LLPENR_TIM12LPEN_Msk
-#define RCC_APB1LLPENR_TIM13LPEN_Pos        (7U)
-#define RCC_APB1LLPENR_TIM13LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM13LPEN_Pos) /*!< 0x00000080 */
-#define RCC_APB1LLPENR_TIM13LPEN            RCC_APB1LLPENR_TIM13LPEN_Msk
-#define RCC_APB1LLPENR_TIM14LPEN_Pos        (8U)
-#define RCC_APB1LLPENR_TIM14LPEN_Msk        (0x1UL << RCC_APB1LLPENR_TIM14LPEN_Pos) /*!< 0x00000100 */
-#define RCC_APB1LLPENR_TIM14LPEN            RCC_APB1LLPENR_TIM14LPEN_Msk
 #define RCC_APB1LLPENR_WWDGLPEN_Pos         (11U)
 #define RCC_APB1LLPENR_WWDGLPEN_Msk         (0x1UL << RCC_APB1LLPENR_WWDGLPEN_Pos)  /*!< 0x00000800 */
 #define RCC_APB1LLPENR_WWDGLPEN             RCC_APB1LLPENR_WWDGLPEN_Msk
@@ -16488,29 +14102,11 @@ typedef struct
 #define RCC_APB1LLPENR_USART6LPEN_Pos       (25U)
 #define RCC_APB1LLPENR_USART6LPEN_Msk       (0x1UL << RCC_APB1LLPENR_USART6LPEN_Pos) /*!< 0x02000000 */
 #define RCC_APB1LLPENR_USART6LPEN           RCC_APB1LLPENR_USART6LPEN_Msk
-#define RCC_APB1LLPENR_USART10LPEN_Pos      (26U)
-#define RCC_APB1LLPENR_USART10LPEN_Msk      (0x1UL << RCC_APB1LLPENR_USART10LPEN_Pos) /*!< 0x04000000 */
-#define RCC_APB1LLPENR_USART10LPEN          RCC_APB1LLPENR_USART10LPEN_Msk
-#define RCC_APB1LLPENR_USART11LPEN_Pos      (27U)
-#define RCC_APB1LLPENR_USART11LPEN_Msk      (0x1UL << RCC_APB1LLPENR_USART11LPEN_Pos) /*!< 0x08000000 */
-#define RCC_APB1LLPENR_USART11LPEN          RCC_APB1LLPENR_USART11LPEN_Msk
 #define RCC_APB1LLPENR_CECLPEN_Pos          (28U)
 #define RCC_APB1LLPENR_CECLPEN_Msk          (0x1UL << RCC_APB1LLPENR_CECLPEN_Pos)    /*!< 0x10000000 */
 #define RCC_APB1LLPENR_CECLPEN              RCC_APB1LLPENR_CECLPEN_Msk
-#define RCC_APB1LLPENR_UART7LPEN_Pos        (30U)
-#define RCC_APB1LLPENR_UART7LPEN_Msk        (0x1UL << RCC_APB1LLPENR_UART7LPEN_Pos)  /*!< 0x40000000 */
-#define RCC_APB1LLPENR_UART7LPEN            RCC_APB1LLPENR_UART7LPEN_Msk
-#define RCC_APB1LLPENR_UART8LPEN_Pos        (31U)
-#define RCC_APB1LLPENR_UART8LPEN_Msk        (0x1UL << RCC_APB1LLPENR_UART8LPEN_Pos)  /*!< 0x80000000 */
-#define RCC_APB1LLPENR_UART8LPEN            RCC_APB1LLPENR_UART8LPEN_Msk
 
 /********************  Bit definition for RCC_APB1HLPENR register  **************/
-#define RCC_APB1HLPENR_UART9LPEN_Pos        (0U)
-#define RCC_APB1HLPENR_UART9LPEN_Msk        (0x1UL << RCC_APB1HLPENR_UART9LPEN_Pos)  /*!< 0x00000001 */
-#define RCC_APB1HLPENR_UART9LPEN            RCC_APB1HLPENR_UART9LPEN_Msk
-#define RCC_APB1HLPENR_UART12LPEN_Pos       (1U)
-#define RCC_APB1HLPENR_UART12LPEN_Msk       (0x1UL << RCC_APB1HLPENR_UART12LPEN_Pos) /*!< 0x00000002 */
-#define RCC_APB1HLPENR_UART12LPEN           RCC_APB1HLPENR_UART12LPEN_Msk
 #define RCC_APB1HLPENR_DTSLPEN_Pos          (3U)
 #define RCC_APB1HLPENR_DTSLPEN_Msk          (0x1UL << RCC_APB1HLPENR_DTSLPEN_Pos)    /*!< 0x00000008 */
 #define RCC_APB1HLPENR_DTSLPEN              RCC_APB1HLPENR_DTSLPEN_Msk
@@ -16540,24 +14136,9 @@ typedef struct
 #define RCC_APB2LPENR_TIM15LPEN_Pos         (16U)
 #define RCC_APB2LPENR_TIM15LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM15LPEN_Pos)  /*!< 0x00010000 */
 #define RCC_APB2LPENR_TIM15LPEN             RCC_APB2LPENR_TIM15LPEN_Msk
-#define RCC_APB2LPENR_TIM16LPEN_Pos         (17U)
-#define RCC_APB2LPENR_TIM16LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM16LPEN_Pos)  /*!< 0x00020000 */
-#define RCC_APB2LPENR_TIM16LPEN             RCC_APB2LPENR_TIM16LPEN_Msk
-#define RCC_APB2LPENR_TIM17LPEN_Pos         (18U)
-#define RCC_APB2LPENR_TIM17LPEN_Msk         (0x1UL << RCC_APB2LPENR_TIM17LPEN_Pos)  /*!< 0x00040000 */
-#define RCC_APB2LPENR_TIM17LPEN             RCC_APB2LPENR_TIM17LPEN_Msk
 #define RCC_APB2LPENR_SPI4LPEN_Pos          (19U)
 #define RCC_APB2LPENR_SPI4LPEN_Msk          (0x1UL << RCC_APB2LPENR_SPI4LPEN_Pos)   /*!< 0x00080000 */
 #define RCC_APB2LPENR_SPI4LPEN              RCC_APB2LPENR_SPI4LPEN_Msk
-#define RCC_APB2LPENR_SPI6LPEN_Pos          (20U)
-#define RCC_APB2LPENR_SPI6LPEN_Msk          (0x1UL << RCC_APB2LPENR_SPI6LPEN_Pos)   /*!< 0x00100000 */
-#define RCC_APB2LPENR_SPI6LPEN              RCC_APB2LPENR_SPI6LPEN_Msk
-#define RCC_APB2LPENR_SAI1LPEN_Pos          (21U)
-#define RCC_APB2LPENR_SAI1LPEN_Msk          (0x1UL << RCC_APB2LPENR_SAI1LPEN_Pos)   /*!< 0x00200000 */
-#define RCC_APB2LPENR_SAI1LPEN              RCC_APB2LPENR_SAI1LPEN_Msk
-#define RCC_APB2LPENR_SAI2LPEN_Pos          (22U)
-#define RCC_APB2LPENR_SAI2LPEN_Msk          (0x1UL << RCC_APB2LPENR_SAI2LPEN_Pos)   /*!< 0x00400000 */
-#define RCC_APB2LPENR_SAI2LPEN              RCC_APB2LPENR_SAI2LPEN_Msk
 #define RCC_APB2LPENR_USBLPEN_Pos           (24U)
 #define RCC_APB2LPENR_USBLPEN_Msk           (0x1UL << RCC_APB2LPENR_USBLPEN_Pos)    /*!< 0x01000000 */
 #define RCC_APB2LPENR_USBLPEN               RCC_APB2LPENR_USBLPEN_Msk
@@ -16566,33 +14147,18 @@ typedef struct
 #define RCC_APB3LPENR_SBSLPEN_Pos           (1U)
 #define RCC_APB3LPENR_SBSLPEN_Msk           (0x1UL << RCC_APB3LPENR_SBSLPEN_Pos)    /*!< 0x00000001 */
 #define RCC_APB3LPENR_SBSLPEN               RCC_APB3LPENR_SBSLPEN_Msk
-#define RCC_APB3LPENR_SPI5LPEN_Pos          (5U)
-#define RCC_APB3LPENR_SPI5LPEN_Msk          (0x1UL << RCC_APB3LPENR_SPI5LPEN_Pos)   /*!< 0x00000010 */
-#define RCC_APB3LPENR_SPI5LPEN              RCC_APB3LPENR_SPI5LPEN_Msk
 #define RCC_APB3LPENR_LPUART1LPEN_Pos       (6U)
 #define RCC_APB3LPENR_LPUART1LPEN_Msk       (0x1UL << RCC_APB3LPENR_LPUART1LPEN_Pos) /*!< 0x00000040 */
 #define RCC_APB3LPENR_LPUART1LPEN           RCC_APB3LPENR_LPUART1LPEN_Msk
 #define RCC_APB3LPENR_I2C3LPEN_Pos          (7U)
 #define RCC_APB3LPENR_I2C3LPEN_Msk          (0x1UL << RCC_APB3LPENR_I2C3LPEN_Pos)   /*!< 0x00000080 */
 #define RCC_APB3LPENR_I2C3LPEN              RCC_APB3LPENR_I2C3LPEN_Msk
-#define RCC_APB3LPENR_I2C4LPEN_Pos          (8U)
-#define RCC_APB3LPENR_I2C4LPEN_Msk          (0x1UL << RCC_APB3LPENR_I2C4LPEN_Pos)   /*!< 0x00000100 */
-#define RCC_APB3LPENR_I2C4LPEN              RCC_APB3LPENR_I2C4LPEN_Msk
+#define RCC_APB3LPENR_I3C2LPEN_Pos          (9U)
+#define RCC_APB3LPENR_I3C2LPEN_Msk          (0x1UL << RCC_APB3LPENR_I3C2LPEN_Pos)   /*!< 0x00000100 */
+#define RCC_APB3LPENR_I3C2LPEN              RCC_APB3LPENR_I3C2LPEN_Msk
 #define RCC_APB3LPENR_LPTIM1LPEN_Pos        (11U)
 #define RCC_APB3LPENR_LPTIM1LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM1LPEN_Pos) /*!< 0x00000800 */
 #define RCC_APB3LPENR_LPTIM1LPEN            RCC_APB3LPENR_LPTIM1LPEN_Msk
-#define RCC_APB3LPENR_LPTIM3LPEN_Pos        (12U)
-#define RCC_APB3LPENR_LPTIM3LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM3LPEN_Pos) /*!< 0x00001000 */
-#define RCC_APB3LPENR_LPTIM3LPEN            RCC_APB3LPENR_LPTIM3LPEN_Msk
-#define RCC_APB3LPENR_LPTIM4LPEN_Pos        (13U)
-#define RCC_APB3LPENR_LPTIM4LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM4LPEN_Pos) /*!< 0x00002000 */
-#define RCC_APB3LPENR_LPTIM4LPEN            RCC_APB3LPENR_LPTIM4LPEN_Msk
-#define RCC_APB3LPENR_LPTIM5LPEN_Pos        (14U)
-#define RCC_APB3LPENR_LPTIM5LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM5LPEN_Pos) /*!< 0x00004000 */
-#define RCC_APB3LPENR_LPTIM5LPEN            RCC_APB3LPENR_LPTIM5LPEN_Msk
-#define RCC_APB3LPENR_LPTIM6LPEN_Pos        (15U)
-#define RCC_APB3LPENR_LPTIM6LPEN_Msk        (0x1UL << RCC_APB3LPENR_LPTIM6LPEN_Pos) /*!< 0x00008000 */
-#define RCC_APB3LPENR_LPTIM6LPEN            RCC_APB3LPENR_LPTIM6LPEN_Msk
 #define RCC_APB3LPENR_VREFLPEN_Pos          (20U)
 #define RCC_APB3LPENR_VREFLPEN_Msk          (0x1UL << RCC_APB3LPENR_VREFLPEN_Pos)   /*!< 0x00100000 */
 #define RCC_APB3LPENR_VREFLPEN              RCC_APB3LPENR_VREFLPEN_Msk
@@ -16642,53 +14208,11 @@ typedef struct
 #define RCC_CCIPR1_USART6SEL_1              (0x2UL << RCC_CCIPR1_USART6SEL_Pos)      /*!< 0x00010000 */
 #define RCC_CCIPR1_USART6SEL_2              (0x4UL << RCC_CCIPR1_USART6SEL_Pos)      /*!< 0x00020000 */
 
-#define RCC_CCIPR1_UART7SEL_Pos             (18U)
-#define RCC_CCIPR1_UART7SEL_Msk             (0x7UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x001C0000 */
-#define RCC_CCIPR1_UART7SEL                 RCC_CCIPR1_UART7SEL_Msk
-#define RCC_CCIPR1_UART7SEL_0               (0x1UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00040000 */
-#define RCC_CCIPR1_UART7SEL_1               (0x2UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00080000 */
-#define RCC_CCIPR1_UART7SEL_2               (0x4UL << RCC_CCIPR1_UART7SEL_Pos)      /*!< 0x00100000 */
-
-#define RCC_CCIPR1_UART8SEL_Pos             (21U)
-#define RCC_CCIPR1_UART8SEL_Msk             (0x7UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00E00000 */
-#define RCC_CCIPR1_UART8SEL                 RCC_CCIPR1_UART8SEL_Msk
-#define RCC_CCIPR1_UART8SEL_0               (0x1UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00200000 */
-#define RCC_CCIPR1_UART8SEL_1               (0x2UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00400000 */
-#define RCC_CCIPR1_UART8SEL_2               (0x4UL << RCC_CCIPR1_UART8SEL_Pos)      /*!< 0x00800000 */
-
-#define RCC_CCIPR1_UART9SEL_Pos             (24U)
-#define RCC_CCIPR1_UART9SEL_Msk             (0x7UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x07000000 */
-#define RCC_CCIPR1_UART9SEL                 RCC_CCIPR1_UART9SEL_Msk
-#define RCC_CCIPR1_UART9SEL_0               (0x1UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x01000000 */
-#define RCC_CCIPR1_UART9SEL_1               (0x2UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x02000000 */
-#define RCC_CCIPR1_UART9SEL_2               (0x4UL << RCC_CCIPR1_UART9SEL_Pos)      /*!< 0x04000000 */
-
-#define RCC_CCIPR1_USART10SEL_Pos           (27U)
-#define RCC_CCIPR1_USART10SEL_Msk           (0x7UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x38000000 */
-#define RCC_CCIPR1_USART10SEL               RCC_CCIPR1_USART10SEL_Msk
-#define RCC_CCIPR1_USART10SEL_0             (0x1UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x08000000 */
-#define RCC_CCIPR1_USART10SEL_1             (0x2UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x10000000 */
-#define RCC_CCIPR1_USART10SEL_2             (0x4UL << RCC_CCIPR1_USART10SEL_Pos)    /*!< 0x20000000 */
-
 #define RCC_CCIPR1_TIMICSEL_Pos             (31U)
 #define RCC_CCIPR1_TIMICSEL_Msk             (0x1UL << RCC_CCIPR1_TIMICSEL_Pos)      /*!< 0x10000000 */
 #define RCC_CCIPR1_TIMICSEL                 RCC_CCIPR1_TIMICSEL_Msk
 
 /********************  Bit definition for RCC_CCIPR2 register  ******************/
-#define RCC_CCIPR2_USART11SEL_Pos           (0U)
-#define RCC_CCIPR2_USART11SEL_Msk           (0x7UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000007 */
-#define RCC_CCIPR2_USART11SEL               RCC_CCIPR2_USART11SEL_Msk
-#define RCC_CCIPR2_USART11SEL_0             (0x1UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000001 */
-#define RCC_CCIPR2_USART11SEL_1             (0x2UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000002 */
-#define RCC_CCIPR2_USART11SEL_2             (0x4UL << RCC_CCIPR2_USART11SEL_Pos)    /*!< 0x00000004 */
-
-#define RCC_CCIPR2_UART12SEL_Pos            (4U)
-#define RCC_CCIPR2_UART12SEL_Msk            (0x7UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000070 */
-#define RCC_CCIPR2_UART12SEL                RCC_CCIPR2_UART12SEL_Msk
-#define RCC_CCIPR2_UART12SEL_0              (0x1UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000010 */
-#define RCC_CCIPR2_UART12SEL_1              (0x2UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000020 */
-#define RCC_CCIPR2_UART12SEL_2              (0x4UL << RCC_CCIPR2_UART12SEL_Pos)     /*!< 0x00000040 */
-
 #define RCC_CCIPR2_LPTIM1SEL_Pos            (8U)
 #define RCC_CCIPR2_LPTIM1SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM1SEL_Pos)     /*!< 0x00000700 */
 #define RCC_CCIPR2_LPTIM1SEL                RCC_CCIPR2_LPTIM1SEL_Msk
@@ -16702,34 +14226,6 @@ typedef struct
 #define RCC_CCIPR2_LPTIM2SEL_0              (0x1UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00001000 */
 #define RCC_CCIPR2_LPTIM2SEL_1              (0x2UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00002000 */
 #define RCC_CCIPR2_LPTIM2SEL_2              (0x4UL << RCC_CCIPR2_LPTIM2SEL_Pos)     /*!< 0x00004000 */
-
-#define RCC_CCIPR2_LPTIM3SEL_Pos            (16U)
-#define RCC_CCIPR2_LPTIM3SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00070000 */
-#define RCC_CCIPR2_LPTIM3SEL                RCC_CCIPR2_LPTIM3SEL_Msk
-#define RCC_CCIPR2_LPTIM3SEL_0              (0x1UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00010000 */
-#define RCC_CCIPR2_LPTIM3SEL_1              (0x2UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00020000 */
-#define RCC_CCIPR2_LPTIM3SEL_2              (0x4UL << RCC_CCIPR2_LPTIM3SEL_Pos)     /*!< 0x00040000 */
-
-#define RCC_CCIPR2_LPTIM4SEL_Pos            (20U)
-#define RCC_CCIPR2_LPTIM4SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00700000 */
-#define RCC_CCIPR2_LPTIM4SEL                RCC_CCIPR2_LPTIM4SEL_Msk
-#define RCC_CCIPR2_LPTIM4SEL_0              (0x1UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00100000 */
-#define RCC_CCIPR2_LPTIM4SEL_1              (0x2UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00200000 */
-#define RCC_CCIPR2_LPTIM4SEL_2              (0x4UL << RCC_CCIPR2_LPTIM4SEL_Pos)     /*!< 0x00400000 */
-
-#define RCC_CCIPR2_LPTIM5SEL_Pos            (24U)
-#define RCC_CCIPR2_LPTIM5SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x07000000 */
-#define RCC_CCIPR2_LPTIM5SEL                RCC_CCIPR2_LPTIM5SEL_Msk
-#define RCC_CCIPR2_LPTIM5SEL_0              (0x1UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x01000000 */
-#define RCC_CCIPR2_LPTIM5SEL_1              (0x2UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x02000000 */
-#define RCC_CCIPR2_LPTIM5SEL_2              (0x4UL << RCC_CCIPR2_LPTIM5SEL_Pos)     /*!< 0x04000000 */
-
-#define RCC_CCIPR2_LPTIM6SEL_Pos            (28U)
-#define RCC_CCIPR2_LPTIM6SEL_Msk            (0x7UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x70000000 */
-#define RCC_CCIPR2_LPTIM6SEL                RCC_CCIPR2_LPTIM6SEL_Msk
-#define RCC_CCIPR2_LPTIM6SEL_0              (0x1UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x10000000 */
-#define RCC_CCIPR2_LPTIM6SEL_1              (0x2UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x20000000 */
-#define RCC_CCIPR2_LPTIM6SEL_2              (0x4UL << RCC_CCIPR2_LPTIM6SEL_Pos)     /*!< 0x40000000 */
 
 /********************  Bit definition for RCC_CCIPR3 register  ***************/
 #define RCC_CCIPR3_SPI1SEL_Pos              (0U)
@@ -16759,20 +14255,6 @@ typedef struct
 #define RCC_CCIPR3_SPI4SEL_0                (0x1UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000200 */
 #define RCC_CCIPR3_SPI4SEL_1                (0x2UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000400 */
 #define RCC_CCIPR3_SPI4SEL_2                (0x4UL << RCC_CCIPR3_SPI4SEL_Pos)       /*!< 0x00000800 */
-
-#define RCC_CCIPR3_SPI5SEL_Pos              (12U)
-#define RCC_CCIPR3_SPI5SEL_Msk              (0x7UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00007000 */
-#define RCC_CCIPR3_SPI5SEL                  RCC_CCIPR3_SPI5SEL_Msk
-#define RCC_CCIPR3_SPI5SEL_0                (0x1UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00001000 */
-#define RCC_CCIPR3_SPI5SEL_1                (0x2UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00002000 */
-#define RCC_CCIPR3_SPI5SEL_2                (0x4UL << RCC_CCIPR3_SPI5SEL_Pos)       /*!< 0x00004000 */
-
-#define RCC_CCIPR3_SPI6SEL_Pos              (15U)
-#define RCC_CCIPR3_SPI6SEL_Msk              (0x7UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00038000 */
-#define RCC_CCIPR3_SPI6SEL                  RCC_CCIPR3_SPI6SEL_Msk
-#define RCC_CCIPR3_SPI6SEL_0                (0x1UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00008000 */
-#define RCC_CCIPR3_SPI6SEL_1                (0x2UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00010000 */
-#define RCC_CCIPR3_SPI6SEL_2                (0x4UL << RCC_CCIPR3_SPI6SEL_Pos)       /*!< 0x00020000 */
 
 #define RCC_CCIPR3_LPUART1SEL_Pos           (24U)
 #define RCC_CCIPR3_LPUART1SEL_Msk           (0x7UL << RCC_CCIPR3_LPUART1SEL_Pos)    /*!< 0x07000000 */
@@ -16805,9 +14287,6 @@ typedef struct
 #define RCC_CCIPR4_SDMMC1SEL_Msk            (0x1UL << RCC_CCIPR4_SDMMC1SEL_Pos)     /*!< 0x00000040 */
 #define RCC_CCIPR4_SDMMC1SEL                RCC_CCIPR4_SDMMC1SEL_Msk
 
-#define RCC_CCIPR4_SDMMC2SEL_Pos            (7U)
-#define RCC_CCIPR4_SDMMC2SEL_Msk            (0x1UL << RCC_CCIPR4_SDMMC2SEL_Pos)     /*!< 0x00000080 */
-#define RCC_CCIPR4_SDMMC2SEL                RCC_CCIPR4_SDMMC2SEL_Msk
 
 #define RCC_CCIPR4_I2C1SEL_Pos             (16U)
 #define RCC_CCIPR4_I2C1SEL_Msk             (0x3UL << RCC_CCIPR4_I2C1SEL_Pos)      /*!< 0x00030000 */
@@ -16827,17 +14306,17 @@ typedef struct
 #define RCC_CCIPR4_I2C3SEL_0               (0x1UL << RCC_CCIPR4_I2C3SEL_Pos)      /*!< 0x00100000 */
 #define RCC_CCIPR4_I2C3SEL_1               (0x2UL << RCC_CCIPR4_I2C3SEL_Pos)      /*!< 0x00200000 */
 
-#define RCC_CCIPR4_I2C4SEL_Pos             (22U)
-#define RCC_CCIPR4_I2C4SEL_Msk             (0x3UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00C00000 */
-#define RCC_CCIPR4_I2C4SEL                 RCC_CCIPR4_I2C4SEL_Msk
-#define RCC_CCIPR4_I2C4SEL_0               (0x1UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00400000 */
-#define RCC_CCIPR4_I2C4SEL_1               (0x2UL << RCC_CCIPR4_I2C4SEL_Pos)      /*!< 0x00800000 */
-
 #define RCC_CCIPR4_I3C1SEL_Pos             (24U)
 #define RCC_CCIPR4_I3C1SEL_Msk             (0x3UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x03000000 */
 #define RCC_CCIPR4_I3C1SEL                 RCC_CCIPR4_I3C1SEL_Msk
 #define RCC_CCIPR4_I3C1SEL_0               (0x1UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x01000000 */
 #define RCC_CCIPR4_I3C1SEL_1               (0x2UL << RCC_CCIPR4_I3C1SEL_Pos)      /*!< 0x02000000 */
+
+#define RCC_CCIPR4_I3C2SEL_Pos             (26U)
+#define RCC_CCIPR4_I3C2SEL_Msk             (0x3UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x0C000000 */
+#define RCC_CCIPR4_I3C2SEL                 RCC_CCIPR4_I3C2SEL_Msk
+#define RCC_CCIPR4_I3C2SEL_0               (0x1UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x04000000 */
+#define RCC_CCIPR4_I3C2SEL_1               (0x2UL << RCC_CCIPR4_I3C2SEL_Pos)      /*!< 0x08000000 */
 
 /********************  Bit definition for RCC_CCIPR5 register  ***************/
 
@@ -16869,20 +14348,6 @@ typedef struct
 #define RCC_CCIPR5_FDCANSEL                RCC_CCIPR5_FDCANSEL_Msk
 #define RCC_CCIPR5_FDCANSEL_0              (0x1UL << RCC_CCIPR5_FDCANSEL_Pos)     /*!< 0x00000100 */
 #define RCC_CCIPR5_FDCANSEL_1              (0x2UL << RCC_CCIPR5_FDCANSEL_Pos)     /*!< 0x00000200 */
-
-#define RCC_CCIPR5_SAI1SEL_Pos             (16U)
-#define RCC_CCIPR5_SAI1SEL_Msk             (0x7UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00070000 */
-#define RCC_CCIPR5_SAI1SEL                 RCC_CCIPR5_SAI1SEL_Msk
-#define RCC_CCIPR5_SAI1SEL_0               (0x1UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00010000 */
-#define RCC_CCIPR5_SAI1SEL_1               (0x2UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00020000 */
-#define RCC_CCIPR5_SAI1SEL_2               (0x4UL << RCC_CCIPR5_SAI1SEL_Pos)      /*!< 0x00040000 */
-
-#define RCC_CCIPR5_SAI2SEL_Pos             (19U)
-#define RCC_CCIPR5_SAI2SEL_Msk             (0x7UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00380000 */
-#define RCC_CCIPR5_SAI2SEL                 RCC_CCIPR5_SAI2SEL_Msk
-#define RCC_CCIPR5_SAI2SEL_0               (0x1UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00080000 */
-#define RCC_CCIPR5_SAI2SEL_1               (0x2UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00100000 */
-#define RCC_CCIPR5_SAI2SEL_2               (0x4UL << RCC_CCIPR5_SAI2SEL_Pos)      /*!< 0x00200000 */
 
 #define RCC_CCIPR5_CKERPSEL_Pos            (30U)
 #define RCC_CCIPR5_CKERPSEL_Msk            (0x3UL << RCC_CCIPR5_CKERPSEL_Pos)     /*!< 0xC0000000 */
@@ -18599,328 +16064,6 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                          Serial Audio Interface                            */
-/*                                                                            */
-/******************************************************************************/
-/********************  Bit definition for SAI_GCR register  *******************/
-#define SAI_GCR_SYNCIN_Pos                  (0U)
-#define SAI_GCR_SYNCIN_Msk                  (0x3UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000003 */
-#define SAI_GCR_SYNCIN                      SAI_GCR_SYNCIN_Msk                      /*!<SYNCIN[1:0] bits (Synchronization Inputs)   */
-#define SAI_GCR_SYNCIN_0                    (0x1UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000001 */
-#define SAI_GCR_SYNCIN_1                    (0x2UL << SAI_GCR_SYNCIN_Pos)           /*!< 0x00000002 */
-#define SAI_GCR_SYNCOUT_Pos                 (4U)
-#define SAI_GCR_SYNCOUT_Msk                 (0x3UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000030 */
-#define SAI_GCR_SYNCOUT                     SAI_GCR_SYNCOUT_Msk                     /*!<SYNCOUT[1:0] bits (Synchronization Outputs) */
-#define SAI_GCR_SYNCOUT_0                   (0x1UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000010 */
-#define SAI_GCR_SYNCOUT_1                   (0x2UL << SAI_GCR_SYNCOUT_Pos)          /*!< 0x00000020 */
-
-/*******************  Bit definition for SAI_xCR1 register  *******************/
-#define SAI_xCR1_MODE_Pos                   (0U)
-#define SAI_xCR1_MODE_Msk                   (0x3UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000003 */
-#define SAI_xCR1_MODE                       SAI_xCR1_MODE_Msk                       /*!<MODE[1:0] bits (Audio Block Mode)           */
-#define SAI_xCR1_MODE_0                     (0x1UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000001 */
-#define SAI_xCR1_MODE_1                     (0x2UL << SAI_xCR1_MODE_Pos)            /*!< 0x00000002 */
-#define SAI_xCR1_PRTCFG_Pos                 (2U)
-#define SAI_xCR1_PRTCFG_Msk                 (0x3UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x0000000C */
-#define SAI_xCR1_PRTCFG                     SAI_xCR1_PRTCFG_Msk                     /*!<PRTCFG[1:0] bits (Protocol Configuration)   */
-#define SAI_xCR1_PRTCFG_0                   (0x1UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x00000004 */
-#define SAI_xCR1_PRTCFG_1                   (0x2UL << SAI_xCR1_PRTCFG_Pos)          /*!< 0x00000008 */
-#define SAI_xCR1_DS_Pos                     (5U)
-#define SAI_xCR1_DS_Msk                     (0x7UL << SAI_xCR1_DS_Pos)              /*!< 0x000000E0 */
-#define SAI_xCR1_DS                         SAI_xCR1_DS_Msk                         /*!<DS[1:0] bits (Data Size) */
-#define SAI_xCR1_DS_0                       (0x1UL << SAI_xCR1_DS_Pos)              /*!< 0x00000020 */
-#define SAI_xCR1_DS_1                       (0x2UL << SAI_xCR1_DS_Pos)              /*!< 0x00000040 */
-#define SAI_xCR1_DS_2                       (0x4UL << SAI_xCR1_DS_Pos)              /*!< 0x00000080 */
-#define SAI_xCR1_LSBFIRST_Pos               (8U)
-#define SAI_xCR1_LSBFIRST_Msk               (0x1UL << SAI_xCR1_LSBFIRST_Pos)        /*!< 0x00000100 */
-#define SAI_xCR1_LSBFIRST                   SAI_xCR1_LSBFIRST_Msk                   /*!<LSB First Configuration  */
-#define SAI_xCR1_CKSTR_Pos                  (9U)
-#define SAI_xCR1_CKSTR_Msk                  (0x1UL << SAI_xCR1_CKSTR_Pos)           /*!< 0x00000200 */
-#define SAI_xCR1_CKSTR                      SAI_xCR1_CKSTR_Msk                      /*!<ClocK STRobing edge      */
-#define SAI_xCR1_SYNCEN_Pos                 (10U)
-#define SAI_xCR1_SYNCEN_Msk                 (0x3UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000C00 */
-#define SAI_xCR1_SYNCEN                     SAI_xCR1_SYNCEN_Msk                     /*!<SYNCEN[1:0](SYNChronization ENable) */
-#define SAI_xCR1_SYNCEN_0                   (0x1UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000400 */
-#define SAI_xCR1_SYNCEN_1                   (0x2UL << SAI_xCR1_SYNCEN_Pos)          /*!< 0x00000800 */
-#define SAI_xCR1_MONO_Pos                   (12U)
-#define SAI_xCR1_MONO_Msk                   (0x1UL << SAI_xCR1_MONO_Pos)            /*!< 0x00001000 */
-#define SAI_xCR1_MONO                       SAI_xCR1_MONO_Msk                       /*!<Mono mode                  */
-#define SAI_xCR1_OUTDRIV_Pos                (13U)
-#define SAI_xCR1_OUTDRIV_Msk                (0x1UL << SAI_xCR1_OUTDRIV_Pos)         /*!< 0x00002000 */
-#define SAI_xCR1_OUTDRIV                    SAI_xCR1_OUTDRIV_Msk                    /*!<Output Drive               */
-#define SAI_xCR1_SAIEN_Pos                  (16U)
-#define SAI_xCR1_SAIEN_Msk                  (0x1UL << SAI_xCR1_SAIEN_Pos)           /*!< 0x00010000 */
-#define SAI_xCR1_SAIEN                      SAI_xCR1_SAIEN_Msk                      /*!<Audio Block enable         */
-#define SAI_xCR1_DMAEN_Pos                  (17U)
-#define SAI_xCR1_DMAEN_Msk                  (0x1UL << SAI_xCR1_DMAEN_Pos)           /*!< 0x00020000 */
-#define SAI_xCR1_DMAEN                      SAI_xCR1_DMAEN_Msk                      /*!<DMA enable                 */
-#define SAI_xCR1_NODIV_Pos                  (19U)
-#define SAI_xCR1_NODIV_Msk                  (0x1UL << SAI_xCR1_NODIV_Pos)           /*!< 0x00080000 */
-#define SAI_xCR1_NODIV                      SAI_xCR1_NODIV_Msk                      /*!<No Divider Configuration   */
-#define SAI_xCR1_MCKDIV_Pos                 (20U)
-#define SAI_xCR1_MCKDIV_Msk                 (0x3FUL << SAI_xCR1_MCKDIV_Pos)         /*!< 0x03F00000 */
-#define SAI_xCR1_MCKDIV                     SAI_xCR1_MCKDIV_Msk                     /*!<MCKDIV[5:0] (Master ClocK Divider)  */
-#define SAI_xCR1_MCKDIV_0                   (0x00100000UL)                          /*!<Bit 0  */
-#define SAI_xCR1_MCKDIV_1                   (0x00200000UL)                          /*!<Bit 1  */
-#define SAI_xCR1_MCKDIV_2                   (0x00400000UL)                          /*!<Bit 2  */
-#define SAI_xCR1_MCKDIV_3                   (0x00800000UL)                          /*!<Bit 3  */
-#define SAI_xCR1_MCKDIV_4                   (0x01000000UL)                          /*!<Bit 4  */
-#define SAI_xCR1_MCKDIV_5                   (0x02000000UL)                          /*!<Bit 5  */
-#define SAI_xCR1_OSR_Pos                    (26U)
-#define SAI_xCR1_OSR_Msk                    (0x1UL << SAI_xCR1_OSR_Pos)             /*!< 0x04000000 */
-#define SAI_xCR1_OSR                        SAI_xCR1_OSR_Msk                        /*!<Oversampling ratio for master clock */
-#define SAI_xCR1_MCKEN_Pos                  (27U)
-#define SAI_xCR1_MCKEN_Msk                  (0x1UL << SAI_xCR1_MCKEN_Pos)           /*!< 0x08000000 */
-#define SAI_xCR1_MCKEN                      SAI_xCR1_MCKEN_Msk                      /*!<Master clock generation enable */
-
-/*******************  Bit definition for SAI_xCR2 register  *******************/
-#define SAI_xCR2_FTH_Pos                    (0U)
-#define SAI_xCR2_FTH_Msk                    (0x7UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000007 */
-#define SAI_xCR2_FTH                        SAI_xCR2_FTH_Msk                        /*!<FTH[2:0](Fifo THreshold)  */
-#define SAI_xCR2_FTH_0                      (0x1UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000001 */
-#define SAI_xCR2_FTH_1                      (0x2UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000002 */
-#define SAI_xCR2_FTH_2                      (0x4UL << SAI_xCR2_FTH_Pos)             /*!< 0x00000004 */
-#define SAI_xCR2_FFLUSH_Pos                 (3U)
-#define SAI_xCR2_FFLUSH_Msk                 (0x1UL << SAI_xCR2_FFLUSH_Pos)          /*!< 0x00000008 */
-#define SAI_xCR2_FFLUSH                     SAI_xCR2_FFLUSH_Msk                     /*!<Fifo FLUSH                       */
-#define SAI_xCR2_TRIS_Pos                   (4U)
-#define SAI_xCR2_TRIS_Msk                   (0x1UL << SAI_xCR2_TRIS_Pos)            /*!< 0x00000010 */
-#define SAI_xCR2_TRIS                       SAI_xCR2_TRIS_Msk                       /*!<TRIState Management on data line */
-#define SAI_xCR2_MUTE_Pos                   (5U)
-#define SAI_xCR2_MUTE_Msk                   (0x1UL << SAI_xCR2_MUTE_Pos)            /*!< 0x00000020 */
-#define SAI_xCR2_MUTE                       SAI_xCR2_MUTE_Msk                       /*!<Mute mode                        */
-#define SAI_xCR2_MUTEVAL_Pos                (6U)
-#define SAI_xCR2_MUTEVAL_Msk                (0x1UL << SAI_xCR2_MUTEVAL_Pos)         /*!< 0x00000040 */
-#define SAI_xCR2_MUTEVAL                    SAI_xCR2_MUTEVAL_Msk                    /*!<Muate value                      */
-#define SAI_xCR2_MUTECNT_Pos                (7U)
-#define SAI_xCR2_MUTECNT_Msk                (0x3FUL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00001F80 */
-#define SAI_xCR2_MUTECNT                    SAI_xCR2_MUTECNT_Msk                    /*!<MUTECNT[5:0] (MUTE counter) */
-#define SAI_xCR2_MUTECNT_0                  (0x01UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000080 */
-#define SAI_xCR2_MUTECNT_1                  (0x02UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000100 */
-#define SAI_xCR2_MUTECNT_2                  (0x04UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000200 */
-#define SAI_xCR2_MUTECNT_3                  (0x08UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000400 */
-#define SAI_xCR2_MUTECNT_4                  (0x10UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00000800 */
-#define SAI_xCR2_MUTECNT_5                  (0x20UL << SAI_xCR2_MUTECNT_Pos)        /*!< 0x00001000 */
-#define SAI_xCR2_CPL_Pos                    (13U)
-#define SAI_xCR2_CPL_Msk                    (0x1UL << SAI_xCR2_CPL_Pos)             /*!< 0x00002000 */
-#define SAI_xCR2_CPL                        SAI_xCR2_CPL_Msk                        /*!<CPL mode                    */
-#define SAI_xCR2_COMP_Pos                   (14U)
-#define SAI_xCR2_COMP_Msk                   (0x3UL << SAI_xCR2_COMP_Pos)            /*!< 0x0000C000 */
-#define SAI_xCR2_COMP                       SAI_xCR2_COMP_Msk                       /*!<COMP[1:0] (Companding mode) */
-#define SAI_xCR2_COMP_0                     (0x1UL << SAI_xCR2_COMP_Pos)            /*!< 0x00004000 */
-#define SAI_xCR2_COMP_1                     (0x2UL << SAI_xCR2_COMP_Pos)            /*!< 0x00008000 */
-
-/******************  Bit definition for SAI_xFRCR register  *******************/
-#define SAI_xFRCR_FRL_Pos                   (0U)
-#define SAI_xFRCR_FRL_Msk                   (0xFFUL << SAI_xFRCR_FRL_Pos)           /*!< 0x000000FF */
-#define SAI_xFRCR_FRL                       SAI_xFRCR_FRL_Msk                       /*!<FRL[7:0](Frame length)  */
-#define SAI_xFRCR_FRL_0                     (0x01UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000001 */
-#define SAI_xFRCR_FRL_1                     (0x02UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000002 */
-#define SAI_xFRCR_FRL_2                     (0x04UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000004 */
-#define SAI_xFRCR_FRL_3                     (0x08UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000008 */
-#define SAI_xFRCR_FRL_4                     (0x10UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000010 */
-#define SAI_xFRCR_FRL_5                     (0x20UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000020 */
-#define SAI_xFRCR_FRL_6                     (0x40UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000040 */
-#define SAI_xFRCR_FRL_7                     (0x80UL << SAI_xFRCR_FRL_Pos)           /*!< 0x00000080 */
-#define SAI_xFRCR_FSALL_Pos                 (8U)
-#define SAI_xFRCR_FSALL_Msk                 (0x7FUL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00007F00 */
-#define SAI_xFRCR_FSALL                     SAI_xFRCR_FSALL_Msk                     /*!<FRL[6:0] (Frame synchronization active level length)  */
-#define SAI_xFRCR_FSALL_0                   (0x01UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000100 */
-#define SAI_xFRCR_FSALL_1                   (0x02UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000200 */
-#define SAI_xFRCR_FSALL_2                   (0x04UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000400 */
-#define SAI_xFRCR_FSALL_3                   (0x08UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00000800 */
-#define SAI_xFRCR_FSALL_4                   (0x10UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00001000 */
-#define SAI_xFRCR_FSALL_5                   (0x20UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00002000 */
-#define SAI_xFRCR_FSALL_6                   (0x40UL << SAI_xFRCR_FSALL_Pos)         /*!< 0x00004000 */
-#define SAI_xFRCR_FSDEF_Pos                 (16U)
-#define SAI_xFRCR_FSDEF_Msk                 (0x1UL << SAI_xFRCR_FSDEF_Pos)          /*!< 0x00010000 */
-#define SAI_xFRCR_FSDEF                     SAI_xFRCR_FSDEF_Msk                     /*!< Frame Synchronization Definition */
-#define SAI_xFRCR_FSPOL_Pos                 (17U)
-#define SAI_xFRCR_FSPOL_Msk                 (0x1UL << SAI_xFRCR_FSPOL_Pos)          /*!< 0x00020000 */
-#define SAI_xFRCR_FSPOL                     SAI_xFRCR_FSPOL_Msk                     /*!<Frame Synchronization POLarity    */
-#define SAI_xFRCR_FSOFF_Pos                 (18U)
-#define SAI_xFRCR_FSOFF_Msk                 (0x1UL << SAI_xFRCR_FSOFF_Pos)          /*!< 0x00040000 */
-#define SAI_xFRCR_FSOFF                     SAI_xFRCR_FSOFF_Msk                     /*!<Frame Synchronization OFFset      */
-
-/******************  Bit definition for SAI_xSLOTR register  *******************/
-#define SAI_xSLOTR_FBOFF_Pos                (0U)
-#define SAI_xSLOTR_FBOFF_Msk                (0x1FUL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x0000001F */
-#define SAI_xSLOTR_FBOFF                    SAI_xSLOTR_FBOFF_Msk                    /*!<FRL[4:0](First Bit Offset)  */
-#define SAI_xSLOTR_FBOFF_0                  (0x01UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000001 */
-#define SAI_xSLOTR_FBOFF_1                  (0x02UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000002 */
-#define SAI_xSLOTR_FBOFF_2                  (0x04UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000004 */
-#define SAI_xSLOTR_FBOFF_3                  (0x08UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000008 */
-#define SAI_xSLOTR_FBOFF_4                  (0x10UL << SAI_xSLOTR_FBOFF_Pos)        /*!< 0x00000010 */
-#define SAI_xSLOTR_SLOTSZ_Pos               (6U)
-#define SAI_xSLOTR_SLOTSZ_Msk               (0x3UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x000000C0 */
-#define SAI_xSLOTR_SLOTSZ                   SAI_xSLOTR_SLOTSZ_Msk                   /*!<SLOTSZ[1:0] (Slot size)  */
-#define SAI_xSLOTR_SLOTSZ_0                 (0x1UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x00000040 */
-#define SAI_xSLOTR_SLOTSZ_1                 (0x2UL << SAI_xSLOTR_SLOTSZ_Pos)        /*!< 0x00000080 */
-#define SAI_xSLOTR_NBSLOT_Pos               (8U)
-#define SAI_xSLOTR_NBSLOT_Msk               (0xFUL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000F00 */
-#define SAI_xSLOTR_NBSLOT                   SAI_xSLOTR_NBSLOT_Msk                   /*!<NBSLOT[3:0] (Number of Slot in audio Frame)  */
-#define SAI_xSLOTR_NBSLOT_0                 (0x1UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000100 */
-#define SAI_xSLOTR_NBSLOT_1                 (0x2UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000200 */
-#define SAI_xSLOTR_NBSLOT_2                 (0x4UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000400 */
-#define SAI_xSLOTR_NBSLOT_3                 (0x8UL << SAI_xSLOTR_NBSLOT_Pos)        /*!< 0x00000800 */
-#define SAI_xSLOTR_SLOTEN_Pos               (16U)
-#define SAI_xSLOTR_SLOTEN_Msk               (0xFFFFUL << SAI_xSLOTR_SLOTEN_Pos)     /*!< 0xFFFF0000 */
-#define SAI_xSLOTR_SLOTEN                   SAI_xSLOTR_SLOTEN_Msk                   /*!<SLOTEN[15:0] (Slot Enable)  */
-
-/*******************  Bit definition for SAI_xIMR register  *******************/
-#define SAI_xIMR_OVRUDRIE_Pos               (0U)
-#define SAI_xIMR_OVRUDRIE_Msk               (0x1UL << SAI_xIMR_OVRUDRIE_Pos)        /*!< 0x00000001 */
-#define SAI_xIMR_OVRUDRIE                   SAI_xIMR_OVRUDRIE_Msk                   /*!<Overrun underrun interrupt enable                              */
-#define SAI_xIMR_MUTEDETIE_Pos              (1U)
-#define SAI_xIMR_MUTEDETIE_Msk              (0x1UL << SAI_xIMR_MUTEDETIE_Pos)       /*!< 0x00000002 */
-#define SAI_xIMR_MUTEDETIE                  SAI_xIMR_MUTEDETIE_Msk                  /*!<Mute detection interrupt enable                                */
-#define SAI_xIMR_WCKCFGIE_Pos               (2U)
-#define SAI_xIMR_WCKCFGIE_Msk               (0x1UL << SAI_xIMR_WCKCFGIE_Pos)        /*!< 0x00000004 */
-#define SAI_xIMR_WCKCFGIE                   SAI_xIMR_WCKCFGIE_Msk                   /*!<Wrong Clock Configuration interrupt enable                     */
-#define SAI_xIMR_FREQIE_Pos                 (3U)
-#define SAI_xIMR_FREQIE_Msk                 (0x1UL << SAI_xIMR_FREQIE_Pos)          /*!< 0x00000008 */
-#define SAI_xIMR_FREQIE                     SAI_xIMR_FREQIE_Msk                     /*!<FIFO request interrupt enable                                  */
-#define SAI_xIMR_CNRDYIE_Pos                (4U)
-#define SAI_xIMR_CNRDYIE_Msk                (0x1UL << SAI_xIMR_CNRDYIE_Pos)         /*!< 0x00000010 */
-#define SAI_xIMR_CNRDYIE                    SAI_xIMR_CNRDYIE_Msk                    /*!<Codec not ready interrupt enable                               */
-#define SAI_xIMR_AFSDETIE_Pos               (5U)
-#define SAI_xIMR_AFSDETIE_Msk               (0x1UL << SAI_xIMR_AFSDETIE_Pos)        /*!< 0x00000020 */
-#define SAI_xIMR_AFSDETIE                   SAI_xIMR_AFSDETIE_Msk                   /*!<Anticipated frame synchronization detection interrupt enable   */
-#define SAI_xIMR_LFSDETIE_Pos               (6U)
-#define SAI_xIMR_LFSDETIE_Msk               (0x1UL << SAI_xIMR_LFSDETIE_Pos)        /*!< 0x00000040 */
-#define SAI_xIMR_LFSDETIE                   SAI_xIMR_LFSDETIE_Msk                   /*!<Late frame synchronization detection interrupt enable          */
-
-/********************  Bit definition for SAI_xSR register  *******************/
-#define SAI_xSR_OVRUDR_Pos                  (0U)
-#define SAI_xSR_OVRUDR_Msk                  (0x1UL << SAI_xSR_OVRUDR_Pos)           /*!< 0x00000001 */
-#define SAI_xSR_OVRUDR                      SAI_xSR_OVRUDR_Msk                      /*!<Overrun underrun                               */
-#define SAI_xSR_MUTEDET_Pos                 (1U)
-#define SAI_xSR_MUTEDET_Msk                 (0x1UL << SAI_xSR_MUTEDET_Pos)          /*!< 0x00000002 */
-#define SAI_xSR_MUTEDET                     SAI_xSR_MUTEDET_Msk                     /*!<Mute detection                                 */
-#define SAI_xSR_WCKCFG_Pos                  (2U)
-#define SAI_xSR_WCKCFG_Msk                  (0x1UL << SAI_xSR_WCKCFG_Pos)           /*!< 0x00000004 */
-#define SAI_xSR_WCKCFG                      SAI_xSR_WCKCFG_Msk                      /*!<Wrong Clock Configuration                      */
-#define SAI_xSR_FREQ_Pos                    (3U)
-#define SAI_xSR_FREQ_Msk                    (0x1UL << SAI_xSR_FREQ_Pos)             /*!< 0x00000008 */
-#define SAI_xSR_FREQ                        SAI_xSR_FREQ_Msk                        /*!<FIFO request                                   */
-#define SAI_xSR_CNRDY_Pos                   (4U)
-#define SAI_xSR_CNRDY_Msk                   (0x1UL << SAI_xSR_CNRDY_Pos)            /*!< 0x00000010 */
-#define SAI_xSR_CNRDY                       SAI_xSR_CNRDY_Msk                       /*!<Codec not ready                                */
-#define SAI_xSR_AFSDET_Pos                  (5U)
-#define SAI_xSR_AFSDET_Msk                  (0x1UL << SAI_xSR_AFSDET_Pos)           /*!< 0x00000020 */
-#define SAI_xSR_AFSDET                      SAI_xSR_AFSDET_Msk                      /*!<Anticipated frame synchronization detection    */
-#define SAI_xSR_LFSDET_Pos                  (6U)
-#define SAI_xSR_LFSDET_Msk                  (0x1UL << SAI_xSR_LFSDET_Pos)           /*!< 0x00000040 */
-#define SAI_xSR_LFSDET                      SAI_xSR_LFSDET_Msk                      /*!<Late frame synchronization detection           */
-#define SAI_xSR_FLVL_Pos                    (16U)
-#define SAI_xSR_FLVL_Msk                    (0x7UL << SAI_xSR_FLVL_Pos)             /*!< 0x00070000 */
-#define SAI_xSR_FLVL                        SAI_xSR_FLVL_Msk                        /*!<FLVL[2:0] (FIFO Level Threshold)               */
-#define SAI_xSR_FLVL_0                      (0x1UL << SAI_xSR_FLVL_Pos)             /*!< 0x00010000 */
-#define SAI_xSR_FLVL_1                      (0x2UL << SAI_xSR_FLVL_Pos)             /*!< 0x00020000 */
-#define SAI_xSR_FLVL_2                      (0x4UL << SAI_xSR_FLVL_Pos)             /*!< 0x00040000 */
-
-/******************  Bit definition for SAI_xCLRFR register  ******************/
-#define SAI_xCLRFR_COVRUDR_Pos              (0U)
-#define SAI_xCLRFR_COVRUDR_Msk              (0x1UL << SAI_xCLRFR_COVRUDR_Pos)       /*!< 0x00000001 */
-#define SAI_xCLRFR_COVRUDR                  SAI_xCLRFR_COVRUDR_Msk                  /*!<Clear Overrun underrun                               */
-#define SAI_xCLRFR_CMUTEDET_Pos             (1U)
-#define SAI_xCLRFR_CMUTEDET_Msk             (0x1UL << SAI_xCLRFR_CMUTEDET_Pos)      /*!< 0x00000002 */
-#define SAI_xCLRFR_CMUTEDET                 SAI_xCLRFR_CMUTEDET_Msk                 /*!<Clear Mute detection                                 */
-#define SAI_xCLRFR_CWCKCFG_Pos              (2U)
-#define SAI_xCLRFR_CWCKCFG_Msk              (0x1UL << SAI_xCLRFR_CWCKCFG_Pos)       /*!< 0x00000004 */
-#define SAI_xCLRFR_CWCKCFG                  SAI_xCLRFR_CWCKCFG_Msk                  /*!<Clear Wrong Clock Configuration                      */
-#define SAI_xCLRFR_CFREQ_Pos                (3U)
-#define SAI_xCLRFR_CFREQ_Msk                (0x1UL << SAI_xCLRFR_CFREQ_Pos)         /*!< 0x00000008 */
-#define SAI_xCLRFR_CFREQ                    SAI_xCLRFR_CFREQ_Msk                    /*!<Clear FIFO request                                   */
-#define SAI_xCLRFR_CCNRDY_Pos               (4U)
-#define SAI_xCLRFR_CCNRDY_Msk               (0x1UL << SAI_xCLRFR_CCNRDY_Pos)        /*!< 0x00000010 */
-#define SAI_xCLRFR_CCNRDY                   SAI_xCLRFR_CCNRDY_Msk                   /*!<Clear Codec not ready                                */
-#define SAI_xCLRFR_CAFSDET_Pos              (5U)
-#define SAI_xCLRFR_CAFSDET_Msk              (0x1UL << SAI_xCLRFR_CAFSDET_Pos)       /*!< 0x00000020 */
-#define SAI_xCLRFR_CAFSDET                  SAI_xCLRFR_CAFSDET_Msk                  /*!<Clear Anticipated frame synchronization detection    */
-#define SAI_xCLRFR_CLFSDET_Pos              (6U)
-#define SAI_xCLRFR_CLFSDET_Msk              (0x1UL << SAI_xCLRFR_CLFSDET_Pos)       /*!< 0x00000040 */
-#define SAI_xCLRFR_CLFSDET                  SAI_xCLRFR_CLFSDET_Msk                  /*!<Clear Late frame synchronization detection           */
-
-/******************  Bit definition for SAI_xDR register  ******************/
-#define SAI_xDR_DATA_Pos                    (0U)
-#define SAI_xDR_DATA_Msk                    (0xFFFFFFFFUL << SAI_xDR_DATA_Pos)      /*!< 0xFFFFFFFF */
-#define SAI_xDR_DATA                        SAI_xDR_DATA_Msk
-
-/******************  Bit definition for SAI_PDMCR register  *******************/
-#define SAI_PDMCR_PDMEN_Pos                 (0U)
-#define SAI_PDMCR_PDMEN_Msk                 (0x1UL << SAI_PDMCR_PDMEN_Pos)          /*!< 0x00000001 */
-#define SAI_PDMCR_PDMEN                     SAI_PDMCR_PDMEN_Msk                     /*!<PDM enable */
-#define SAI_PDMCR_MICNBR_Pos                (4U)
-#define SAI_PDMCR_MICNBR_Msk                (0x3UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000030 */
-#define SAI_PDMCR_MICNBR                    SAI_PDMCR_MICNBR_Msk                    /*!<MICNBR[1:0] (Number of microphones) */
-#define SAI_PDMCR_MICNBR_0                  (0x1UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000010 */
-#define SAI_PDMCR_MICNBR_1                  (0x2UL << SAI_PDMCR_MICNBR_Pos)         /*!< 0x00000020 */
-#define SAI_PDMCR_CKEN1_Pos                 (8U)
-#define SAI_PDMCR_CKEN1_Msk                 (0x1UL << SAI_PDMCR_CKEN1_Pos)          /*!< 0x00000100 */
-#define SAI_PDMCR_CKEN1                     SAI_PDMCR_CKEN1_Msk                     /*!<Clock 1 enable */
-#define SAI_PDMCR_CKEN2_Pos                 (9U)
-#define SAI_PDMCR_CKEN2_Msk                 (0x1UL << SAI_PDMCR_CKEN2_Pos)          /*!< 0x00000200 */
-#define SAI_PDMCR_CKEN2                     SAI_PDMCR_CKEN2_Msk                     /*!<Clock 2 enable */
-#define SAI_PDMCR_CKEN3_Pos                 (10U)
-#define SAI_PDMCR_CKEN3_Msk                 (0x1UL << SAI_PDMCR_CKEN3_Pos)          /*!< 0x00000400 */
-#define SAI_PDMCR_CKEN3                     SAI_PDMCR_CKEN3_Msk                     /*!<Clock 3 enable */
-#define SAI_PDMCR_CKEN4_Pos                 (11U)
-#define SAI_PDMCR_CKEN4_Msk                 (0x1UL << SAI_PDMCR_CKEN4_Pos)          /*!< 0x00000800 */
-#define SAI_PDMCR_CKEN4                     SAI_PDMCR_CKEN4_Msk                     /*!<Clock 4 enable */
-
-/******************  Bit definition for SAI_PDMDLY register  ******************/
-#define SAI_PDMDLY_DLYM1L_Pos               (0U)
-#define SAI_PDMDLY_DLYM1L_Msk               (0x7UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000007 */
-#define SAI_PDMDLY_DLYM1L                   SAI_PDMDLY_DLYM1L_Msk                   /*!<DLYM1L[2:0] (Delay line adjust for left microphone of pair 1) */
-#define SAI_PDMDLY_DLYM1L_0                 (0x1UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000001 */
-#define SAI_PDMDLY_DLYM1L_1                 (0x2UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000002 */
-#define SAI_PDMDLY_DLYM1L_2                 (0x4UL << SAI_PDMDLY_DLYM1L_Pos)        /*!< 0x00000004 */
-#define SAI_PDMDLY_DLYM1R_Pos               (4U)
-#define SAI_PDMDLY_DLYM1R_Msk               (0x7UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000070 */
-#define SAI_PDMDLY_DLYM1R                   SAI_PDMDLY_DLYM1R_Msk                   /*!<DLYM1R[2:0] (Delay line adjust for right microphone of pair 1) */
-#define SAI_PDMDLY_DLYM1R_0                 (0x1UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000010 */
-#define SAI_PDMDLY_DLYM1R_1                 (0x2UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000020 */
-#define SAI_PDMDLY_DLYM1R_2                 (0x4UL << SAI_PDMDLY_DLYM1R_Pos)        /*!< 0x00000040 */
-#define SAI_PDMDLY_DLYM2L_Pos               (8U)
-#define SAI_PDMDLY_DLYM2L_Msk               (0x7UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000700 */
-#define SAI_PDMDLY_DLYM2L                   SAI_PDMDLY_DLYM2L_Msk                   /*!<DLYM2L[2:0] (Delay line adjust for left microphone of pair 2) */
-#define SAI_PDMDLY_DLYM2L_0                 (0x1UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000100 */
-#define SAI_PDMDLY_DLYM2L_1                 (0x2UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000200 */
-#define SAI_PDMDLY_DLYM2L_2                 (0x4UL << SAI_PDMDLY_DLYM2L_Pos)        /*!< 0x00000400 */
-#define SAI_PDMDLY_DLYM2R_Pos               (12U)
-#define SAI_PDMDLY_DLYM2R_Msk               (0x7UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00007000 */
-#define SAI_PDMDLY_DLYM2R                   SAI_PDMDLY_DLYM2R_Msk                   /*!<DLYM2R[2:0] (Delay line adjust for right microphone of pair 2) */
-#define SAI_PDMDLY_DLYM2R_0                 (0x1UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00001000 */
-#define SAI_PDMDLY_DLYM2R_1                 (0x2UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00002000 */
-#define SAI_PDMDLY_DLYM2R_2                 (0x4UL << SAI_PDMDLY_DLYM2R_Pos)        /*!< 0x00004000 */
-#define SAI_PDMDLY_DLYM3L_Pos               (16U)
-#define SAI_PDMDLY_DLYM3L_Msk               (0x7UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00070000 */
-#define SAI_PDMDLY_DLYM3L                   SAI_PDMDLY_DLYM3L_Msk                   /*!<DLYM3L[2:0] (Delay line adjust for left microphone of pair 3) */
-#define SAI_PDMDLY_DLYM3L_0                 (0x1UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00010000 */
-#define SAI_PDMDLY_DLYM3L_1                 (0x2UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00020000 */
-#define SAI_PDMDLY_DLYM3L_2                 (0x4UL << SAI_PDMDLY_DLYM3L_Pos)        /*!< 0x00040000 */
-#define SAI_PDMDLY_DLYM3R_Pos               (20U)
-#define SAI_PDMDLY_DLYM3R_Msk               (0x7UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00700000 */
-#define SAI_PDMDLY_DLYM3R                   SAI_PDMDLY_DLYM3R_Msk                   /*!<DLYM3R[2:0] (Delay line adjust for right microphone of pair 3) */
-#define SAI_PDMDLY_DLYM3R_0                 (0x1UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00100000 */
-#define SAI_PDMDLY_DLYM3R_1                 (0x2UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00200000 */
-#define SAI_PDMDLY_DLYM3R_2                 (0x4UL << SAI_PDMDLY_DLYM3R_Pos)        /*!< 0x00400000 */
-#define SAI_PDMDLY_DLYM4L_Pos               (24U)
-#define SAI_PDMDLY_DLYM4L_Msk               (0x7UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x07000000 */
-#define SAI_PDMDLY_DLYM4L                   SAI_PDMDLY_DLYM4L_Msk                   /*!<DLYM4L[2:0] (Delay line adjust for left microphone of pair 4) */
-#define SAI_PDMDLY_DLYM4L_0                 (0x1UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x01000000 */
-#define SAI_PDMDLY_DLYM4L_1                 (0x2UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x02000000 */
-#define SAI_PDMDLY_DLYM4L_2                 (0x4UL << SAI_PDMDLY_DLYM4L_Pos)        /*!< 0x04000000 */
-#define SAI_PDMDLY_DLYM4R_Pos               (28U)
-#define SAI_PDMDLY_DLYM4R_Msk               (0x7UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x70000000 */
-#define SAI_PDMDLY_DLYM4R                   SAI_PDMDLY_DLYM4R_Msk                   /*!<DLYM4R[2:0] (Delay line adjust for right microphone of pair 4) */
-#define SAI_PDMDLY_DLYM4R_0                 (0x1UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x10000000 */
-#define SAI_PDMDLY_DLYM4R_1                 (0x2UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x20000000 */
-#define SAI_PDMDLY_DLYM4R_2                 (0x4UL << SAI_PDMDLY_DLYM4R_Pos)        /*!< 0x40000000 */
-
-/******************************************************************************/
-/*                                                                            */
 /*                                 SBS                                        */
 /*                                                                            */
 /******************************************************************************/
@@ -18988,12 +16131,6 @@ typedef struct
 #define SBS_PMCR_PB9_FMP_Pos              (19U)
 #define SBS_PMCR_PB9_FMP_Msk              (0x1UL << SBS_PMCR_PB9_FMP_Pos)            /*!< 0x00080000 */
 #define SBS_PMCR_PB9_FMP                  SBS_PMCR_PB9_FMP_Msk                       /*!< Fast-mode Plus command on PB(9) */
-#define SBS_PMCR_ETH_SEL_PHY_Pos          (21U)
-#define SBS_PMCR_ETH_SEL_PHY_Msk          (0x7UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00E00000 */
-#define SBS_PMCR_ETH_SEL_PHY              SBS_PMCR_ETH_SEL_PHY_Msk                   /*!< Ethernet PHY Interface Selection */
-#define SBS_PMCR_ETH_SEL_PHY_0            (0x1UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00200000 */
-#define SBS_PMCR_ETH_SEL_PHY_1            (0x2UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00400000 */
-#define SBS_PMCR_ETH_SEL_PHY_2            (0x4UL << SBS_PMCR_ETH_SEL_PHY_Pos)        /*!< 0x00800000 */
 
 /******************  Bit definition for SBS_FPUIMR register  ***************/
 #define SBS_FPUIMR_FPU_IE_Pos            (0U)
@@ -19160,10 +16297,6 @@ typedef struct
 #define GTZC_CFGR1_TIM7_Msk                 (0x01UL << GTZC_CFGR1_TIM7_Pos)
 #define GTZC_CFGR1_TIM12_Pos                (6U)
 #define GTZC_CFGR1_TIM12_Msk                (0x01UL << GTZC_CFGR1_TIM12_Pos)
-#define GTZC_CFGR1_TIM13_Pos                (7U)
-#define GTZC_CFGR1_TIM13_Msk                (0x01UL << GTZC_CFGR1_TIM13_Pos)
-#define GTZC_CFGR1_TIM14_Pos                (8U)
-#define GTZC_CFGR1_TIM14_Msk                (0x01UL << GTZC_CFGR1_TIM14_Pos)
 #define GTZC_CFGR1_WWDG_Pos                 (9U)
 #define GTZC_CFGR1_WWDG_Msk                 (0x01UL << GTZC_CFGR1_WWDG_Pos)
 #define GTZC_CFGR1_IWDG_Pos                 (10U)
@@ -19190,22 +16323,10 @@ typedef struct
 #define GTZC_CFGR1_CRS_Msk                  (0x01UL << GTZC_CFGR1_CRS_Pos)
 #define GTZC_CFGR1_USART6_Pos               (21U)
 #define GTZC_CFGR1_USART6_Msk               (0x01UL << GTZC_CFGR1_USART6_Pos)
-#define GTZC_CFGR1_USART10_Pos              (22U)
-#define GTZC_CFGR1_USART10_Msk              (0x01UL << GTZC_CFGR1_USART10_Pos)
-#define GTZC_CFGR1_USART11_Pos              (23U)
-#define GTZC_CFGR1_USART11_Msk              (0x01UL << GTZC_CFGR1_USART11_Pos)
 #define GTZC_CFGR1_HDMICEC_Pos              (24U)
 #define GTZC_CFGR1_HDMICEC_Msk              (0x01UL << GTZC_CFGR1_HDMICEC_Pos)
 #define GTZC_CFGR1_DAC1_Pos                 (25U)
 #define GTZC_CFGR1_DAC1_Msk                 (0x01UL << GTZC_CFGR1_DAC1_Pos)
-#define GTZC_CFGR1_UART7_Pos                (26U)
-#define GTZC_CFGR1_UART7_Msk                (0x01UL << GTZC_CFGR1_UART7_Pos)
-#define GTZC_CFGR1_UART8_Pos                (27U)
-#define GTZC_CFGR1_UART8_Msk                (0x01UL << GTZC_CFGR1_UART8_Pos)
-#define GTZC_CFGR1_UART9_Pos                (28U)
-#define GTZC_CFGR1_UART9_Msk                (0x01UL << GTZC_CFGR1_UART9_Pos)
-#define GTZC_CFGR1_UART12_Pos               (29U)
-#define GTZC_CFGR1_UART12_Msk               (0x01UL << GTZC_CFGR1_UART12_Pos)
 #define GTZC_CFGR1_DTS_Pos                  (30U)
 #define GTZC_CFGR1_DTS_Msk                  (0x01UL << GTZC_CFGR1_DTS_Pos)
 #define GTZC_CFGR1_LPTIM2_Pos               (31U)
@@ -19228,50 +16349,24 @@ typedef struct
 #define GTZC_CFGR2_USART1_Msk               (0x01UL << GTZC_CFGR2_USART1_Pos)
 #define GTZC_CFGR2_TIM15_Pos                (12U)
 #define GTZC_CFGR2_TIM15_Msk                (0x01UL << GTZC_CFGR2_TIM15_Pos)
-#define GTZC_CFGR2_TIM16_Pos                (13U)
-#define GTZC_CFGR2_TIM16_Msk                (0x01UL << GTZC_CFGR2_TIM16_Pos)
-#define GTZC_CFGR2_TIM17_Pos                (14U)
-#define GTZC_CFGR2_TIM17_Msk                (0x01UL << GTZC_CFGR2_TIM17_Pos)
 #define GTZC_CFGR2_SPI4_Pos                 (15U)
 #define GTZC_CFGR2_SPI4_Msk                 (0x01UL << GTZC_CFGR2_SPI4_Pos)
-#define GTZC_CFGR2_SPI6_Pos                 (16U)
-#define GTZC_CFGR2_SPI6_Msk                 (0x01UL << GTZC_CFGR2_SPI6_Pos)
-#define GTZC_CFGR2_SAI1_Pos                 (17U)
-#define GTZC_CFGR2_SAI1_Msk                 (0x01UL << GTZC_CFGR2_SAI1_Pos)
-#define GTZC_CFGR2_SAI2_Pos                 (18U)
-#define GTZC_CFGR2_SAI2_Msk                 (0x01UL << GTZC_CFGR2_SAI2_Pos)
 #define GTZC_CFGR2_USB_Pos                  (19U)
 #define GTZC_CFGR2_USB_Msk                  (0x01UL << GTZC_CFGR2_USB_Pos)
-#define GTZC_CFGR2_SPI5_Pos                 (24U)
-#define GTZC_CFGR2_SPI5_Msk                 (0x01UL << GTZC_CFGR2_SPI5_Pos)
 #define GTZC_CFGR2_LPUART1_Pos              (25U)
 #define GTZC_CFGR2_LPUART1_Msk              (0x01UL << GTZC_CFGR2_LPUART1_Pos)
 #define GTZC_CFGR2_I2C3_Pos                 (26U)
 #define GTZC_CFGR2_I2C3_Msk                 (0x01UL << GTZC_CFGR2_I2C3_Pos)
-#define GTZC_CFGR2_I2C4_Pos                 (27U)
-#define GTZC_CFGR2_I2C4_Msk                 (0x01UL << GTZC_CFGR2_I2C4_Pos)
 #define GTZC_CFGR2_LPTIM1_Pos               (28U)
 #define GTZC_CFGR2_LPTIM1_Msk               (0x01UL << GTZC_CFGR2_LPTIM1_Pos)
-#define GTZC_CFGR2_LPTIM3_Pos               (29U)
-#define GTZC_CFGR2_LPTIM3_Msk               (0x01UL << GTZC_CFGR2_LPTIM3_Pos)
-#define GTZC_CFGR2_LPTIM4_Pos               (30U)
-#define GTZC_CFGR2_LPTIM4_Msk               (0x01UL << GTZC_CFGR2_LPTIM4_Pos)
-#define GTZC_CFGR2_LPTIM5_Pos               (31U)
-#define GTZC_CFGR2_LPTIM5_Msk               (0x01UL << GTZC_CFGR2_LPTIM5_Pos)
 
 /***************  Bits definition for register x=3 (TZSC1) *************/
-#define GTZC_CFGR3_LPTIM6_Pos               (0U)
-#define GTZC_CFGR3_LPTIM6_Msk               (0x01UL << GTZC_CFGR3_LPTIM6_Pos)
 #define GTZC_CFGR3_VREFBUF_Pos              (1U)
 #define GTZC_CFGR3_VREFBUF_Msk              (0x01UL << GTZC_CFGR3_VREFBUF_Pos)
+#define GTZC_CFGR3_I3C2_Pos                 (2U)
+#define GTZC_CFGR3_I3C2_Msk                 (0x01UL << GTZC_CFGR3_I3C2_Pos)
 #define GTZC_CFGR3_CRC_Pos                  (8U)
 #define GTZC_CFGR3_CRC_Msk                  (0x01UL << GTZC_CFGR3_CRC_Pos)
-#define GTZC_CFGR3_CORDIC_Pos               (9U)
-#define GTZC_CFGR3_CORDIC_Msk               (0x01UL << GTZC_CFGR3_CORDIC_Pos)
-#define GTZC_CFGR3_FMAC_Pos                 (10U)
-#define GTZC_CFGR3_FMAC_Msk                 (0x01UL << GTZC_CFGR3_FMAC_Pos)
-#define GTZC_CFGR3_ETHERNET_Pos             (11U)
-#define GTZC_CFGR3_ETHERNET_Msk             (0x01UL << GTZC_CFGR3_ETHERNET_Pos)
 #define GTZC_CFGR3_ICACHE_REG_Pos           (12U)
 #define GTZC_CFGR3_ICACHE_REG_Msk           (0x01UL << GTZC_CFGR3_ICACHE_REG_Pos)
 #define GTZC_CFGR3_DCACHE1_REG_Pos          (13U)
@@ -19280,14 +16375,18 @@ typedef struct
 #define GTZC_CFGR3_ADC_Msk                  (0x01UL << GTZC_CFGR3_ADC_Pos)
 #define GTZC_CFGR3_DCMI_PSSI_Pos            (15U)
 #define GTZC_CFGR3_DCMI_PSSI_Msk            (0x01UL << GTZC_CFGR3_DCMI_PSSI_Pos)
+#define GTZC_CFGR3_AES_Pos                  (16U)
+#define GTZC_CFGR3_AES_Msk                  (0x01UL << GTZC_CFGR3_AES_Pos)
 #define GTZC_CFGR3_HASH_Pos                 (17U)
 #define GTZC_CFGR3_HASH_Msk                 (0x01UL << GTZC_CFGR3_HASH_Pos)
 #define GTZC_CFGR3_RNG_Pos                  (18U)
 #define GTZC_CFGR3_RNG_Msk                  (0x01UL << GTZC_CFGR3_RNG_Pos)
+#define GTZC_CFGR3_SAES_Pos                 (19U)
+#define GTZC_CFGR3_SAES_Msk                 (0x01UL << GTZC_CFGR3_SAES_Pos)
+#define GTZC_CFGR3_PKA_Pos                  (20U)
+#define GTZC_CFGR3_PKA_Msk                  (0x01UL << GTZC_CFGR3_PKA_Pos)
 #define GTZC_CFGR3_SDMMC1_Pos               (21U)
 #define GTZC_CFGR3_SDMMC1_Msk               (0x01UL << GTZC_CFGR3_SDMMC1_Pos)
-#define GTZC_CFGR3_SDMMC2_Pos               (22U)
-#define GTZC_CFGR3_SDMMC2_Msk               (0x01UL << GTZC_CFGR3_SDMMC2_Pos)
 #define GTZC_CFGR3_FMC_REG_Pos              (23U)
 #define GTZC_CFGR3_FMC_REG_Msk              (0x01UL << GTZC_CFGR3_FMC_REG_Pos)
 #define GTZC_CFGR3_OCTOSPI1_Pos             (24U)
@@ -19305,6 +16404,8 @@ typedef struct
 #define GTZC_CFGR4_FLASH_REG_Pos            (3U)
 #define GTZC_CFGR4_FLASH_REG_Msk            (0x01UL << GTZC_CFGR4_FLASH_REG_Pos)
 
+#define GTZC_CFGR4_OTFDEC1_Pos              (4U)
+#define GTZC_CFGR4_OTFDEC1_Msk              (0x01UL << GTZC_CFGR4_OTFDEC1_Pos)
 #define GTZC_CFGR4_SBS_Pos                  (6U)
 #define GTZC_CFGR4_SBS_Msk                  (0x01UL << GTZC_CFGR4_SBS_Pos)
 #define GTZC_CFGR4_RTC_Pos                  (7U)
@@ -19355,10 +16456,6 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZSC1_SECCFGR1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZSC1_SECCFGR1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZSC1_SECCFGR1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZSC1_SECCFGR1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZSC1_SECCFGR1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZSC1_SECCFGR1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZSC1_SECCFGR1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZSC1_SECCFGR1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZSC1_SECCFGR1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -19385,22 +16482,10 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZSC1_SECCFGR1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZSC1_SECCFGR1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZSC1_SECCFGR1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZSC1_SECCFGR1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZSC1_SECCFGR1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZSC1_SECCFGR1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZSC1_SECCFGR1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZSC1_SECCFGR1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZSC1_SECCFGR1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZSC1_SECCFGR1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZSC1_SECCFGR1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZSC1_SECCFGR1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZSC1_SECCFGR1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZSC1_SECCFGR1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZSC1_SECCFGR1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZSC1_SECCFGR1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZSC1_SECCFGR1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZSC1_SECCFGR1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZSC1_SECCFGR1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZSC1_SECCFGR1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -19423,50 +16508,24 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZSC1_SECCFGR2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZSC1_SECCFGR2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZSC1_SECCFGR2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZSC1_SECCFGR2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZSC1_SECCFGR2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZSC1_SECCFGR2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZSC1_SECCFGR2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZSC1_SECCFGR2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZSC1_SECCFGR2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZSC1_SECCFGR2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZSC1_SECCFGR2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZSC1_SECCFGR2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZSC1_SECCFGR2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZSC1_SECCFGR2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZSC1_SECCFGR2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZSC1_SECCFGR2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZSC1_SECCFGR2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZSC1_SECCFGR2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZSC1_SECCFGR2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZSC1_SECCFGR2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZSC1_SECCFGR2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZSC1_SECCFGR2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZSC1_SECCFGR2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZSC1_SECCFGR2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZSC1_SECCFGR2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZSC1_SECCFGR2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZSC1_SECCFGR2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZSC1_SECCFGR2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZSC_SECCFGR3 register  ***************/
-#define GTZC_TZSC1_SECCFGR3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZSC1_SECCFGR3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZSC1_SECCFGR3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZSC1_SECCFGR3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZSC1_SECCFGR3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZSC1_SECCFGR3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZSC1_SECCFGR3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZSC1_SECCFGR3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZSC1_SECCFGR3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZSC1_SECCFGR3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZSC1_SECCFGR3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZSC1_SECCFGR3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZSC1_SECCFGR3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZSC1_SECCFGR3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZSC1_SECCFGR3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZSC1_SECCFGR3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZSC1_SECCFGR3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19475,14 +16534,18 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR3_ADC_Msk             GTZC_CFGR3_ADC_Msk
 #define GTZC_TZSC1_SECCFGR3_DCMI_PSSI_Pos       GTZC_CFGR3_DCMI_PSSI_Pos
 #define GTZC_TZSC1_SECCFGR3_DCMI_PSSI_Msk       GTZC_CFGR3_DCMI_PSSI_Msk
+#define GTZC_TZSC1_SECCFGR3_AES_Pos             GTZC_CFGR3_AES_Pos
+#define GTZC_TZSC1_SECCFGR3_AES_Msk             GTZC_CFGR3_AES_Msk
 #define GTZC_TZSC1_SECCFGR3_HASH_Pos            GTZC_CFGR3_HASH_Pos
 #define GTZC_TZSC1_SECCFGR3_HASH_Msk            GTZC_CFGR3_HASH_Msk
 #define GTZC_TZSC1_SECCFGR3_RNG_Pos             GTZC_CFGR3_RNG_Pos
 #define GTZC_TZSC1_SECCFGR3_RNG_Msk             GTZC_CFGR3_RNG_Msk
+#define GTZC_TZSC1_SECCFGR3_SAES_Pos            GTZC_CFGR3_SAES_Pos
+#define GTZC_TZSC1_SECCFGR3_SAES_Msk            GTZC_CFGR3_SAES_Msk
+#define GTZC_TZSC1_SECCFGR3_PKA_Pos             GTZC_CFGR3_PKA_Pos
+#define GTZC_TZSC1_SECCFGR3_PKA_Msk             GTZC_CFGR3_PKA_Msk
 #define GTZC_TZSC1_SECCFGR3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZSC1_SECCFGR3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZSC1_SECCFGR3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZSC1_SECCFGR3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZSC1_SECCFGR3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZSC1_SECCFGR3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZSC1_SECCFGR3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -19506,10 +16569,6 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR1_TIM7_Msk           GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZSC1_PRIVCFGR1_TIM12_Pos          GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZSC1_PRIVCFGR1_TIM12_Msk          GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZSC1_PRIVCFGR1_TIM13_Pos          GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZSC1_PRIVCFGR1_TIM13_Msk          GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZSC1_PRIVCFGR1_TIM14_Pos          GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZSC1_PRIVCFGR1_TIM14_Msk          GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZSC1_PRIVCFGR1_WWDG_Pos           GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZSC1_PRIVCFGR1_WWDG_Msk           GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZSC1_PRIVCFGR1_IWDG_Pos           GTZC_CFGR1_IWDG_Pos
@@ -19536,22 +16595,10 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR1_CRS_Msk            GTZC_CFGR1_CRS_Msk
 #define GTZC_TZSC1_PRIVCFGR1_USART6_Pos         GTZC_CFGR1_USART6_Pos
 #define GTZC_TZSC1_PRIVCFGR1_USART6_Msk         GTZC_CFGR1_USART6_Msk
-#define GTZC_TZSC1_PRIVCFGR1_USART10_Pos        GTZC_CFGR1_USART10_Pos
-#define GTZC_TZSC1_PRIVCFGR1_USART10_Msk        GTZC_CFGR1_USART10_Msk
-#define GTZC_TZSC1_PRIVCFGR1_USART11_Pos        GTZC_CFGR1_USART11_Pos
-#define GTZC_TZSC1_PRIVCFGR1_USART11_Msk        GTZC_CFGR1_USART11_Msk
 #define GTZC_TZSC1_PRIVCFGR1_HDMICEC_Pos        GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZSC1_PRIVCFGR1_HDMICEC_Msk        GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZSC1_PRIVCFGR1_DAC1_Pos           GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZSC1_PRIVCFGR1_DAC1_Msk           GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART7_Pos          GTZC_CFGR1_UART7_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART7_Msk          GTZC_CFGR1_UART7_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART8_Pos          GTZC_CFGR1_UART8_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART8_Msk          GTZC_CFGR1_UART8_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART9_Pos          GTZC_CFGR1_UART9_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART9_Msk          GTZC_CFGR1_UART9_Msk
-#define GTZC_TZSC1_PRIVCFGR1_UART12_Pos         GTZC_CFGR1_UART12_Pos
-#define GTZC_TZSC1_PRIVCFGR1_UART12Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZSC1_PRIVCFGR1_DTS_Pos            GTZC_CFGR1_DTS_Pos
 #define GTZC_TZSC1_PRIVCFGR1_DTS_Msk            GTZC_CFGR1_DTS_Msk
 #define GTZC_TZSC1_PRIVCFGR1_LPTIM2_Pos         GTZC_CFGR1_LPTIM2_Pos
@@ -19574,50 +16621,24 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR2_USART1_Msk         GTZC_CFGR2_USART1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_TIM15_Pos          GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZSC1_PRIVCFGR2_TIM15_Msk          GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZSC1_PRIVCFGR2_TIM16_Pos          GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZSC1_PRIVCFGR2_TIM16_Msk          GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZSC1_PRIVCFGR2_TIM17_Pos          GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZSC1_PRIVCFGR2_TIM17_Msk          GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZSC1_PRIVCFGR2_SPI4_Pos           GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZSC1_PRIVCFGR2_SPI4_Msk           GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SPI6_Pos           GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SPI6_Msk           GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SAI1_Pos           GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SAI1_Msk           GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SAI2_Pos           GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SAI2_Msk           GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZSC1_PRIVCFGR2_USB_Pos            GTZC_CFGR2_USB_Pos
 #define GTZC_TZSC1_PRIVCFGR2_USB_Msk            GTZC_CFGR2_USB_Msk
-#define GTZC_TZSC1_PRIVCFGR2_SPI5_Pos           GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZSC1_PRIVCFGR2_SPI5_Msk           GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZSC1_PRIVCFGR2_LPUART1_Pos        GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_LPUART1_Msk        GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_I2C3_Pos           GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZSC1_PRIVCFGR2_I2C3_Msk           GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZSC1_PRIVCFGR2_I2C4_Pos           GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZSC1_PRIVCFGR2_I2C4_Msk           GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZSC1_PRIVCFGR2_LPTIM1_Pos         GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_LPTIM1_Msk         GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM3_Pos         GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM3_Msk         GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM4_Pos         GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM4_Msk         GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM5_Pos         GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZSC1_PRIVCFGR2_LPTIM5_Msk         GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR3 register  ***************/
-#define GTZC_TZSC1_PRIVCFGR3_LPTIM6_Pos         GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZSC1_PRIVCFGR3_LPTIM6_Msk         GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZSC1_PRIVCFGR3_VREFBUF_Pos        GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZSC1_PRIVCFGR3_VREFBUF_Msk        GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Pos           GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZSC1_PRIVCFGR3_I3C2_Msk           GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Pos            GTZC_CFGR3_CRC_Pos
 #define GTZC_TZSC1_PRIVCFGR3_CRC_Msk            GTZC_CFGR3_CRC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_CORDIC_Pos         GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZSC1_PRIVCFGR3_CORDIC_Msk         GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_FMAC_Pos           GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZSC1_PRIVCFGR3_FMAC_Msk           GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZSC1_PRIVCFGR3_ETHERNET_Pos       GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZSC1_PRIVCFGR3_ETHERNET_Msk       GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZSC1_PRIVCFGR3_ICACHE_REG_Pos     GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZSC1_PRIVCFGR3_ICACHE_REG_Msk     GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZSC1_PRIVCFGR3_DCACHE1_REG_Pos    GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19626,14 +16647,18 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR3_ADC_Msk            GTZC_CFGR3_ADC_Msk
 #define GTZC_TZSC1_PRIVCFGR3_DCMI_PSSI_Pos      GTZC_CFGR3_DCMI_PSSI_Pos
 #define GTZC_TZSC1_PRIVCFGR3_DCMI_PSSI_Msk      GTZC_CFGR3_DCMI_PSSI_Msk
+#define GTZC_TZSC1_PRIVCFGR3_AES_Pos            GTZC_CFGR3_AES_Pos
+#define GTZC_TZSC1_PRIVCFGR3_AES_Msk            GTZC_CFGR3_AES_Msk
 #define GTZC_TZSC1_PRIVCFGR3_HASH_Pos           GTZC_CFGR3_HASH_Pos
 #define GTZC_TZSC1_PRIVCFGR3_HASH_Msk           GTZC_CFGR3_HASH_Msk
 #define GTZC_TZSC1_PRIVCFGR3_RNG_Pos            GTZC_CFGR3_RNG_Pos
 #define GTZC_TZSC1_PRIVCFGR3_RNG_Msk            GTZC_CFGR3_RNG_Msk
+#define GTZC_TZSC1_PRIVCFGR3_SAES_Pos           GTZC_CFGR3_SAES_Pos
+#define GTZC_TZSC1_PRIVCFGR3_SAES_Msk           GTZC_CFGR3_SAES_Msk
+#define GTZC_TZSC1_PRIVCFGR3_PKA_Pos            GTZC_CFGR3_PKA_Pos
+#define GTZC_TZSC1_PRIVCFGR3_PKA_Msk            GTZC_CFGR3_PKA_Msk
 #define GTZC_TZSC1_PRIVCFGR3_SDMMC1_Pos         GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZSC1_PRIVCFGR3_SDMMC1_Msk         GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZSC1_PRIVCFGR3_SDMMC2_Pos         GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZSC1_PRIVCFGR3_SDMMC2_Msk         GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZSC1_PRIVCFGR3_FMC_REG_Pos        GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZSC1_PRIVCFGR3_FMC_REG_Msk        GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZSC1_PRIVCFGR3_OCTOSPI1_Pos       GTZC_CFGR3_OCTOSPI1_Pos
@@ -19656,10 +16681,6 @@ typedef struct
 #define GTZC_TZIC1_IER1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_IER1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_IER1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_IER1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_IER1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_IER1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_IER1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_IER1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_IER1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_IER1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -19686,22 +16707,10 @@ typedef struct
 #define GTZC_TZIC1_IER1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_IER1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_IER1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_IER1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_IER1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_IER1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_IER1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_IER1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_IER1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_IER1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_IER1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_IER1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_IER1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_IER1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_IER1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_IER1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_IER1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_IER1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_IER1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_IER1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_IER1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_IER1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -19724,50 +16733,24 @@ typedef struct
 #define GTZC_TZIC1_IER2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_IER2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_IER2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_IER2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_IER2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_IER2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_IER2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_IER2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_IER2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_IER2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_IER2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_IER2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_IER2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_IER2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_IER2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_IER2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_IER2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_IER2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_IER2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_IER2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_IER2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_IER2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_IER2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_IER2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_IER2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_IER2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_IER2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_IER2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_IER2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_IER2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_IER2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_IER2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_IER2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZIC_IER3 register  ***************/
-#define GTZC_TZIC1_IER3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_IER3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_IER3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_IER3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_IER3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_IER3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_IER3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_IER3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_IER3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_IER3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_IER3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_IER3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_IER3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_IER3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_IER3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_IER3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_IER3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19776,14 +16759,18 @@ typedef struct
 #define GTZC_TZIC1_IER3_ADC_Msk             GTZC_CFGR3_ADC_Msk
 #define GTZC_TZIC1_IER3_DCMI_PSSI_Pos       GTZC_CFGR3_DCMI_PSSI_Pos
 #define GTZC_TZIC1_IER3_DCMI_PSSI_Msk       GTZC_CFGR3_DCMI_PSSI_Msk
+#define GTZC_TZIC1_IER3_AES_Pos             GTZC_CFGR3_AES_Pos
+#define GTZC_TZIC1_IER3_AES_Msk             GTZC_CFGR3_AES_Msk
 #define GTZC_TZIC1_IER3_HASH_Pos            GTZC_CFGR3_HASH_Pos
 #define GTZC_TZIC1_IER3_HASH_Msk            GTZC_CFGR3_HASH_Msk
 #define GTZC_TZIC1_IER3_RNG_Pos             GTZC_CFGR3_RNG_Pos
 #define GTZC_TZIC1_IER3_RNG_Msk             GTZC_CFGR3_RNG_Msk
+#define GTZC_TZIC1_IER3_SAES_Pos            GTZC_CFGR3_SAES_Pos
+#define GTZC_TZIC1_IER3_SAES_Msk            GTZC_CFGR3_SAES_Msk
+#define GTZC_TZIC1_IER3_PKA_Pos             GTZC_CFGR3_PKA_Pos
+#define GTZC_TZIC1_IER3_PKA_Msk             GTZC_CFGR3_PKA_Msk
 #define GTZC_TZIC1_IER3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_IER3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_IER3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_IER3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_IER3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_IER3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_IER3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -19800,6 +16787,8 @@ typedef struct
 #define GTZC_TZIC1_IER4_FLASH_Msk           GTZC_CFGR4_FLASH_Msk
 #define GTZC_TZIC1_IER4_FLASH_REG_Pos       GTZC_CFGR4_FLASH_REG_Pos
 #define GTZC_TZIC1_IER4_FLASH_REG_Msk       GTZC_CFGR4_FLASH_REG_Msk
+#define GTZC_TZIC1_IER4_OTFDEC1_Pos         GTZC_CFGR4_OTFDEC1_Pos
+#define GTZC_TZIC1_IER4_OTFDEC1_Msk         GTZC_CFGR4_OTFDEC1_Msk
 #define GTZC_TZIC1_IER4_SBS_Pos             GTZC_CFGR4_SBS_Pos
 #define GTZC_TZIC1_IER4_SBS_Msk             GTZC_CFGR4_SBS_Msk
 #define GTZC_TZIC1_IER4_RTC_Pos             GTZC_CFGR4_RTC_Pos
@@ -19850,10 +16839,6 @@ typedef struct
 #define GTZC_TZIC1_SR1_TIM7_Msk             GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_SR1_TIM12_Pos            GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_SR1_TIM12_Msk            GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_SR1_TIM13_Pos            GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_SR1_TIM13_Msk            GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_SR1_TIM14_Pos            GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_SR1_TIM14_Msk            GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_SR1_WWDG_Pos             GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_SR1_WWDG_Msk             GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_SR1_IWDG_Pos             GTZC_CFGR1_IWDG_Pos
@@ -19880,22 +16865,10 @@ typedef struct
 #define GTZC_TZIC1_SR1_CRS_Msk              GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_SR1_USART6_Pos           GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_SR1_USART6_Msk           GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_SR1_USART10_Pos          GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_SR1_USART10_Msk          GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_SR1_USART11_Pos          GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_SR1_USART11_Msk          GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_SR1_HDMICEC_Pos          GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_SR1_HDMICEC_Msk          GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_SR1_DAC1_Pos             GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_SR1_DAC1_Msk             GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_SR1_UART7_Pos            GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_SR1_UART7_Msk            GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_SR1_UART8_Pos            GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_SR1_UART8_Msk            GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_SR1_UART9_Pos            GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_SR1_UART9_Msk            GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_SR1_UART12_Pos           GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_SR1_UART12_Msk           GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_SR1_DTS_Pos              GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_SR1_DTS_Msk              GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_SR1_LPTIM2_Pos           GTZC_CFGR1_LPTIM2_Pos
@@ -19918,50 +16891,24 @@ typedef struct
 #define GTZC_TZIC1_SR2_USART1_Msk           GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_SR2_TIM15_Pos            GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_SR2_TIM15_Msk            GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_SR2_TIM16_Pos            GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_SR2_TIM16_Msk            GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_SR2_TIM17_Pos            GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_SR2_TIM17_Msk            GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_SR2_SPI4_Pos             GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_SR2_SPI4_Msk             GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_SR2_SPI6_Pos             GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_SR2_SPI6_Msk             GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_SR2_SAI1_Pos             GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_SR2_SAI1_Msk             GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_SR2_SAI2_Pos             GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_SR2_SAI2_Msk             GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_SR2_USB_Pos              GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_SR2_USB_Msk              GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_SR2_SPI5_Pos             GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_SR2_SPI5_Msk             GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_SR2_LPUART1_Pos          GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_SR2_LPUART1_Msk          GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_SR2_I2C3_Pos             GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_SR2_I2C3_Msk             GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_SR2_I2C4_Pos             GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_SR2_I2C4_Msk             GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_SR2_LPTIM1_Pos           GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_SR2_LPTIM1_Msk           GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_SR2_LPTIM3_Pos           GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_SR2_LPTIM3_Msk           GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_SR2_LPTIM4_Pos           GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_SR2_LPTIM4_Msk           GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_SR2_LPTIM5_Pos           GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_SR2_LPTIM5_Msk           GTZC_CFGR2_LPTIM5_Msk
 
 /*******************  Bits definition for GTZC_TZIC_SR3 register  **************/
-#define GTZC_TZIC1_SR3_LPTIM6_Pos           GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_SR3_LPTIM6_Msk           GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_SR3_VREFBUF_Pos          GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_SR3_VREFBUF_Msk          GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_SR3_I3C2_Pos             GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_SR3_I3C2_Msk             GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_SR3_CRC_Pos              GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_SR3_CRC_Msk              GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_SR3_CORDIC_Pos           GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_SR3_CORDIC_Msk           GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_SR3_FMAC_Pos             GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_SR3_FMAC_Msk             GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_SR3_ETHERNET_Pos         GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_SR3_ETHERNET_Msk         GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_SR3_ICACHE_REG_Pos       GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_SR3_ICACHE_REG_Msk       GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_SR3_DCACHE1_REG_Pos      GTZC_CFGR3_DCACHE1_REG_Pos
@@ -19970,14 +16917,18 @@ typedef struct
 #define GTZC_TZIC1_SR3_ADC_Msk              GTZC_CFGR3_ADC_Msk
 #define GTZC_TZIC1_SR3_DCMI_PSSI_Pos        GTZC_CFGR3_DCMI_PSSI_Pos
 #define GTZC_TZIC1_SR3_DCMI_PSSI_Msk        GTZC_CFGR3_DCMI_PSSI_Msk
+#define GTZC_TZIC1_SR3_AES_Pos              GTZC_CFGR3_AES_Pos
+#define GTZC_TZIC1_SR3_AES_Msk              GTZC_CFGR3_AES_Msk
 #define GTZC_TZIC1_SR3_HASH_Pos             GTZC_CFGR3_HASH_Pos
 #define GTZC_TZIC1_SR3_HASH_Msk             GTZC_CFGR3_HASH_Msk
 #define GTZC_TZIC1_SR3_RNG_Pos              GTZC_CFGR3_RNG_Pos
 #define GTZC_TZIC1_SR3_RNG_Msk              GTZC_CFGR3_RNG_Msk
+#define GTZC_TZIC1_SR3_SAES_Pos             GTZC_CFGR3_SAES_Pos
+#define GTZC_TZIC1_SR3_SAES_Msk             GTZC_CFGR3_SAES_Msk
+#define GTZC_TZIC1_SR3_PKA_Pos              GTZC_CFGR3_PKA_Pos
+#define GTZC_TZIC1_SR3_PKA_Msk              GTZC_CFGR3_PKA_Msk
 #define GTZC_TZIC1_SR3_SDMMC1_Pos           GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_SR3_SDMMC1_Msk           GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_SR3_SDMMC2_Pos           GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_SR3_SDMMC2_Msk           GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_SR3_FMC_REG_Pos          GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_SR3_FMC_REG_Msk          GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_SR3_OCTOSPI1_Pos         GTZC_CFGR3_OCTOSPI1_Pos
@@ -19994,6 +16945,8 @@ typedef struct
 #define GTZC_TZIC1_SR4_FLASH_Msk            GTZC_CFGR4_FLASH_Msk
 #define GTZC_TZIC1_SR4_FLASH_REG_Pos        GTZC_CFGR4_FLASH_REG_Pos
 #define GTZC_TZIC1_SR4_FLASH_REG_Msk        GTZC_CFGR4_FLASH_REG_Msk
+#define GTZC_TZIC1_SR4_OTFDEC1_Pos          GTZC_CFGR4_OTFDEC1_Pos
+#define GTZC_TZIC1_SR4_OTFDEC1_Msk          GTZC_CFGR4_OTFDEC1_Msk
 #define GTZC_TZIC1_SR4_SBS_Pos              GTZC_CFGR4_SBS_Pos
 #define GTZC_TZIC1_SR4_SBS_Msk              GTZC_CFGR4_SBS_Msk
 #define GTZC_TZIC1_SR4_RTC_Pos              GTZC_CFGR4_RTC_Pos
@@ -20044,10 +16997,6 @@ typedef struct
 #define GTZC_TZIC1_FCR1_TIM7_Msk            GTZC_CFGR1_TIM7_Msk
 #define GTZC_TZIC1_FCR1_TIM12_Pos           GTZC_CFGR1_TIM12_Pos
 #define GTZC_TZIC1_FCR1_TIM12_Msk           GTZC_CFGR1_TIM12_Msk
-#define GTZC_TZIC1_FCR1_TIM13_Pos           GTZC_CFGR1_TIM13_Pos
-#define GTZC_TZIC1_FCR1_TIM13_Msk           GTZC_CFGR1_TIM13_Msk
-#define GTZC_TZIC1_FCR1_TIM14_Pos           GTZC_CFGR1_TIM14_Pos
-#define GTZC_TZIC1_FCR1_TIM14_Msk           GTZC_CFGR1_TIM14_Msk
 #define GTZC_TZIC1_FCR1_WWDG_Pos            GTZC_CFGR1_WWDG_Pos
 #define GTZC_TZIC1_FCR1_WWDG_Msk            GTZC_CFGR1_WWDG_Msk
 #define GTZC_TZIC1_FCR1_IWDG_Pos            GTZC_CFGR1_IWDG_Pos
@@ -20074,22 +17023,10 @@ typedef struct
 #define GTZC_TZIC1_FCR1_CRS_Msk             GTZC_CFGR1_CRS_Msk
 #define GTZC_TZIC1_FCR1_USART6_Pos          GTZC_CFGR1_USART6_Pos
 #define GTZC_TZIC1_FCR1_USART6_Msk          GTZC_CFGR1_USART6_Msk
-#define GTZC_TZIC1_FCR1_USART10_Pos         GTZC_CFGR1_USART10_Pos
-#define GTZC_TZIC1_FCR1_USART10_Msk         GTZC_CFGR1_USART10_Msk
-#define GTZC_TZIC1_FCR1_USART11_Pos         GTZC_CFGR1_USART11_Pos
-#define GTZC_TZIC1_FCR1_USART11_Msk         GTZC_CFGR1_USART11_Msk
 #define GTZC_TZIC1_FCR1_HDMICEC_Pos         GTZC_CFGR1_HDMICEC_Pos
 #define GTZC_TZIC1_FCR1_HDMICEC_Msk         GTZC_CFGR1_HDMICEC_Msk
 #define GTZC_TZIC1_FCR1_DAC1_Pos            GTZC_CFGR1_DAC1_Pos
 #define GTZC_TZIC1_FCR1_DAC1_Msk            GTZC_CFGR1_DAC1_Msk
-#define GTZC_TZIC1_FCR1_UART7_Pos           GTZC_CFGR1_UART7_Pos
-#define GTZC_TZIC1_FCR1_UART7_Msk           GTZC_CFGR1_UART7_Msk
-#define GTZC_TZIC1_FCR1_UART8_Pos           GTZC_CFGR1_UART8_Pos
-#define GTZC_TZIC1_FCR1_UART8_Msk           GTZC_CFGR1_UART8_Msk
-#define GTZC_TZIC1_FCR1_UART9_Pos           GTZC_CFGR1_UART9_Pos
-#define GTZC_TZIC1_FCR1_UART9_Msk           GTZC_CFGR1_UART9_Msk
-#define GTZC_TZIC1_FCR1_UART12_Pos          GTZC_CFGR1_UART12_Pos
-#define GTZC_TZIC1_FCR1_UART12_Msk          GTZC_CFGR1_UART12_Msk
 #define GTZC_TZIC1_FCR1_DTS_Pos             GTZC_CFGR1_DTS_Pos
 #define GTZC_TZIC1_FCR1_DTS_Msk             GTZC_CFGR1_DTS_Msk
 #define GTZC_TZIC1_FCR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
@@ -20112,50 +17049,24 @@ typedef struct
 #define GTZC_TZIC1_FCR2_USART1_Msk          GTZC_CFGR2_USART1_Msk
 #define GTZC_TZIC1_FCR2_TIM15_Pos           GTZC_CFGR2_TIM15_Pos
 #define GTZC_TZIC1_FCR2_TIM15_Msk           GTZC_CFGR2_TIM15_Msk
-#define GTZC_TZIC1_FCR2_TIM16_Pos           GTZC_CFGR2_TIM16_Pos
-#define GTZC_TZIC1_FCR2_TIM16_Msk           GTZC_CFGR2_TIM16_Msk
-#define GTZC_TZIC1_FCR2_TIM17_Pos           GTZC_CFGR2_TIM17_Pos
-#define GTZC_TZIC1_FCR2_TIM17_Msk           GTZC_CFGR2_TIM17_Msk
 #define GTZC_TZIC1_FCR2_SPI4_Pos            GTZC_CFGR2_SPI4_Pos
 #define GTZC_TZIC1_FCR2_SPI4_Msk            GTZC_CFGR2_SPI4_Msk
-#define GTZC_TZIC1_FCR2_SPI6_Pos            GTZC_CFGR2_SPI6_Pos
-#define GTZC_TZIC1_FCR2_SPI6_Msk            GTZC_CFGR2_SPI6_Msk
-#define GTZC_TZIC1_FCR2_SAI1_Pos            GTZC_CFGR2_SAI1_Pos
-#define GTZC_TZIC1_FCR2_SAI1_Msk            GTZC_CFGR2_SAI1_Msk
-#define GTZC_TZIC1_FCR2_SAI2_Pos            GTZC_CFGR2_SAI2_Pos
-#define GTZC_TZIC1_FCR2_SAI2_Msk            GTZC_CFGR2_SAI2_Msk
 #define GTZC_TZIC1_FCR2_USB_Pos             GTZC_CFGR2_USB_Pos
 #define GTZC_TZIC1_FCR2_USB_Msk             GTZC_CFGR2_USB_Msk
-#define GTZC_TZIC1_FCR2_SPI5_Pos            GTZC_CFGR2_SPI5_Pos
-#define GTZC_TZIC1_FCR2_SPI5_Msk            GTZC_CFGR2_SPI5_Msk
 #define GTZC_TZIC1_FCR2_LPUART1_Pos         GTZC_CFGR2_LPUART1_Pos
 #define GTZC_TZIC1_FCR2_LPUART1_Msk         GTZC_CFGR2_LPUART1_Msk
 #define GTZC_TZIC1_FCR2_I2C3_Pos            GTZC_CFGR2_I2C3_Pos
 #define GTZC_TZIC1_FCR2_I2C3_Msk            GTZC_CFGR2_I2C3_Msk
-#define GTZC_TZIC1_FCR2_I2C4_Pos            GTZC_CFGR2_I2C4_Pos
-#define GTZC_TZIC1_FCR2_I2C4_Msk            GTZC_CFGR2_I2C4_Msk
 #define GTZC_TZIC1_FCR2_LPTIM1_Pos          GTZC_CFGR2_LPTIM1_Pos
 #define GTZC_TZIC1_FCR2_LPTIM1_Msk          GTZC_CFGR2_LPTIM1_Msk
-#define GTZC_TZIC1_FCR2_LPTIM3_Pos          GTZC_CFGR2_LPTIM3_Pos
-#define GTZC_TZIC1_FCR2_LPTIM3_Msk          GTZC_CFGR2_LPTIM3_Msk
-#define GTZC_TZIC1_FCR2_LPTIM4_Pos          GTZC_CFGR2_LPTIM4_Pos
-#define GTZC_TZIC1_FCR2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
-#define GTZC_TZIC1_FCR2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
-#define GTZC_TZIC1_FCR2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
 
 /******************  Bits definition for GTZC_TZIC_FCR3 register  ****************/
-#define GTZC_TZIC1_FCR3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
-#define GTZC_TZIC1_FCR3_LPTIM6_Msk          GTZC_CFGR3_LPTIM6_Msk
 #define GTZC_TZIC1_FCR3_VREFBUF_Pos         GTZC_CFGR3_VREFBUF_Pos
 #define GTZC_TZIC1_FCR3_VREFBUF_Msk         GTZC_CFGR3_VREFBUF_Msk
+#define GTZC_TZIC1_FCR3_I3C2_Pos            GTZC_CFGR3_I3C2_Pos
+#define GTZC_TZIC1_FCR3_I3C2_Msk            GTZC_CFGR3_I3C2_Msk
 #define GTZC_TZIC1_FCR3_CRC_Pos             GTZC_CFGR3_CRC_Pos
 #define GTZC_TZIC1_FCR3_CRC_Msk             GTZC_CFGR3_CRC_Msk
-#define GTZC_TZIC1_FCR3_CORDIC_Pos          GTZC_CFGR3_CORDIC_Pos
-#define GTZC_TZIC1_FCR3_CORDIC_Msk          GTZC_CFGR3_CORDIC_Msk
-#define GTZC_TZIC1_FCR3_FMAC_Pos            GTZC_CFGR3_FMAC_Pos
-#define GTZC_TZIC1_FCR3_FMAC_Msk            GTZC_CFGR3_FMAC_Msk
-#define GTZC_TZIC1_FCR3_ETHERNET_Pos        GTZC_CFGR3_ETHERNET_Pos
-#define GTZC_TZIC1_FCR3_ETHERNET_Msk        GTZC_CFGR3_ETHERNET_Msk
 #define GTZC_TZIC1_FCR3_ICACHE_REG_Pos      GTZC_CFGR3_ICACHE_REG_Pos
 #define GTZC_TZIC1_FCR3_ICACHE_REG_Msk      GTZC_CFGR3_ICACHE_REG_Msk
 #define GTZC_TZIC1_FCR3_DCACHE1_REG_Pos     GTZC_CFGR3_DCACHE1_REG_Pos
@@ -20164,14 +17075,18 @@ typedef struct
 #define GTZC_TZIC1_FCR3_ADC_Msk             GTZC_CFGR3_ADC_Msk
 #define GTZC_TZIC1_FCR3_DCMI_PSSI_Pos       GTZC_CFGR3_DCMI_PSSI_Pos
 #define GTZC_TZIC1_FCR3_DCMI_PSSI_Msk       GTZC_CFGR3_DCMI_PSSI_Msk
+#define GTZC_TZIC1_FCR3_AES_Pos             GTZC_CFGR3_AES_Pos
+#define GTZC_TZIC1_FCR3_AES_Msk             GTZC_CFGR3_AES_Msk
 #define GTZC_TZIC1_FCR3_HASH_Pos            GTZC_CFGR3_HASH_Pos
 #define GTZC_TZIC1_FCR3_HASH_Msk            GTZC_CFGR3_HASH_Msk
 #define GTZC_TZIC1_FCR3_RNG_Pos             GTZC_CFGR3_RNG_Pos
 #define GTZC_TZIC1_FCR3_RNG_Msk             GTZC_CFGR3_RNG_Msk
+#define GTZC_TZIC1_FCR3_SAES_Pos            GTZC_CFGR3_SAES_Pos
+#define GTZC_TZIC1_FCR3_SAES_Msk            GTZC_CFGR3_SAES_Msk
+#define GTZC_TZIC1_FCR3_PKA_Pos             GTZC_CFGR3_PKA_Pos
+#define GTZC_TZIC1_FCR3_PKA_Msk             GTZC_CFGR3_PKA_Msk
 #define GTZC_TZIC1_FCR3_SDMMC1_Pos          GTZC_CFGR3_SDMMC1_Pos
 #define GTZC_TZIC1_FCR3_SDMMC1_Msk          GTZC_CFGR3_SDMMC1_Msk
-#define GTZC_TZIC1_FCR3_SDMMC2_Pos          GTZC_CFGR3_SDMMC2_Pos
-#define GTZC_TZIC1_FCR3_SDMMC2_Msk          GTZC_CFGR3_SDMMC2_Msk
 #define GTZC_TZIC1_FCR3_FMC_REG_Pos         GTZC_CFGR3_FMC_REG_Pos
 #define GTZC_TZIC1_FCR3_FMC_REG_Msk         GTZC_CFGR3_FMC_REG_Msk
 #define GTZC_TZIC1_FCR3_OCTOSPI1_Pos        GTZC_CFGR3_OCTOSPI1_Pos
@@ -20188,6 +17103,8 @@ typedef struct
 #define GTZC_TZIC1_FCR4_FLASH_Msk           GTZC_CFGR4_FLASH_Msk
 #define GTZC_TZIC1_FCR4_FLASH_REG_Pos       GTZC_CFGR4_FLASH_REG_Pos
 #define GTZC_TZIC1_FCR4_FLASH_REG_Msk       GTZC_CFGR4_FLASH_REG_Msk
+#define GTZC_TZIC1_FCR4_OTFDEC1_Pos         GTZC_CFGR4_OTFDEC1_Pos
+#define GTZC_TZIC1_FCR4_OTFDEC1_Msk         GTZC_CFGR4_OTFDEC1_Msk
 #define GTZC_TZIC1_FCR4_SBS_Pos             GTZC_CFGR4_SBS_Pos
 #define GTZC_TZIC1_FCR4_SBS_Msk             GTZC_CFGR4_SBS_Msk
 #define GTZC_TZIC1_FCR4_RTC_Pos             GTZC_CFGR4_RTC_Pos
@@ -23215,11 +20132,11 @@ typedef struct
 
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) (((INSTANCE) == ADC12_COMMON_NS) ||         \
                                           ((INSTANCE) == ADC12_COMMON_S))
+/******************************* AES Instances ********************************/
+#define IS_AES_ALL_INSTANCE(INSTANCE) (((INSTANCE) == AES_NS) || ((INSTANCE) == AES_S))
+
 /******************************* PKA Instances ********************************/
 #define IS_PKA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == PKA_NS) || ((INSTANCE) == PKA_S))
-
-/******************************* CORDIC Instances *****************************/
-#define IS_CORDIC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CORDIC_NS) || ((INSTANCE) == CORDIC_S))
 
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CRC_NS) || ((INSTANCE) == CRC_S))
@@ -23232,11 +20149,10 @@ typedef struct
 
 /******************************* DELAYBLOCK Instances *******************************/
 #define IS_DLYB_ALL_INSTANCE(INSTANCE)  (((INSTANCE) == DLYB_SDMMC1_NS)   || \
-                                         ((INSTANCE) == DLYB_SDMMC2_NS)   || \
                                          ((INSTANCE) == DLYB_SDMMC1_S)    || \
-                                         ((INSTANCE) == DLYB_SDMMC2_S)    || \
                                          ((INSTANCE) == DLYB_OCTOSPI1_NS) || \
                                          ((INSTANCE) == DLYB_OCTOSPI1_S ))
+
 /******************************** DMA Instances *******************************/
 #define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPDMA1_Channel0_NS)  || ((INSTANCE) == GPDMA1_Channel0_S)  || \
                                        ((INSTANCE) == GPDMA1_Channel1_NS)  || ((INSTANCE) == GPDMA1_Channel1_S)  || \
@@ -23267,6 +20183,9 @@ typedef struct
                                          ((INSTANCE) == GPDMA2_Channel0_NS)  || ((INSTANCE) == GPDMA2_Channel0_S)  || \
                                          ((INSTANCE) == GPDMA2_Channel7_NS)  || ((INSTANCE) == GPDMA2_Channel7_S))
 
+/****************************** OTFDEC Instances ********************************/
+#define IS_OTFDEC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == OTFDEC1_NS) || ((INSTANCE) == OTFDEC1_S))
+
 /****************************** RAMCFG Instances ********************************/
 #define IS_RAMCFG_ALL_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM1_NS)  || ((INSTANCE) == RAMCFG_SRAM1_S)  || \
                                           ((INSTANCE) == RAMCFG_SRAM2_NS)  || ((INSTANCE) == RAMCFG_SRAM2_S)  || \
@@ -23281,10 +20200,6 @@ typedef struct
 /************************ RAMCFG Write Protection Instances *********************/
 #define IS_RAMCFG_WP_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM2_NS)  || ((INSTANCE) == RAMCFG_SRAM2_S))
 
-
-/******************************** FMAC Instances ******************************/
-#define IS_FMAC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == FMAC_NS) || ((INSTANCE) == FMAC_S))
-
 /******************************* GPIO Instances *******************************/
 #define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA_NS) || ((INSTANCE) == GPIOA_S) || \
                                         ((INSTANCE) == GPIOB_NS) || ((INSTANCE) == GPIOB_S) || \
@@ -23293,8 +20208,7 @@ typedef struct
                                         ((INSTANCE) == GPIOE_NS) || ((INSTANCE) == GPIOE_S) || \
                                         ((INSTANCE) == GPIOF_NS) || ((INSTANCE) == GPIOF_S) || \
                                         ((INSTANCE) == GPIOG_NS) || ((INSTANCE) == GPIOG_S) || \
-                                        ((INSTANCE) == GPIOH_NS) || ((INSTANCE) == GPIOH_S) || \
-                                        ((INSTANCE) == GPIOI_NS) || ((INSTANCE) == GPIOI_S))
+                                        ((INSTANCE) == GPIOH_NS) || ((INSTANCE) == GPIOH_S))
 
 /******************************* DCMI Instances *******************************/
 #define IS_DCMI_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == DCMI_NS) || ((__INSTANCE__) == DCMI_S))
@@ -23316,14 +20230,14 @@ typedef struct
 /******************************** I2C Instances *******************************/
 #define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1_NS) || ((INSTANCE) == I2C1_S) || \
                                        ((INSTANCE) == I2C2_NS) || ((INSTANCE) == I2C2_S) || \
-                                       ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S) || \
-                                       ((INSTANCE) == I2C4_NS) || ((INSTANCE) == I2C4_S))
+                                       ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S))
 
 /****************** I2C Instances : wakeup capability from stop modes *********/
 #define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
 
 /******************************** I3C Instances *******************************/
-#define IS_I3C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I3C1_NS) || ((INSTANCE) == I3C1_S))
+#define IS_I3C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I3C1_NS) || ((INSTANCE) == I3C1_S) || \
+                                       ((INSTANCE) == I3C2_NS) || ((INSTANCE) == I3C2_S))
 
 /******************************* OSPI Instances *******************************/
 #define IS_OSPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == OCTOSPI1_NS) || ((INSTANCE) == OCTOSPI1_S))
@@ -23334,15 +20248,8 @@ typedef struct
 /****************************** RTC Instances *********************************/
 #define IS_RTC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == RTC_NS) || ((INSTANCE) == RTC_S))
 
-/******************************** SAI Instances *******************************/
-#define IS_SAI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SAI1_Block_A_NS) || ((INSTANCE) == SAI1_Block_A_S) || \
-                                       ((INSTANCE) == SAI1_Block_B_NS) || ((INSTANCE) == SAI1_Block_B_S) || \
-                                       ((INSTANCE) == SAI2_Block_A_NS) || ((INSTANCE) == SAI2_Block_A_S) || \
-                                       ((INSTANCE) == SAI2_Block_B_NS) || ((INSTANCE) == SAI2_Block_B_S))
-
 /****************************** SDMMC Instances *******************************/
-#define IS_SDMMC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SDMMC1_NS) || ((INSTANCE) == SDMMC1_S) || \
-                                         ((INSTANCE) == SDMMC2_NS) || ((INSTANCE) == SDMMC2_S))
+#define IS_SDMMC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SDMMC1_NS) || ((INSTANCE) == SDMMC1_S))
 
 /****************************** FDCAN Instances *******************************/
 #define IS_FDCAN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == FDCAN1_NS) || ((INSTANCE) == FDCAN1_S) || \
@@ -23351,20 +20258,15 @@ typedef struct
 /****************************** SMBUS Instances *******************************/
 #define IS_SMBUS_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1_NS) || ((INSTANCE) == I2C1_S) || \
                                          ((INSTANCE) == I2C2_NS) || ((INSTANCE) == I2C2_S) || \
-                                         ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S) || \
-                                         ((INSTANCE) == I2C4_NS) || ((INSTANCE) == I2C4_S))
+                                         ((INSTANCE) == I2C3_NS) || ((INSTANCE) == I2C3_S))
 
 /******************************** SPI Instances *******************************/
 #define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1_NS) || ((INSTANCE) == SPI1_S) || \
                                        ((INSTANCE) == SPI2_NS) || ((INSTANCE) == SPI2_S) || \
                                        ((INSTANCE) == SPI3_NS) || ((INSTANCE) == SPI3_S) || \
-                                       ((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S) || \
-                                       ((INSTANCE) == SPI5_NS) || ((INSTANCE) == SPI5_S) || \
-                                       ((INSTANCE) == SPI6_NS) || ((INSTANCE) == SPI6_S))
+                                       ((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S))
 
-#define IS_SPI_LIMITED_INSTANCE(INSTANCE) (((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S) || \
-                                           ((INSTANCE) == SPI5_NS) || ((INSTANCE) == SPI5_S) || \
-                                           ((INSTANCE) == SPI6_NS) || ((INSTANCE) == SPI6_S))
+#define IS_SPI_LIMITED_INSTANCE(INSTANCE) (((INSTANCE) == SPI4_NS) || ((INSTANCE) == SPI4_S))
 
 #define IS_SPI_FULL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1_NS) || ((INSTANCE) == SPI1_S) || \
                                         ((INSTANCE) == SPI2_NS) || ((INSTANCE) == SPI2_S) || \
@@ -23372,47 +20274,27 @@ typedef struct
 
 /****************** LPTIM Instances : All supported instances *****************/
 #define IS_LPTIM_INSTANCE(INSTANCE)  (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                      ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                      ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                      ((INSTANCE) == LPTIM4_NS) || ((INSTANCE) == LPTIM4_S) ||\
-                                      ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                      ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                      ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : DMA supported instances *****************/
 #define IS_LPTIM_DMA_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /************* LPTIM Instances : at least 1 capture/compare channel ***********/
 #define IS_LPTIM_CC1_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS)  || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS)  || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS)  || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM4_NS)  || ((INSTANCE) == LPTIM4_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS)  || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS)  || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS)  || ((INSTANCE) == LPTIM2_S))
 
 /************* LPTIM Instances : at least 2 capture/compare channel ***********/
 #define IS_LPTIM_CC2_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                         ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                         ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                         ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                         ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : supporting encoder interface **************/
 #define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                                       ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                                       ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                                       ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                                       ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                                       ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** LPTIM Instances : supporting Input Capture **************/
 #define IS_LPTIM_INPUT_CAPTURE_INSTANCE(INSTANCE) (((INSTANCE) == LPTIM1_NS) || ((INSTANCE) == LPTIM1_S) ||\
-                                                   ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S) ||\
-                                                   ((INSTANCE) == LPTIM3_NS) || ((INSTANCE) == LPTIM3_S) ||\
-                                                   ((INSTANCE) == LPTIM5_NS) || ((INSTANCE) == LPTIM5_S) ||\
-                                                   ((INSTANCE) == LPTIM6_NS) || ((INSTANCE) == LPTIM6_S))
+                                                   ((INSTANCE) == LPTIM2_NS) || ((INSTANCE) == LPTIM2_S))
 
 /****************** TIM Instances : All supported instances *******************/
 #define IS_TIM_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23424,11 +20306,7 @@ typedef struct
                                     ((INSTANCE) == TIM7_NS)  || ((INSTANCE) == TIM7_S)  || \
                                     ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                     ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                    ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                    ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                    ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                    ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting 32 bits counter ****************/
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) (((INSTANCE) == TIM2_NS)  || ((INSTANCE) == TIM2_S)  || \
@@ -23437,16 +20315,12 @@ typedef struct
 /****************** TIM Instances : supporting the break function *************/
 #define IS_TIM_BREAK_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************** TIM Instances : supporting Break source selection *************/
 #define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                               ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                               ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                               ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                               ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting 2 break inputs *****************/
 #define IS_TIM_BKIN2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23460,11 +20334,7 @@ typedef struct
                                          ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                          ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                          ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                         ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                         ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                         ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                         ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************ TIM Instances : at least 2 capture/compare channels *************/
 #define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23509,9 +20379,7 @@ typedef struct
                                             ((INSTANCE) == TIM6_NS)  || ((INSTANCE) == TIM6_S)  || \
                                             ((INSTANCE) == TIM7_NS)  || ((INSTANCE) == TIM7_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
 #define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23520,9 +20388,7 @@ typedef struct
                                             ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                             ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /******************** TIM Instances : DMA burst feature ***********************/
 #define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23531,9 +20397,7 @@ typedef struct
                                             ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                             ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                             ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                            ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                            ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                            ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
@@ -23581,21 +20445,9 @@ typedef struct
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
       ((CHANNEL) == TIM_CHANNEL_2)))           \
      ||                                        \
-     ((((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
      ((((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)) && \
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
-      ((CHANNEL) == TIM_CHANNEL_2)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1)))           \
-     ||                                        \
-     ((((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S)) && \
-     (((CHANNEL) == TIM_CHANNEL_1))))
+      ((CHANNEL) == TIM_CHANNEL_2))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
@@ -23612,12 +20464,6 @@ typedef struct
       ((CHANNEL) == TIM_CHANNEL_4)))            \
     ||                                          \
     ((((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)) && \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    ((((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)) && \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    ((((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S)) && \
      ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
@@ -23628,11 +20474,7 @@ typedef struct
                                                     ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                     ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                                     ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                                    ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                                    ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
-                                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                    ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                    ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                    ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
 #define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23668,8 +20510,6 @@ typedef struct
                                                         ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                         ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
                                                         ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S) || \
-                                                        ((INSTANCE) == TIM13_NS) || ((INSTANCE) == TIM13_S) || \
-                                                        ((INSTANCE) == TIM14_NS) || ((INSTANCE) == TIM14_S) || \
                                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting combined 3-phase PWM mode ******/
@@ -23679,9 +20519,7 @@ typedef struct
 /****************** TIM Instances : supporting commutation event generation ***/
 #define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                      ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                     ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                     ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                     ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                     ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting counting mode selection ********/
 #define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23752,9 +20590,7 @@ typedef struct
                                                        ((INSTANCE) == TIM4_NS)  || ((INSTANCE) == TIM4_S)  || \
                                                        ((INSTANCE) == TIM5_NS)  || ((INSTANCE) == TIM5_S)  || \
                                                        ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                       ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                       ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
@@ -23767,9 +20603,7 @@ typedef struct
 /****************** TIM Instances : supporting repetition counter *************/
 #define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S)  || \
                                                        ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S)  || \
-                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S) || \
-                                                       ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S) || \
-                                                       ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
+                                                       ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
@@ -23788,12 +20622,7 @@ typedef struct
 #define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM2_NS)  || ((INSTANCE) == TIM2_S) || \
                                          ((INSTANCE) == TIM3_NS)  || ((INSTANCE) == TIM3_S) || \
                                          ((INSTANCE) == TIM12_NS) || ((INSTANCE) == TIM12_S)|| \
-                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S)|| \
-                                         ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)|| \
-                                         ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
-
-/******************* TIM Instances : supporting bitfield RTCPREEN in OR1 register  ********************/
-#define IS_TIM_RTCPREEN_INSTANCE(INSTANCE) (((INSTANCE) == TIM17_NS)  || ((INSTANCE) == TIM17_S))
+                                         ((INSTANCE) == TIM15_NS) || ((INSTANCE) == TIM15_S))
 
 /****************** TIM Instances : Advanced timer instances *******************/
 #define IS_TIM_ADVANCED_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
@@ -23815,9 +20644,7 @@ typedef struct
 #define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
                                      ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)  || \
                                      ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
-                                     ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                     ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                     ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                     ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** UART Instances : Asynchronous mode **********************/
 #define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23825,13 +20652,7 @@ typedef struct
                                     ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                     ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                     ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                    ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                    ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                    ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                    ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                    ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                    ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /*********************** UART Instances : FIFO mode ***************************/
 #define IS_UART_FIFO_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23840,21 +20661,13 @@ typedef struct
                                          ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                          ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                         ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                         ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                         ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                         ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                         ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                         ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                          ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /*********************** UART Instances : SPI Slave mode **********************/
 #define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)   || \
                                               ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)   || \
                                               ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)   || \
-                                              ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)   || \
-                                              ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S)  || \
-                                              ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                              ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************************** I2S Instances *******************************/
 #define IS_I2S_ALL_INSTANCE(INSTANCE)   (((INSTANCE) == SPI1) || \
@@ -23867,13 +20680,7 @@ typedef struct
                                                             ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                                             ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                             ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                            ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                            ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                            ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                            ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                            ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                            ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /****************** UART Instances : Driver Enable *****************/
 #define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE)     (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23882,12 +20689,6 @@ typedef struct
                                                       ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                       ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                       ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                      ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                      ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                      ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                      ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                      ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                      ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                       ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /******************** UART Instances : Half-Duplex mode **********************/
@@ -23897,12 +20698,6 @@ typedef struct
                                                  ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                  ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                  ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                 ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                 ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                 ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                 ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                 ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                 ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                  ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /****************** UART Instances : Hardware Flow control ********************/
@@ -23912,12 +20707,6 @@ typedef struct
                                            ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                            ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                            ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                           ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                           ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                           ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                           ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                           ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                           ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                            ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /******************** UART Instances : LIN mode **********************/
@@ -23926,13 +20715,7 @@ typedef struct
                                           ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                           ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                           ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                          ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                          ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                          ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                          ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                          ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                          ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                          ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** UART Instances : Wake-up from Stop mode **********************/
 #define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
@@ -23941,12 +20724,6 @@ typedef struct
                                                       ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                                       ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
                                                       ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                                      ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                                      ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                                      ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                                      ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                                      ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                                      ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S)  || \
                                                       ((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
 
 /*********************** UART Instances : IRDA mode ***************************/
@@ -23955,21 +20732,13 @@ typedef struct
                                     ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
                                     ((INSTANCE) == UART4_NS)   || ((INSTANCE) == UART4_S)   || \
                                     ((INSTANCE) == UART5_NS)   || ((INSTANCE) == UART5_S)   || \
-                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                    ((INSTANCE) == UART7_NS)   || ((INSTANCE) == UART7_S)   || \
-                                    ((INSTANCE) == UART8_NS)   || ((INSTANCE) == UART8_S)   || \
-                                    ((INSTANCE) == UART9_NS)   || ((INSTANCE) == UART9_S)   || \
-                                    ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                    ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S) || \
-                                    ((INSTANCE) == UART12_NS)  || ((INSTANCE) == UART12_S))
+                                    ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /********************* USART Instances : Smard card mode ***********************/
 #define IS_SMARTCARD_INSTANCE(INSTANCE) (((INSTANCE) == USART1_NS)  || ((INSTANCE) == USART1_S)  || \
                                          ((INSTANCE) == USART2_NS)  || ((INSTANCE) == USART2_S)  || \
                                          ((INSTANCE) == USART3_NS)  || ((INSTANCE) == USART3_S)  || \
-                                         ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S)  || \
-                                         ((INSTANCE) == USART10_NS) || ((INSTANCE) == USART10_S) || \
-                                         ((INSTANCE) == USART11_NS) || ((INSTANCE) == USART11_S))
+                                         ((INSTANCE) == USART6_NS)  || ((INSTANCE) == USART6_S))
 
 /******************** LPUART Instance *****************************************/
 #define IS_LPUART_INSTANCE(INSTANCE)    (((INSTANCE) == LPUART1_NS) || ((INSTANCE) == LPUART1_S))
@@ -23994,7 +20763,7 @@ typedef struct
 
 /** @} */ /* End of group STM32H5xx_Peripheral_Exported_macros */
 
-/** @} */ /* End of group STM32H563xx */
+/** @} */ /* End of group STM32H533xx */
 
 /** @} */ /* End of group ST */
 
@@ -24002,4 +20771,4 @@ typedef struct
 }
 #endif
 
-#endif  /* STM32H563xx_H */
+#endif  /* STM32H533xx_H */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h562xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h562xx.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
   ******************************************************************************
   * @file    stm32h562xx.h
   * @author  MCD Application Team
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -176,6 +176,7 @@ typedef enum
   DTS_IRQn                  = 113,    /*!< DTS global interrupt                                              */
   RNG_IRQn                  = 114,    /*!< RNG global interrupt                                              */
   HASH_IRQn                 = 117,    /*!< HASH global interrupt                                             */
+  PKA_IRQn                  = 118,    /*!< PKA global interrupt                                              */
   CEC_IRQn                  = 119,    /*!< CEC-HDMI global interrupt                                         */
   TIM12_IRQn                = 120,    /*!< TIM12 global interrupt                                            */
   TIM13_IRQn                = 121,    /*!< TIM13 global interrupt                                            */
@@ -396,7 +397,7 @@ typedef struct
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
   __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
-  uint32_t RESERVED;
+  __IO uint32_t NSCR;  /*!< RNG noise source control register ,     Address offset: 0x0C */
   __IO uint32_t HTCR;  /*!< RNG health test configuration register, Address offset: 0x10 */
 } RNG_TypeDef;
 
@@ -627,6 +628,7 @@ typedef struct
   __IO uint32_t WDATA;           /*!< FMAC Write Data register,              Address offset: 0x18          */
   __IO uint32_t RDATA;           /*!< FMAC Read Data register,               Address offset: 0x1C          */
 } FMAC_TypeDef;
+
 /**
   * @brief General Purpose I/O
   */
@@ -773,7 +775,8 @@ typedef struct
   __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x5C */
   __IO uint32_t AF1;         /*!< TIM alternate function option register 1, Address offset: 0x60 */
   __IO uint32_t AF2;         /*!< TIM alternate function option register 2, Address offset: 0x64 */
-       uint32_t RESERVED0[221];/*!< Reserved,                               Address offset: 0x68 */
+  __IO uint32_t OR1 ;        /*!< TIM option register,                      Address offset: 0x68 */
+       uint32_t RESERVED0[220];/*!< Reserved,                               Address offset: 0x6C */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x3DC */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x3E0 */
 } TIM_TypeDef;
@@ -974,6 +977,18 @@ typedef struct
   __IO uint32_t SECCFGR;       /*!< RCC Secure mode configuration register                                   Address offset: 0x110 */
   __IO uint32_t PRIVCFGR;      /*!< RCC Privilege configuration register                                     Address offset: 0x114 */
 } RCC_TypeDef;
+
+/**
+  * @brief PKA
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< PKA control register,             Address offset: 0x00 */
+  __IO uint32_t SR;            /*!< PKA status register,              Address offset: 0x04 */
+  __IO uint32_t CLRFR;         /*!< PKA clear flag register,          Address offset: 0x08 */
+  uint32_t Reserved[253];      /*!< Reserved memory area              Address offset: 0x0C  -> 0x03FC */
+  __IO uint32_t RAM[1334];     /*!< PKA RAM                           Address offset: 0x400 -> 0x18D4 */
+} PKA_TypeDef;
 
 /*
 * @brief RTC Specific device feature definitions
@@ -1692,11 +1707,11 @@ typedef struct
 #define DAC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08400UL)
 #define DCMI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C000UL)
 #define PSSI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C400UL)
-
 #define HASH_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0400UL)
 #define HASH_DIGEST_BASE_NS      (AHB2PERIPH_BASE_NS + 0xA0710UL)
 #define RNG_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA0800UL)
-
+#define PKA_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA2000UL)
+#define PKA_RAM_BASE_NS          (AHB2PERIPH_BASE_NS + 0xA2400UL)
 
 /*!< APB3 Non secure peripherals */
 #define SBS_BASE_NS              (APB3PERIPH_BASE_NS + 0x0400UL)
@@ -1718,10 +1733,10 @@ typedef struct
 #define RCC_BASE_NS              (AHB3PERIPH_BASE_NS + 0x0C00UL)
 #define EXTI_BASE_NS             (AHB3PERIPH_BASE_NS + 0x2000UL)
 #define DEBUG_BASE_NS            (AHB3PERIPH_BASE_NS + 0x4000UL)
+
 /*!< AHB4 Non secure peripherals */
 #define SDMMC1_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8000UL)
 #define DLYB_SDMMC1_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8400UL)
-
 #define FMC_R_BASE_NS            (AHB4PERIPH_BASE_NS + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_NS       (AHB4PERIPH_BASE_NS + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_NS    (AHB4PERIPH_BASE_NS + 0x0F000UL)
@@ -1734,9 +1749,9 @@ typedef struct
 
 /* Flash, Peripheral and internal SRAMs base addresses - Secure */
 #define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 2 MB) secure base address */
-#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (192 KB) secure base address     */
+#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (256 KB) secure base address     */
 #define SRAM2_BASE_S            (0x30040000UL) /*!< SRAM2 (64 KB) secure base address      */
-#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (512 KB) secure base address     */
+#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (320 KB) secure base address     */
 #define PERIPH_BASE_S           (0x50000000UL) /*!< Peripheral secure base address         */
 
 /* Peripheral memory map - Secure */
@@ -1820,7 +1835,6 @@ typedef struct
 #define GTZC_MPCBB2_BASE_S      (AHB1PERIPH_BASE_S + 0x13000UL)
 #define GTZC_MPCBB3_BASE_S      (AHB1PERIPH_BASE_S + 0x13400UL)
 #define BKPSRAM_BASE_S          (AHB1PERIPH_BASE_S + 0x16400UL)
-
 #define GPDMA1_Channel0_BASE_S   (GPDMA1_BASE_S + 0x0050UL)
 #define GPDMA1_Channel1_BASE_S   (GPDMA1_BASE_S + 0x00D0UL)
 #define GPDMA1_Channel2_BASE_S   (GPDMA1_BASE_S + 0x0150UL)
@@ -1837,7 +1851,6 @@ typedef struct
 #define GPDMA2_Channel5_BASE_S   (GPDMA2_BASE_S + 0x02D0UL)
 #define GPDMA2_Channel6_BASE_S   (GPDMA2_BASE_S + 0x0350UL)
 #define GPDMA2_Channel7_BASE_S   (GPDMA2_BASE_S + 0x03D0UL)
-
 #define RAMCFG_SRAM1_BASE_S     (RAMCFG_BASE_S)
 #define RAMCFG_SRAM2_BASE_S     (RAMCFG_BASE_S + 0x0040UL)
 #define RAMCFG_SRAM3_BASE_S     (RAMCFG_BASE_S + 0x0080UL)
@@ -1862,6 +1875,8 @@ typedef struct
 #define HASH_BASE_S             (AHB2PERIPH_BASE_S + 0xA0400UL)
 #define HASH_DIGEST_BASE_S      (AHB2PERIPH_BASE_S + 0xA0710UL)
 #define RNG_BASE_S              (AHB2PERIPH_BASE_S + 0xA0800UL)
+#define PKA_BASE_S              (AHB2PERIPH_BASE_S + 0xA2000UL)
+#define PKA_RAM_BASE_S          (AHB2PERIPH_BASE_S + 0xA2400UL)
 
 /*!< APB3 secure peripherals */
 #define SBS_BASE_S              (APB3PERIPH_BASE_S + 0x0400UL)
@@ -1887,7 +1902,6 @@ typedef struct
 /*!< AHB4 secure peripherals */
 #define SDMMC1_BASE_S           (AHB4PERIPH_BASE_S + 0x8000UL)
 #define DLYB_SDMMC1_BASE_S      (AHB4PERIPH_BASE_S + 0x8400UL)
-
 #define FMC_R_BASE_S            (AHB4PERIPH_BASE_S + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_S       (AHB4PERIPH_BASE_S + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_S    (AHB4PERIPH_BASE_S + 0x0F000UL)
@@ -1900,11 +1914,9 @@ typedef struct
 
 /* Debug MCU registers base address */
 #define DBGMCU_BASE             (0x44024000UL)
-
 #define PACKAGE_BASE            (0x08FFF80EUL) /*!< Package data register base address     */
 #define UID_BASE                (0x08FFF800UL) /*!< Unique device ID register base address */
 #define FLASHSIZE_BASE          (0x08FFF80CUL) /*!< Flash size data register base address  */
-
 
 /* Internal Flash OTP Area */
 #define FLASH_OTP_BASE          (0x08FFF000UL) /*!< FLASH OTP (one-time programmable) base address */
@@ -1947,9 +1959,6 @@ typedef struct
 #define FLASH_OBK_HDPL3NS_BASE_S  (FLASH_OBK_HDPL3_BASE_S + FLASH_OBK_HDPL3S_SIZE)  /*!< FLASH OBK HDPL3 secure base address             */
 #define FLASH_OBK_HDPL3NS_SIZE    (FLASH_OBK_HDPL3_SIZE - FLASH_OBK_HDPL3S_SIZE)    /*!< 2032 Bytes of non-secure HDPL3 option byte keys */
 #endif /* CMSE */
-
-/*!< USB PMA SIZE */
-#define USB_DRD_PMA_SIZE        (2048U)         /*!< USB PMA Size 2Kbyte */
 
 /*!< Root Secure Service Library */
 /************ RSSLIB SAU system Flash region definition constants *************/
@@ -2233,6 +2242,7 @@ typedef struct
 #define HASH_NS                ((HASH_TypeDef *) HASH_BASE_NS)
 #define HASH_DIGEST_NS         ((HASH_DIGEST_TypeDef *) HASH_DIGEST_BASE_NS)
 #define RNG_NS                 ((RNG_TypeDef *) RNG_BASE_NS)
+#define PKA_NS                 ((PKA_TypeDef *) PKA_BASE_NS)
 
 
 /*!< APB3 Non secure peripherals */
@@ -2378,6 +2388,7 @@ typedef struct
 #define HASH_S                 ((HASH_TypeDef *) HASH_BASE_S)
 #define HASH_DIGEST_S          ((HASH_DIGEST_TypeDef *) HASH_DIGEST_BASE_S)
 #define RNG_S                  ((RNG_TypeDef *) RNG_BASE_S)
+#define PKA_S                  ((PKA_TypeDef *) PKA_BASE_S)
 
 /*!< APB3 secure peripherals */
 #define SBS_S                  ((SBS_TypeDef *) SBS_BASE_S)
@@ -2791,6 +2802,9 @@ typedef struct
 #define RNG                            RNG_S
 #define RNG_BASE                       RNG_BASE_S
 
+#define PKA                            PKA_S
+#define PKA_BASE                       PKA_BASE_S
+#define PKA_RAM_BASE                   PKA_RAM_BASE_S
 
 
 #define SDMMC1                         SDMMC1_S
@@ -3196,6 +3210,10 @@ typedef struct
 
 #define RNG                            RNG_NS
 #define RNG_BASE                       RNG_BASE_NS
+
+#define PKA                            PKA_NS
+#define PKA_BASE                       PKA_BASE_NS
+#define PKA_RAM_BASE                   PKA_RAM_BASE_NS
 
 
 
@@ -4479,10 +4497,35 @@ typedef struct
 #define RNG_SR_SEIS_Msk                     (0x1UL << RNG_SR_SEIS_Pos)              /*!< 0x00000040 */
 #define RNG_SR_SEIS                         RNG_SR_SEIS_Msk
 
+/********************  Bits definition for RNG_NSCR register  *******************/
+#define RNG_NSCR_EN_OSC1_Pos                (0U)
+#define RNG_NSCR_EN_OSC1_Msk                (0x7UL << RNG_NSCR_EN_OSC1_Pos)         /*!< 0x00000007 */
+#define RNG_NSCR_EN_OSC1                    RNG_NSCR_EN_OSC1_Msk
+#define RNG_NSCR_EN_OSC2_Pos                (3U)
+#define RNG_NSCR_EN_OSC2_Msk                (0x7UL << RNG_NSCR_EN_OSC2_Pos)         /*!< 0x00000038 */
+#define RNG_NSCR_EN_OSC2                    RNG_NSCR_EN_OSC2_Msk
+#define RNG_NSCR_EN_OSC3_Pos                (6U)
+#define RNG_NSCR_EN_OSC3_Msk                (0x7UL << RNG_NSCR_EN_OSC3_Pos)         /*!< 0x000001C0 */
+#define RNG_NSCR_EN_OSC3                    RNG_NSCR_EN_OSC3_Msk
+#define RNG_NSCR_EN_OSC4_Pos                (9U)
+#define RNG_NSCR_EN_OSC4_Msk                (0x7UL << RNG_NSCR_EN_OSC4_Pos)         /*!< 0x00000E00 */
+#define RNG_NSCR_EN_OSC4                    RNG_NSCR_EN_OSC4_Msk
+#define RNG_NSCR_EN_OSC5_Pos                (12U)
+#define RNG_NSCR_EN_OSC5_Msk                (0x7UL << RNG_NSCR_EN_OSC5_Pos)         /*!< 0x00007000 */
+#define RNG_NSCR_EN_OSC5                    RNG_NSCR_EN_OSC5_Msk
+#define RNG_NSCR_EN_OSC6_Pos                (15U)
+#define RNG_NSCR_EN_OSC6_Msk                (0x7UL << RNG_NSCR_EN_OSC6_Pos)         /*!< 0x00038000 */
+#define RNG_NSCR_EN_OSC6                    RNG_NSCR_EN_OSC6_Msk
+
 /********************  Bits definition for RNG_HTCR register  *******************/
 #define RNG_HTCR_HTCFG_Pos                  (0U)
 #define RNG_HTCR_HTCFG_Msk                  (0xFFFFFFFFUL << RNG_HTCR_HTCFG_Pos)    /*!< 0xFFFFFFFF */
 #define RNG_HTCR_HTCFG                      RNG_HTCR_HTCFG_Msk
+
+/********************  RNG Nist Compliance Values  ******************************/
+#define RNG_CR_NIST_VALUE                   (0x00F00E00U)
+#define RNG_HTCR_NIST_VALUE                 (0x6A91U)
+#define RNG_NSCR_NIST_VALUE                 (0x3AF66U)
 
 /******************************************************************************/
 /*                                                                            */
@@ -6241,32 +6284,32 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV31                EXTI_PRIVENR1_PRIV31_Msk                 /*!< Privilege enable on line 31 */
 
 /******************  Bit definition for EXTI_RTSR2 register  *******************/
-#define EXTI_RTSR2_TR_Pos                   (14U)
-#define EXTI_RTSR2_TR_Msk                   (0x244UL << EXTI_RTSR2_TR_Pos)              /*!< 0x00244000 */
-#define EXTI_RTSR2_TR                       EXTI_RTSR2_TR_Msk                           /*!< Rising trigger event configuration bit */
-#define EXTI_RTSR2_TR46_Pos                 (14U)
-#define EXTI_RTSR2_TR46_Msk                 (0x1UL << EXTI_RTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_RTSR2_TR46                     EXTI_RTSR2_TR46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
-#define EXTI_RTSR2_TR50_Pos                 (18U)
-#define EXTI_RTSR2_TR50_Msk                 (0x1UL << EXTI_RTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_RTSR2_TR50                     EXTI_RTSR2_TR50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
-#define EXTI_RTSR2_TR53_Pos                 (21U)
-#define EXTI_RTSR2_TR53_Msk                 (0x1UL << EXTI_RTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_RTSR2_TR53                     EXTI_RTSR2_TR53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
+#define EXTI_RTSR2_RT_Pos                   (12U)
+#define EXTI_RTSR2_RT_Msk                   (0x244UL << EXTI_RTSR2_RT_Pos)              /*!< 0x00244000 */
+#define EXTI_RTSR2_RT                       EXTI_RTSR2_RT_Msk                           /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT46_Pos                 (14U)
+#define EXTI_RTSR2_RT46_Msk                 (0x1UL << EXTI_RTSR2_RT46_Pos)              /*!< 0x00004000 */
+#define EXTI_RTSR2_RT46                     EXTI_RTSR2_RT46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
+#define EXTI_RTSR2_RT50_Pos                 (18U)
+#define EXTI_RTSR2_RT50_Msk                 (0x1UL << EXTI_RTSR2_RT50_Pos)              /*!< 0x00040000 */
+#define EXTI_RTSR2_RT50                     EXTI_RTSR2_RT50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
+#define EXTI_RTSR2_RT53_Pos                 (21U)
+#define EXTI_RTSR2_RT53_Msk                 (0x1UL << EXTI_RTSR2_RT53_Pos)              /*!< 0x00200000 */
+#define EXTI_RTSR2_RT53                     EXTI_RTSR2_RT53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FTSR2 register  *******************/
-#define EXTI_FTSR2_TR_Pos                   (14U)
-#define EXTI_FTSR2_TR_Msk                   (0x244 << EXTI_FTSR2_TR_Pos)                /*!< 0x00244000 */
-#define EXTI_FTSR2_TR                       EXTI_FTSR2_TR_Msk                           /*!< Falling trigger event configuration bit */
-#define EXTI_FTSR2_TR46_Pos                 (14U)
-#define EXTI_FTSR2_TR46_Msk                 (0x1UL << EXTI_FTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_FTSR2_TR46                     EXTI_FTSR2_TR46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
-#define EXTI_FTSR2_TR50_Pos                 (18U)
-#define EXTI_FTSR2_TR50_Msk                 (0x1UL << EXTI_FTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_FTSR2_TR50                     EXTI_FTSR2_TR50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
-#define EXTI_FTSR2_TR53_Pos                 (21U)
-#define EXTI_FTSR2_TR53_Msk                 (0x1UL << EXTI_FTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_FTSR2_TR53                     EXTI_FTSR2_TR53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
+#define EXTI_FTSR2_FT_Pos                   (12U)
+#define EXTI_FTSR2_FT_Msk                   (0x244 << EXTI_FTSR2_FT_Pos)                /*!< 0x00244000 */
+#define EXTI_FTSR2_FT                       EXTI_FTSR2_FT_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT46_Pos                 (14U)
+#define EXTI_FTSR2_FT46_Msk                 (0x1UL << EXTI_FTSR2_FT46_Pos)              /*!< 0x00004000 */
+#define EXTI_FTSR2_FT46                     EXTI_FTSR2_FT46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
+#define EXTI_FTSR2_FT50_Pos                 (18U)
+#define EXTI_FTSR2_FT50_Msk                 (0x1UL << EXTI_FTSR2_FT50_Pos)              /*!< 0x00040000 */
+#define EXTI_FTSR2_FT50                     EXTI_FTSR2_FT50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
+#define EXTI_FTSR2_FT53_Pos                 (21U)
+#define EXTI_FTSR2_FT53_Msk                 (0x1UL << EXTI_FTSR2_FT53_Pos)              /*!< 0x00200000 */
+#define EXTI_FTSR2_FT53                     EXTI_FTSR2_FT53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_SWIER2 register  ******************/
 #define EXTI_SWIER2_SWIER46_Pos            (14U)
@@ -6280,7 +6323,7 @@ typedef struct
 #define EXTI_SWIER2_SWIER53                EXTI_SWIER2_SWIER53_Msk                     /*!< Software Interrupt on line 53 */
 
 /******************  Bit definition for EXTI_RPR2 register  *******************/
-#define EXTI_RPR2_RPIF_Pos                   (14U)
+#define EXTI_RPR2_RPIF_Pos                   (12U)
 #define EXTI_RPR2_RPIF_Msk                   (0x244UL << EXTI_RPR2_RPIF_Pos)        /*!< 0x00244000 */
 #define EXTI_RPR2_RPIF                       EXTI_RPR2_RPIF_Msk                     /*!< Rising pending edge configuration bits */
 #define EXTI_RPR2_RPIF46_Pos                 (14U)
@@ -6294,7 +6337,7 @@ typedef struct
 #define EXTI_RPR2_RPIF53                     EXTI_RPR2_RPIF53_Msk                   /*!< Rising pending edge configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FPR2 register  *******************/
-#define EXTI_FPR2_FPIF_Pos                   (14U)
+#define EXTI_FPR2_FPIF_Pos                   (12U)
 #define EXTI_FPR2_FPIF_Msk                   (0x244UL << EXTI_FPR2_FPIF_Pos)        /*!< 0x00244000 */
 #define EXTI_FPR2_FPIF                       EXTI_FPR2_FPIF_Msk                     /*!< Rising falling edge configuration bits */
 #define EXTI_FPR2_FPIF46_Pos                 (14U)
@@ -6837,6 +6880,9 @@ typedef struct
 #define EXTI_IMR2_IM44_Pos                  (12U)
 #define EXTI_IMR2_IM44_Msk                  (0x1UL << EXTI_IMR2_IM44_Pos)           /*!< 0x00001000 */
 #define EXTI_IMR2_IM44                      EXTI_IMR2_IM44_Msk                      /*!< Interrupt Mask on line 44 */
+#define EXTI_IMR2_IM45_Pos                  (13U)
+#define EXTI_IMR2_IM45_Msk                  (0x1UL << EXTI_IMR2_IM45_Pos)           /*!< 0x00002000 */
+#define EXTI_IMR2_IM45                      EXTI_IMR2_IM45_Msk                      /*!< Interrupt Mask on line 45 */
 #define EXTI_IMR2_IM46_Pos                  (14U)
 #define EXTI_IMR2_IM46_Msk                  (0x1UL << EXTI_IMR2_IM46_Pos)           /*!< 0x00004000 */
 #define EXTI_IMR2_IM46                      EXTI_IMR2_IM46_Msk                      /*!< Interrupt Mask on line 46 */
@@ -6918,6 +6964,9 @@ typedef struct
 #define EXTI_EMR2_EM44_Pos                  (12U)
 #define EXTI_EMR2_EM44_Msk                  (0x1UL << EXTI_EMR2_EM44_Pos)           /*!< 0x00001000 */
 #define EXTI_EMR2_EM44                      EXTI_EMR2_EM44_Msk                      /*!< Event Mask on line 44 */
+#define EXTI_EMR2_EM45_Pos                  (13U)
+#define EXTI_EMR2_EM45_Msk                  (0x1UL << EXTI_EMR2_EM45_Pos)           /*!< 0x00002000 */
+#define EXTI_EMR2_EM45                      EXTI_EMR2_EM45_Msk                      /*!< Event Mask on line 45 */
 #define EXTI_EMR2_EM46_Pos                  (14U)
 #define EXTI_EMR2_EM46_Msk                  (0x1UL << EXTI_EMR2_EM46_Pos)           /*!< 0x00004000 */
 #define EXTI_EMR2_EM46                      EXTI_EMR2_EM46_Msk                      /*!< Event Mask on line 46 */
@@ -7676,7 +7725,7 @@ typedef struct
 /*                                    FLASH                                   */
 /*                                                                            */
 /******************************************************************************/
-#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /* FLASH Three Latency cycle */
+#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /*!< FLASH Three Latency cycle */
 #define FLASH_BLOCKBASED_NB_REG             (4U)                                    /*!< 4 Block-based registers for each Flash bank */
 #define FLASH_SIZE_DEFAULT                  (0x200000U)                             /*!< FLASH Size */
 #define FLASH_SECTOR_NB                     (128U)                                  /*!< Flash Sector number */
@@ -7970,6 +8019,9 @@ typedef struct
 #define FLASH_OPTSR2_SRAM2_ECC_Pos          (6U)
 #define FLASH_OPTSR2_SRAM2_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM2_ECC_Pos)   /*!< 0x00000040 */
 #define FLASH_OPTSR2_SRAM2_ECC              FLASH_OPTSR2_SRAM2_ECC_Msk              /*!< SRAM2 ECC detection and correction disable */
+#define FLASH_OPTSR2_USBPD_DIS_Pos          (8U)
+#define FLASH_OPTSR2_USBPD_DIS_Msk          (0x1UL << FLASH_OPTSR2_USBPD_DIS_Pos)   /*!< 0x00000100 */
+#define FLASH_OPTSR2_USBPD_DIS              FLASH_OPTSR2_USBPD_DIS_Msk              /*!< USB power delivery configuration disable */
 #define FLASH_OPTSR2_TZEN_Pos               (24U)
 #define FLASH_OPTSR2_TZEN_Msk               (0xFFUL << FLASH_OPTSR2_TZEN_Pos)       /*!< 0xFF000000 */
 #define FLASH_OPTSR2_TZEN                   FLASH_OPTSR2_TZEN_Msk                   /*!< TrustZone enable */
@@ -8002,7 +8054,7 @@ typedef struct
 
 /*****************  Bits definition for FLASH_EDATA register  ********************/
 #define FLASH_EDATAR_EDATA_STRT_Pos         (0U)
-#define FLASH_EDATAR_EDATA_STRT_Msk         (0x3UL << FLASH_EDATAR_EDATA_STRT_Pos)  /*!< 0x00000003 */
+#define FLASH_EDATAR_EDATA_STRT_Msk         (0x7UL << FLASH_EDATAR_EDATA_STRT_Pos)  /*!< 0x00000007 */
 #define FLASH_EDATAR_EDATA_STRT             FLASH_EDATAR_EDATA_STRT_Msk             /*!< Flash high-cycle data start sector */
 #define FLASH_EDATAR_EDATA_EN_Pos           (15U)
 #define FLASH_EDATAR_EDATA_EN_Msk           (0x1UL << FLASH_EDATAR_EDATA_EN_Pos)    /*!< 0x00008000 */
@@ -8049,7 +8101,6 @@ typedef struct
 #define FLASH_ECCDR_FAIL_DATA_Pos           (0U)
 #define FLASH_ECCDR_FAIL_DATA_Msk           (0xFFFFUL << FLASH_ECCDR_FAIL_DATA_Pos) /*!< 0x0000FFFF */
 #define FLASH_ECCDR_FAIL_DATA               FLASH_ECCDR_FAIL_DATA_Msk               /*!< ECC fail data */
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -8165,7 +8216,6 @@ typedef struct
 #define FMAC_RDATA_RDATA_Pos                (0U)
 #define FMAC_RDATA_RDATA_Msk                (0xFFFFUL << FMAC_RDATA_RDATA_Pos)      /*!< 0x0000FFFF */
 #define FMAC_RDATA_RDATA                    FMAC_RDATA_RDATA_Msk                    /*!< Read data */
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -8625,7 +8675,7 @@ typedef struct
 #define FMC_SDCMR_MODE             FMC_SDCMR_MODE_Msk                          /*!<MODE[2:0] bits (Command mode) */
 #define FMC_SDCMR_MODE_0           (0x1UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000001 */
 #define FMC_SDCMR_MODE_1           (0x2UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000002 */
-#define FMC_SDCMR_MODE_2           (0x3UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000003 */
+#define FMC_SDCMR_MODE_2           (0x4UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000004 */
 
 #define FMC_SDCMR_CTB2_Pos         (3U)
 #define FMC_SDCMR_CTB2_Msk         (0x1UL << FMC_SDCMR_CTB2_Pos)               /*!< 0x00000008 */
@@ -10386,27 +10436,27 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR1 register  *******************/
 #define TIM_CCR1_CCR1_Pos                   (0U)
-#define TIM_CCR1_CCR1_Msk                   (0xFFFFUL << TIM_CCR1_CCR1_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1_Msk                   (0xFFFFFFFFUL << TIM_CCR1_CCR1_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR1_CCR1                       TIM_CCR1_CCR1_Msk                       /*!<Capture/Compare 1 Value */
 
 /*******************  Bit definition for TIM_CCR2 register  *******************/
 #define TIM_CCR2_CCR2_Pos                   (0U)
-#define TIM_CCR2_CCR2_Msk                   (0xFFFFUL << TIM_CCR2_CCR2_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2_Msk                   (0xFFFFFFFFUL << TIM_CCR2_CCR2_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR2_CCR2                       TIM_CCR2_CCR2_Msk                       /*!<Capture/Compare 2 Value */
 
 /*******************  Bit definition for TIM_CCR3 register  *******************/
 #define TIM_CCR3_CCR3_Pos                   (0U)
-#define TIM_CCR3_CCR3_Msk                   (0xFFFFUL << TIM_CCR3_CCR3_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3_Msk                   (0xFFFFFFFFUL << TIM_CCR3_CCR3_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR3_CCR3                       TIM_CCR3_CCR3_Msk                       /*!<Capture/Compare 3 Value */
 
 /*******************  Bit definition for TIM_CCR4 register  *******************/
 #define TIM_CCR4_CCR4_Pos                   (0U)
-#define TIM_CCR4_CCR4_Msk                   (0xFFFFUL << TIM_CCR4_CCR4_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4_Msk                   (0xFFFFFFFFUL << TIM_CCR4_CCR4_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR4_CCR4                       TIM_CCR4_CCR4_Msk                       /*!<Capture/Compare 4 Value */
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos                   (0U)
-#define TIM_CCR5_CCR5_Msk                   (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)     /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk                   (0xFFFFFUL << TIM_CCR5_CCR5_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR5_CCR5                       TIM_CCR5_CCR5_Msk                       /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos                  (29U)
 #define TIM_CCR5_GC5C1_Msk                  (0x1UL << TIM_CCR5_GC5C1_Pos)           /*!< 0x20000000 */
@@ -10420,7 +10470,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR6 register  *******************/
 #define TIM_CCR6_CCR6_Pos                   (0U)
-#define TIM_CCR6_CCR6_Msk                   (0xFFFFUL << TIM_CCR6_CCR6_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6_Msk                   (0xFFFFFUL << TIM_CCR6_CCR6_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR6_CCR6                       TIM_CCR6_CCR6_Msk                       /*!<Capture/Compare 6 Value */
 
 /*******************  Bit definition for TIM_BDTR register  *******************/
@@ -10564,6 +10614,11 @@ typedef struct
 #define TIM1_AF2_OCRSEL_Msk                 (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
 #define TIM1_AF2_OCRSEL                     TIM1_AF2_OCRSEL_Msk                     /*!<OCREF_CLR source selection */
 #define TIM1_AF2_OCRSEL_0                   (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM_OR1 register  *********************/
+#define TIM_OR1_RTCPREEN_Pos                 (1U)
+#define TIM_OR1_RTCPREEN_Msk                 (0x1UL << TIM_OR1_RTCPREEN_Pos)           /*!< 0x00000002 */
+#define TIM_OR1_RTCPREEN                     TIM_OR1_RTCPREEN_Msk                      /*!< RTCPRE HSE divider enable */
 
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos                (0U)
@@ -11915,7 +11970,7 @@ typedef struct
 #define OCTOSPI_CR_TCIE_Msk                 XSPI_CR_TCIE_Msk                              /*!< 0x00020000 */
 #define OCTOSPI_CR_TCIE                     XSPI_CR_TCIE                                  /*!< Transfer Complete Interrupt Enable */
 #define OCTOSPI_CR_FTIE_Pos                 XSPI_CR_FTIE_Pos
-#define OCTOSPI_CR_FTIE_Msk                 XSPI_CR_FTIE_Msk)                             /*!< 0x00040000 */
+#define OCTOSPI_CR_FTIE_Msk                 XSPI_CR_FTIE_Msk                              /*!< 0x00040000 */
 #define OCTOSPI_CR_FTIE                     XSPI_CR_FTIE                                  /*!< FIFO Threshold Interrupt Enable */
 #define OCTOSPI_CR_SMIE_Pos                 XSPI_CR_SMIE_Pos
 #define OCTOSPI_CR_SMIE_Msk                 XSPI_CR_SMIE_Msk                              /*!< 0x00080000 */
@@ -12372,9 +12427,9 @@ typedef struct
 #define PWR_PMCR_AVD_READY_Pos               (13U)
 #define PWR_PMCR_AVD_READY_Msk               (0x1UL << PWR_PMCR_AVD_READY_Pos)
 #define PWR_PMCR_AVD_READY                   PWR_PMCR_AVD_READY_Msk
-#define PWR_PMCR_ETHERNETSO_Pos             (16U)
-#define PWR_PMCR_ETHERNETSO_Msk             (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
-#define PWR_PMCR_ETHERNETSO                 PWR_PMCR_ETHERNETSO_Msk
+#define PWR_PMCR_ETHERNETSO_Pos              (16U)
+#define PWR_PMCR_ETHERNETSO_Msk              (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
+#define PWR_PMCR_ETHERNETSO                  PWR_PMCR_ETHERNETSO_Msk
 #define PWR_PMCR_SRAM3SO_Pos                 (23U)
 #define PWR_PMCR_SRAM3SO_Msk                 (0x1UL << PWR_PMCR_SRAM3SO_Pos)
 #define PWR_PMCR_SRAM3SO                     PWR_PMCR_SRAM3SO_Msk
@@ -12472,9 +12527,9 @@ typedef struct
 #define PWR_SCCR_SMPSEN                      PWR_SCCR_SMPSEN_Msk
 
 /********************  Bit definition for PWR_VMCR register  ******************/
-#define PWR_VMCR_PVDEN_Pos                    (0U)
-#define PWR_VMCR_PVDEN_Msk                    (0x1UL << PWR_VMCR_PVDEN_Pos)
-#define PWR_VMCR_PVDEN                        PWR_VMCR_PVDEN_Msk
+#define PWR_VMCR_PVDEN_Pos                   (0U)
+#define PWR_VMCR_PVDEN_Msk                   (0x1UL << PWR_VMCR_PVDEN_Pos)
+#define PWR_VMCR_PVDEN                       PWR_VMCR_PVDEN_Msk
 #define PWR_VMCR_PLS_Pos                     (1U)
 #define PWR_VMCR_PLS_Msk                     (0x7UL << PWR_VMCR_PLS_Pos)
 #define PWR_VMCR_PLS                         PWR_VMCR_PLS_Msk
@@ -12491,12 +12546,12 @@ typedef struct
 #define PWR_VMCR_ALS_1                       (0x2UL << PWR_VMCR_ALS_Pos)
 
 /********************  Bit definition for PWR_USBSCR register  ******************/
-#define PWR_USBSCR_USB33DEN_Pos               (24U)
-#define PWR_USBSCR_USB33DEN_Msk               (0x1UL << PWR_USBSCR_USB33DEN_Pos)
-#define PWR_USBSCR_USB33DEN                   PWR_USBSCR_USB33DEN_Msk
-#define PWR_USBSCR_USB33SV_Pos                (25U)
-#define PWR_USBSCR_USB33SV_Msk                (0x1UL << PWR_USBSCR_USB33SV_Pos)
-#define PWR_USBSCR_USB33SV                    PWR_USBSCR_USB33SV_Msk
+#define PWR_USBSCR_USB33DEN_Pos              (24U)
+#define PWR_USBSCR_USB33DEN_Msk              (0x1UL << PWR_USBSCR_USB33DEN_Pos)
+#define PWR_USBSCR_USB33DEN                  PWR_USBSCR_USB33DEN_Msk
+#define PWR_USBSCR_USB33SV_Pos               (25U)
+#define PWR_USBSCR_USB33SV_Msk               (0x1UL << PWR_USBSCR_USB33SV_Pos)
+#define PWR_USBSCR_USB33SV                   PWR_USBSCR_USB33SV_Msk
 
 /********************  Bit definition for PWR_VMSR register  ******************/
 #define PWR_VMSR_AVDO_Pos                    (19U)
@@ -13702,6 +13757,9 @@ typedef struct
 #define RCC_AHB2RSTR_RNGRST_Pos             (18U)
 #define RCC_AHB2RSTR_RNGRST_Msk             (0x1UL << RCC_AHB2RSTR_RNGRST_Pos)      /*!< 0x00040000 */
 #define RCC_AHB2RSTR_RNGRST                 RCC_AHB2RSTR_RNGRST_Msk
+#define RCC_AHB2RSTR_PKARST_Pos             (19U)
+#define RCC_AHB2RSTR_PKARST_Msk             (0x1UL << RCC_AHB2RSTR_PKARST_Pos)      /*!< 0x00080000 */
+#define RCC_AHB2RSTR_PKARST                 RCC_AHB2RSTR_PKARST_Msk
 
 /********************  Bit definition for RCC_AHB4RSTR register  **************/
 #define RCC_AHB4RSTR_SDMMC1RST_Pos          (11U)
@@ -13968,6 +14026,9 @@ typedef struct
 #define RCC_AHB2ENR_RNGEN_Pos               (18U)
 #define RCC_AHB2ENR_RNGEN_Msk               (0x1UL << RCC_AHB2ENR_RNGEN_Pos)        /*!< 0x00040000 */
 #define RCC_AHB2ENR_RNGEN                   RCC_AHB2ENR_RNGEN_Msk
+#define RCC_AHB2ENR_PKAEN_Pos               (19U)
+#define RCC_AHB2ENR_PKAEN_Msk               (0x1UL << RCC_AHB2ENR_PKAEN_Pos)        /*!< 0x00080000 */
+#define RCC_AHB2ENR_PKAEN                   RCC_AHB2ENR_PKAEN_Msk
 #define RCC_AHB2ENR_SRAM2EN_Pos             (30U)
 #define RCC_AHB2ENR_SRAM2EN_Msk             (0x1UL << RCC_AHB2ENR_SRAM2EN_Pos)      /*!< 0x40000000 */
 #define RCC_AHB2ENR_SRAM2EN                 RCC_AHB2ENR_SRAM2EN_Msk
@@ -16929,9 +16990,6 @@ typedef struct
 #define SBS_SECCFGR_FPUSEC_Pos           (3U)
 #define SBS_SECCFGR_FPUSEC_Msk           (0x1UL << SBS_SECCFGR_FPUSEC_Pos)    /*!< 0x00000008 */
 #define SBS_SECCFGR_FPUSEC               SBS_SECCFGR_FPUSEC_Msk               /*!< FPU SBS security enable */
-#define SBS_SECCFGR_SDCE_SEC_EN_Pos      (31U)
-#define SBS_SECCFGR_SDCE_SEC_EN_Msk      (0x1UL << SBS_SECCFGR_SDCE_SEC_EN_Pos) /*!< 0x80000000 */
-#define SBS_SECCFGR_SDCE_SEC_EN          SBS_SECCFGR_SDCE_SEC_EN_Msk            /*!< SMPS SBS security enable */
 
 /******************  Bit definition for SBS_CNSLCKR register  **************/
 #define SBS_CNSLCKR_LOCKNSVTOR_Pos       (0U)
@@ -16989,7 +17047,7 @@ typedef struct
 #define GTZC_TZSC_MPCWMR_SUBZ_LENGTH        GTZC_TZSC_MPCWMR_SUBZ_LENGTH_Msk
 
 /*******  Bits definition for TZSC _SECCFGRx/_PRIVCFGRx registers  *****/
-/*******  Bits definition for TZIC _IERx/_SRx/_IFCRx registers  ********/
+/*******  Bits definition for TZIC _IERx/_SRx/_IFCRx registers     *****/
 
 /***************  Bits definition for register x=1 (TZSC1) *************/
 #define GTZC_CFGR1_TIM2_Pos                 (0U)
@@ -17056,7 +17114,6 @@ typedef struct
 #define GTZC_CFGR1_DTS_Msk                  (0x01UL << GTZC_CFGR1_DTS_Pos)
 #define GTZC_CFGR1_LPTIM2_Pos               (31U)
 #define GTZC_CFGR1_LPTIM2_Msk               (0x01UL << GTZC_CFGR1_LPTIM2_Pos)
-
 
 /***************  Bits definition for register x=2 (TZSC1) *************/
 #define GTZC_CFGR2_FDCAN1_Pos               (0U)
@@ -17145,6 +17202,7 @@ typedef struct
 #define GTZC_CFGR4_FLASH_Msk                (0x01UL << GTZC_CFGR4_FLASH_Pos)
 #define GTZC_CFGR4_FLASH_REG_Pos            (3U)
 #define GTZC_CFGR4_FLASH_REG_Msk            (0x01UL << GTZC_CFGR4_FLASH_REG_Pos)
+
 #define GTZC_CFGR4_SBS_Pos                  (6U)
 #define GTZC_CFGR4_SBS_Msk                  (0x01UL << GTZC_CFGR4_SBS_Pos)
 #define GTZC_CFGR4_RTC_Pos                  (7U)
@@ -17246,12 +17304,11 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Msk          GTZC_CFGR1_LPTIM2_Msk
 
-
 /*******************  Bits definition for GTZC_TZSC_SECCFGR2 register  ***************/
 #define GTZC_TZSC1_SECCFGR2_FDCAN1_Pos          GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZSC1_SECCFGR2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
-#define GTZC_TZSC1_SECCFGR2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZSC1_SECCFGR2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZSC1_SECCFGR2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZSC1_SECCFGR2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZSC1_SECCFGR2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZSC1_SECCFGR2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZSC1_SECCFGR2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -17325,6 +17382,7 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR3_RAMCFG_Pos          GTZC_CFGR3_RAMCFG_Pos
 #define GTZC_TZSC1_SECCFGR3_RAMCFG_Msk          GTZC_CFGR3_RAMCFG_Msk
 
+
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR1 register  ***************/
 #define GTZC_TZSC1_PRIVCFGR1_TIM2_Pos           GTZC_CFGR1_TIM2_Pos
 #define GTZC_TZSC1_PRIVCFGR1_TIM2_Msk           GTZC_CFGR1_TIM2_Msk
@@ -17394,8 +17452,8 @@ typedef struct
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR2 register  ***************/
 #define GTZC_TZSC1_PRIVCFGR2_FDCAN1_Pos         GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_FDCAN1_Msk         GTZC_CFGR2_FDCAN1_Msk
-#define GTZC_TZSC1_PRIVCFGR2_UCPD_Pos           GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZSC1_PRIVCFGR2_UCPD_Msk           GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZSC1_PRIVCFGR2_UCPD1_Pos          GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZSC1_PRIVCFGR2_UCPD1_Msk          GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_TIM1_Pos           GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_TIM1_Msk           GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_SPI1_Pos           GTZC_CFGR2_SPI1_Pos
@@ -17538,8 +17596,8 @@ typedef struct
 /*******************  Bits definition for GTZC_TZIC_IER2 register  ***************/
 #define GTZC_TZIC1_IER2_FDCAN1_Pos          GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZIC1_IER2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
-#define GTZC_TZIC1_IER2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_IER2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_IER2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_IER2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_IER2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_IER2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_IER2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -17580,7 +17638,6 @@ typedef struct
 #define GTZC_TZIC1_IER2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
 #define GTZC_TZIC1_IER2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
 #define GTZC_TZIC1_IER2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
-
 
 /*******************  Bits definition for GTZC_TZIC_IER3 register  ***************/
 #define GTZC_TZIC1_IER3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
@@ -17727,8 +17784,8 @@ typedef struct
 /*******************  Bits definition for GTZC_TZIC_SR2 register  **************/
 #define GTZC_TZIC1_SR2_FDCAN1_Pos           GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZIC1_SR2_FDCAN1_Msk           GTZC_CFGR2_FDCAN1_Msk
-#define GTZC_TZIC1_SR2_UCPD_Pos             GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_SR2_UCPD_Msk             GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_SR2_UCPD1_Pos            GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_SR2_UCPD1_Msk            GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_SR2_TIM1_Pos             GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_SR2_TIM1_Msk             GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_SR2_SPI1_Pos             GTZC_CFGR2_SPI1_Pos
@@ -17915,8 +17972,8 @@ typedef struct
 /*******************  Bits definition for GTZC_TZIC_FCR2 register  **************/
 #define GTZC_TZIC1_FCR2_FDCAN1_Pos          GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZIC1_FCR2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
-#define GTZC_TZIC1_FCR2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_FCR2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_FCR2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_FCR2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_FCR2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_FCR2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_FCR2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -18482,6 +18539,7 @@ typedef struct
 /*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
 /*                                                                            */
 /******************************************************************************/
+#define USART_DMAREQUESTS_SW_WA
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_UE_Pos                    (0U)
 #define USART_CR1_UE_Msk                    (0x1UL << USART_CR1_UE_Pos)             /*!< 0x00000001 */
@@ -19806,6 +19864,15 @@ typedef struct
 #define I3C_BCR_BCR2_Pos                    (2U)
 #define I3C_BCR_BCR2_Msk                    (0x1UL << I3C_BCR_BCR2_Pos)             /*!< 0x00000004 */
 #define I3C_BCR_BCR2                        I3C_BCR_BCR2_Msk                        /*!< IBI Payload additional Mandatory Data Byte */
+#define I3C_BCR_BCR3_Pos                    (3U)
+#define I3C_BCR_BCR3_Msk                    (0x1UL << I3C_BCR_BCR3_Pos)             /*!< 0x00000008 */
+#define I3C_BCR_BCR3                        I3C_BCR_BCR3_Msk                        /*!< Offline capable */
+#define I3C_BCR_BCR4_Pos                    (4U)
+#define I3C_BCR_BCR4_Msk                    (0x1UL << I3C_BCR_BCR4_Pos)             /*!< 0x00000010 */
+#define I3C_BCR_BCR4                        I3C_BCR_BCR4_Msk                        /*!< Virtual target support */
+#define I3C_BCR_BCR5_Pos                    (5U)
+#define I3C_BCR_BCR5_Msk                    (0x1UL << I3C_BCR_BCR5_Pos)             /*!< 0x00000020 */
+#define I3C_BCR_BCR5                        I3C_BCR_BCR5_Msk                        /*!< Advanced capabilities */
 #define I3C_BCR_BCR6_Pos                    (6U)
 #define I3C_BCR_BCR6_Msk                    (0x1UL << I3C_BCR_BCR6_Pos)             /*!< 0x00000040 */
 #define I3C_BCR_BCR6                        I3C_BCR_BCR6_Msk                        /*!< Device Role shared during Dynamic Address Assignment */
@@ -20678,6 +20745,327 @@ typedef struct
 #define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
 #define USB_PMA_RXBD_COUNTMSK                      (0x03FFFFFFUL)
 
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE                                  (2048U)           /*!< USB PMA Size 2Kbyte */
+
+#define USB_DRD_FS_EP_NBR                                    (8U)           /*!< Number of USB Device endpoints */
+#define USB_DRD_FS_CH_NBR                                    (8U)           /*!< Number of USB Host channels */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Public Key Accelerator (PKA)                         */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for PKA_CR register  *********************/
+#define PKA_CR_EN_Pos                       (0U)
+#define PKA_CR_EN_Msk                       (0x1UL << PKA_CR_EN_Pos)                /*!< 0x00000001 */
+#define PKA_CR_EN                           PKA_CR_EN_Msk                           /*!< PKA enable */
+#define PKA_CR_START_Pos                    (1U)
+#define PKA_CR_START_Msk                    (0x1UL << PKA_CR_START_Pos)             /*!< 0x00000002 */
+#define PKA_CR_START                        PKA_CR_START_Msk                        /*!< Start operation */
+#define PKA_CR_MODE_Pos                     (8U)
+#define PKA_CR_MODE_Msk                     (0x3FUL << PKA_CR_MODE_Pos)             /*!< 0x00003F00 */
+#define PKA_CR_MODE                         PKA_CR_MODE_Msk                         /*!< MODE[5:0] PKA operation code */
+#define PKA_CR_MODE_0                       (0x01UL << PKA_CR_MODE_Pos)             /*!< 0x00000100 */
+#define PKA_CR_MODE_1                       (0x02UL << PKA_CR_MODE_Pos)             /*!< 0x00000200 */
+#define PKA_CR_MODE_2                       (0x04UL << PKA_CR_MODE_Pos)             /*!< 0x00000400 */
+#define PKA_CR_MODE_3                       (0x08UL << PKA_CR_MODE_Pos)             /*!< 0x00000800 */
+#define PKA_CR_MODE_4                       (0x10UL << PKA_CR_MODE_Pos)             /*!< 0x00001000 */
+#define PKA_CR_MODE_5                       (0x20UL << PKA_CR_MODE_Pos)             /*!< 0x00002000 */
+#define PKA_CR_PROCENDIE_Pos                (17U)
+#define PKA_CR_PROCENDIE_Msk                (0x1UL << PKA_CR_PROCENDIE_Pos)         /*!< 0x00020000 */
+#define PKA_CR_PROCENDIE                    PKA_CR_PROCENDIE_Msk                    /*!< End of operation interrupt enable */
+#define PKA_CR_RAMERRIE_Pos                 (19U)
+#define PKA_CR_RAMERRIE_Msk                 (0x1UL << PKA_CR_RAMERRIE_Pos)          /*!< 0x00080000 */
+#define PKA_CR_RAMERRIE                     PKA_CR_RAMERRIE_Msk                     /*!< RAM error interrupt enable */
+#define PKA_CR_ADDRERRIE_Pos                (20U)
+#define PKA_CR_ADDRERRIE_Msk                (0x1UL << PKA_CR_ADDRERRIE_Pos)         /*!< 0x00100000 */
+#define PKA_CR_ADDRERRIE                    PKA_CR_ADDRERRIE_Msk                    /*!< Address error interrupt enable */
+#define PKA_CR_OPERRIE_Pos                  (21U)
+#define PKA_CR_OPERRIE_Msk                  (0x1UL << PKA_CR_OPERRIE_Pos)           /*!< 0x00200000 */
+#define PKA_CR_OPERRIE                      PKA_CR_OPERRIE_Msk                      /*!< Operation Error interrupt enable */
+
+/*******************  Bit definition for PKA_SR register  *********************/
+#define PKA_SR_INITOK_Pos                   (0U)
+#define PKA_SR_INITOK_Msk                   (0x1UL << PKA_SR_INITOK_Pos)            /*!< 0x00000001 */
+#define PKA_SR_INITOK                       PKA_SR_INITOK_Msk                       /*!< PKA initialisation flag */
+#define PKA_SR_BUSY_Pos                     (16U)
+#define PKA_SR_BUSY_Msk                     (0x1UL << PKA_SR_BUSY_Pos)              /*!< 0x00010000 */
+#define PKA_SR_BUSY                         PKA_SR_BUSY_Msk                         /*!< PKA operation is in progress */
+#define PKA_SR_PROCENDF_Pos                 (17U)
+#define PKA_SR_PROCENDF_Msk                 (0x1UL << PKA_SR_PROCENDF_Pos)          /*!< 0x00020000 */
+#define PKA_SR_PROCENDF                     PKA_SR_PROCENDF_Msk                     /*!< PKA end of operation flag */
+#define PKA_SR_RAMERRF_Pos                  (19U)
+#define PKA_SR_RAMERRF_Msk                  (0x1UL << PKA_SR_RAMERRF_Pos)           /*!< 0x00080000 */
+#define PKA_SR_RAMERRF                      PKA_SR_RAMERRF_Msk                      /*!< PKA RAM error flag */
+#define PKA_SR_ADDRERRF_Pos                 (20U)
+#define PKA_SR_ADDRERRF_Msk                 (0x1UL << PKA_SR_ADDRERRF_Pos)          /*!< 0x00100000 */
+#define PKA_SR_ADDRERRF                     PKA_SR_ADDRERRF_Msk                     /*!< Address error flag */
+#define PKA_SR_OPERRF_Pos                   (21U)
+#define PKA_SR_OPERRF_Msk                   (0x1UL << PKA_SR_OPERRF_Pos)            /*!< 0x00200000 */
+#define PKA_SR_OPERRF                       PKA_SR_OPERRF_Msk                       /*!< PKA operation Error flag*/
+
+/*******************  Bit definition for PKA_CLRFR register  ******************/
+#define PKA_CLRFR_PROCENDFC_Pos             (17U)
+#define PKA_CLRFR_PROCENDFC_Msk             (0x1UL << PKA_CLRFR_PROCENDFC_Pos)      /*!< 0x00020000 */
+#define PKA_CLRFR_PROCENDFC                 PKA_CLRFR_PROCENDFC_Msk                 /*!< Clear PKA end of operation flag */
+#define PKA_CLRFR_RAMERRFC_Pos              (19U)
+#define PKA_CLRFR_RAMERRFC_Msk              (0x1UL << PKA_CLRFR_RAMERRFC_Pos)       /*!< 0x00080000 */
+#define PKA_CLRFR_RAMERRFC                  PKA_CLRFR_RAMERRFC_Msk                  /*!< Clear PKA RAM error flag */
+#define PKA_CLRFR_ADDRERRFC_Pos             (20U)
+#define PKA_CLRFR_ADDRERRFC_Msk             (0x1UL << PKA_CLRFR_ADDRERRFC_Pos)      /*!< 0x00100000 */
+#define PKA_CLRFR_ADDRERRFC                 PKA_CLRFR_ADDRERRFC_Msk                 /*!< Clear address error flag */
+#define PKA_CLRFR_OPERRFC_Pos               (21U)
+#define PKA_CLRFR_OPERRFC_Msk               (0x1UL << PKA_CLRFR_OPERRFC_Pos)        /*!< 0x00200000 */
+#define PKA_CLRFR_OPERRFC                   PKA_CLRFR_OPERRFC_Msk                   /*!< Clear PKA operation Error flag*/
+
+/*******************  Bits definition for PKA RAM  *************************/
+#define PKA_RAM_OFFSET                                 (0x0400UL)                          /*!< PKA RAM address offset */
+
+/* Compute Montgomery parameter input data */
+#define PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS            ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus number of bits */
+#define PKA_MONTGOMERY_PARAM_IN_MODULUS                ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus */
+
+/* Compute Montgomery parameter output data */
+#define PKA_MONTGOMERY_PARAM_OUT_PARAMETER             ((0x0620UL - PKA_RAM_OFFSET)>>2)    /*!< Output Montgomery parameter */
+
+/* Compute modular exponentiation input data */
+#define PKA_MODULAR_EXP_IN_EXP_NB_BITS                 ((0x0400UL - PKA_RAM_OFFSET)>>2)    /*!< Input exponent number of bits */
+#define PKA_MODULAR_EXP_IN_OP_NB_BITS                  ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM            ((0x0620UL - PKA_RAM_OFFSET)>>2)    /*!< Input storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_IN_EXPONENT_BASE               ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input base of the exponentiation */
+#define PKA_MODULAR_EXP_IN_EXPONENT                    ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Input exponent to process */
+#define PKA_MODULAR_EXP_IN_MODULUS                     ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus */
+#define PKA_MODULAR_EXP_PROTECT_IN_EXPONENT_BASE       ((0x16C8UL - PKA_RAM_OFFSET)>>2)    /*!< Input base of the protected exponentiation */
+#define PKA_MODULAR_EXP_PROTECT_IN_EXPONENT            ((0x14B8UL - PKA_RAM_OFFSET)>>2)    /*!< Input exponent to process protected exponentiation*/
+#define PKA_MODULAR_EXP_PROTECT_IN_MODULUS             ((0x0838UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus to process protected exponentiation */
+#define PKA_MODULAR_EXP_PROTECT_IN_PHI                 ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input phi to process protected exponentiation */
+
+/* Compute modular exponentiation output data */
+#define PKA_MODULAR_EXP_OUT_RESULT                     ((0x0838UL - PKA_RAM_OFFSET)>>2)    /*!< Output result of the exponentiation */
+#define PKA_MODULAR_EXP_OUT_ERROR                      ((0x1298UL - PKA_RAM_OFFSET)>>2)    /*!< Output error of the exponentiation */
+#define PKA_MODULAR_EXP_OUT_MONTGOMERY_PARAM           ((0x0620UL - PKA_RAM_OFFSET)>>2)    /*!< Output storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_OUT_EXPONENT_BASE              ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Output base of the exponentiation */
+
+/* Compute ECC scalar multiplication input data */
+#define PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS              ((0x0400UL - PKA_RAM_OFFSET)>>2)    /*!< Input curve prime order n number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS               ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN             ((0x0410UL - PKA_RAM_OFFSET)>>2)    /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF                  ((0x0418UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_B_COEFF                  ((0x0520UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'b' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_MOD_GF                   ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus GF(p) */
+#define PKA_ECC_SCALAR_MUL_IN_K                        ((0x12A0UL - PKA_RAM_OFFSET)>>2)    /*!< Input 'k' of KP */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X          ((0x0578UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P X coordinate */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y          ((0x0470UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Y coordinate */
+#define PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER            ((0x0F88UL - PKA_RAM_OFFSET)>>2)    /*!< Input prime order n */
+
+/* Compute ECC scalar multiplication output data */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_X                ((0x0578UL - PKA_RAM_OFFSET)>>2)    /*!< Output result X coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_Y                ((0x05D0UL - PKA_RAM_OFFSET)>>2)    /*!< Output result Y coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_ERROR                   ((0x0680UL - PKA_RAM_OFFSET)>>2)    /*!< Output result error */
+
+/* Point check input data */
+#define PKA_POINT_CHECK_IN_MOD_NB_BITS                 ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus number of bits */
+#define PKA_POINT_CHECK_IN_A_COEFF_SIGN                ((0x0410UL - PKA_RAM_OFFSET)>>2)    /*!< Input sign of the 'a' coefficient */
+#define PKA_POINT_CHECK_IN_A_COEFF                     ((0x0418UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'a' coefficient */
+#define PKA_POINT_CHECK_IN_B_COEFF                     ((0x0520UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'b' coefficient */
+#define PKA_POINT_CHECK_IN_MOD_GF                      ((0x0470UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus GF(p) */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_X             ((0x0578UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P X coordinate */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_Y             ((0x05D0UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Y coordinate */
+#define PKA_POINT_CHECK_IN_MONTGOMERY_PARAM            ((0x04C8UL - PKA_RAM_OFFSET)>>2)    /*!< Input storage area for Montgomery parameter */
+
+/* Point check output data */
+#define PKA_POINT_CHECK_OUT_ERROR                      ((0x0680UL - PKA_RAM_OFFSET)>>2)    /*!< Output error */
+
+/* ECDSA signature input data */
+#define PKA_ECDSA_SIGN_IN_ORDER_NB_BITS                ((0x0400UL - PKA_RAM_OFFSET)>>2)    /*!< Input order number of bits */
+#define PKA_ECDSA_SIGN_IN_MOD_NB_BITS                  ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus number of bits */
+#define PKA_ECDSA_SIGN_IN_A_COEFF_SIGN                 ((0x0410UL - PKA_RAM_OFFSET)>>2)    /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_A_COEFF                      ((0x0418UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_B_COEFF                      ((0x0520UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'b' coefficient */
+#define PKA_ECDSA_SIGN_IN_MOD_GF                       ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus GF(p) */
+#define PKA_ECDSA_SIGN_IN_K                            ((0x12A0UL - PKA_RAM_OFFSET)>>2)    /*!< Input k value of the ECDSA */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_X              ((0x0578UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_Y              ((0x0470UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_SIGN_IN_HASH_E                       ((0x0FE8UL - PKA_RAM_OFFSET)>>2)    /*!< Input e, hash of the message */
+#define PKA_ECDSA_SIGN_IN_PRIVATE_KEY_D                ((0x0F28UL - PKA_RAM_OFFSET)>>2)    /*!< Input d, private key */
+#define PKA_ECDSA_SIGN_IN_ORDER_N                      ((0x0F88UL - PKA_RAM_OFFSET)>>2)    /*!< Input n, order of the curve */
+
+/* ECDSA signature output data */
+#define PKA_ECDSA_SIGN_OUT_ERROR                       ((0x0FE0UL - PKA_RAM_OFFSET)>>2)    /*!< Output error */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_R                 ((0x0730UL - PKA_RAM_OFFSET)>>2)    /*!< Output signature r */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_S                 ((0x0788UL - PKA_RAM_OFFSET)>>2)    /*!< Output signature s */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_X               ((0x1400UL - PKA_RAM_OFFSET)>>2)    /*!< Extended output result point X coordinate */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_Y               ((0x1458UL - PKA_RAM_OFFSET)>>2)    /*!< Extended output result point Y coordinate */
+
+
+/* ECDSA verification input data */
+#define PKA_ECDSA_VERIF_IN_ORDER_NB_BITS               ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input order number of bits */
+#define PKA_ECDSA_VERIF_IN_MOD_NB_BITS                 ((0x04C8UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus number of bits */
+#define PKA_ECDSA_VERIF_IN_A_COEFF_SIGN                ((0x0468UL - PKA_RAM_OFFSET)>>2)    /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_A_COEFF                     ((0x0470UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_MOD_GF                      ((0x04D0UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus GF(p) */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_X             ((0x0678UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y             ((0x06D0UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X          ((0x12F8UL - PKA_RAM_OFFSET)>>2)    /*!< Input public key point X coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y          ((0x1350UL - PKA_RAM_OFFSET)>>2)    /*!< Input public key point Y coordinate */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_R                 ((0x10E0UL - PKA_RAM_OFFSET)>>2)    /*!< Input r, part of the signature */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_S                 ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input s, part of the signature */
+#define PKA_ECDSA_VERIF_IN_HASH_E                      ((0x13A8UL - PKA_RAM_OFFSET)>>2)    /*!< Input e, hash of the message */
+#define PKA_ECDSA_VERIF_IN_ORDER_N                     ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input n, order of the curve */
+
+/* ECDSA verification output data */
+#define PKA_ECDSA_VERIF_OUT_RESULT                     ((0x05D0UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* RSA CRT exponentiation input data */
+#define PKA_RSA_CRT_EXP_IN_MOD_NB_BITS                 ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operands number of bits */
+#define PKA_RSA_CRT_EXP_IN_DP_CRT                      ((0x0730UL - PKA_RAM_OFFSET)>>2)    /*!< Input Dp CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_DQ_CRT                      ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Input Dq CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_QINV_CRT                    ((0x0948UL - PKA_RAM_OFFSET)>>2)    /*!< Input qInv CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_PRIME_P                     ((0x0B60UL - PKA_RAM_OFFSET)>>2)    /*!< Input Prime p */
+#define PKA_RSA_CRT_EXP_IN_PRIME_Q                     ((0x1088UL - PKA_RAM_OFFSET)>>2)    /*!< Input Prime q */
+#define PKA_RSA_CRT_EXP_IN_EXPONENT_BASE               ((0x12A0UL - PKA_RAM_OFFSET)>>2)    /*!< Input base of the exponentiation */
+
+/* RSA CRT exponentiation output data */
+#define PKA_RSA_CRT_EXP_OUT_RESULT                     ((0x0838UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Modular reduction input data */
+#define PKA_MODULAR_REDUC_IN_OP_LENGTH                 ((0x0400UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand length */
+#define PKA_MODULAR_REDUC_IN_MOD_LENGTH                ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus length */
+#define PKA_MODULAR_REDUC_IN_OPERAND                   ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand */
+#define PKA_MODULAR_REDUC_IN_MODULUS                   ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus */
+
+/* Modular reduction output data */
+#define PKA_MODULAR_REDUC_OUT_RESULT                   ((0xE78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Arithmetic addition input data */
+#define PKA_ARITHMETIC_ADD_IN_OP_NB_BITS               ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ADD_IN_OP1                      ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ADD_IN_OP2                      ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+
+/* Arithmetic addition output data */
+#define PKA_ARITHMETIC_ADD_OUT_RESULT                  ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Arithmetic subtraction input data */
+#define PKA_ARITHMETIC_SUB_IN_OP_NB_BITS               ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_SUB_IN_OP1                      ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_ARITHMETIC_SUB_IN_OP2                      ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+
+/* Arithmetic subtraction output data */
+#define PKA_ARITHMETIC_SUB_OUT_RESULT                  ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Arithmetic multiplication input data */
+#define PKA_ARITHMETIC_MUL_NB_BITS                     ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_MUL_IN_OP1                      ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_ARITHMETIC_MUL_IN_OP2                      ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+
+/* Arithmetic multiplication output data */
+#define PKA_ARITHMETIC_MUL_OUT_RESULT                  ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Comparison input data */
+#define PKA_COMPARISON_IN_OP_NB_BITS                   ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_COMPARISON_IN_OP1                          ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_COMPARISON_IN_OP2                          ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+
+/* Comparison output data */
+#define PKA_COMPARISON_OUT_RESULT                      ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Modular addition input data */
+#define PKA_MODULAR_ADD_NB_BITS                        ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_MODULAR_ADD_IN_OP1                         ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_MODULAR_ADD_IN_OP2                         ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+#define PKA_MODULAR_ADD_IN_OP3_MOD                     ((0x1088UL - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 (modulus) */
+
+/* Modular addition output data */
+#define PKA_MODULAR_ADD_OUT_RESULT                     ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Modular inversion input data */
+#define PKA_MODULAR_INV_NB_BITS                        ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_MODULAR_INV_IN_OP1                         ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_MODULAR_INV_IN_OP2_MOD                     ((0x0C68UL - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 (modulus) */
+
+/* Modular inversion output data */
+#define PKA_MODULAR_INV_OUT_RESULT                     ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Modular subtraction input data */
+#define PKA_MODULAR_SUB_IN_OP_NB_BITS                  ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_MODULAR_SUB_IN_OP1                         ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_MODULAR_SUB_IN_OP2                         ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+#define PKA_MODULAR_SUB_IN_OP3_MOD                     ((0x1088UL - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
+
+/* Modular subtraction output data */
+#define PKA_MODULAR_SUB_OUT_RESULT                     ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Montgomery multiplication input data */
+#define PKA_MONTGOMERY_MUL_IN_OP_NB_BITS               ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_MONTGOMERY_MUL_IN_OP1                      ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_MONTGOMERY_MUL_IN_OP2                      ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+#define PKA_MONTGOMERY_MUL_IN_OP3_MOD                  ((0x1088UL - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Montgomery multiplication output data */
+#define PKA_MONTGOMERY_MUL_OUT_RESULT                  ((0x0E78UL - PKA_RAM_OFFSET)>>2)    /*!< Output result */
+
+/* Generic Arithmetic input data */
+#define PKA_ARITHMETIC_ALL_OPS_NB_BITS                 ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP1                  ((0x0A50UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP2                  ((0x0C68UL - PKA_RAM_OFFSET)>>2)    /*!< Input operand op2 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP3                  ((0x1088UL - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Generic Arithmetic output data */
+#define PKA_ARITHMETIC_ALL_OPS_OUT_RESULT              ((0x0E78UL - PKA_RAM_OFFSET)>>2)   /*!< Output result for arithmetic operations */
+
+/* Compute ECC complete addition input data */
+#define PKA_ECC_COMPLETE_ADD_IN_MOD_NB_BITS            ((0x0408UL - PKA_RAM_OFFSET)>>2)   /*!< Input Modulus number of bits */
+#define PKA_ECC_COMPLETE_ADD_IN_A_COEFF_SIGN           ((0x0410UL - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_COMPLETE_ADD_IN_A_COEFF                ((0x0418UL - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve '|a|' coefficient */
+#define PKA_ECC_COMPLETE_ADD_IN_MOD_P                  ((0x0470UL - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT1_X               ((0x0628UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT1_Y               ((0x0680UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT1_Z               ((0x06D8UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Z coordinate */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT2_X               ((0x0730UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point Q X coordinate */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT2_Y               ((0x0788UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point Q Y coordinate */
+#define PKA_ECC_COMPLETE_ADD_IN_POINT2_Z               ((0x07E0UL - PKA_RAM_OFFSET)>>2)   /*!< Input initial point Q Z coordinate */
+
+/* Compute ECC complete addition output data */
+#define PKA_ECC_COMPLETE_ADD_OUT_RESULT_X              ((0x0D60UL - PKA_RAM_OFFSET)>>2)   /*!< Output result X coordinate */
+#define PKA_ECC_COMPLETE_ADD_OUT_RESULT_Y              ((0x0DB8UL - PKA_RAM_OFFSET)>>2)   /*!< Output result Y coordinate */
+#define PKA_ECC_COMPLETE_ADD_OUT_RESULT_Z              ((0x0E10UL - PKA_RAM_OFFSET)>>2)   /*!< Output result Z coordinate */
+
+/* Compute ECC double base ladder input data */
+#define PKA_ECC_DOUBLE_LADDER_IN_PRIME_ORDER_NB_BITS  ((0x0400UL - PKA_RAM_OFFSET)>>2)    /*!< Input n, order of the curve */
+#define PKA_ECC_DOUBLE_LADDER_IN_MOD_NB_BITS          ((0x0408UL - PKA_RAM_OFFSET)>>2)    /*!< Input Modulus number of bits */
+#define PKA_ECC_DOUBLE_LADDER_IN_A_COEFF_SIGN         ((0x0410UL - PKA_RAM_OFFSET)>>2)    /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_DOUBLE_LADDER_IN_A_COEFF              ((0x0418UL - PKA_RAM_OFFSET)>>2)    /*!< Input ECC curve '|a|' coefficient */
+#define PKA_ECC_DOUBLE_LADDER_IN_MOD_P                ((0x0470UL - PKA_RAM_OFFSET)>>2)    /*!< Input modulus GF(p) */
+#define PKA_ECC_DOUBLE_LADDER_IN_K_INTEGER            ((0x0520UL - PKA_RAM_OFFSET)>>2)    /*!< Input 'k' integer coefficient */
+#define PKA_ECC_DOUBLE_LADDER_IN_M_INTEGER            ((0x0578UL - PKA_RAM_OFFSET)>>2)    /*!< Input 'm' integer coefficient */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT1_X             ((0x0628UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P X coordinate */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT1_Y             ((0x0680UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Y coordinate */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT1_Z             ((0x06D8UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point P Z coordinate */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT2_X             ((0x0730UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point Q X coordinate */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT2_Y             ((0x0788UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point Q Y coordinate */
+#define PKA_ECC_DOUBLE_LADDER_IN_POINT2_Z             ((0x07E0UL - PKA_RAM_OFFSET)>>2)    /*!< Input initial point Q Z coordinate */
+
+/* Compute ECC double base ladder output data */
+#define PKA_ECC_DOUBLE_LADDER_OUT_RESULT_X          ((0x0578UL - PKA_RAM_OFFSET)>>2)      /*!< Output result X coordinate (affine coordinate) */
+#define PKA_ECC_DOUBLE_LADDER_OUT_RESULT_Y          ((0x05D0UL - PKA_RAM_OFFSET)>>2)      /*!< Output result Y coordinate (affine coordinate) */
+#define PKA_ECC_DOUBLE_LADDER_OUT_ERROR             ((0x0520UL - PKA_RAM_OFFSET)>>2)      /*!< Output result error */
+
+/* Compute ECC projective to affine conversion input data */
+#define PKA_ECC_PROJECTIVE_AFF_IN_MOD_NB_BITS           ((0x0408UL - PKA_RAM_OFFSET)>>2)  /*!< Input Modulus number of bits */
+#define PKA_ECC_PROJECTIVE_AFF_IN_MOD_P                 ((0x0470UL - PKA_RAM_OFFSET)>>2)  /*!< Input modulus GF(p) */
+#define PKA_ECC_PROJECTIVE_AFF_IN_POINT_X               ((0x0D60UL - PKA_RAM_OFFSET)>>2)  /*!< Input initial projective point P X coordinate */
+#define PKA_ECC_PROJECTIVE_AFF_IN_POINT_Y               ((0x0DB8UL - PKA_RAM_OFFSET)>>2)  /*!< Input initial projective point P Y coordinate */
+#define PKA_ECC_PROJECTIVE_AFF_IN_POINT_Z               ((0x0E10UL - PKA_RAM_OFFSET)>>2)  /*!< Input initial projective point P Z coordinate */
+#define PKA_ECC_PROJECTIVE_AFF_IN_MONTGOMERY_PARAM_R2   ((0x04C8UL - PKA_RAM_OFFSET)>>2)  /*!< Input storage area for Montgomery parameter */
+
+/* Compute ECC projective to affine conversion output data */
+#define PKA_ECC_PROJECTIVE_AFF_OUT_RESULT_X      ((0x0578UL - PKA_RAM_OFFSET)>>2)         /*!< Output result x affine coordinate */
+#define PKA_ECC_PROJECTIVE_AFF_OUT_RESULT_Y      ((0x05D0UL - PKA_RAM_OFFSET)>>2)         /*!< Output result y affine coordinate */
+#define PKA_ECC_PROJECTIVE_AFF_OUT_ERROR         ((0x0680UL - PKA_RAM_OFFSET)>>2)         /*!< Output result error */
+
 
 /** @addtogroup STM32H5xx_Peripheral_Exported_macros
   * @{
@@ -20695,6 +21083,8 @@ typedef struct
 
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) (((INSTANCE) == ADC12_COMMON_NS) ||         \
                                           ((INSTANCE) == ADC12_COMMON_S))
+/******************************* PKA Instances ********************************/
+#define IS_PKA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == PKA_NS) || ((INSTANCE) == PKA_S))
 
 /******************************* CORDIC Instances *****************************/
 #define IS_CORDIC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CORDIC_NS) || ((INSTANCE) == CORDIC_S))
@@ -20737,6 +21127,11 @@ typedef struct
                                                  ((INSTANCE) == GPDMA1_Channel7_NS)  || ((INSTANCE) == GPDMA1_Channel7_S)  || \
                                                  ((INSTANCE) == GPDMA2_Channel6_NS)  || ((INSTANCE) == GPDMA2_Channel6_S)  || \
                                                  ((INSTANCE) == GPDMA2_Channel7_NS)  || ((INSTANCE) == GPDMA2_Channel7_S))
+
+#define IS_DMA_PFREQ_INSTANCE(INSTANCE) (((INSTANCE) == GPDMA1_Channel0_NS)  || ((INSTANCE) == GPDMA1_Channel0_S)  || \
+                                         ((INSTANCE) == GPDMA1_Channel7_NS)  || ((INSTANCE) == GPDMA1_Channel7_S)  || \
+                                         ((INSTANCE) == GPDMA2_Channel0_NS)  || ((INSTANCE) == GPDMA2_Channel0_S)  || \
+                                         ((INSTANCE) == GPDMA2_Channel7_NS)  || ((INSTANCE) == GPDMA2_Channel7_S))
 
 /****************************** RAMCFG Instances ********************************/
 #define IS_RAMCFG_ALL_INSTANCE(INSTANCE) (((INSTANCE) == RAMCFG_SRAM1_NS)  || ((INSTANCE) == RAMCFG_SRAM1_S)  || \
@@ -21261,6 +21656,9 @@ typedef struct
                                          ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)|| \
                                          ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
 
+/******************* TIM Instances : supporting bitfield RTCPREEN in OR1 register  ********************/
+#define IS_TIM_RTCPREEN_INSTANCE(INSTANCE) (((INSTANCE) == TIM17_NS)  || ((INSTANCE) == TIM17_S))
+
 /****************** TIM Instances : Advanced timer instances *******************/
 #define IS_TIM_ADVANCED_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
                                                   ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S))
@@ -21457,7 +21855,6 @@ typedef struct
 
 /******************************* USB DRD FS PCD Instances *************************/
 #define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS_NS) || ((INSTANCE) == USB_DRD_FS_S))
-
 
 /** @} */ /* End of group STM32H5xx_Peripheral_Exported_macros */
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h573xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h573xx.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
   ******************************************************************************
   * @file    stm32h573xx.h
   * @author  MCD Application Team
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -439,7 +439,7 @@ typedef struct
   __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
   __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
   __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
-  uint32_t RESERVED;
+  __IO uint32_t NSCR;  /*!< RNG noise source control register ,     Address offset: 0x0C */
   __IO uint32_t HTCR;  /*!< RNG health test configuration register, Address offset: 0x10 */
 } RNG_TypeDef;
 
@@ -843,6 +843,7 @@ typedef struct
   __IO uint32_t WDATA;           /*!< FMAC Write Data register,              Address offset: 0x18          */
   __IO uint32_t RDATA;           /*!< FMAC Read Data register,               Address offset: 0x1C          */
 } FMAC_TypeDef;
+
 /**
   * @brief General Purpose I/O
   */
@@ -989,7 +990,8 @@ typedef struct
   __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x5C */
   __IO uint32_t AF1;         /*!< TIM alternate function option register 1, Address offset: 0x60 */
   __IO uint32_t AF2;         /*!< TIM alternate function option register 2, Address offset: 0x64 */
-       uint32_t RESERVED0[221];/*!< Reserved,                               Address offset: 0x68 */
+  __IO uint32_t OR1 ;        /*!< TIM option register,                      Address offset: 0x68 */
+       uint32_t RESERVED0[220];/*!< Reserved,                               Address offset: 0x6C */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x3DC */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x3E0 */
 } TIM_TypeDef;
@@ -1950,7 +1952,6 @@ typedef struct
 #define DAC1_BASE_NS             (AHB2PERIPH_BASE_NS + 0x08400UL)
 #define DCMI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C000UL)
 #define PSSI_BASE_NS             (AHB2PERIPH_BASE_NS + 0x0C400UL)
-
 #define AES_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA0000UL)
 #define HASH_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0400UL)
 #define HASH_DIGEST_BASE_NS      (AHB2PERIPH_BASE_NS + 0xA0710UL)
@@ -1958,7 +1959,6 @@ typedef struct
 #define SAES_BASE_NS             (AHB2PERIPH_BASE_NS + 0xA0C00UL)
 #define PKA_BASE_NS              (AHB2PERIPH_BASE_NS + 0xA2000UL)
 #define PKA_RAM_BASE_NS          (AHB2PERIPH_BASE_NS + 0xA2400UL)
-
 
 /*!< APB3 Non secure peripherals */
 #define SBS_BASE_NS              (APB3PERIPH_BASE_NS + 0x0400UL)
@@ -1980,6 +1980,7 @@ typedef struct
 #define RCC_BASE_NS              (AHB3PERIPH_BASE_NS + 0x0C00UL)
 #define EXTI_BASE_NS             (AHB3PERIPH_BASE_NS + 0x2000UL)
 #define DEBUG_BASE_NS            (AHB3PERIPH_BASE_NS + 0x4000UL)
+
 /*!< AHB4 Non secure peripherals */
 #define OTFDEC1_BASE_NS          (AHB4PERIPH_BASE_NS + 0x5000UL)
 #define OTFDEC1_REGION1_BASE_NS  (OTFDEC1_BASE_NS + 0x20UL)
@@ -1990,7 +1991,6 @@ typedef struct
 #define DLYB_SDMMC1_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8400UL)
 #define SDMMC2_BASE_NS           (AHB4PERIPH_BASE_NS + 0x8C00UL)
 #define DLYB_SDMMC2_BASE_NS      (AHB4PERIPH_BASE_NS + 0x8800UL)
-
 #define FMC_R_BASE_NS            (AHB4PERIPH_BASE_NS + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_NS       (AHB4PERIPH_BASE_NS + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_NS    (AHB4PERIPH_BASE_NS + 0x0F000UL)
@@ -2003,9 +2003,9 @@ typedef struct
 
 /* Flash, Peripheral and internal SRAMs base addresses - Secure */
 #define FLASH_BASE_S            (0x0C000000UL) /*!< FLASH (up to 2 MB) secure base address */
-#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (192 KB) secure base address     */
+#define SRAM1_BASE_S            (0x30000000UL) /*!< SRAM1 (256 KB) secure base address     */
 #define SRAM2_BASE_S            (0x30040000UL) /*!< SRAM2 (64 KB) secure base address      */
-#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (512 KB) secure base address     */
+#define SRAM3_BASE_S            (0x30050000UL) /*!< SRAM3 (320 KB) secure base address     */
 #define PERIPH_BASE_S           (0x50000000UL) /*!< Peripheral secure base address         */
 
 /* Peripheral memory map - Secure */
@@ -2092,7 +2092,6 @@ typedef struct
 #define GTZC_MPCBB2_BASE_S      (AHB1PERIPH_BASE_S + 0x13000UL)
 #define GTZC_MPCBB3_BASE_S      (AHB1PERIPH_BASE_S + 0x13400UL)
 #define BKPSRAM_BASE_S          (AHB1PERIPH_BASE_S + 0x16400UL)
-
 #define GPDMA1_Channel0_BASE_S   (GPDMA1_BASE_S + 0x0050UL)
 #define GPDMA1_Channel1_BASE_S   (GPDMA1_BASE_S + 0x00D0UL)
 #define GPDMA1_Channel2_BASE_S   (GPDMA1_BASE_S + 0x0150UL)
@@ -2109,7 +2108,6 @@ typedef struct
 #define GPDMA2_Channel5_BASE_S   (GPDMA2_BASE_S + 0x02D0UL)
 #define GPDMA2_Channel6_BASE_S   (GPDMA2_BASE_S + 0x0350UL)
 #define GPDMA2_Channel7_BASE_S   (GPDMA2_BASE_S + 0x03D0UL)
-
 #define RAMCFG_SRAM1_BASE_S     (RAMCFG_BASE_S)
 #define RAMCFG_SRAM2_BASE_S     (RAMCFG_BASE_S + 0x0040UL)
 #define RAMCFG_SRAM3_BASE_S     (RAMCFG_BASE_S + 0x0080UL)
@@ -2170,7 +2168,6 @@ typedef struct
 #define DLYB_SDMMC1_BASE_S      (AHB4PERIPH_BASE_S + 0x8400UL)
 #define SDMMC2_BASE_S           (AHB4PERIPH_BASE_S + 0x8C00UL)
 #define DLYB_SDMMC2_BASE_S      (AHB4PERIPH_BASE_S + 0x8800UL)
-
 #define FMC_R_BASE_S            (AHB4PERIPH_BASE_S + 0x1000400UL) /*!< FMC control registers base address              */
 #define OCTOSPI1_R_BASE_S       (AHB4PERIPH_BASE_S + 0x1001400UL) /*!< OCTOSPI1 control registers base address         */
 #define DLYB_OCTOSPI1_BASE_S    (AHB4PERIPH_BASE_S + 0x0F000UL)
@@ -2183,11 +2180,9 @@ typedef struct
 
 /* Debug MCU registers base address */
 #define DBGMCU_BASE             (0x44024000UL)
-
 #define PACKAGE_BASE            (0x08FFF80EUL) /*!< Package data register base address     */
 #define UID_BASE                (0x08FFF800UL) /*!< Unique device ID register base address */
 #define FLASHSIZE_BASE          (0x08FFF80CUL) /*!< Flash size data register base address  */
-
 
 /* Internal Flash OTP Area */
 #define FLASH_OTP_BASE          (0x08FFF000UL) /*!< FLASH OTP (one-time programmable) base address */
@@ -2230,9 +2225,6 @@ typedef struct
 #define FLASH_OBK_HDPL3NS_BASE_S  (FLASH_OBK_HDPL3_BASE_S + FLASH_OBK_HDPL3S_SIZE)  /*!< FLASH OBK HDPL3 secure base address             */
 #define FLASH_OBK_HDPL3NS_SIZE    (FLASH_OBK_HDPL3_SIZE - FLASH_OBK_HDPL3S_SIZE)    /*!< 2032 Bytes of non-secure HDPL3 option byte keys */
 #endif /* CMSE */
-
-/*!< USB PMA SIZE */
-#define USB_DRD_PMA_SIZE        (2048U)         /*!< USB PMA Size 2Kbyte */
 
 /*!< Root Secure Service Library */
 /************ RSSLIB SAU system Flash region definition constants *************/
@@ -4884,10 +4876,35 @@ typedef struct
 #define RNG_SR_SEIS_Msk                     (0x1UL << RNG_SR_SEIS_Pos)              /*!< 0x00000040 */
 #define RNG_SR_SEIS                         RNG_SR_SEIS_Msk
 
+/********************  Bits definition for RNG_NSCR register  *******************/
+#define RNG_NSCR_EN_OSC1_Pos                (0U)
+#define RNG_NSCR_EN_OSC1_Msk                (0x7UL << RNG_NSCR_EN_OSC1_Pos)         /*!< 0x00000007 */
+#define RNG_NSCR_EN_OSC1                    RNG_NSCR_EN_OSC1_Msk
+#define RNG_NSCR_EN_OSC2_Pos                (3U)
+#define RNG_NSCR_EN_OSC2_Msk                (0x7UL << RNG_NSCR_EN_OSC2_Pos)         /*!< 0x00000038 */
+#define RNG_NSCR_EN_OSC2                    RNG_NSCR_EN_OSC2_Msk
+#define RNG_NSCR_EN_OSC3_Pos                (6U)
+#define RNG_NSCR_EN_OSC3_Msk                (0x7UL << RNG_NSCR_EN_OSC3_Pos)         /*!< 0x000001C0 */
+#define RNG_NSCR_EN_OSC3                    RNG_NSCR_EN_OSC3_Msk
+#define RNG_NSCR_EN_OSC4_Pos                (9U)
+#define RNG_NSCR_EN_OSC4_Msk                (0x7UL << RNG_NSCR_EN_OSC4_Pos)         /*!< 0x00000E00 */
+#define RNG_NSCR_EN_OSC4                    RNG_NSCR_EN_OSC4_Msk
+#define RNG_NSCR_EN_OSC5_Pos                (12U)
+#define RNG_NSCR_EN_OSC5_Msk                (0x7UL << RNG_NSCR_EN_OSC5_Pos)         /*!< 0x00007000 */
+#define RNG_NSCR_EN_OSC5                    RNG_NSCR_EN_OSC5_Msk
+#define RNG_NSCR_EN_OSC6_Pos                (15U)
+#define RNG_NSCR_EN_OSC6_Msk                (0x7UL << RNG_NSCR_EN_OSC6_Pos)         /*!< 0x00038000 */
+#define RNG_NSCR_EN_OSC6                    RNG_NSCR_EN_OSC6_Msk
+
 /********************  Bits definition for RNG_HTCR register  *******************/
 #define RNG_HTCR_HTCFG_Pos                  (0U)
 #define RNG_HTCR_HTCFG_Msk                  (0xFFFFFFFFUL << RNG_HTCR_HTCFG_Pos)    /*!< 0xFFFFFFFF */
 #define RNG_HTCR_HTCFG                      RNG_HTCR_HTCFG_Msk
+
+/********************  RNG Nist Compliance Values  ******************************/
+#define RNG_CR_NIST_VALUE                   (0x00F00E00U)
+#define RNG_HTCR_NIST_VALUE                 (0x6A91U)
+#define RNG_NSCR_NIST_VALUE                 (0x3AF66U)
 
 /******************************************************************************/
 /*                                                                            */
@@ -8760,32 +8777,32 @@ typedef struct
 #define EXTI_PRIVENR1_PRIV31                EXTI_PRIVENR1_PRIV31_Msk                 /*!< Privilege enable on line 31 */
 
 /******************  Bit definition for EXTI_RTSR2 register  *******************/
-#define EXTI_RTSR2_TR_Pos                   (14U)
-#define EXTI_RTSR2_TR_Msk                   (0x244UL << EXTI_RTSR2_TR_Pos)              /*!< 0x00244000 */
-#define EXTI_RTSR2_TR                       EXTI_RTSR2_TR_Msk                           /*!< Rising trigger event configuration bit */
-#define EXTI_RTSR2_TR46_Pos                 (14U)
-#define EXTI_RTSR2_TR46_Msk                 (0x1UL << EXTI_RTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_RTSR2_TR46                     EXTI_RTSR2_TR46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
-#define EXTI_RTSR2_TR50_Pos                 (18U)
-#define EXTI_RTSR2_TR50_Msk                 (0x1UL << EXTI_RTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_RTSR2_TR50                     EXTI_RTSR2_TR50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
-#define EXTI_RTSR2_TR53_Pos                 (21U)
-#define EXTI_RTSR2_TR53_Msk                 (0x1UL << EXTI_RTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_RTSR2_TR53                     EXTI_RTSR2_TR53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
+#define EXTI_RTSR2_RT_Pos                   (12U)
+#define EXTI_RTSR2_RT_Msk                   (0x244UL << EXTI_RTSR2_RT_Pos)              /*!< 0x00244000 */
+#define EXTI_RTSR2_RT                       EXTI_RTSR2_RT_Msk                           /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT46_Pos                 (14U)
+#define EXTI_RTSR2_RT46_Msk                 (0x1UL << EXTI_RTSR2_RT46_Pos)              /*!< 0x00004000 */
+#define EXTI_RTSR2_RT46                     EXTI_RTSR2_RT46_Msk                         /*!< Rising trigger event configuration bit of line 46 */
+#define EXTI_RTSR2_RT50_Pos                 (18U)
+#define EXTI_RTSR2_RT50_Msk                 (0x1UL << EXTI_RTSR2_RT50_Pos)              /*!< 0x00040000 */
+#define EXTI_RTSR2_RT50                     EXTI_RTSR2_RT50_Msk                         /*!< Rising trigger event configuration bit of line 50 */
+#define EXTI_RTSR2_RT53_Pos                 (21U)
+#define EXTI_RTSR2_RT53_Msk                 (0x1UL << EXTI_RTSR2_RT53_Pos)              /*!< 0x00200000 */
+#define EXTI_RTSR2_RT53                     EXTI_RTSR2_RT53_Msk                         /*!< Rising trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FTSR2 register  *******************/
-#define EXTI_FTSR2_TR_Pos                   (14U)
-#define EXTI_FTSR2_TR_Msk                   (0x244 << EXTI_FTSR2_TR_Pos)                /*!< 0x00244000 */
-#define EXTI_FTSR2_TR                       EXTI_FTSR2_TR_Msk                           /*!< Falling trigger event configuration bit */
-#define EXTI_FTSR2_TR46_Pos                 (14U)
-#define EXTI_FTSR2_TR46_Msk                 (0x1UL << EXTI_FTSR2_TR46_Pos)              /*!< 0x00004000 */
-#define EXTI_FTSR2_TR46                     EXTI_FTSR2_TR46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
-#define EXTI_FTSR2_TR50_Pos                 (18U)
-#define EXTI_FTSR2_TR50_Msk                 (0x1UL << EXTI_FTSR2_TR50_Pos)              /*!< 0x00040000 */
-#define EXTI_FTSR2_TR50                     EXTI_FTSR2_TR50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
-#define EXTI_FTSR2_TR53_Pos                 (21U)
-#define EXTI_FTSR2_TR53_Msk                 (0x1UL << EXTI_FTSR2_TR53_Pos)              /*!< 0x00200000 */
-#define EXTI_FTSR2_TR53                     EXTI_FTSR2_TR53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
+#define EXTI_FTSR2_FT_Pos                   (12U)
+#define EXTI_FTSR2_FT_Msk                   (0x244 << EXTI_FTSR2_FT_Pos)                /*!< 0x00244000 */
+#define EXTI_FTSR2_FT                       EXTI_FTSR2_FT_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT46_Pos                 (14U)
+#define EXTI_FTSR2_FT46_Msk                 (0x1UL << EXTI_FTSR2_FT46_Pos)              /*!< 0x00004000 */
+#define EXTI_FTSR2_FT46                     EXTI_FTSR2_FT46_Msk                         /*!< Falling trigger event configuration bit of line 46 */
+#define EXTI_FTSR2_FT50_Pos                 (18U)
+#define EXTI_FTSR2_FT50_Msk                 (0x1UL << EXTI_FTSR2_FT50_Pos)              /*!< 0x00040000 */
+#define EXTI_FTSR2_FT50                     EXTI_FTSR2_FT50_Msk                         /*!< Falling trigger event configuration bit of line 50 */
+#define EXTI_FTSR2_FT53_Pos                 (21U)
+#define EXTI_FTSR2_FT53_Msk                 (0x1UL << EXTI_FTSR2_FT53_Pos)              /*!< 0x00200000 */
+#define EXTI_FTSR2_FT53                     EXTI_FTSR2_FT53_Msk                         /*!< Falling trigger event configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_SWIER2 register  ******************/
 #define EXTI_SWIER2_SWIER46_Pos            (14U)
@@ -8799,7 +8816,7 @@ typedef struct
 #define EXTI_SWIER2_SWIER53                EXTI_SWIER2_SWIER53_Msk                     /*!< Software Interrupt on line 53 */
 
 /******************  Bit definition for EXTI_RPR2 register  *******************/
-#define EXTI_RPR2_RPIF_Pos                   (14U)
+#define EXTI_RPR2_RPIF_Pos                   (12U)
 #define EXTI_RPR2_RPIF_Msk                   (0x244UL << EXTI_RPR2_RPIF_Pos)        /*!< 0x00244000 */
 #define EXTI_RPR2_RPIF                       EXTI_RPR2_RPIF_Msk                     /*!< Rising pending edge configuration bits */
 #define EXTI_RPR2_RPIF46_Pos                 (14U)
@@ -8813,7 +8830,7 @@ typedef struct
 #define EXTI_RPR2_RPIF53                     EXTI_RPR2_RPIF53_Msk                   /*!< Rising pending edge configuration bit of line 53 */
 
 /******************  Bit definition for EXTI_FPR2 register  *******************/
-#define EXTI_FPR2_FPIF_Pos                   (14U)
+#define EXTI_FPR2_FPIF_Pos                   (12U)
 #define EXTI_FPR2_FPIF_Msk                   (0x244UL << EXTI_FPR2_FPIF_Pos)        /*!< 0x00244000 */
 #define EXTI_FPR2_FPIF                       EXTI_FPR2_FPIF_Msk                     /*!< Rising falling edge configuration bits */
 #define EXTI_FPR2_FPIF46_Pos                 (14U)
@@ -9356,6 +9373,9 @@ typedef struct
 #define EXTI_IMR2_IM44_Pos                  (12U)
 #define EXTI_IMR2_IM44_Msk                  (0x1UL << EXTI_IMR2_IM44_Pos)           /*!< 0x00001000 */
 #define EXTI_IMR2_IM44                      EXTI_IMR2_IM44_Msk                      /*!< Interrupt Mask on line 44 */
+#define EXTI_IMR2_IM45_Pos                  (13U)
+#define EXTI_IMR2_IM45_Msk                  (0x1UL << EXTI_IMR2_IM45_Pos)           /*!< 0x00002000 */
+#define EXTI_IMR2_IM45                      EXTI_IMR2_IM45_Msk                      /*!< Interrupt Mask on line 45 */
 #define EXTI_IMR2_IM46_Pos                  (14U)
 #define EXTI_IMR2_IM46_Msk                  (0x1UL << EXTI_IMR2_IM46_Pos)           /*!< 0x00004000 */
 #define EXTI_IMR2_IM46                      EXTI_IMR2_IM46_Msk                      /*!< Interrupt Mask on line 46 */
@@ -9437,6 +9457,9 @@ typedef struct
 #define EXTI_EMR2_EM44_Pos                  (12U)
 #define EXTI_EMR2_EM44_Msk                  (0x1UL << EXTI_EMR2_EM44_Pos)           /*!< 0x00001000 */
 #define EXTI_EMR2_EM44                      EXTI_EMR2_EM44_Msk                      /*!< Event Mask on line 44 */
+#define EXTI_EMR2_EM45_Pos                  (13U)
+#define EXTI_EMR2_EM45_Msk                  (0x1UL << EXTI_EMR2_EM45_Pos)           /*!< 0x00002000 */
+#define EXTI_EMR2_EM45                      EXTI_EMR2_EM45_Msk                      /*!< Event Mask on line 45 */
 #define EXTI_EMR2_EM46_Pos                  (14U)
 #define EXTI_EMR2_EM46_Msk                  (0x1UL << EXTI_EMR2_EM46_Pos)           /*!< 0x00004000 */
 #define EXTI_EMR2_EM46                      EXTI_EMR2_EM46_Msk                      /*!< Event Mask on line 46 */
@@ -10195,7 +10218,7 @@ typedef struct
 /*                                    FLASH                                   */
 /*                                                                            */
 /******************************************************************************/
-#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /* FLASH Three Latency cycle */
+#define FLASH_LATENCY_DEFAULT               FLASH_ACR_LATENCY_3WS                   /*!< FLASH Three Latency cycle */
 #define FLASH_BLOCKBASED_NB_REG             (4U)                                    /*!< 4 Block-based registers for each Flash bank */
 #define FLASH_SIZE_DEFAULT                  (0x200000U)                             /*!< FLASH Size */
 #define FLASH_SECTOR_NB                     (128U)                                  /*!< Flash Sector number */
@@ -10489,6 +10512,9 @@ typedef struct
 #define FLASH_OPTSR2_SRAM2_ECC_Pos          (6U)
 #define FLASH_OPTSR2_SRAM2_ECC_Msk          (0x1UL << FLASH_OPTSR2_SRAM2_ECC_Pos)   /*!< 0x00000040 */
 #define FLASH_OPTSR2_SRAM2_ECC              FLASH_OPTSR2_SRAM2_ECC_Msk              /*!< SRAM2 ECC detection and correction disable */
+#define FLASH_OPTSR2_USBPD_DIS_Pos          (8U)
+#define FLASH_OPTSR2_USBPD_DIS_Msk          (0x1UL << FLASH_OPTSR2_USBPD_DIS_Pos)   /*!< 0x00000100 */
+#define FLASH_OPTSR2_USBPD_DIS              FLASH_OPTSR2_USBPD_DIS_Msk              /*!< USB power delivery configuration disable */
 #define FLASH_OPTSR2_TZEN_Pos               (24U)
 #define FLASH_OPTSR2_TZEN_Msk               (0xFFUL << FLASH_OPTSR2_TZEN_Pos)       /*!< 0xFF000000 */
 #define FLASH_OPTSR2_TZEN                   FLASH_OPTSR2_TZEN_Msk                   /*!< TrustZone enable */
@@ -10521,7 +10547,7 @@ typedef struct
 
 /*****************  Bits definition for FLASH_EDATA register  ********************/
 #define FLASH_EDATAR_EDATA_STRT_Pos         (0U)
-#define FLASH_EDATAR_EDATA_STRT_Msk         (0x3UL << FLASH_EDATAR_EDATA_STRT_Pos)  /*!< 0x00000003 */
+#define FLASH_EDATAR_EDATA_STRT_Msk         (0x7UL << FLASH_EDATAR_EDATA_STRT_Pos)  /*!< 0x00000007 */
 #define FLASH_EDATAR_EDATA_STRT             FLASH_EDATAR_EDATA_STRT_Msk             /*!< Flash high-cycle data start sector */
 #define FLASH_EDATAR_EDATA_EN_Pos           (15U)
 #define FLASH_EDATAR_EDATA_EN_Msk           (0x1UL << FLASH_EDATAR_EDATA_EN_Pos)    /*!< 0x00008000 */
@@ -10568,7 +10594,6 @@ typedef struct
 #define FLASH_ECCDR_FAIL_DATA_Pos           (0U)
 #define FLASH_ECCDR_FAIL_DATA_Msk           (0xFFFFUL << FLASH_ECCDR_FAIL_DATA_Pos) /*!< 0x0000FFFF */
 #define FLASH_ECCDR_FAIL_DATA               FLASH_ECCDR_FAIL_DATA_Msk               /*!< ECC fail data */
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -10684,7 +10709,6 @@ typedef struct
 #define FMAC_RDATA_RDATA_Pos                (0U)
 #define FMAC_RDATA_RDATA_Msk                (0xFFFFUL << FMAC_RDATA_RDATA_Pos)      /*!< 0x0000FFFF */
 #define FMAC_RDATA_RDATA                    FMAC_RDATA_RDATA_Msk                    /*!< Read data */
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -11144,7 +11168,7 @@ typedef struct
 #define FMC_SDCMR_MODE             FMC_SDCMR_MODE_Msk                          /*!<MODE[2:0] bits (Command mode) */
 #define FMC_SDCMR_MODE_0           (0x1UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000001 */
 #define FMC_SDCMR_MODE_1           (0x2UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000002 */
-#define FMC_SDCMR_MODE_2           (0x3UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000003 */
+#define FMC_SDCMR_MODE_2           (0x4UL << FMC_SDCMR_MODE_Pos)                /*!< 0x00000004 */
 
 #define FMC_SDCMR_CTB2_Pos         (3U)
 #define FMC_SDCMR_CTB2_Msk         (0x1UL << FMC_SDCMR_CTB2_Pos)               /*!< 0x00000008 */
@@ -12905,27 +12929,27 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR1 register  *******************/
 #define TIM_CCR1_CCR1_Pos                   (0U)
-#define TIM_CCR1_CCR1_Msk                   (0xFFFFUL << TIM_CCR1_CCR1_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1_Msk                   (0xFFFFFFFFUL << TIM_CCR1_CCR1_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR1_CCR1                       TIM_CCR1_CCR1_Msk                       /*!<Capture/Compare 1 Value */
 
 /*******************  Bit definition for TIM_CCR2 register  *******************/
 #define TIM_CCR2_CCR2_Pos                   (0U)
-#define TIM_CCR2_CCR2_Msk                   (0xFFFFUL << TIM_CCR2_CCR2_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2_Msk                   (0xFFFFFFFFUL << TIM_CCR2_CCR2_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR2_CCR2                       TIM_CCR2_CCR2_Msk                       /*!<Capture/Compare 2 Value */
 
 /*******************  Bit definition for TIM_CCR3 register  *******************/
 #define TIM_CCR3_CCR3_Pos                   (0U)
-#define TIM_CCR3_CCR3_Msk                   (0xFFFFUL << TIM_CCR3_CCR3_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3_Msk                   (0xFFFFFFFFUL << TIM_CCR3_CCR3_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR3_CCR3                       TIM_CCR3_CCR3_Msk                       /*!<Capture/Compare 3 Value */
 
 /*******************  Bit definition for TIM_CCR4 register  *******************/
 #define TIM_CCR4_CCR4_Pos                   (0U)
-#define TIM_CCR4_CCR4_Msk                   (0xFFFFUL << TIM_CCR4_CCR4_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4_Msk                   (0xFFFFFFFFUL << TIM_CCR4_CCR4_Pos)     /*!< 0xFFFFFFFF */
 #define TIM_CCR4_CCR4                       TIM_CCR4_CCR4_Msk                       /*!<Capture/Compare 4 Value */
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos                   (0U)
-#define TIM_CCR5_CCR5_Msk                   (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)     /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk                   (0xFFFFFUL << TIM_CCR5_CCR5_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR5_CCR5                       TIM_CCR5_CCR5_Msk                       /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos                  (29U)
 #define TIM_CCR5_GC5C1_Msk                  (0x1UL << TIM_CCR5_GC5C1_Pos)           /*!< 0x20000000 */
@@ -12939,7 +12963,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR6 register  *******************/
 #define TIM_CCR6_CCR6_Pos                   (0U)
-#define TIM_CCR6_CCR6_Msk                   (0xFFFFUL << TIM_CCR6_CCR6_Pos)         /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6_Msk                   (0xFFFFFUL << TIM_CCR6_CCR6_Pos)        /*!< 0x000FFFFF */
 #define TIM_CCR6_CCR6                       TIM_CCR6_CCR6_Msk                       /*!<Capture/Compare 6 Value */
 
 /*******************  Bit definition for TIM_BDTR register  *******************/
@@ -13083,6 +13107,11 @@ typedef struct
 #define TIM1_AF2_OCRSEL_Msk                 (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
 #define TIM1_AF2_OCRSEL                     TIM1_AF2_OCRSEL_Msk                     /*!<OCREF_CLR source selection */
 #define TIM1_AF2_OCRSEL_0                   (0x1UL << TIM1_AF2_OCRSEL_Pos)          /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM_OR1 register  *********************/
+#define TIM_OR1_RTCPREEN_Pos                 (1U)
+#define TIM_OR1_RTCPREEN_Msk                 (0x1UL << TIM_OR1_RTCPREEN_Pos)           /*!< 0x00000002 */
+#define TIM_OR1_RTCPREEN                     TIM_OR1_RTCPREEN_Msk                      /*!< RTCPRE HSE divider enable */
 
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos                (0U)
@@ -14434,7 +14463,7 @@ typedef struct
 #define OCTOSPI_CR_TCIE_Msk                 XSPI_CR_TCIE_Msk                              /*!< 0x00020000 */
 #define OCTOSPI_CR_TCIE                     XSPI_CR_TCIE                                  /*!< Transfer Complete Interrupt Enable */
 #define OCTOSPI_CR_FTIE_Pos                 XSPI_CR_FTIE_Pos
-#define OCTOSPI_CR_FTIE_Msk                 XSPI_CR_FTIE_Msk)                             /*!< 0x00040000 */
+#define OCTOSPI_CR_FTIE_Msk                 XSPI_CR_FTIE_Msk                              /*!< 0x00040000 */
 #define OCTOSPI_CR_FTIE                     XSPI_CR_FTIE                                  /*!< FIFO Threshold Interrupt Enable */
 #define OCTOSPI_CR_SMIE_Pos                 XSPI_CR_SMIE_Pos
 #define OCTOSPI_CR_SMIE_Msk                 XSPI_CR_SMIE_Msk                              /*!< 0x00080000 */
@@ -15001,9 +15030,9 @@ typedef struct
 #define PWR_PMCR_AVD_READY_Pos               (13U)
 #define PWR_PMCR_AVD_READY_Msk               (0x1UL << PWR_PMCR_AVD_READY_Pos)
 #define PWR_PMCR_AVD_READY                   PWR_PMCR_AVD_READY_Msk
-#define PWR_PMCR_ETHERNETSO_Pos             (16U)
-#define PWR_PMCR_ETHERNETSO_Msk             (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
-#define PWR_PMCR_ETHERNETSO                 PWR_PMCR_ETHERNETSO_Msk
+#define PWR_PMCR_ETHERNETSO_Pos              (16U)
+#define PWR_PMCR_ETHERNETSO_Msk              (0x1UL << PWR_PMCR_ETHERNETSO_Pos)
+#define PWR_PMCR_ETHERNETSO                  PWR_PMCR_ETHERNETSO_Msk
 #define PWR_PMCR_SRAM3SO_Pos                 (23U)
 #define PWR_PMCR_SRAM3SO_Msk                 (0x1UL << PWR_PMCR_SRAM3SO_Pos)
 #define PWR_PMCR_SRAM3SO                     PWR_PMCR_SRAM3SO_Msk
@@ -15101,9 +15130,9 @@ typedef struct
 #define PWR_SCCR_SMPSEN                      PWR_SCCR_SMPSEN_Msk
 
 /********************  Bit definition for PWR_VMCR register  ******************/
-#define PWR_VMCR_PVDEN_Pos                    (0U)
-#define PWR_VMCR_PVDEN_Msk                    (0x1UL << PWR_VMCR_PVDEN_Pos)
-#define PWR_VMCR_PVDEN                        PWR_VMCR_PVDEN_Msk
+#define PWR_VMCR_PVDEN_Pos                   (0U)
+#define PWR_VMCR_PVDEN_Msk                   (0x1UL << PWR_VMCR_PVDEN_Pos)
+#define PWR_VMCR_PVDEN                       PWR_VMCR_PVDEN_Msk
 #define PWR_VMCR_PLS_Pos                     (1U)
 #define PWR_VMCR_PLS_Msk                     (0x7UL << PWR_VMCR_PLS_Pos)
 #define PWR_VMCR_PLS                         PWR_VMCR_PLS_Msk
@@ -15120,12 +15149,12 @@ typedef struct
 #define PWR_VMCR_ALS_1                       (0x2UL << PWR_VMCR_ALS_Pos)
 
 /********************  Bit definition for PWR_USBSCR register  ******************/
-#define PWR_USBSCR_USB33DEN_Pos               (24U)
-#define PWR_USBSCR_USB33DEN_Msk               (0x1UL << PWR_USBSCR_USB33DEN_Pos)
-#define PWR_USBSCR_USB33DEN                   PWR_USBSCR_USB33DEN_Msk
-#define PWR_USBSCR_USB33SV_Pos                (25U)
-#define PWR_USBSCR_USB33SV_Msk                (0x1UL << PWR_USBSCR_USB33SV_Pos)
-#define PWR_USBSCR_USB33SV                    PWR_USBSCR_USB33SV_Msk
+#define PWR_USBSCR_USB33DEN_Pos              (24U)
+#define PWR_USBSCR_USB33DEN_Msk              (0x1UL << PWR_USBSCR_USB33DEN_Pos)
+#define PWR_USBSCR_USB33DEN                  PWR_USBSCR_USB33DEN_Msk
+#define PWR_USBSCR_USB33SV_Pos               (25U)
+#define PWR_USBSCR_USB33SV_Msk               (0x1UL << PWR_USBSCR_USB33SV_Pos)
+#define PWR_USBSCR_USB33SV                   PWR_USBSCR_USB33SV_Msk
 
 /********************  Bit definition for PWR_VMSR register  ******************/
 #define PWR_VMSR_AVDO_Pos                    (19U)
@@ -19606,9 +19635,6 @@ typedef struct
 #define SBS_SECCFGR_FPUSEC_Pos           (3U)
 #define SBS_SECCFGR_FPUSEC_Msk           (0x1UL << SBS_SECCFGR_FPUSEC_Pos)    /*!< 0x00000008 */
 #define SBS_SECCFGR_FPUSEC               SBS_SECCFGR_FPUSEC_Msk               /*!< FPU SBS security enable */
-#define SBS_SECCFGR_SDCE_SEC_EN_Pos      (31U)
-#define SBS_SECCFGR_SDCE_SEC_EN_Msk      (0x1UL << SBS_SECCFGR_SDCE_SEC_EN_Pos) /*!< 0x80000000 */
-#define SBS_SECCFGR_SDCE_SEC_EN          SBS_SECCFGR_SDCE_SEC_EN_Msk            /*!< SMPS SBS security enable */
 
 /******************  Bit definition for SBS_CNSLCKR register  **************/
 #define SBS_CNSLCKR_LOCKNSVTOR_Pos       (0U)
@@ -19666,7 +19692,7 @@ typedef struct
 #define GTZC_TZSC_MPCWMR_SUBZ_LENGTH        GTZC_TZSC_MPCWMR_SUBZ_LENGTH_Msk
 
 /*******  Bits definition for TZSC _SECCFGRx/_PRIVCFGRx registers  *****/
-/*******  Bits definition for TZIC _IERx/_SRx/_IFCRx registers  ********/
+/*******  Bits definition for TZIC _IERx/_SRx/_IFCRx registers     *****/
 
 /***************  Bits definition for register x=1 (TZSC1) *************/
 #define GTZC_CFGR1_TIM2_Pos                 (0U)
@@ -19733,7 +19759,6 @@ typedef struct
 #define GTZC_CFGR1_DTS_Msk                  (0x01UL << GTZC_CFGR1_DTS_Pos)
 #define GTZC_CFGR1_LPTIM2_Pos               (31U)
 #define GTZC_CFGR1_LPTIM2_Msk               (0x01UL << GTZC_CFGR1_LPTIM2_Pos)
-
 
 /***************  Bits definition for register x=2 (TZSC1) *************/
 #define GTZC_CFGR2_FDCAN1_Pos               (0U)
@@ -19834,6 +19859,7 @@ typedef struct
 #define GTZC_CFGR4_FLASH_Msk                (0x01UL << GTZC_CFGR4_FLASH_Pos)
 #define GTZC_CFGR4_FLASH_REG_Pos            (3U)
 #define GTZC_CFGR4_FLASH_REG_Msk            (0x01UL << GTZC_CFGR4_FLASH_REG_Pos)
+
 #define GTZC_CFGR4_OTFDEC1_Pos              (4U)
 #define GTZC_CFGR4_OTFDEC1_Msk              (0x01UL << GTZC_CFGR4_OTFDEC1_Pos)
 #define GTZC_CFGR4_SBS_Pos                  (6U)
@@ -19937,14 +19963,13 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Pos          GTZC_CFGR1_LPTIM2_Pos
 #define GTZC_TZSC1_SECCFGR1_LPTIM2_Msk          GTZC_CFGR1_LPTIM2_Msk
 
-
 /*******************  Bits definition for GTZC_TZSC_SECCFGR2 register  ***************/
 #define GTZC_TZSC1_SECCFGR2_FDCAN1_Pos          GTZC_CFGR2_FDCAN1_Pos
 #define GTZC_TZSC1_SECCFGR2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
 #define GTZC_TZSC1_SECCFGR2_FDCAN2_Pos          GTZC_CFGR2_FDCAN2_Pos
 #define GTZC_TZSC1_SECCFGR2_FDCAN2_Msk          GTZC_CFGR2_FDCAN2_Msk
-#define GTZC_TZSC1_SECCFGR2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZSC1_SECCFGR2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZSC1_SECCFGR2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZSC1_SECCFGR2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZSC1_SECCFGR2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZSC1_SECCFGR2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZSC1_SECCFGR2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -20028,6 +20053,7 @@ typedef struct
 #define GTZC_TZSC1_SECCFGR3_RAMCFG_Pos          GTZC_CFGR3_RAMCFG_Pos
 #define GTZC_TZSC1_SECCFGR3_RAMCFG_Msk          GTZC_CFGR3_RAMCFG_Msk
 
+
 /*******************  Bits definition for GTZC_TZSC_PRIVCFGR1 register  ***************/
 #define GTZC_TZSC1_PRIVCFGR1_TIM2_Pos           GTZC_CFGR1_TIM2_Pos
 #define GTZC_TZSC1_PRIVCFGR1_TIM2_Msk           GTZC_CFGR1_TIM2_Msk
@@ -20099,8 +20125,8 @@ typedef struct
 #define GTZC_TZSC1_PRIVCFGR2_FDCAN1_Msk         GTZC_CFGR2_FDCAN1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_FDCAN2_Pos         GTZC_CFGR2_FDCAN2_Pos
 #define GTZC_TZSC1_PRIVCFGR2_FDCAN2_Msk         GTZC_CFGR2_FDCAN2_Msk
-#define GTZC_TZSC1_PRIVCFGR2_UCPD_Pos           GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZSC1_PRIVCFGR2_UCPD_Msk           GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZSC1_PRIVCFGR2_UCPD1_Pos          GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZSC1_PRIVCFGR2_UCPD1_Msk          GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_TIM1_Pos           GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZSC1_PRIVCFGR2_TIM1_Msk           GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZSC1_PRIVCFGR2_SPI1_Pos           GTZC_CFGR2_SPI1_Pos
@@ -20255,8 +20281,8 @@ typedef struct
 #define GTZC_TZIC1_IER2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
 #define GTZC_TZIC1_IER2_FDCAN2_Pos          GTZC_CFGR2_FDCAN2_Pos
 #define GTZC_TZIC1_IER2_FDCAN2_Msk          GTZC_CFGR2_FDCAN2_Msk
-#define GTZC_TZIC1_IER2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_IER2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_IER2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_IER2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_IER2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_IER2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_IER2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -20297,7 +20323,6 @@ typedef struct
 #define GTZC_TZIC1_IER2_LPTIM4_Msk          GTZC_CFGR2_LPTIM4_Msk
 #define GTZC_TZIC1_IER2_LPTIM5_Pos          GTZC_CFGR2_LPTIM5_Pos
 #define GTZC_TZIC1_IER2_LPTIM5_Msk          GTZC_CFGR2_LPTIM5_Msk
-
 
 /*******************  Bits definition for GTZC_TZIC_IER3 register  ***************/
 #define GTZC_TZIC1_IER3_LPTIM6_Pos          GTZC_CFGR3_LPTIM6_Pos
@@ -20458,8 +20483,8 @@ typedef struct
 #define GTZC_TZIC1_SR2_FDCAN1_Msk           GTZC_CFGR2_FDCAN1_Msk
 #define GTZC_TZIC1_SR2_FDCAN2_Pos           GTZC_CFGR2_FDCAN2_Pos
 #define GTZC_TZIC1_SR2_FDCAN2_Msk           GTZC_CFGR2_FDCAN2_Msk
-#define GTZC_TZIC1_SR2_UCPD_Pos             GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_SR2_UCPD_Msk             GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_SR2_UCPD1_Pos            GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_SR2_UCPD1_Msk            GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_SR2_TIM1_Pos             GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_SR2_TIM1_Msk             GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_SR2_SPI1_Pos             GTZC_CFGR2_SPI1_Pos
@@ -20660,8 +20685,8 @@ typedef struct
 #define GTZC_TZIC1_FCR2_FDCAN1_Msk          GTZC_CFGR2_FDCAN1_Msk
 #define GTZC_TZIC1_FCR2_FDCAN2_Pos          GTZC_CFGR2_FDCAN2_Pos
 #define GTZC_TZIC1_FCR2_FDCAN2_Msk          GTZC_CFGR2_FDCAN2_Msk
-#define GTZC_TZIC1_FCR2_UCPD_Pos            GTZC_CFGR2_UCPD_Pos
-#define GTZC_TZIC1_FCR2_UCPD_Msk            GTZC_CFGR2_UCPD_Msk
+#define GTZC_TZIC1_FCR2_UCPD1_Pos           GTZC_CFGR2_UCPD1_Pos
+#define GTZC_TZIC1_FCR2_UCPD1_Msk           GTZC_CFGR2_UCPD1_Msk
 #define GTZC_TZIC1_FCR2_TIM1_Pos            GTZC_CFGR2_TIM1_Pos
 #define GTZC_TZIC1_FCR2_TIM1_Msk            GTZC_CFGR2_TIM1_Msk
 #define GTZC_TZIC1_FCR2_SPI1_Pos            GTZC_CFGR2_SPI1_Pos
@@ -21239,6 +21264,7 @@ typedef struct
 /*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
 /*                                                                            */
 /******************************************************************************/
+#define USART_DMAREQUESTS_SW_WA
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_UE_Pos                    (0U)
 #define USART_CR1_UE_Msk                    (0x1UL << USART_CR1_UE_Pos)             /*!< 0x00000001 */
@@ -22563,6 +22589,15 @@ typedef struct
 #define I3C_BCR_BCR2_Pos                    (2U)
 #define I3C_BCR_BCR2_Msk                    (0x1UL << I3C_BCR_BCR2_Pos)             /*!< 0x00000004 */
 #define I3C_BCR_BCR2                        I3C_BCR_BCR2_Msk                        /*!< IBI Payload additional Mandatory Data Byte */
+#define I3C_BCR_BCR3_Pos                    (3U)
+#define I3C_BCR_BCR3_Msk                    (0x1UL << I3C_BCR_BCR3_Pos)             /*!< 0x00000008 */
+#define I3C_BCR_BCR3                        I3C_BCR_BCR3_Msk                        /*!< Offline capable */
+#define I3C_BCR_BCR4_Pos                    (4U)
+#define I3C_BCR_BCR4_Msk                    (0x1UL << I3C_BCR_BCR4_Pos)             /*!< 0x00000010 */
+#define I3C_BCR_BCR4                        I3C_BCR_BCR4_Msk                        /*!< Virtual target support */
+#define I3C_BCR_BCR5_Pos                    (5U)
+#define I3C_BCR_BCR5_Msk                    (0x1UL << I3C_BCR_BCR5_Pos)             /*!< 0x00000020 */
+#define I3C_BCR_BCR5                        I3C_BCR_BCR5_Msk                        /*!< Advanced capabilities */
 #define I3C_BCR_BCR6_Pos                    (6U)
 #define I3C_BCR_BCR6_Msk                    (0x1UL << I3C_BCR_BCR6_Pos)             /*!< 0x00000040 */
 #define I3C_BCR_BCR6                        I3C_BCR_BCR6_Msk                        /*!< Device Role shared during Dynamic Address Assignment */
@@ -23435,6 +23470,12 @@ typedef struct
 #define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
 #define USB_PMA_RXBD_COUNTMSK                      (0x03FFFFFFUL)
 
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE                                  (2048U)           /*!< USB PMA Size 2Kbyte */
+
+#define USB_DRD_FS_EP_NBR                                    (8U)           /*!< Number of USB Device endpoints */
+#define USB_DRD_FS_CH_NBR                                    (8U)           /*!< Number of USB Host channels */
+
 
 /******************************************************************************/
 /*                                                                            */
@@ -23773,7 +23814,6 @@ typedef struct
 /******************************* PKA Instances ********************************/
 #define IS_PKA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == PKA_NS) || ((INSTANCE) == PKA_S))
 
-
 /******************************* CORDIC Instances *****************************/
 #define IS_CORDIC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == CORDIC_NS) || ((INSTANCE) == CORDIC_S))
 
@@ -23817,6 +23857,11 @@ typedef struct
                                                  ((INSTANCE) == GPDMA1_Channel7_NS)  || ((INSTANCE) == GPDMA1_Channel7_S)  || \
                                                  ((INSTANCE) == GPDMA2_Channel6_NS)  || ((INSTANCE) == GPDMA2_Channel6_S)  || \
                                                  ((INSTANCE) == GPDMA2_Channel7_NS)  || ((INSTANCE) == GPDMA2_Channel7_S))
+
+#define IS_DMA_PFREQ_INSTANCE(INSTANCE) (((INSTANCE) == GPDMA1_Channel0_NS)  || ((INSTANCE) == GPDMA1_Channel0_S)  || \
+                                         ((INSTANCE) == GPDMA1_Channel7_NS)  || ((INSTANCE) == GPDMA1_Channel7_S)  || \
+                                         ((INSTANCE) == GPDMA2_Channel0_NS)  || ((INSTANCE) == GPDMA2_Channel0_S)  || \
+                                         ((INSTANCE) == GPDMA2_Channel7_NS)  || ((INSTANCE) == GPDMA2_Channel7_S))
 
 /****************************** OTFDEC Instances ********************************/
 #define IS_OTFDEC_ALL_INSTANCE(INSTANCE) (((INSTANCE) == OTFDEC1_NS) || ((INSTANCE) == OTFDEC1_S))
@@ -24346,6 +24391,9 @@ typedef struct
                                          ((INSTANCE) == TIM16_NS) || ((INSTANCE) == TIM16_S)|| \
                                          ((INSTANCE) == TIM17_NS) || ((INSTANCE) == TIM17_S))
 
+/******************* TIM Instances : supporting bitfield RTCPREEN in OR1 register  ********************/
+#define IS_TIM_RTCPREEN_INSTANCE(INSTANCE) (((INSTANCE) == TIM17_NS)  || ((INSTANCE) == TIM17_S))
+
 /****************** TIM Instances : Advanced timer instances *******************/
 #define IS_TIM_ADVANCED_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1_NS)  || ((INSTANCE) == TIM1_S) || \
                                                   ((INSTANCE) == TIM8_NS)  || ((INSTANCE) == TIM8_S))
@@ -24542,7 +24590,6 @@ typedef struct
 
 /******************************* USB DRD FS PCD Instances *************************/
 #define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS_NS) || ((INSTANCE) == USB_DRD_FS_S))
-
 
 /** @} */ /* End of group STM32H5xx_Peripheral_Exported_macros */
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h5xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h5xx.h
@@ -8,8 +8,8 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The STM32H5xx device used in the target application
-  *              - To use or not the peripheral's drivers in application code(i.e.
-  *                code will be based on direct access to peripheral's registers
+  *              - To use or not the peripheral’s drivers in application code(i.e.
+  *                code will be based on direct access to peripheral’s registers
   *                rather than drivers API), this option is controlled by
   *                "#define USE_HAL_DRIVER"
   *
@@ -57,12 +57,15 @@
    application
   */
 
-#if !defined (STM32H573xx)  && !defined (STM32H563xx) \
-    && !defined (STM32H562xx) && !defined (STM32H503xx)
-  /* #define STM32H573xx  */   /*!< STM32H5753xx Devices  */
+#if !defined (STM32H573xx) && !defined (STM32H563xx)    \
+    && !defined (STM32H562xx) && !defined (STM32H503xx) \
+    && !defined (STM32H533xx) && !defined (STM32H523xx)
+  /* #define STM32H573xx  */   /*!< STM32H573xx Devices   */
   /* #define STM32H563xx  */   /*!< STM32H563xx Devices   */
   /* #define STM32H562xx  */   /*!< STM32H562xx Devices   */
-  /* #define STM32H503xx  */   /*!< STM32H503xx Devices   */  
+  /* #define STM32H503xx  */   /*!< STM32H503xx Devices   */
+  /* #define STM32H533xx  */   /*!< STM32H533xx Devices   */
+  /* #define STM32H523xx  */   /*!< STM32H523xx Devices   */  
 #endif
 
 /*  Tip: To avoid modifying this file each time you need to switch between these
@@ -78,12 +81,12 @@
 #endif /* USE_HAL_DRIVER */
 
 /**
-  * @brief CMSIS Device version number 1.1.0
+  * @brief CMSIS Device version number 1.3.0
   */
-#define __STM32H5_CMSIS_VERSION_MAIN   (0x01) /*!< [31:24] main version */
-#define __STM32H5_CMSIS_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
-#define __STM32H5_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
-#define __STM32H5_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32H5_CMSIS_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
+#define __STM32H5_CMSIS_VERSION_SUB1   (0x03U) /*!< [23:16] sub1 version */
+#define __STM32H5_CMSIS_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
+#define __STM32H5_CMSIS_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32H5_CMSIS_VERSION        ((__STM32H5_CMSIS_VERSION_MAIN << 24U)\
                                        |(__STM32H5_CMSIS_VERSION_SUB1 << 16U)\
                                        |(__STM32H5_CMSIS_VERSION_SUB2 << 8U )\
@@ -96,7 +99,6 @@
 /** @addtogroup Device_Included
   * @{
   */
-
 #if defined(STM32H573xx)
   #include "stm32h573xx.h"
 #elif defined(STM32H563xx)
@@ -105,6 +107,10 @@
   #include "stm32h562xx.h"
 #elif defined(STM32H503xx)
   #include "stm32h503xx.h"
+#elif defined(STM32H523xx)
+  #include "stm32h523xx.h"
+#elif defined(STM32H533xx)
+  #include "stm32h533xx.h"
 #else
   #error "Please select first the target STM32H5xx device used in your application (in stm32h5xx.h file)"
 #endif

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h5xx.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMSIS/stm32h5xx.h
@@ -8,8 +8,8 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The STM32H5xx device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e.
-  *                code will be based on direct access to peripheral’s registers
+  *              - To use or not the peripheral drivers in application code(i.e.
+  *                code will be based on direct access to peripherals' registers
   *                rather than drivers API), this option is controlled by
   *                "#define USE_HAL_DRIVER"
   *

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
@@ -118,9 +118,6 @@ target_sources(mbed-stm32h5cube-fw
         # HAL driver for i3c is enabled due to a circular include issue.
 )
 
-# Silence warning
-set_property(SOURCE STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c PROPERTY COMPILE_OPTIONS -Wno-old-style-declaration)
-
 target_include_directories(mbed-stm32h5cube-fw
     INTERFACE
         .

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
@@ -97,7 +97,6 @@ target_sources(mbed-stm32h5cube-fw
         STM32H5xx_HAL_Driver/stm32h5xx_ll_fmc.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_gpio.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_i2c.c
-        STM32H5xx_HAL_Driver/stm32h5xx_ll_i3c.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_icache.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_lptim.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_lpuart.c
@@ -114,6 +113,9 @@ target_sources(mbed-stm32h5cube-fw
         STM32H5xx_HAL_Driver/stm32h5xx_ll_usb.c
         STM32H5xx_HAL_Driver/stm32h5xx_ll_utils.c
         STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.c
+
+        # NOTE: Don't compile stm32h5xx_ll_i3c.c, it does not build if the
+        # HAL driver for i3c is enabled due to a circular include issue.
 )
 
 # Silence warning

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/CMakeLists.txt
@@ -116,6 +116,9 @@ target_sources(mbed-stm32h5cube-fw
         STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.c
 )
 
+# Silence warning
+set_property(SOURCE STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c PROPERTY COMPILE_OPTIONS -Wno-old-style-declaration)
+
 target_include_directories(mbed-stm32h5cube-fw
     INTERFACE
         .

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/Note_add_new_STM32_family.md
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/Note_add_new_STM32_family.md
@@ -1,15 +1,12 @@
 # How to add new STM32 family
 1. 	In path mbed-os\targets\TARGET_STM\ add new family folder, in our my case TARGET_STM32H5, and also do not forget add same name into CmakeLists.txt in same folder level.
 2.	In path mbed-os\targets\TARGET_STM\TARGET_STM32H5\ prepare another folders. First is STM32Cube_FW and second CMSIS
-3. 	Visit https://github.com/STMicroelectronics. Select package for your family and chose latest tag. Then download it as a zip.
-	For example https://github.com/STMicroelectronics/STM32CubeH5/tree/v1.1.0
-4. 	Exctract the STM32CubeH5-1.1.0.zip 
-6.	From STM32CubeH5-1.1.0\STM32CubeH5-1.1.0\Drivers\CMSIS\Device\ST\STM32H5xx\Source\Templates copy system_stm32h5xx.c into mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\
-5.	From STM32CubeH5-1.1.0\Drivers\CMSIS\Device\ST\STM32H5xx\Include\ copy all .h files into  mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\CMSIS\
-6. 	From STM32CubeH5-1.1.0\Drivers copy dolder STM32H5xx_HAL_Driver folder into mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\
-8. 	In mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\STM32H5xx_HAL_Driver could be deleted everyting exclude folders Include and Source. 
-9. 	Whole content of folders Include and Source (from previous point) move to from their folder to one level up. Then delete both folders.
-10.	From folder STM32Cube_FW\STM32H5xx_HAL_Driver move file stm32h5xx_hal_conf_template.h to one folder level up. 
+3. 	Clone or download the [stm32h5xx_hal_driver](https://github.com/STMicroelectronics/stm32h5xx_hal_driver) repository
+4.  Copy `stm32h5xx_hal_driver/*.h` and `stm32h5xx_hal_driver/*.c` (but not the _template files) into `mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\STM32H5xx_HAL_Driver`
+5.  Clone or download [cmsis_device_h5](https://github.com/STMicroelectronics/cmsis_device_h5/tree/main)
+6.  Copy `cmsis_device_h5\Include\*.h` to mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\CMSIS\
+6.	From `cmsis_device_h5\Source\Templates` copy system_stm32h5xx.c into mbed-os\targets\TARGET_STM\TARGET_STM32H5\STM32Cube_FW\
+10.	From `stm32h5xx_hal_driver\Inc` move file stm32h5xx_hal_conf_template.h to one folder level up. 
 	- Rest of templates could be deleted.
 	- The moved file stm32h5xx_hal_conf_template.h should be renamed to stm32h5xx_hal_conf.h
 	- inside of stm32h5xx_hal_conf_template.h file should be all macros #define  USE_HAL_XXXXXXXXX covered by macro #if !defined(USE_HAL_XXXXXXXXX) statement

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/Legacy/stm32_hal_legacy.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/Legacy/stm32_hal_legacy.h
@@ -7,7 +7,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2023 STMicroelectronics.
+  * Copyright (c) 2021 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -275,7 +275,7 @@ extern "C" {
 #define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
 #define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
 
-#if defined(STM32G4) || defined(STM32L5) || defined(STM32H7) || defined (STM32U5)
+#if defined(STM32G4) || defined(STM32H7) || defined (STM32U5)
 #define DAC_CHIPCONNECT_DISABLE       DAC_CHIPCONNECT_EXTERNAL
 #define DAC_CHIPCONNECT_ENABLE        DAC_CHIPCONNECT_INTERNAL
 #endif
@@ -548,6 +548,16 @@ extern "C" {
 #define OB_SRAM134_RST_ERASE          OB_SRAM_RST_ERASE
 #define OB_SRAM134_RST_NOT_ERASE      OB_SRAM_RST_NOT_ERASE
 #endif /* STM32U5 */
+#if defined(STM32U0)
+#define OB_USER_nRST_STOP             OB_USER_NRST_STOP
+#define OB_USER_nRST_STDBY            OB_USER_NRST_STDBY
+#define OB_USER_nRST_SHDW             OB_USER_NRST_SHDW
+#define OB_USER_nBOOT_SEL             OB_USER_NBOOT_SEL
+#define OB_USER_nBOOT0                OB_USER_NBOOT0
+#define OB_USER_nBOOT1                OB_USER_NBOOT1
+#define OB_nBOOT0_RESET               OB_NBOOT0_RESET
+#define OB_nBOOT0_SET                 OB_NBOOT0_SET
+#endif /* STM32U0 */
 
 /**
   * @}
@@ -1239,10 +1249,10 @@ extern "C" {
 #define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1
 #define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
 
-#if defined(STM32H5)
+#if defined(STM32H5) || defined(STM32H7RS)
 #define TAMP_SECRETDEVICE_ERASE_NONE        TAMP_DEVICESECRETS_ERASE_NONE
 #define TAMP_SECRETDEVICE_ERASE_BKP_SRAM    TAMP_DEVICESECRETS_ERASE_BKPSRAM
-#endif /* STM32H5 */
+#endif /* STM32H5 || STM32H7RS */
 
 #if defined(STM32WBA)
 #define TAMP_SECRETDEVICE_ERASE_NONE            TAMP_DEVICESECRETS_ERASE_NONE
@@ -1254,10 +1264,10 @@ extern "C" {
 #define TAMP_SECRETDEVICE_ERASE_ALL             TAMP_DEVICESECRETS_ERASE_ALL
 #endif /* STM32WBA */
 
-#if defined(STM32H5) || defined(STM32WBA)
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS)
 #define TAMP_SECRETDEVICE_ERASE_DISABLE     TAMP_DEVICESECRETS_ERASE_NONE
 #define TAMP_SECRETDEVICE_ERASE_ENABLE      TAMP_SECRETDEVICE_ERASE_ALL
-#endif /* STM32H5 || STM32WBA */
+#endif /* STM32H5 || STM32WBA || STM32H7RS */
 
 #if defined(STM32F7)
 #define RTC_TAMPCR_TAMPXE          RTC_TAMPER_ENABLE_BITS_MASK
@@ -1595,6 +1605,8 @@ extern "C" {
 #define ETH_MAC_SMALL_FIFO_RW_ACTIVE          0x00000006U  /* MAC small FIFO read / write controllers active */
 #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   0x00000001U  /* MAC MII receive protocol engine active */
 
+#define ETH_TxPacketConfig        ETH_TxPacketConfigTypeDef   /* Transmit Packet Configuration structure definition */
+
 /**
   * @}
   */
@@ -1805,7 +1817,7 @@ extern "C" {
 #define HAL_FMPI2CEx_AnalogFilter_Config      HAL_FMPI2CEx_ConfigAnalogFilter
 #define HAL_FMPI2CEx_DigitalFilter_Config     HAL_FMPI2CEx_ConfigDigitalFilter
 
-#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) ((cmd == ENABLE)? \
+#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd) == ENABLE)? \
                                                                 HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): \
                                                                 HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
 
@@ -1987,12 +1999,12 @@ extern "C" {
 /** @defgroup HAL_RTC_Aliased_Functions HAL RTC Aliased Functions maintained for legacy purpose
   * @{
   */
-#if defined(STM32H5) || defined(STM32WBA)
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS)
 #define HAL_RTCEx_SetBoothardwareKey            HAL_RTCEx_LockBootHardwareKey
 #define HAL_RTCEx_BKUPBlock_Enable              HAL_RTCEx_BKUPBlock
 #define HAL_RTCEx_BKUPBlock_Disable             HAL_RTCEx_BKUPUnblock
 #define HAL_RTCEx_Erase_SecretDev_Conf          HAL_RTCEx_ConfigEraseDeviceSecrets
-#endif /* STM32H5 || STM32WBA */
+#endif /* STM32H5 || STM32WBA || STM32H7RS */
 
 /**
   * @}
@@ -2307,8 +2319,8 @@ extern "C" {
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F302xE) || defined(STM32F302xC)
+#endif
+#if defined(STM32F302xE) || defined(STM32F302xC)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
@@ -2341,8 +2353,8 @@ extern "C" {
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#endif
+#if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_RISING_EDGE() : \
@@ -2399,8 +2411,8 @@ extern "C" {
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP7_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F373xC) ||defined(STM32F378xx)
+#endif
+#if defined(STM32F373xC) ||defined(STM32F378xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
 #define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
@@ -2417,7 +2429,7 @@ extern "C" {
                                                           __HAL_COMP_COMP2_EXTI_GET_FLAG())
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
-# endif
+#endif
 #else
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
@@ -2719,6 +2731,12 @@ extern "C" {
 #define __APB1_RELEASE_RESET __HAL_RCC_APB1_RELEASE_RESET
 #define __APB2_FORCE_RESET __HAL_RCC_APB2_FORCE_RESET
 #define __APB2_RELEASE_RESET __HAL_RCC_APB2_RELEASE_RESET
+#if defined(STM32C0)
+#define __HAL_RCC_APB1_FORCE_RESET    __HAL_RCC_APB1_GRP1_FORCE_RESET
+#define __HAL_RCC_APB1_RELEASE_RESET  __HAL_RCC_APB1_GRP1_RELEASE_RESET
+#define __HAL_RCC_APB2_FORCE_RESET    __HAL_RCC_APB1_GRP2_FORCE_RESET
+#define __HAL_RCC_APB2_RELEASE_RESET  __HAL_RCC_APB1_GRP2_RELEASE_RESET
+#endif /* STM32C0 */
 #define __BKP_CLK_DISABLE __HAL_RCC_BKP_CLK_DISABLE
 #define __BKP_CLK_ENABLE __HAL_RCC_BKP_CLK_ENABLE
 #define __BKP_FORCE_RESET __HAL_RCC_BKP_FORCE_RESET
@@ -3642,8 +3660,12 @@ extern "C" {
 #define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
 #define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
 
+#if defined(STM32U0)
+#define RCC_SYSCLKSOURCE_STATUS_PLLR   RCC_SYSCLKSOURCE_STATUS_PLLCLK
+#endif
+
 #if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5) || \
-    defined(STM32WL) || defined(STM32C0)
+      defined(STM32WL) || defined(STM32C0) || defined(STM32H7RS) || defined(STM32U0)
 #define RCC_RTCCLKSOURCE_NO_CLK     RCC_RTCCLKSOURCE_NONE
 #else
 #define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
@@ -3745,8 +3767,10 @@ extern "C" {
 #define __HAL_RCC_GET_DFSDM_SOURCE  __HAL_RCC_GET_DFSDM1_SOURCE
 #define RCC_DFSDM1CLKSOURCE_PCLK    RCC_DFSDM1CLKSOURCE_PCLK2
 #define RCC_SWPMI1CLKSOURCE_PCLK    RCC_SWPMI1CLKSOURCE_PCLK1
+#if !defined(STM32U0)
 #define RCC_LPTIM1CLKSOURCE_PCLK    RCC_LPTIM1CLKSOURCE_PCLK1
 #define RCC_LPTIM2CLKSOURCE_PCLK    RCC_LPTIM2CLKSOURCE_PCLK1
+#endif
 
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB1    RCC_DFSDM1AUDIOCLKSOURCE_I2S1
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB2    RCC_DFSDM1AUDIOCLKSOURCE_I2S2
@@ -3892,7 +3916,8 @@ extern "C" {
   */
 #if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || \
     defined (STM32L4P5xx)|| defined (STM32L4Q5xx) || defined (STM32G4) || defined (STM32WL) || defined (STM32U5) || \
-    defined (STM32WBA) || defined (STM32H5) || defined (STM32C0)
+    defined (STM32WBA) || defined (STM32H5) || \
+    defined (STM32C0) || defined (STM32H7RS) ||  defined (STM32U0)
 #else
 #define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
 #endif
@@ -3929,7 +3954,8 @@ extern "C" {
 
 #if defined (STM32F0) || defined (STM32F2) || defined (STM32F3) || defined (STM32F4) || defined (STM32F7) || \
     defined (STM32H7) || \
-    defined (STM32L0) || defined (STM32L1)
+    defined (STM32L0) || defined (STM32L1) || \
+    defined (STM32WB)
 #define __HAL_RTC_TAMPER_GET_IT                   __HAL_RTC_TAMPER_GET_FLAG
 #endif
 
@@ -4214,6 +4240,9 @@ extern "C" {
 #define __HAL_TIM_GetCompare            __HAL_TIM_GET_COMPARE
 
 #define TIM_BREAKINPUTSOURCE_DFSDM  TIM_BREAKINPUTSOURCE_DFSDM1
+
+#define TIM_OCMODE_ASSYMETRIC_PWM1      TIM_OCMODE_ASYMMETRIC_PWM1
+#define TIM_OCMODE_ASSYMETRIC_PWM2      TIM_OCMODE_ASYMMETRIC_PWM2
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal.c
@@ -48,10 +48,10 @@
 /* Private typedef ---------------------------------------------------------------------------------------------------*/
 /* Private define ----------------------------------------------------------------------------------------------------*/
 /**
-  * @brief STM32H5xx HAL Driver version number 1.1.0
+  * @brief STM32H5xx HAL Driver version number 1.3.0
    */
 #define __STM32H5XX_HAL_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
-#define __STM32H5XX_HAL_VERSION_SUB1   (0x01U) /*!< [23:16] sub1 version */
+#define __STM32H5XX_HAL_VERSION_SUB1   (0x03U) /*!< [23:16] sub1 version */
 #define __STM32H5XX_HAL_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
 #define __STM32H5XX_HAL_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32H5XX_HAL_VERSION         ((__STM32H5XX_HAL_VERSION_MAIN << 24U)\
@@ -132,8 +132,8 @@ HAL_TickFreqTypeDef uwTickFreq = HAL_TICK_FREQ_DEFAULT;  /* 1KHz */
   * @note   HAL_Init() function is called at the beginning of program after reset and before
   *         the clock configuration.
   *
-  * @note   In the default implementation the System Timer (Systick) is used as source of time base.
-  *         The Systick configuration is based on HSI clock, as HSI is the clock
+  * @note   In the default implementation the System Timer (SysTick) is used as source of time base.
+  *         The SysTick configuration is based on HSI clock, as HSI is the clock
   *         used after a system Reset and the NVIC configuration is set to Priority group 4.
   *         Once done, time base tick starts incrementing: the tick variable counter is incremented
   *         each 1ms in the SysTick_Handler() interrupt handler.
@@ -152,6 +152,9 @@ HAL_StatusTypeDef HAL_Init(void)
 
   /* Update the SystemCoreClock global variable */
   SystemCoreClock = HAL_RCC_GetSysClockFreq() >> AHBPrescTable[(RCC->CFGR2 & RCC_CFGR2_HPRE) >> RCC_CFGR2_HPRE_Pos];
+
+  /* Select HCLK as SysTick clock source */
+  HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
   if (HAL_InitTick(TICK_INT_PRIORITY) != HAL_OK)
@@ -241,28 +244,56 @@ __weak void HAL_MspDeInit(void)
   */
 __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
+  uint32_t ticknumber = 0U;
+  uint32_t systicksel;
+
   /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero)*/
   if ((uint32_t)uwTickFreq == 0UL)
   {
     return HAL_ERROR;
   }
 
+  /* Check Clock source to calculate the tickNumber */
+  if (READ_BIT(SysTick->CTRL, SysTick_CTRL_CLKSOURCE_Msk) == SysTick_CTRL_CLKSOURCE_Msk)
+  {
+    /* HCLK selected as SysTick clock source */
+    ticknumber = SystemCoreClock / (1000UL / (uint32_t)uwTickFreq);
+  }
+  else
+  {
+    systicksel = HAL_SYSTICK_GetCLKSourceConfig();
+    switch (systicksel)
+    {
+      /* HCLK_DIV8 selected as SysTick clock source */
+      case SYSTICK_CLKSOURCE_HCLK_DIV8:
+        /* Calculate tick value */
+        ticknumber = (SystemCoreClock / (8000UL / (uint32_t)uwTickFreq));
+        break;
+      /* LSI selected as SysTick clock source */
+      case SYSTICK_CLKSOURCE_LSI:
+        /* Calculate tick value */
+        ticknumber = (LSI_VALUE / (1000UL / (uint32_t)uwTickFreq));
+        break;
+      /* LSE selected as SysTick clock source */
+      case SYSTICK_CLKSOURCE_LSE:
+        /* Calculate tick value */
+        ticknumber = (LSE_VALUE / (1000UL / (uint32_t)uwTickFreq));
+        break;
+      default:
+        /* Nothing to do */
+        break;
+    }
+  }
+
   /* Configure the SysTick to have interrupt in 1ms time basis*/
-  if (HAL_SYSTICK_Config(SystemCoreClock / (1000UL / (uint32_t)uwTickFreq)) > 0U)
+  if (HAL_SYSTICK_Config(ticknumber) > 0U)
   {
     return HAL_ERROR;
   }
 
   /* Configure the SysTick IRQ priority */
-  if (TickPriority < (1UL << __NVIC_PRIO_BITS))
-  {
-    HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority, 0U);
-    uwTickPrio = TickPriority;
-  }
-  else
-  {
-    return HAL_ERROR;
-  }
+  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority, 0U);
+  uwTickPrio = TickPriority;
 
   /* Return function status */
   return HAL_OK;
@@ -296,7 +327,7 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   * @brief This function is called to increment a global variable "uwTick"
   *        used as application time base.
   * @note In the default implementation, this variable is incremented each 1ms
-  *       in Systick ISR.
+  *       in SysTick ISR.
   * @note This function is declared as __weak to be overwritten in case of other
   *      implementations in user file.
   * @retval None

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal.h
@@ -202,8 +202,8 @@ extern HAL_TickFreqTypeDef      uwTickFreq;
 /** @defgroup SBS_EPOCH_Selection  EPOCH Selection
   * @{
   */
-#define SBS_EPOCH_SEL_SECURE             0x0UL                         /*!< EPOCH secure selected */
-#define SBS_EPOCH_SEL_NONSECURE          SBS_EPOCHSELCR_EPOCH_SEL_0    /*!< EPOCH non secure selected */
+#define SBS_EPOCH_SEL_NONSECURE          0x0UL                         /*!< EPOCH non secure selected */
+#define SBS_EPOCH_SEL_SECURE             SBS_EPOCHSELCR_EPOCH_SEL_0    /*!< EPOCH secure selected */
 #define SBS_EPOCH_SEL_PUFCHECK           SBS_EPOCHSELCR_EPOCH_SEL_1    /*!< EPOCH all zeros for PUF integrity check */
 
 #define IS_SBS_EPOCH_SELECTION(SELECT) (((SELECT) == SBS_EPOCH_SEL_SECURE)    || \
@@ -231,9 +231,9 @@ extern HAL_TickFreqTypeDef      uwTickFreq;
   * @{
   */
 #define SBS_HDPL_VALUE_0                     0x000000B4U   /*!< Hide protection level 0 */
-#define SBS_HDPL_VALUE_1                     0x00000051U   /*!< Hide protection level 0 */
-#define SBS_HDPL_VALUE_2                     0x0000008AU   /*!< Hide protection level 0 */
-#define SBS_HDPL_VALUE_3                     0x0000006FU   /*!< Hide protection level 0 */
+#define SBS_HDPL_VALUE_1                     0x00000051U   /*!< Hide protection level 1 */
+#define SBS_HDPL_VALUE_2                     0x0000008AU   /*!< Hide protection level 2 */
+#define SBS_HDPL_VALUE_3                     0x0000006FU   /*!< Hide protection level 3 */
 /**
   * @}
   */
@@ -278,8 +278,7 @@ extern HAL_TickFreqTypeDef      uwTickFreq;
 #define SBS_CLK                     SBS_SECCFGR_SBSSEC      /*!< SBS clock control */
 #define SBS_CLASSB                  SBS_SECCFGR_CLASSBSEC   /*!< Class B */
 #define SBS_FPU                     SBS_SECCFGR_FPUSEC      /*!< FPU */
-#define SBS_SMPS                    SBS_SECCFGR_SDCE_SEC_EN /*!< SMPS */
-#define SBS_ALL                     (SBS_CLK | SBS_CLASSB | SBS_FPU | SBS_SMPS) /*!< All */
+#define SBS_ALL                     (SBS_CLK | SBS_CLASSB | SBS_FPU) /*!< All */
 /**
   * @}
   */
@@ -667,7 +666,6 @@ extern HAL_TickFreqTypeDef      uwTickFreq;
 #define IS_SBS_ITEMS_ATTRIBUTES(__ITEM__) ((((__ITEM__) & SBS_CLK)    == SBS_CLK)    || \
                                            (((__ITEM__) & SBS_CLASSB) == SBS_CLASSB) || \
                                            (((__ITEM__) & SBS_FPU)    == SBS_FPU)    || \
-                                           (((__ITEM__) & SBS_SMPS)   == SBS_SMPS)  || \
                                            (((__ITEM__) & ~(SBS_ALL)) == 0U))
 
 #define IS_SBS_ATTRIBUTES(__ATTRIBUTES__) (((__ATTRIBUTES__) == SBS_SEC)  ||\

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_adc.h
@@ -1755,6 +1755,30 @@ __LL_ADC_CALC_DATA_TO_VOLTAGE((__VREFANALOG_VOLTAGE__),\
                               (__ADC_RESOLUTION__))
 
 /**
+  * @brief  Helper macro to calculate the voltage (unit: mVolt)
+  *         corresponding to a ADC conversion data (unit: digital value)
+  *         in differential ended mode.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @param  __VREFANALOG_VOLTAGE__ Analog reference voltage (unit: mV)
+  * @param  __ADC_DATA__ ADC conversion data (resolution 12 bits)
+  *                       (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  *         @arg @ref ADC_RESOLUTION_6B
+  * @retval ADC conversion data equivalent voltage value (unit: mVolt)
+  */
+#define __HAL_ADC_CALC_DIFF_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
+                                            __ADC_DATA__,\
+                                            __ADC_RESOLUTION__) \
+__LL_ADC_CALC_DIFF_DATA_TO_VOLTAGE((__VREFANALOG_VOLTAGE__),\
+                                   (__ADC_DATA__),\
+                                   (__ADC_RESOLUTION__))
+
+/**
   * @brief  Helper macro to calculate analog reference voltage (Vref+)
   *         (unit: mVolt) from ADC conversion data of internal voltage
   *         reference VrefInt.

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cordic.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cordic.c
@@ -164,12 +164,12 @@ static void CORDIC_ReadOutDataIncrementPtr(const CORDIC_HandleTypeDef *hcordic, 
 static void CORDIC_DMAInCplt(DMA_HandleTypeDef *hdma);
 static void CORDIC_DMAOutCplt(DMA_HandleTypeDef *hdma);
 static void CORDIC_DMAError(DMA_HandleTypeDef *hdma);
+
 /**
   * @}
   */
 
 /* Exported functions --------------------------------------------------------*/
-
 /** @defgroup CORDIC_Exported_Functions CORDIC Exported Functions
   * @{
   */
@@ -1141,7 +1141,7 @@ void HAL_CORDIC_IRQHandler(CORDIC_HandleTypeDef *hcordic)
         /*Call registered callback*/
         hcordic->CalculateCpltCallback(hcordic);
 #else
-        /*Call legacy weak (surcharged) callback*/
+        /*Call legacy weak callback*/
         HAL_CORDIC_CalculateCpltCallback(hcordic);
 #endif /* USE_HAL_CORDIC_REGISTER_CALLBACKS */
       }
@@ -1282,7 +1282,7 @@ static void CORDIC_DMAInCplt(DMA_HandleTypeDef *hdma)
     /*Call registered callback*/
     hcordic->CalculateCpltCallback(hcordic);
 #else
-    /*Call legacy weak (surcharged) callback*/
+    /*Call legacy weak callback*/
     HAL_CORDIC_CalculateCpltCallback(hcordic);
 #endif /* USE_HAL_CORDIC_REGISTER_CALLBACKS */
   }
@@ -1311,7 +1311,7 @@ static void CORDIC_DMAOutCplt(DMA_HandleTypeDef *hdma)
   /*Call registered callback*/
   hcordic->CalculateCpltCallback(hcordic);
 #else
-  /*Call legacy weak (surcharged) callback*/
+  /*Call legacy weak callback*/
   HAL_CORDIC_CalculateCpltCallback(hcordic);
 #endif /* USE_HAL_CORDIC_REGISTER_CALLBACKS */
 }
@@ -1336,7 +1336,7 @@ static void CORDIC_DMAError(DMA_HandleTypeDef *hdma)
   /*Call registered callback*/
   hcordic->ErrorCallback(hcordic);
 #else
-  /*Call legacy weak (surcharged) callback*/
+  /*Call legacy weak callback*/
   HAL_CORDIC_ErrorCallback(hcordic);
 #endif /* USE_HAL_CORDIC_REGISTER_CALLBACKS */
 }

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cordic.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cordic.h
@@ -149,7 +149,6 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @}
   */
 
-
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup CORDIC_Exported_Constants CORDIC Exported Constants
   * @{
@@ -166,6 +165,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
 #if USE_HAL_CORDIC_REGISTER_CALLBACKS == 1
 #define HAL_CORDIC_ERROR_INVALID_CALLBACK  ((uint32_t)0x00000010U)   /*!< Invalid Callback error  */
 #endif /* USE_HAL_CORDIC_REGISTER_CALLBACKS */
+
 /**
   * @}
   */
@@ -183,6 +183,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
 #define CORDIC_FUNCTION_HARCTANGENT ((uint32_t)(CORDIC_CSR_FUNC_2 | CORDIC_CSR_FUNC_1 | CORDIC_CSR_FUNC_0))/*!< Hyperbolic Arctangent */
 #define CORDIC_FUNCTION_NATURALLOG  ((uint32_t)(CORDIC_CSR_FUNC_3))                                        /*!< Natural Logarithm */
 #define CORDIC_FUNCTION_SQUAREROOT  ((uint32_t)(CORDIC_CSR_FUNC_3 | CORDIC_CSR_FUNC_0))                    /*!< Square Root */
+
 /**
   * @}
   */
@@ -212,6 +213,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
 #define CORDIC_PRECISION_15CYCLES   ((uint32_t)(CORDIC_CSR_PRECISION_3\
                                                 | CORDIC_CSR_PRECISION_2 | CORDIC_CSR_PRECISION_1\
                                                 |CORDIC_CSR_PRECISION_0))
+
 /**
   * @}
   */
@@ -229,6 +231,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
 #define CORDIC_SCALE_5              ((uint32_t)(CORDIC_CSR_SCALE_2 | CORDIC_CSR_SCALE_0))
 #define CORDIC_SCALE_6              ((uint32_t)(CORDIC_CSR_SCALE_2 | CORDIC_CSR_SCALE_1))
 #define CORDIC_SCALE_7              ((uint32_t)(CORDIC_CSR_SCALE_2 | CORDIC_CSR_SCALE_1 | CORDIC_CSR_SCALE_0))
+
 /**
   * @}
   */
@@ -237,6 +240,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @{
   */
 #define CORDIC_IT_IEN              CORDIC_CSR_IEN            /*!< Result ready interrupt enable */
+
 /**
   * @}
   */
@@ -245,6 +249,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @{
   */
 #define CORDIC_DMA_REN             CORDIC_CSR_DMAREN         /*!< DMA Read requests enable */
+
 /**
   * @}
   */
@@ -253,6 +258,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @{
   */
 #define CORDIC_DMA_WEN             CORDIC_CSR_DMAWEN         /*!< DMA Write channel enable */
+
 /**
   * @}
   */
@@ -288,6 +294,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   */
 #define CORDIC_INSIZE_32BITS       (0x00000000U)             /*!< 32 bits input data size (Q1.31 format) */
 #define CORDIC_INSIZE_16BITS       CORDIC_CSR_ARGSIZE        /*!< 16 bits input data size (Q1.15 format) */
+
 /**
   * @}
   */
@@ -297,6 +304,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   */
 #define CORDIC_OUTSIZE_32BITS      (0x00000000U)             /*!< 32 bits output data size (Q1.31 format) */
 #define CORDIC_OUTSIZE_16BITS      CORDIC_CSR_RESSIZE        /*!< 16 bits output data size (Q1.15 format) */
+
 /**
   * @}
   */
@@ -305,6 +313,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @{
   */
 #define CORDIC_FLAG_RRDY           CORDIC_CSR_RRDY           /*!< Result Ready Flag */
+
 /**
   * @}
   */
@@ -316,6 +325,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
 #define CORDIC_DMA_DIR_IN          ((uint32_t)0x00000001U)   /*!< DMA direction : Input of CORDIC */
 #define CORDIC_DMA_DIR_OUT         ((uint32_t)0x00000002U)   /*!< DMA direction : Output of CORDIC */
 #define CORDIC_DMA_DIR_IN_OUT      ((uint32_t)0x00000003U)   /*!< DMA direction : Input and Output of CORDIC */
+
 /**
   * @}
   */
@@ -336,9 +346,9 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   */
 #if USE_HAL_CORDIC_REGISTER_CALLBACKS == 1
 #define __HAL_CORDIC_RESET_HANDLE_STATE(__HANDLE__) do{                                                \
-                                                        (__HANDLE__)->State = HAL_CORDIC_STATE_RESET;   \
-                                                        (__HANDLE__)->MspInitCallback = NULL;           \
-                                                        (__HANDLE__)->MspDeInitCallback = NULL;         \
+                                                        (__HANDLE__)->State = HAL_CORDIC_STATE_RESET;  \
+                                                        (__HANDLE__)->MspInitCallback = NULL;          \
+                                                        (__HANDLE__)->MspDeInitCallback = NULL;        \
                                                       } while(0)
 #else
 #define __HAL_CORDIC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_CORDIC_STATE_RESET)
@@ -416,7 +426,7 @@ typedef  void (*pCORDIC_CallbackTypeDef)(CORDIC_HandleTypeDef *hcordic);  /*!< p
   * @}
   */
 
-/* Private macros --------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
 /** @defgroup  CORDIC_Private_Macros   CORDIC Private Macros
   * @{
   */
@@ -584,6 +594,7 @@ void HAL_CORDIC_IRQHandler(CORDIC_HandleTypeDef *hcordic);
 /* Peripheral State functions *************************************************/
 HAL_CORDIC_StateTypeDef HAL_CORDIC_GetState(const CORDIC_HandleTypeDef *hcordic);
 uint32_t HAL_CORDIC_GetError(const CORDIC_HandleTypeDef *hcordic);
+
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cortex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cortex.c
@@ -392,7 +392,23 @@ uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn)
   */
 uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
 {
-  return SysTick_Config(TicksNumb);
+  if ((TicksNumb - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    /* Reload value impossible */
+    return (1UL);
+  }
+
+  /* Set reload register */
+  WRITE_REG(SysTick->LOAD, (uint32_t)(TicksNumb - 1UL));
+
+  /* Load the SysTick Counter Value */
+  WRITE_REG(SysTick->VAL, 0UL);
+
+  /* Enable SysTick IRQ and SysTick Timer */
+  SET_BIT(SysTick->CTRL, (SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk));
+
+  /* Function successful */
+  return (0UL);
 }
 
 /**
@@ -434,6 +450,52 @@ void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
       /* Nothing to do */
       break;
   }
+}
+
+/**
+  * @brief  Get the SysTick clock source configuration.
+  * @retval  SysTick clock source that can be one of the following values:
+  *             @arg SYSTICK_CLKSOURCE_LSI: LSI clock selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_LSE: LSE clock selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  */
+uint32_t HAL_SYSTICK_GetCLKSourceConfig(void)
+{
+  uint32_t systick_source;
+  uint32_t systick_rcc_source;
+
+  /* Read SysTick->CTRL register for internal or external clock source */
+  if (READ_BIT(SysTick->CTRL, SysTick_CTRL_CLKSOURCE_Msk) != 0U)
+  {
+    /* Internal clock source */
+    systick_source = SYSTICK_CLKSOURCE_HCLK;
+  }
+  else
+  {
+    /* External clock source, check the selected one in RCC */
+    systick_rcc_source = READ_BIT(RCC->CCIPR4, RCC_CCIPR4_SYSTICKSEL);
+
+    switch (systick_rcc_source)
+    {
+      case (0x00000000U):
+        systick_source = SYSTICK_CLKSOURCE_HCLK_DIV8;
+        break;
+
+      case (RCC_CCIPR4_SYSTICKSEL_0):
+        systick_source = SYSTICK_CLKSOURCE_LSI;
+        break;
+
+      case (RCC_CCIPR4_SYSTICKSEL_1):
+        systick_source = SYSTICK_CLKSOURCE_LSE;
+        break;
+
+      default:
+        systick_source = SYSTICK_CLKSOURCE_HCLK_DIV8;
+        break;
+    }
+  }
+  return systick_source;
 }
 
 /**
@@ -574,6 +636,82 @@ void HAL_MPU_Disable_NS(void)
 #endif /* __ARM_FEATURE_CMSE */
 
 /**
+  * @brief  Enable the MPU Region.
+  * @param  RegionNumber Specifies the index of the region to enable.
+  *         this parameter can be a value of @ref CORTEX_MPU_Region_Number
+  * @retval None
+  */
+void HAL_MPU_EnableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Enable the Region */
+  SET_BIT(MPU->RLAR, MPU_RLAR_EN_Msk);
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  * @brief  Enable the MPU_NS Region.
+  * @param  RegionNumber Specifies the index of the region to enable.
+  *         this parameter can be a value of @ref CORTEX_MPU_Region_Number
+  * @retval None
+  */
+void HAL_MPU_EnableRegion_NS(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER_NS(RegionNumber));
+
+  /* Set the Region number */
+  MPU_NS->RNR = RegionNumber;
+
+  /* Enable the Region */
+  SET_BIT(MPU_NS->RLAR, MPU_RLAR_EN_Msk);
+}
+#endif /* __ARM_FEATURE_CMSE */
+
+/**
+  * @brief  Disable the MPU Region.
+  * @param  RegionNumber Specifies the index of the region to disable.
+  *         this parameter can be a value of @ref CORTEX_MPU_Region_Number
+  * @retval None
+  */
+void HAL_MPU_DisableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Disable the Region */
+  CLEAR_BIT(MPU->RLAR, MPU_RLAR_EN_Msk);
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  * @brief  Disable the MPU_NS Region.
+  * @param  RegionNumber Specifies the index of the region to disable.
+  *         this parameter can be a value of @ref CORTEX_MPU_Region_Number
+  * @retval None
+  */
+void HAL_MPU_DisableRegion_NS(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER_NS(RegionNumber));
+
+  /* Set the Region number */
+  MPU_NS->RNR = RegionNumber;
+
+  /* Disable the Region */
+  CLEAR_BIT(MPU_NS->RLAR, MPU_RLAR_EN_Msk);
+}
+#endif /* __ARM_FEATURE_CMSE */
+
+/**
   * @brief  Initialize and configure the Region and the memory to be protected.
   * @param  pMPU_RegionInit: Pointer to a MPU_Region_InitTypeDef structure that contains
   *                the initialization and configuration information.
@@ -650,6 +788,9 @@ static void MPU_ConfigRegion(MPU_Type *MPUx, const MPU_Region_InitTypeDef *const
 #endif /* __ARM_FEATURE_CMSE */
   assert_param(IS_MPU_REGION_NUMBER(pMPU_RegionInit->Number));
   assert_param(IS_MPU_REGION_ENABLE(pMPU_RegionInit->Enable));
+  assert_param(IS_MPU_INSTRUCTION_ACCESS(pMPU_RegionInit->DisableExec));
+  assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(pMPU_RegionInit->AccessPermission));
+  assert_param(IS_MPU_ACCESS_SHAREABLE(pMPU_RegionInit->IsShareable));
 
   /* Follow ARM recommendation with Data Memory Barrier prior to MPU configuration */
   __DMB();
@@ -657,27 +798,17 @@ static void MPU_ConfigRegion(MPU_Type *MPUx, const MPU_Region_InitTypeDef *const
   /* Set the Region number */
   MPUx->RNR = pMPU_RegionInit->Number;
 
-  if (pMPU_RegionInit->Enable != MPU_REGION_DISABLE)
-  {
-    /* Check the parameters */
-    assert_param(IS_MPU_INSTRUCTION_ACCESS(pMPU_RegionInit->DisableExec));
-    assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(pMPU_RegionInit->AccessPermission));
-    assert_param(IS_MPU_ACCESS_SHAREABLE(pMPU_RegionInit->IsShareable));
+  /* Disable the Region */
+  CLEAR_BIT(MPUx->RLAR, MPU_RLAR_EN_Msk);
 
-    MPUx->RBAR = (((uint32_t)pMPU_RegionInit->BaseAddress               & 0xFFFFFFE0UL)  |
-                  ((uint32_t)pMPU_RegionInit->IsShareable           << MPU_RBAR_SH_Pos)  |
-                  ((uint32_t)pMPU_RegionInit->AccessPermission      << MPU_RBAR_AP_Pos)  |
-                  ((uint32_t)pMPU_RegionInit->DisableExec           << MPU_RBAR_XN_Pos));
+  MPUx->RBAR = (((uint32_t)pMPU_RegionInit->BaseAddress               & 0xFFFFFFE0UL)  |
+                ((uint32_t)pMPU_RegionInit->IsShareable           << MPU_RBAR_SH_Pos)  |
+                ((uint32_t)pMPU_RegionInit->AccessPermission      << MPU_RBAR_AP_Pos)  |
+                ((uint32_t)pMPU_RegionInit->DisableExec           << MPU_RBAR_XN_Pos));
 
-    MPUx->RLAR = (((uint32_t)pMPU_RegionInit->LimitAddress                    & 0xFFFFFFE0UL) |
-                  ((uint32_t)pMPU_RegionInit->AttributesIndex       << MPU_RLAR_AttrIndx_Pos) |
-                  ((uint32_t)pMPU_RegionInit->Enable                << MPU_RLAR_EN_Pos));
-  }
-  else
-  {
-    MPUx->RLAR = 0U;
-    MPUx->RBAR = 0U;
-  }
+  MPUx->RLAR = (((uint32_t)pMPU_RegionInit->LimitAddress                    & 0xFFFFFFE0UL) |
+                ((uint32_t)pMPU_RegionInit->AttributesIndex       << MPU_RLAR_AttrIndx_Pos) |
+                ((uint32_t)pMPU_RegionInit->Enable                << MPU_RLAR_EN_Pos));
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cortex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cortex.h
@@ -157,7 +157,7 @@ typedef struct
   * @{
   */
 #define  MPU_ACCESS_NOT_SHAREABLE        0U /*!< MPU region not shareable   */
-#define  MPU_ACCESS_OUTER_SHAREABLE      1U /*!< MPU region outer shareable */
+#define  MPU_ACCESS_OUTER_SHAREABLE      2U /*!< MPU region outer shareable */
 #define  MPU_ACCESS_INNER_SHAREABLE      3U /*!< MPU region inner shareable */
 /**
   * @}
@@ -282,6 +282,7 @@ uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn);
 /* SYSTICK functions ***********************************************/
 uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
 void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource);
+uint32_t HAL_SYSTICK_GetCLKSourceConfig(void);
 void HAL_SYSTICK_IRQHandler(void);
 void HAL_SYSTICK_Callback(void);
 /**
@@ -295,12 +296,16 @@ void HAL_SYSTICK_Callback(void);
 /* MPU functions ***********************************************/
 void HAL_MPU_Enable(uint32_t MPU_Control);
 void HAL_MPU_Disable(void);
+void HAL_MPU_EnableRegion(uint32_t RegionNumber);
+void HAL_MPU_DisableRegion(uint32_t RegionNumber);
 void HAL_MPU_ConfigRegion(const MPU_Region_InitTypeDef *const pMPU_RegionInit);
 void HAL_MPU_ConfigMemoryAttributes(const MPU_Attributes_InitTypeDef *const pMPU_AttributesInit);
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /* MPU_NS Control functions ***********************************************/
 void HAL_MPU_Enable_NS(uint32_t MPU_Control);
 void HAL_MPU_Disable_NS(void);
+void HAL_MPU_EnableRegion_NS(uint32_t RegionNumber);
+void HAL_MPU_DisableRegion_NS(uint32_t RegionNumber);
 void HAL_MPU_ConfigRegion_NS(const MPU_Region_InitTypeDef *const pMPU_RegionInit);
 void HAL_MPU_ConfigMemoryAttributes_NS(const MPU_Attributes_InitTypeDef *const pMPU_AttributesInit);
 #endif /* __ARM_FEATURE_CMSE */
@@ -368,6 +373,15 @@ void HAL_MPU_ConfigMemoryAttributes_NS(const MPU_Attributes_InitTypeDef *const p
                                          ((NUMBER) == MPU_REGION_NUMBER9) || \
                                          ((NUMBER) == MPU_REGION_NUMBER10)|| \
                                          ((NUMBER) == MPU_REGION_NUMBER11))
+
+#define IS_MPU_REGION_NUMBER_NS(NUMBER) (((NUMBER) == MPU_REGION_NUMBER0) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER1) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER2) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER3) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER4) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER5) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER6) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER7))
 #else
 #define IS_MPU_REGION_NUMBER(NUMBER)    (((NUMBER) == MPU_REGION_NUMBER0) || \
                                          ((NUMBER) == MPU_REGION_NUMBER1) || \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_crc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_crc.c
@@ -200,7 +200,7 @@ HAL_StatusTypeDef HAL_CRC_DeInit(CRC_HandleTypeDef *hcrc)
   __HAL_CRC_DR_RESET(hcrc);
 
   /* Reset IDR register content */
-  CLEAR_BIT(hcrc->Instance->IDR, CRC_IDR_IDR);
+  CLEAR_REG(hcrc->Instance->IDR);
 
   /* DeInit the low level hardware */
   HAL_CRC_MspDeInit(hcrc);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cryp.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_cryp.c
@@ -2005,26 +2005,30 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *pInp
   */
 void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
 {
+  uint32_t itsource   = hcryp->Instance->IER;
+  uint32_t itflagsr   = hcryp->Instance->SR;
+  uint32_t itflagisr  = hcryp->Instance->ISR;
+
   /* Check if Read or write error occurred */
-  if (__HAL_CRYP_GET_IT_SOURCE(hcryp, CRYP_IT_RWEIE) != RESET)
+  if ((itsource & CRYP_IT_RWEIE) != 0U)
   {
     /* If write Error occurred */
-    if (__HAL_CRYP_GET_FLAG(hcryp, CRYP_FLAG_WRERR) != RESET)
+    if ((itflagsr & CRYP_FLAG_WRERR) != 0U)
     {
       hcryp->ErrorCode |= HAL_CRYP_ERROR_WRITE;
       __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CLEAR_RWEIF);
     }
     /* If read Error occurred */
-    if (__HAL_CRYP_GET_FLAG(hcryp, CRYP_FLAG_RDERR) != RESET)
+    if ((itflagsr & CRYP_FLAG_RDERR) != 0U)
     {
       hcryp->ErrorCode |= HAL_CRYP_ERROR_READ;
       __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CLEAR_RWEIF);
     }
   }
   /* Check if Key error occurred */
-  if (__HAL_CRYP_GET_IT_SOURCE(hcryp, CRYP_IT_KEIE) != RESET)
+  if ((itsource & CRYP_IT_KEIE) != 0U)
   {
-    if (__HAL_CRYP_GET_FLAG(hcryp, CRYP_FLAG_KEIF) != RESET)
+    if ((itflagisr & CRYP_FLAG_KEIF) != 0U)
     {
       hcryp->ErrorCode |= HAL_CRYP_ERROR_KEY;
       __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CLEAR_KEIF);
@@ -2033,9 +2037,9 @@ void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
     }
   }
 
-  if (__HAL_CRYP_GET_FLAG(hcryp, CRYP_FLAG_CCF) != RESET)
+  if ((itflagisr & CRYP_FLAG_CCF) != 0U)
   {
-    if (__HAL_CRYP_GET_IT_SOURCE(hcryp, CRYP_IT_CCFIE) != RESET)
+    if ((itsource & CRYP_IT_CCFIE) != 0U)
     {
       /* Clear computation complete flag */
       __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CLEAR_CCF);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dcache.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dcache.c
@@ -944,6 +944,22 @@ uint32_t HAL_DCACHE_Monitor_GetWriteMissValue(const DCACHE_HandleTypeDef *hdcach
 }
 
 /**
+  * @}
+  */
+
+/** @addtogroup DCACHE_Exported_Functions_Group3
+  *
+@verbatim
+  ==============================================================================
+            ##### DCACHE IRQ Handler and Callback functions #####
+  ==============================================================================
+  [..]
+  This section provides functions allowing to treat ISR and provide user callback
+@endverbatim
+  * @{
+  */
+
+/**
   * @brief Handle the Data Cache interrupt request.
   * @param  hdcache Pointer to a DCACHE_HandleTypeDef structure that contains
   *                 the configuration information for the specified DCACHEx peripheral.
@@ -1321,7 +1337,7 @@ __weak void HAL_DCACHE_ErrorCallback(DCACHE_HandleTypeDef *hdcache)
   * @}
   */
 
-/** @addtogroup DCACHE_Exported_Functions_Group3
+/** @addtogroup DCACHE_Exported_Functions_Group4
   *
 @verbatim
  ===============================================================================
@@ -1358,6 +1374,10 @@ uint32_t HAL_DCACHE_GetError(const DCACHE_HandleTypeDef *hdcache)
   /* Return DCACHE handle error code */
   return hdcache->ErrorCode;
 }
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma.h
@@ -663,7 +663,7 @@ typedef struct __DMA_HandleTypeDef
 #endif /* I3C2 */
 
 /* Software request */
-#define DMA_REQUEST_SW                DMA_CTR2_SWREQ /*!< DMA SW request          */
+#define DMA_REQUEST_SW                DMA_CTR2_SWREQ /*!< DMA SW request              */
 /**
   * @}
   */
@@ -805,7 +805,6 @@ typedef struct __DMA_HandleTypeDef
 /**
   * @}
   */
-
 
 
 /**
@@ -1017,11 +1016,11 @@ HAL_StatusTypeDef HAL_DMA_GetConfigChannelAttributes(DMA_HandleTypeDef const *co
 #if defined (DMA_RCFGLOCKR_LOCK0)
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 HAL_StatusTypeDef HAL_DMA_LockChannelAttributes(DMA_HandleTypeDef const *const hdma);
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 HAL_StatusTypeDef HAL_DMA_GetLockChannelAttributes(DMA_HandleTypeDef const *const hdma,
                                                    uint32_t *const pLockState);
 
-#endif /* defined (DMA_RCFGLOCKR_LOCK0) */
+#endif /* DMA_RCFGLOCKR_LOCK0 */
 
 /**
   * @}
@@ -1137,12 +1136,12 @@ HAL_StatusTypeDef HAL_DMA_GetLockChannelAttributes(DMA_HandleTypeDef const *cons
 #define IS_DMA_ATTRIBUTES(ATTRIBUTE)    \
   (((ATTRIBUTE) == DMA_CHANNEL_PRIV) || \
    ((ATTRIBUTE) == DMA_CHANNEL_NPRIV))
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 #define IS_DMA_GLOBAL_ACTIVE_FLAG_S(INSTANCE, GLOBAL_FLAG) \
   (((INSTANCE)->SMISR & (GLOBAL_FLAG)))
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 #define IS_DMA_GLOBAL_ACTIVE_FLAG_NS(INSTANCE, GLOBAL_FLAG) \
   (((INSTANCE)->MISR & (GLOBAL_FLAG)))
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma_ex.c
@@ -25,7 +25,7 @@
   **********************************************************************************************************************
   @verbatim
   ======================================================================================================================
-                                 ############### How to use this driver ###############
+                                 ##### How to use this driver #####
   ======================================================================================================================
     [..]
       Alternatively to the normal programming mode, a DMA channel can be programmed by a list of transfers, known as
@@ -581,7 +581,7 @@ static void DMA_List_CleanQueue(DMA_QListTypeDef *const pQList);
   *
 @verbatim
   ======================================================================================================================
-                 ############### Linked-List Initialization and De-Initialization Functions ###############
+                 ##### Linked-List Initialization and De-Initialization Functions #####
   ======================================================================================================================
     [..]
       This section provides functions allowing to initialize and de-initialize the DMA channel in linked-list mode.
@@ -676,7 +676,6 @@ HAL_StatusTypeDef HAL_DMAEx_List_DeInit(DMA_HandleTypeDef *const hdma)
   /* Get DMA instance */
   DMA_TypeDef *p_dma_instance;
 
-
   /* Get tick number */
   uint32_t tickstart = HAL_GetTick();
 
@@ -692,7 +691,6 @@ HAL_StatusTypeDef HAL_DMAEx_List_DeInit(DMA_HandleTypeDef *const hdma)
 
   /* Get DMA instance */
   p_dma_instance = GET_DMA_INSTANCE(hdma);
-
 
   /* Disable the selected DMA Channel */
   __HAL_DMA_DISABLE(hdma);
@@ -738,7 +736,7 @@ HAL_StatusTypeDef HAL_DMAEx_List_DeInit(DMA_HandleTypeDef *const hdma)
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   /* Clear secure attribute */
   CLEAR_BIT(p_dma_instance->SECCFGR, (1UL << (GET_DMA_CHANNEL(hdma) & 0x1FU)));
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   /* Clear all flags */
   __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_TC | DMA_FLAG_HT | DMA_FLAG_DTE | DMA_FLAG_ULE | DMA_FLAG_USE | DMA_FLAG_SUSP |
@@ -790,7 +788,7 @@ HAL_StatusTypeDef HAL_DMAEx_List_DeInit(DMA_HandleTypeDef *const hdma)
   *
 @verbatim
   ======================================================================================================================
-                         ############### Linked-List IO Operation Functions ###############
+                         ##### Linked-List IO Operation Functions #####
   ======================================================================================================================
     [..]
       This section provides functions allowing to :
@@ -956,7 +954,7 @@ HAL_StatusTypeDef HAL_DMAEx_List_Start_IT(DMA_HandleTypeDef *const hdma)
   *
 @verbatim
   ======================================================================================================================
-                         ############### Linked-List Management Functions ###############
+                         ##### Linked-List Management Functions #####
   ======================================================================================================================
     [..]
       This section provides functions allowing to :
@@ -1103,7 +1101,7 @@ HAL_StatusTypeDef HAL_DMAEx_List_BuildNode(DMA_NodeConfTypeDef const *const pNod
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   assert_param(IS_DMA_ATTRIBUTES(pNodeConfig->SrcSecure));
   assert_param(IS_DMA_ATTRIBUTES(pNodeConfig->DestSecure));
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   /* Build the DMA channel node */
   DMA_List_BuildNode(pNodeConfig, pNode);
@@ -3223,7 +3221,7 @@ HAL_StatusTypeDef HAL_DMAEx_List_UnLinkQ(DMA_HandleTypeDef *const hdma)
   *
 @verbatim
   ======================================================================================================================
-             ############### Data handling, repeated block and trigger configuration functions ###############
+             ##### Data handling, repeated block and trigger configuration functions #####
   ======================================================================================================================
     [..]
       This section provides functions allowing to :
@@ -3449,7 +3447,7 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigRepeatBlock(DMA_HandleTypeDef *const hdma,
   *
 @verbatim
   ======================================================================================================================
-                         ############### Suspend and resume operation functions ###############
+                         ##### Suspend and resume operation functions #####
   ======================================================================================================================
     [..]
       This section provides functions allowing to :
@@ -3612,7 +3610,7 @@ HAL_StatusTypeDef HAL_DMAEx_Resume(DMA_HandleTypeDef *const hdma)
   *
 @verbatim
   ======================================================================================================================
-                               ############### Fifo status function ###############
+                               ##### Fifo status function #####
   ======================================================================================================================
     [..]
       This section provides function allowing to get DMA channel FIFO level.
@@ -3734,7 +3732,7 @@ static void DMA_List_BuildNode(DMA_NodeConfTypeDef const *const pNodeConfig,
   {
     pNode->LinkRegisters[NODE_CTR1_DEFAULT_OFFSET] |= DMA_CTR1_DSEC;
   }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   /* Add parameters related to DMA configuration */
   if ((pNodeConfig->NodeType & DMA_CHANNEL_TYPE_GPDMA) == DMA_CHANNEL_TYPE_GPDMA)
@@ -3972,7 +3970,7 @@ static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
   {
     pNodeConfig->DestSecure = DMA_CHANNEL_DEST_NSEC;
   }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
   /*********************************************************************************** CTR1 fields values are updated */
 
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_dma_ex.h
@@ -150,7 +150,7 @@ typedef struct
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   uint32_t                    SrcSecure;          /*!< Specifies the source security attribute                        */
   uint32_t                    DestSecure;         /*!< Specifies the destination security attribute                   */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 } DMA_NodeConfTypeDef;
 
@@ -235,11 +235,9 @@ typedef struct __DMA_QListTypeDef
                                                            => Left Aligned Right Truncated down to the
                                                               destination data width                             */
 #define DMA_DATA_PACK                  DMA_CTR1_PAM_1 /*!< If source data width < destination data width
-                                                           => Packed at the destination data width
-                                                              (Available only for GPDMA)                         */
+                                                           => Packed at the destination data width               */
 #define DMA_DATA_UNPACK                DMA_CTR1_PAM_1 /*!< If source data width > destination data width
-                                                           => Unpacked at the destination data width
-                                                              (Available only for GPDMA)                         */
+                                                           => Unpacked at the destination data width             */
 /**
   * @}
   */
@@ -345,9 +343,9 @@ typedef struct __DMA_QListTypeDef
 #if defined (COMP1)
 #define GPDMA1_TRIGGER_COMP1_OUT        44U      /*!< GPDMA1 HW Trigger signal is COMP1_OUT       */
 #endif /* COMP1 */
-#if defined (STM32H503xx)
-#define GPDMA1_TRIGGER_EVENTOUT         45U      /*!< GPDMA1 HW Trigger signal is COMP1_OUT       */
-#endif /* STM32H503xx */
+#if defined (STM32H503xx) || defined(STM32H523xx) || defined(STM32H533xx)
+#define GPDMA1_TRIGGER_EVENTOUT         45U      /*!< GPDMA1 HW Trigger signal is EVENTOUT        */
+#endif /* STM32H503xx || STM32H523xx || STM32H533xx */
 
 /* GPDMA2 triggers */
 #define GPDMA2_TRIGGER_EXTI_LINE0       0U       /*!< GPDMA2 HW Trigger signal is EXTI_LINE0      */
@@ -409,9 +407,9 @@ typedef struct __DMA_QListTypeDef
 #if defined (COMP1)
 #define GPDMA2_TRIGGER_COMP1_OUT        44U      /*!< GPDMA2 HW Trigger signal is COMP1_OUT       */
 #endif /* COMP1 */
-#if defined (STM32H503xx)
-#define GPDMA2_TRIGGER_EVENTOUT         45U      /*!< GPDMA2 HW Trigger signal is COMP1_OUT       */
-#endif /* STM32H503xx */
+#if defined (STM32H503xx) || defined(STM32H523xx) || defined(STM32H533xx)
+#define GPDMA2_TRIGGER_EVENTOUT         45U      /*!< GPDMA2 HW Trigger signal is EVENTOUT        */
+#endif /* STM32H503xx || STM32H523xx || STM32H533xx */
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth.c
@@ -250,12 +250,13 @@
 /** @defgroup ETH_Private_Functions   ETH Private Functions
   * @{
   */
-static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf);
-static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf);
+static void ETH_SetMACConfig(ETH_HandleTypeDef *heth, const ETH_MACConfigTypeDef *macconf);
+static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth, const ETH_DMAConfigTypeDef *dmaconf);
 static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth);
 static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth);
 static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth);
-static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t ItMode);
+static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, const ETH_TxPacketConfigTypeDef *pTxConfig,
+                                           uint32_t ItMode);
 static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
@@ -336,7 +337,6 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 
   __HAL_RCC_SBS_CLK_ENABLE();
 
-
   if (heth->Init.MediaInterface == HAL_ETH_MII_MODE)
   {
     HAL_SBS_ETHInterfaceSelect(SBS_ETH_MII);
@@ -410,6 +410,14 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   /* Set MAC addr bits 0 to 31 */
   heth->Instance->MACA0LR = (((uint32_t)(heth->Init.MACAddr[3]) << 24) | ((uint32_t)(heth->Init.MACAddr[2]) << 16) |
                              ((uint32_t)(heth->Init.MACAddr[1]) << 8) | (uint32_t)heth->Init.MACAddr[0]);
+
+  /* Disable Rx MMC Interrupts */
+  SET_BIT(heth->Instance->MMCRIMR, ETH_MMCRIMR_RXLPITRCIM | ETH_MMCRIMR_RXLPIUSCIM | \
+          ETH_MMCRIMR_RXUCGPIM | ETH_MMCRIMR_RXALGNERPIM | ETH_MMCRIMR_RXCRCERPIM);
+
+  /* Disable Tx MMC Interrupts */
+  SET_BIT(heth->Instance->MMCTIMR, ETH_MMCTIMR_TXLPITRCIM | ETH_MMCTIMR_TXLPIUSCIM | \
+          ETH_MMCTIMR_TXGPKTIM | ETH_MMCTIMR_TXMCOLGPIM | ETH_MMCTIMR_TXSCOLGPIM);
 
   heth->ErrorCode = HAL_ETH_ERROR_NONE;
   heth->gState = HAL_ETH_STATE_READY;
@@ -712,7 +720,7 @@ HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
   {
     heth->gState = HAL_ETH_STATE_BUSY;
 
-    /* Set nombre of descriptors to build */
+    /* Set number of descriptors to build */
     heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
 
     /* Build all descriptors */
@@ -760,28 +768,12 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
 
     /* save IT mode to ETH Handle */
     heth->RxDescList.ItMode = 1U;
-    /* Disable Rx MMC Interrupts */
-    SET_BIT(heth->Instance->MMCRIMR, ETH_MMCRIMR_RXLPITRCIM | ETH_MMCRIMR_RXLPIUSCIM | \
-            ETH_MMCRIMR_RXUCGPIM | ETH_MMCRIMR_RXALGNERPIM | ETH_MMCRIMR_RXCRCERPIM);
 
-    /* Disable Tx MMC Interrupts */
-    SET_BIT(heth->Instance->MMCTIMR, ETH_MMCTIMR_TXLPITRCIM | ETH_MMCTIMR_TXLPIUSCIM | \
-            ETH_MMCTIMR_TXGPKTIM | ETH_MMCTIMR_TXMCOLGPIM | ETH_MMCTIMR_TXSCOLGPIM);
-
-    /* Set nombre of descriptors to build */
+    /* Set number of descriptors to build */
     heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
 
     /* Build all descriptors */
     ETH_UpdateDescriptor(heth);
-
-    /* Enable the MAC transmission */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
-
-    /* Enable the MAC reception */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
-
-    /* Set the Flush Transmit FIFO bit */
-    SET_BIT(heth->Instance->MTLTQOMR, ETH_MTLTQOMR_FTQ);
 
     /* Enable the DMA transmission */
     SET_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_ST);
@@ -791,6 +783,16 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
 
     /* Clear Tx and Rx process stopped flags */
     heth->Instance->DMACSR |= (ETH_DMACSR_TPS | ETH_DMACSR_RPS);
+
+    /* Set the Flush Transmit FIFO bit */
+    SET_BIT(heth->Instance->MTLTQOMR, ETH_MTLTQOMR_FTQ);
+
+    /* Enable the MAC transmission */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Enable the MAC reception */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
     /* Enable ETH DMA interrupts:
     - Tx complete interrupt
     - Rx complete interrupt
@@ -914,7 +916,7 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
   * @param  Timeout: timeout value
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout)
+HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfigTypeDef *pTxConfig, uint32_t Timeout)
 {
   uint32_t tickstart;
   ETH_DMADescTypeDef *dmatxdesc;
@@ -989,7 +991,7 @@ HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *
   * @param  pTxConfig: Hold the configuration of packet to be transmitted
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig)
+HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfigTypeDef *pTxConfig)
 {
   if (pTxConfig == NULL)
   {
@@ -1079,12 +1081,12 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
         heth->RxDescList.RxDataLength = 0;
       }
 
+      /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
+      bufflength = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL) - heth->RxDescList.RxDataLength;
+
       /* Check if last descriptor */
-      bufflength = heth->Init.RxBuffLen;
       if (READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_LD) != (uint32_t)RESET)
       {
-        bufflength = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL) - heth->RxDescList.RxDataLength;
-
         /* Save Last descriptor index */
         heth->RxDescList.pRxLastRxDesc = dmarxdesc->DESC3;
 
@@ -1150,6 +1152,7 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
 static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth)
 {
   uint32_t descidx;
+  uint32_t tailidx;
   uint32_t desccount;
   ETH_DMADescTypeDef *dmarxdesc;
   uint8_t *buff = NULL;
@@ -1185,8 +1188,6 @@ static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth)
 
     if (allocStatus != 0U)
     {
-      /* Ensure rest of descriptor is written to RAM before the OWN bit */
-      __DMB();
 
       if (heth->RxDescList.ItMode != 0U)
       {
@@ -1207,8 +1208,14 @@ static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth)
 
   if (heth->RxDescList.RxBuildDescCnt != desccount)
   {
+    /* Set the tail pointer index */
+    tailidx = (ETH_RX_DESC_CNT + descidx - 1U) % ETH_RX_DESC_CNT;
+
+    /* DMB instruction to avoid race condition */
+    __DMB();
+
     /* Set the Tail pointer address */
-    WRITE_REG(heth->Instance->DMACRDTPR, 0U);
+    WRITE_REG(heth->Instance->DMACRDTPR, ((uint32_t)(heth->Init.RxDesc + (tailidx))));
 
     heth->RxDescList.RxBuildDescIdx = descidx;
     heth->RxDescList.RxBuildDescCnt = desccount;
@@ -1327,7 +1334,7 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth)
   * @param  pErrorCode: pointer to uint32_t to hold the error code
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode)
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(const ETH_HandleTypeDef *heth, uint32_t *pErrorCode)
 {
   /* Get error bits. */
   *pErrorCode = READ_BIT(heth->RxDescList.pRxLastRxDesc, ETH_DMARXNDESCWBF_ERRORS_MASK);
@@ -1410,7 +1417,7 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
     if (dmatxdesclist->PacketAddress[idx] == NULL)
     {
       /* No packet in use, skip to next.  */
-      idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+      INCR_TX_DESC_INDEX(idx, 1U);
       pktInUse = 0U;
     }
 
@@ -1420,20 +1427,32 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
       if ((heth->Init.TxDesc[idx].DESC3 & ETH_DMATXNDESCRF_OWN) == 0U)
       {
 #ifdef HAL_ETH_USE_PTP
+
         /* Disable Ptp transmission */
         CLEAR_BIT(heth->Init.TxDesc[idx].DESC3, (0x40000000U));
 
-        /* Get timestamp low */
-        timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC0;
-        /* Get timestamp high */
-        timestamp->TimeStampHigh = heth->Init.TxDesc[idx].DESC1;
+        if ((heth->Init.TxDesc[idx].DESC3 & ETH_DMATXNDESCWBF_LD)
+            && (heth->Init.TxDesc[idx].DESC3 & ETH_DMATXNDESCWBF_TTSS))
+        {
+          /* Get timestamp low */
+          timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC0;
+          /* Get timestamp high */
+          timestamp->TimeStampHigh = heth->Init.TxDesc[idx].DESC1;
+        }
+        else
+        {
+          timestamp->TimeStampHigh = timestamp->TimeStampLow = UINT32_MAX;
+        }
 #endif /* HAL_ETH_USE_PTP */
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
         /*Call registered callbacks*/
 #ifdef HAL_ETH_USE_PTP
         /* Handle Ptp  */
-        heth->txPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+        if (timestamp->TimeStampHigh != UINT32_MAX && timestamp->TimeStampLow != UINT32_MAX)
+        {
+          heth->txPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+        }
 #endif  /* HAL_ETH_USE_PTP */
         /* Release the packet.  */
         heth->txFreeCallback(dmatxdesclist->PacketAddress[idx]);
@@ -1441,7 +1460,10 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
         /* Call callbacks */
 #ifdef HAL_ETH_USE_PTP
         /* Handle Ptp  */
-        HAL_ETH_TxPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+        if (timestamp->TimeStampHigh != UINT32_MAX && timestamp->TimeStampLow != UINT32_MAX)
+        {
+          HAL_ETH_TxPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+        }
 #endif  /* HAL_ETH_USE_PTP */
         /* Release the packet.  */
         HAL_ETH_TxFreeCallback(dmatxdesclist->PacketAddress[idx]);
@@ -1451,7 +1473,7 @@ HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
         dmatxdesclist->PacketAddress[idx] = NULL;
 
         /* Update the transmit relesae index and number of buffers in use.  */
-        idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+        INCR_TX_DESC_INDEX(idx, 1U);
         dmatxdesclist->BuffersInUse = numOfBuf;
         dmatxdesclist->releaseIndex = idx;
       }
@@ -1511,25 +1533,24 @@ HAL_StatusTypeDef HAL_ETH_PTP_SetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigT
   if (ptpconfig->TimestampAddendUpdate == ENABLE)
   {
     SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSADDREG);
-    while ((heth->Instance->MACTSCR & ETH_MACTSCR_TSADDREG) != 0) {}
-  }
+    while ((heth->Instance->MACTSCR & ETH_MACTSCR_TSADDREG) != 0)
+    {
 
-  /* Enable Update mode */
-  if (ptpconfig->TimestampUpdateMode == ENABLE)
-  {
-    SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSCFUPDT);
+    }
   }
-
-  /* Initialize Time */
-  time.Seconds = 0;
-  time.NanoSeconds = 0;
-  HAL_ETH_PTP_SetTime(heth, &time);
 
   /* Ptp Init */
   SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSINIT);
 
   /* Set PTP Configuration done */
-  heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
+  heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURED;
+
+  /* Set Seconds */
+  time.Seconds = heth->Instance->MACSTSR;
+  /* Set NanoSeconds */
+  time.NanoSeconds = heth->Instance->MACSTNR;
+
+  HAL_ETH_PTP_SetTime(heth, &time);
 
   /* Return function status */
   return HAL_OK;
@@ -1589,19 +1610,22 @@ HAL_StatusTypeDef HAL_ETH_PTP_GetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigT
   * @brief  Set Seconds and Nanoseconds for the Ethernet PTP registers.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  * @param  time: pointer to a ETH_TimeTypeDef structure that contains
   *         time to set
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
 {
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     /* Set Seconds */
     heth->Instance->MACSTSUR = time->Seconds;
 
     /* Set NanoSeconds */
     heth->Instance->MACSTNUR = time->NanoSeconds;
+
+    /* the system time is updated */
+    SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSUPDT);
 
     /* Return function status */
     return HAL_OK;
@@ -1617,19 +1641,18 @@ HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *
   * @brief  Get Seconds and Nanoseconds for the Ethernet PTP registers.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  * @param  time: pointer to a ETH_TimeTypeDef structure that contains
   *         time to get
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
 {
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     /* Get Seconds */
-    time->Seconds = heth->Instance->MACSTSUR;
-
+    time->Seconds = heth->Instance->MACSTSR;
     /* Get NanoSeconds */
-    time->NanoSeconds = heth->Instance->MACSTNUR;
+    time->NanoSeconds = heth->Instance->MACSTNR;
 
     /* Return function status */
     return HAL_OK;
@@ -1645,14 +1668,14 @@ HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *
   * @brief  Update time for the Ethernet PTP registers.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  timeupdate: pointer to a ETH_TIMEUPDATETypeDef structure that contains
+  * @param  timeoffset: pointer to a ETH_PtpUpdateTypeDef structure that contains
   *         the time update information
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpdateTypeDef ptpoffsettype,
                                             ETH_TimeTypeDef *timeoffset)
 {
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     if (ptpoffsettype ==  HAL_ETH_PTP_NEGATIVE_UPDATE)
     {
@@ -1678,6 +1701,8 @@ HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpda
       heth->Instance->MACSTNUR = timeoffset->NanoSeconds;
     }
 
+    SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSUPDT);
+
     /* Return function status */
     return HAL_OK;
   }
@@ -1692,7 +1717,6 @@ HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpda
   * @brief  Insert Timestamp in transmission.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  txtimestampconf: Enable or Disable timestamp in transmission
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth)
@@ -1701,7 +1725,7 @@ HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth)
   uint32_t descidx = dmatxdesclist->CurTxDesc;
   ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
 
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     /* Enable Time Stamp transmission */
     SET_BIT(dmatxdesc->DESC2, ETH_DMATXNDESCRF_TTSE);
@@ -1730,7 +1754,7 @@ HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeSt
   uint32_t idx =       dmatxdesclist->releaseIndex;
   ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[idx];
 
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     /* Get timestamp low */
     timestamp->TimeStampLow = dmatxdesc->DESC0;
@@ -1757,7 +1781,7 @@ HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeSt
   */
 HAL_StatusTypeDef HAL_ETH_PTP_GetRxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp)
 {
-  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURED)
   {
     /* Get timestamp low */
     timestamp->TimeStampLow = heth->RxDescList.TimeStamp.TimeStampLow;
@@ -1811,6 +1835,8 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth)
 /**
   * @brief  Tx Ptp callback.
   * @param  buff: pointer to application buffer
+  * @param  timestamp: pointer to ETH_TimeStampTypeDef structure that contains
+  *         transmission timestamp
   * @retval None
   */
 __weak void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
@@ -1831,87 +1857,79 @@ __weak void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestam
   */
 void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
 {
-  uint32_t macirqenable;
+  uint32_t mac_flag = READ_REG(heth->Instance->MACISR);
+  uint32_t dma_flag = READ_REG(heth->Instance->DMACSR);
+  uint32_t dma_itsource = READ_REG(heth->Instance->DMACIER);
+  uint32_t exti_flag = READ_REG(EXTI->RPR2);
 
   /* Packet received */
-  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_RI))
+  if (((dma_flag & ETH_DMACSR_RI) != 0U) && ((dma_itsource & ETH_DMACIER_RIE) != 0U))
   {
-    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_RIE))
-    {
-      /* Clear the Eth DMA Rx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
+    /* Clear the Eth DMA Rx IT pending bits */
+    __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-      /*Call registered Receive complete callback*/
-      heth->RxCpltCallback(heth);
+    /*Call registered Receive complete callback*/
+    heth->RxCpltCallback(heth);
 #else
-      /* Receive complete callback */
-      HAL_ETH_RxCpltCallback(heth);
+    /* Receive complete callback */
+    HAL_ETH_RxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-    }
   }
 
   /* Packet transmitted */
-  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_TI))
+  if (((dma_flag & ETH_DMACSR_TI) != 0U) && ((dma_itsource & ETH_DMACIER_TIE) != 0U))
   {
-    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_TIE))
-    {
-      /* Clear the Eth DMA Tx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
+    /* Clear the Eth DMA Tx IT pending bits */
+    __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-      /*Call registered Transmit complete callback*/
-      heth->TxCpltCallback(heth);
+    /*Call registered Transmit complete callback*/
+    heth->TxCpltCallback(heth);
 #else
-      /* Transfer complete callback */
-      HAL_ETH_TxCpltCallback(heth);
+    /* Transfer complete callback */
+    HAL_ETH_TxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-    }
   }
 
   /* ETH DMA Error */
-  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_AIS))
+  if (((dma_flag & ETH_DMACSR_AIS) != 0U) && ((dma_itsource & ETH_DMACIER_AIE) != 0U))
   {
-    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_AIE))
+    heth->ErrorCode |= HAL_ETH_ERROR_DMA;
+    /* if fatal bus error occurred */
+    if ((dma_flag & ETH_DMACSR_FBE) != 0U)
     {
-      heth->ErrorCode |= HAL_ETH_ERROR_DMA;
-      /* if fatal bus error occurred */
-      if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_FBE))
-      {
-        /* Get DMA error code  */
-        heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_FBE | ETH_DMACSR_TPS | ETH_DMACSR_RPS));
+      /* Get DMA error code  */
+      heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_FBE | ETH_DMACSR_TPS | ETH_DMACSR_RPS));
 
-        /* Disable all interrupts */
-        __HAL_ETH_DMA_DISABLE_IT(heth, ETH_DMACIER_NIE | ETH_DMACIER_AIE);
+      /* Disable all interrupts */
+      __HAL_ETH_DMA_DISABLE_IT(heth, ETH_DMACIER_NIE | ETH_DMACIER_AIE);
 
-        /* Set HAL state to ERROR */
-        heth->gState = HAL_ETH_STATE_ERROR;
-      }
-      else
-      {
-        /* Get DMA error status  */
-        heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                                               ETH_DMACSR_RBU | ETH_DMACSR_AIS));
-
-        /* Clear the interrupt summary flag */
-        __HAL_ETH_DMA_CLEAR_IT(heth, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                      ETH_DMACSR_RBU | ETH_DMACSR_AIS));
-      }
-#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-      /* Call registered Error callback*/
-      heth->ErrorCallback(heth);
-#else
-      /* Ethernet DMA Error callback */
-      HAL_ETH_ErrorCallback(heth);
-#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
+      /* Set HAL state to ERROR */
+      heth->gState = HAL_ETH_STATE_ERROR;
     }
+    else
+    {
+      /* Get DMA error status  */
+      heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
+                                                             ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+
+      /* Clear the interrupt summary flag */
+      __HAL_ETH_DMA_CLEAR_IT(heth, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
+                                    ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+    }
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+    /* Call registered Error callback*/
+    heth->ErrorCallback(heth);
+#else
+    /* Ethernet DMA Error callback */
+    HAL_ETH_ErrorCallback(heth);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
   }
 
   /* ETH MAC Error IT */
-  macirqenable = heth->Instance->MACIER;
-  if (((macirqenable & ETH_MACIER_RXSTSIE) == ETH_MACIER_RXSTSIE) || \
-      ((macirqenable & ETH_MACIER_TXSTSIE) == ETH_MACIER_TXSTSIE))
+  if (((mac_flag & ETH_MACIER_RXSTSIE) == ETH_MACIER_RXSTSIE) || \
+      ((mac_flag & ETH_MACIER_TXSTSIE) == ETH_MACIER_TXSTSIE))
   {
     heth->ErrorCode |= HAL_ETH_ERROR_MAC;
 
@@ -1931,7 +1949,7 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   }
 
   /* ETH PMT IT */
-  if (__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_PMT_IT))
+  if ((mac_flag & ETH_MAC_PMT_IT) != 0U)
   {
     /* Get MAC Wake-up source and clear the status register pending bit */
     heth->MACWakeUpEvent = READ_BIT(heth->Instance->MACPCSR, (ETH_MACPCSR_RWKPRCVD | ETH_MACPCSR_MGKPRCVD));
@@ -1948,7 +1966,7 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   }
 
   /* ETH EEE IT */
-  if (__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_LPI_IT))
+  if ((mac_flag & ETH_MAC_LPI_IT) != 0U)
   {
     /* Get MAC LPI interrupt source and clear the status register pending bit */
     heth->MACLPIEvent = READ_BIT(heth->Instance->MACPCSR, 0x0000000FU);
@@ -1965,7 +1983,7 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   }
 
   /* check ETH WAKEUP exti flag */
-  if (__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
+  if ((exti_flag & ETH_WAKEUP_EXTI_LINE) != 0U)
   {
     /* Clear ETH WAKEUP Exti pending bit */
     __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(ETH_WAKEUP_EXTI_LINE);
@@ -2124,7 +2142,6 @@ HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYA
   return HAL_OK;
 }
 
-
 /**
   * @brief  Writes to a PHY register.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
@@ -2206,7 +2223,7 @@ HAL_StatusTypeDef HAL_ETH_WritePHYRegister(const ETH_HandleTypeDef *heth, uint32
   *         the configuration of the MAC.
   * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf)
+HAL_StatusTypeDef HAL_ETH_GetMACConfig(const ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf)
 {
   if (macconf == NULL)
   {
@@ -2278,7 +2295,7 @@ HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTyp
   *         the configuration of the ETH DMA.
   * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf)
+HAL_StatusTypeDef HAL_ETH_GetDMAConfig(const ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf)
 {
   if (dmaconf == NULL)
   {
@@ -2300,7 +2317,6 @@ HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTyp
   dmaconf->SecondPacketOperate = ((READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_OSP) >> 4) > 0U) ? ENABLE : DISABLE;
   dmaconf->TCPSegmentation = ((READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_TSE) >> 12) > 0U) ? ENABLE : DISABLE;
   dmaconf->TxDMABurstLength = READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_TPBL);
-
 
   return HAL_OK;
 }
@@ -2380,34 +2396,34 @@ void HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth)
   hclk = HAL_RCC_GetHCLKFreq();
 
   /* Set CR bits depending on hclk value */
-  if ((hclk >= 20000000U) && (hclk < 35000000U))
+  if (hclk < 35000000U)
   {
-    /* CSR Clock Range between 20-35 MHz */
+    /* CSR Clock Range between 0-35 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV16;
   }
-  else if ((hclk >= 35000000U) && (hclk < 60000000U))
+  else if (hclk < 60000000U)
   {
     /* CSR Clock Range between 35-60 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV26;
   }
-  else if ((hclk >= 60000000U) && (hclk < 100000000U))
+  else if (hclk < 100000000U)
   {
     /* CSR Clock Range between 60-100 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV42;
   }
-  else if ((hclk >= 100000000U) && (hclk < 150000000U))
+  else if (hclk < 150000000U)
   {
     /* CSR Clock Range between 100-150 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV62;
   }
-  else if ((hclk >= 150000000U) && (hclk <= 250000000U))
+  else if (hclk < 250000000U)
   {
-    /* CSR Clock Range between 150-200 MHz */
+    /* CSR Clock Range between 150-250 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV102;
   }
-  else /*(hclk >= 250000000U) && (hclk <= 300000000U)*/
+  else /* (hclk >= 250000000U) */
   {
-    /* CSR Clock Range between 250-300 MHz */
+    /* CSR Clock >= 250 MHz */
     tmpreg |= (uint32_t)(ETH_MACMDIOAR_CR_DIV124);
   }
 
@@ -2457,7 +2473,7 @@ HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, const ETH_
   *         the configuration of the ETH MAC filters.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig)
+HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(const ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig)
 {
   if (pFilterConfig == NULL)
   {
@@ -2730,8 +2746,7 @@ uint32_t HAL_ETH_GetMACWakeUpSource(const ETH_HandleTypeDef *heth)
   * @{
   */
 
-
-static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf)
+static void ETH_SetMACConfig(ETH_HandleTypeDef *heth, const ETH_MACConfigTypeDef *macconf)
 {
   uint32_t macregval;
 
@@ -2778,7 +2793,6 @@ static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *mac
   /* Write to MACWTR */
   MODIFY_REG(heth->Instance->MACWTR, ETH_MACWTR_MASK, macregval);
 
-
   /*------------------------ MACTFCR Configuration --------------------*/
   macregval = (((uint32_t)macconf->TransmitFlowControl << 1) |
                macconf->PauseLowThreshold |
@@ -2809,7 +2823,7 @@ static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *mac
   MODIFY_REG(heth->Instance->MTLRQOMR, ETH_MTLRQOMR_MASK, macregval);
 }
 
-static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf)
+static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth, const ETH_DMAConfigTypeDef *dmaconf)
 {
   uint32_t dmaregval;
 
@@ -2916,7 +2930,6 @@ static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth)
   ETH_SetDMAConfig(heth, &dmaDefaultConf);
 }
 
-
 /**
   * @brief  Initializes the DMA Tx descriptors.
   *         called by HAL_ETH_Init() API.
@@ -2978,7 +2991,6 @@ static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth)
     WRITE_REG(dmarxdesc->BackupAddr0, 0x0U);
     WRITE_REG(dmarxdesc->BackupAddr1, 0x0U);
 
-
     /* Set Rx descritors addresses */
     WRITE_REG(heth->RxDescList.RxDesc[i], (uint32_t)dmarxdesc);
 
@@ -3009,7 +3021,8 @@ static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth)
   * @param  ItMode: Enable or disable Tx EOT interrept
   * @retval Status
   */
-static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t ItMode)
+static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, const ETH_TxPacketConfigTypeDef *pTxConfig,
+                                           uint32_t ItMode)
 {
   ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
   uint32_t descidx = dmatxdesclist->CurTxDesc;
@@ -3020,6 +3033,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
 
   ETH_BufferTypeDef  *txbuffer = pTxConfig->TxBuffer;
   uint32_t           bd_count = 0;
+  uint32_t primask_bit;
 
   /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
   if ((READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCWBF_OWN) == ETH_DMATXNDESCWBF_OWN)
@@ -3277,14 +3291,15 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   dmatxdesclist->PacketAddress[descidx] = dmatxdesclist->CurrentPacketAddress;
 
   dmatxdesclist->CurTxDesc = descidx;
-  /* disable the interrupt */
-  __disable_irq();
+
+  /* Enter critical section */
+  primask_bit = __get_PRIMASK();
+  __set_PRIMASK(1);
 
   dmatxdesclist->BuffersInUse += bd_count + 1U;
 
-  /* Enable interrupts back */
-  __enable_irq();
-
+  /* Exit critical section: restore previous priority mask */
+  __set_PRIMASK(primask_bit);
 
   /* Return function status */
   return HAL_ETH_ERROR_NONE;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth.h
@@ -24,7 +24,6 @@
 extern "C" {
 #endif
 
-
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h5xx_hal_def.h"
 
@@ -160,7 +159,7 @@ typedef struct
 
   void *pData;                     /*!< Specifies Application packet pointer to save   */
 
-} ETH_TxPacketConfig;
+} ETH_TxPacketConfigTypeDef;
 /**
   *
   */
@@ -792,7 +791,6 @@ typedef struct
 #define ETH_DMATXNDESCWBF_DB                      0x00000002U  /*!< Deferred Bit */
 #define ETH_DMATXNDESCWBF_IHE                     0x00000004U  /*!< IP Header Error */
 
-
 /*
    DMA Tx Context Descriptor
   -----------------------------------------------------------------------------------------------
@@ -842,7 +840,6 @@ typedef struct
 /**
   * @}
   */
-
 
 /** @defgroup ETH_DMA_Rx_Descriptor_Bit_Definition ETH DMA Rx Descriptor Bit Definition
   * @{
@@ -941,7 +938,6 @@ typedef struct
 #define ETH_DMARXNDESCWBF_SAF             0x00010000U  /*!< SA Address Filter Fail                */
 #define ETH_DMARXNDESCWBF_VF              0x00008000U  /*!< VLAN Filter Status                    */
 #define ETH_DMARXNDESCWBF_ARPNR           0x00000400U  /*!< ARP Reply Not Generated               */
-
 
 /**
   * @brief  Bit definition of Rx normal descriptor register 3 write back format
@@ -1487,11 +1483,12 @@ typedef struct
 /** @defgroup ETH_PTP_Config_Status ETH PTP Config Status
   * @{
   */
-#define HAL_ETH_PTP_NOT_CONFIGURATED       0x00000000U    /*!< ETH PTP Configuration not done */
-#define HAL_ETH_PTP_CONFIGURATED           0x00000001U    /*!< ETH PTP Configuration done     */
+#define HAL_ETH_PTP_NOT_CONFIGURED        0x00000000U    /*!< ETH PTP Configuration not done */
+#define HAL_ETH_PTP_CONFIGURED            0x00000001U    /*!< ETH PTP Configuration done     */
 /**
   * @}
   */
+
 /**
   * @}
   */
@@ -1632,7 +1629,6 @@ typedef struct
   */
 #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(__EXTI_LINE__)  (EXTI->RPR2 = (__EXTI_LINE__))
 
-
 /**
   * @brief  enable rising edge interrupt on selected EXTI line.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP EXTI sources to be disabled.
@@ -1719,7 +1715,7 @@ HAL_StatusTypeDef HAL_ETH_RegisterRxAllocateCallback(ETH_HandleTypeDef *heth,
 HAL_StatusTypeDef HAL_ETH_UnRegisterRxAllocateCallback(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_RegisterRxLinkCallback(ETH_HandleTypeDef *heth, pETH_rxLinkCallbackTypeDef rxLinkCallback);
 HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode);
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(const ETH_HandleTypeDef *heth, uint32_t *pErrorCode);
 HAL_StatusTypeDef HAL_ETH_RegisterTxFreeCallback(ETH_HandleTypeDef *heth, pETH_txFreeCallbackTypeDef txFreeCallback);
 HAL_StatusTypeDef HAL_ETH_UnRegisterTxFreeCallback(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth);
@@ -1738,8 +1734,8 @@ HAL_StatusTypeDef HAL_ETH_RegisterTxPtpCallback(ETH_HandleTypeDef *heth, pETH_tx
 HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth);
 #endif /* HAL_ETH_USE_PTP */
 
-HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout);
-HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig);
+HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfigTypeDef *pTxConfig, uint32_t Timeout);
+HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfigTypeDef *pTxConfig);
 
 HAL_StatusTypeDef HAL_ETH_WritePHYRegister(const ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
                                            uint32_t RegValue);
@@ -1766,8 +1762,8 @@ void              HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *ti
   */
 /* Peripheral Control functions  **********************************************/
 /* MAC & DMA Configuration APIs  **********************************************/
-HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf);
-HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf);
+HAL_StatusTypeDef HAL_ETH_GetMACConfig(const ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf);
+HAL_StatusTypeDef HAL_ETH_GetDMAConfig(const ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf);
 HAL_StatusTypeDef HAL_ETH_SetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf);
 HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf);
 void              HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth);
@@ -1777,7 +1773,7 @@ void              HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t 
                                               uint32_t VLANIdentifier);
 
 /* MAC L2 Packet Filtering APIs  **********************************************/
-HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig);
+HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(const ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig);
 HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, const ETH_MACFilterConfigTypeDef *pFilterConfig);
 HAL_StatusTypeDef HAL_ETH_SetHashTable(ETH_HandleTypeDef *heth, uint32_t *pHashTable);
 HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(const ETH_HandleTypeDef *heth, uint32_t AddrNbr,

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth_ex.c
@@ -56,6 +56,9 @@
 
 #define ETH_MACTXVLAN_MASK (ETH_MACVIR_VLTI | ETH_MACVIR_CSVL | \
                             ETH_MACVIR_VLP | ETH_MACVIR_VLC)
+
+#define ETH_MAC_L4_SRSP_MASK          0x0000FFFFU
+#define ETH_MAC_L4_DSTP_MASK          0xFFFF0000U
 /**
   * @}
   */
@@ -133,25 +136,34 @@ void HAL_ETHEx_SetARPAddressMatch(ETH_HandleTypeDef *heth, uint32_t IpAddress)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
-                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig)
+                                              const ETH_L4FilterConfigTypeDef *pL4FilterConfig)
 {
-  __IO uint32_t *configreg = ((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter));
-
   if (pL4FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
-  /* Write configuration to (MACL3L4C0R + filter )register */
-  MODIFY_REG(*configreg, ETH_MACL4CR_MASK, (pL4FilterConfig->Protocol |
-                                            pL4FilterConfig->SrcPortFilterMatch |
-                                            pL4FilterConfig->DestPortFilterMatch));
+  if (Filter == ETH_L4_FILTER_0)
+  {
+    /* Write configuration to MACL3L4C0R register */
+    MODIFY_REG(heth->Instance->MACL3L4C0R, ETH_MACL4CR_MASK, (pL4FilterConfig->Protocol |
+                                                              pL4FilterConfig->SrcPortFilterMatch |
+                                                              pL4FilterConfig->DestPortFilterMatch));
 
-  configreg = ((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter));
+    /* Write configuration to MACL4A0R register */
+    WRITE_REG(heth->Instance->MACL4A0R, (pL4FilterConfig->SourcePort | (pL4FilterConfig->DestinationPort << 16)));
 
-  /* Write configuration to (MACL4A0R + filter )register */
-  MODIFY_REG(*configreg, (ETH_MACL4AR_L4DP | ETH_MACL4AR_L4SP), (pL4FilterConfig->SourcePort |
-                                                                 (pL4FilterConfig->DestinationPort << 16)));
+  }
+  else /* Filter == ETH_L4_FILTER_1 */
+  {
+    /* Write configuration to MACL3L4C1R register */
+    MODIFY_REG(heth->Instance->MACL3L4C1R, ETH_MACL4CR_MASK, (pL4FilterConfig->Protocol |
+                                                              pL4FilterConfig->SrcPortFilterMatch |
+                                                              pL4FilterConfig->DestPortFilterMatch));
+
+    /* Write configuration to MACL4A1R register */
+    WRITE_REG(heth->Instance->MACL4A1R, (pL4FilterConfig->SourcePort | (pL4FilterConfig->DestinationPort << 16)));
+  }
 
   /* Enable L4 filter */
   SET_BIT(heth->Instance->MACPFR, ETH_MACPFR_IPFE);
@@ -172,7 +184,7 @@ HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   *         that contains L4 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(const ETH_HandleTypeDef *heth, uint32_t Filter,
                                               ETH_L4FilterConfigTypeDef *pL4FilterConfig)
 {
   if (pL4FilterConfig == NULL)
@@ -180,18 +192,32 @@ HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
     return HAL_ERROR;
   }
 
-  /* Get configuration to (MACL3L4C0R + filter )register */
-  pL4FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
-                                       ETH_MACL3L4CR_L4PEN);
-  pL4FilterConfig->DestPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
-                                                  (ETH_MACL3L4CR_L4DPM | ETH_MACL3L4CR_L4DPIM));
-  pL4FilterConfig->SrcPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
-                                                 (ETH_MACL3L4CR_L4SPM | ETH_MACL3L4CR_L4SPIM));
+  if (Filter == ETH_L4_FILTER_0)
+  {
+    /* Get configuration from MACL3L4C0R register */
+    pL4FilterConfig->Protocol = READ_BIT(heth->Instance->MACL3L4C0R, ETH_MACL3L4CR_L4PEN);
+    pL4FilterConfig->DestPortFilterMatch = READ_BIT(heth->Instance->MACL3L4C0R,
+                                                    (ETH_MACL3L4CR_L4DPM | ETH_MACL3L4CR_L4DPIM));
+    pL4FilterConfig->SrcPortFilterMatch = READ_BIT(heth->Instance->MACL3L4C0R,
+                                                   (ETH_MACL3L4CR_L4SPM | ETH_MACL3L4CR_L4SPIM));
 
-  /* Get configuration to (MACL3L4C0R + filter )register */
-  pL4FilterConfig->DestinationPort = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter)),
-                                               ETH_MACL4AR_L4DP) >> 16);
-  pL4FilterConfig->SourcePort = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter)), ETH_MACL4AR_L4SP);
+    /* Get configuration from MACL4A0R register */
+    pL4FilterConfig->DestinationPort = (READ_BIT(heth->Instance->MACL4A0R, ETH_MAC_L4_DSTP_MASK) >> 16);
+    pL4FilterConfig->SourcePort = READ_BIT(heth->Instance->MACL4A0R, ETH_MAC_L4_SRSP_MASK);
+  }
+  else /* Filter == ETH_L4_FILTER_1 */
+  {
+    /* Get configuration from MACL3L4C1R register */
+    pL4FilterConfig->Protocol = READ_BIT(heth->Instance->MACL3L4C1R, ETH_MACL3L4CR_L4PEN);
+    pL4FilterConfig->DestPortFilterMatch = READ_BIT(heth->Instance->MACL3L4C1R,
+                                                    (ETH_MACL3L4CR_L4DPM | ETH_MACL3L4CR_L4DPIM));
+    pL4FilterConfig->SrcPortFilterMatch = READ_BIT(heth->Instance->MACL3L4C1R,
+                                                   (ETH_MACL3L4CR_L4SPM | ETH_MACL3L4CR_L4SPIM));
+
+    /* Get configuration from MACL4A1R register */
+    pL4FilterConfig->DestinationPort = (READ_BIT(heth->Instance->MACL4A1R, ETH_MAC_L4_DSTP_MASK) >> 16);
+    pL4FilterConfig->SourcePort = READ_BIT(heth->Instance->MACL4A1R, ETH_MAC_L4_SRSP_MASK);
+  }
 
   return HAL_OK;
 }
@@ -210,42 +236,82 @@ HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
-                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig)
+                                              const ETH_L3FilterConfigTypeDef *pL3FilterConfig)
 {
-  __IO uint32_t *configreg = ((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter));
-
   if (pL3FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
-  /* Write configuration to (MACL3L4C0R + filter )register */
-  MODIFY_REG(*configreg, ETH_MACL3CR_MASK, (pL3FilterConfig->Protocol |
-                                            pL3FilterConfig->SrcAddrFilterMatch |
-                                            pL3FilterConfig->DestAddrFilterMatch |
-                                            (pL3FilterConfig->SrcAddrHigherBitsMatch << 6) |
-                                            (pL3FilterConfig->DestAddrHigherBitsMatch << 11)));
+  if (Filter == ETH_L3_FILTER_0)
+  {
+    /* Write configuration to MACL3L4C0R register */
+    MODIFY_REG(heth->Instance->MACL3L4C0R, ETH_MACL3CR_MASK, (pL3FilterConfig->Protocol |
+                                                              pL3FilterConfig->SrcAddrFilterMatch |
+                                                              pL3FilterConfig->DestAddrFilterMatch |
+                                                              (pL3FilterConfig->SrcAddrHigherBitsMatch << 6) |
+                                                              (pL3FilterConfig->DestAddrHigherBitsMatch << 11)));
+  }
+  else  /* Filter == ETH_L3_FILTER_1 */
+  {
+    /* Write configuration to MACL3L4C1R register */
+    MODIFY_REG(heth->Instance->MACL3L4C1R, ETH_MACL3CR_MASK, (pL3FilterConfig->Protocol |
+                                                              pL3FilterConfig->SrcAddrFilterMatch |
+                                                              pL3FilterConfig->DestAddrFilterMatch |
+                                                              (pL3FilterConfig->SrcAddrHigherBitsMatch << 6) |
+                                                              (pL3FilterConfig->DestAddrHigherBitsMatch << 11)));
+  }
 
-  /* Check if IPv6 protocol is selected */
-  if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+  if (Filter == ETH_L3_FILTER_0)
   {
-    /* Set the IPv6 address match */
-    /* Set Bits[31:0] of 128-bit IP addr */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A0R0R) + Filter)) = pL3FilterConfig->Ip6Addr[0];
-    /* Set Bits[63:32] of 128-bit IP addr */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A1R0R) + Filter)) = pL3FilterConfig->Ip6Addr[1];
-    /* update Bits[95:64] of 128-bit IP addr */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A2R0R) + Filter)) = pL3FilterConfig->Ip6Addr[2];
-    /* update Bits[127:96] of 128-bit IP addr */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A3R0R) + Filter)) = pL3FilterConfig->Ip6Addr[3];
+    /* Check if IPv6 protocol is selected */
+    if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+    {
+      /* Set the IPv6 address match */
+      /* Set Bits[31:0] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A0R0R, pL3FilterConfig->Ip6Addr[0]);
+      /* Set Bits[63:32] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A1R0R, pL3FilterConfig->Ip6Addr[1]);
+      /* update Bits[95:64] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A2R0R, pL3FilterConfig->Ip6Addr[2]);
+      /* update Bits[127:96] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A3R0R, pL3FilterConfig->Ip6Addr[3]);
+    }
+    else /* IPv4 protocol is selected */
+    {
+      /* Set the IPv4 source address match */
+      WRITE_REG(heth->Instance->MACL3A0R0R, pL3FilterConfig->Ip4SrcAddr);
+      /* Set the IPv4 destination address match */
+      WRITE_REG(heth->Instance->MACL3A1R0R, pL3FilterConfig->Ip4DestAddr);
+    }
   }
-  else /* IPv4 protocol is selected */
+  else  /* Filter == ETH_L3_FILTER_1 */
   {
-    /* Set the IPv4 source address match */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A0R0R) + Filter)) = pL3FilterConfig->Ip4SrcAddr;
-    /* Set the IPv4 destination address match */
-    *((__IO uint32_t *)(&(heth->Instance->MACL3A1R0R) + Filter)) = pL3FilterConfig->Ip4DestAddr;
+    /* Check if IPv6 protocol is selected */
+    if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+    {
+      /* Set the IPv6 address match */
+      /* Set Bits[31:0] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A0R1R, pL3FilterConfig->Ip6Addr[0]);
+      /* Set Bits[63:32] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A1R1R, pL3FilterConfig->Ip6Addr[1]);
+      /* update Bits[95:64] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A1R1R, pL3FilterConfig->Ip6Addr[2]);
+      /* update Bits[127:96] of 128-bit IP addr */
+      WRITE_REG(heth->Instance->MACL3A1R1R, pL3FilterConfig->Ip6Addr[3]);
+    }
+    else /* IPv4 protocol is selected */
+    {
+      /* Set the IPv4 source address match */
+      WRITE_REG(heth->Instance->MACL3A0R1R, pL3FilterConfig->Ip4SrcAddr);
+      /* Set the IPv4 destination address match */
+      WRITE_REG(heth->Instance->MACL3A0R1R, pL3FilterConfig->Ip4DestAddr);
+
+    }
   }
+
+  /* Enable L3 filter */
+  SET_BIT(heth->Instance->MACPFR, ETH_MACPFR_IPFE);
 
   return HAL_OK;
 }
@@ -263,14 +329,13 @@ HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   *         that will contain the L3 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(const ETH_HandleTypeDef *heth, uint32_t Filter,
                                               ETH_L3FilterConfigTypeDef *pL3FilterConfig)
 {
   if (pL3FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
-
   pL3FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
                                        ETH_MACL3L4CR_L3PEN);
   pL3FilterConfig->SrcAddrFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
@@ -282,17 +347,35 @@ HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   pL3FilterConfig->DestAddrHigherBitsMatch = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
                                                        ETH_MACL3L4CR_L3HDBM) >> 11);
 
-  if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+  if (Filter == ETH_L3_FILTER_0)
   {
-    pL3FilterConfig->Ip6Addr[0] = *((__IO uint32_t *)(&(heth->Instance->MACL3A0R0R) + Filter));
-    pL3FilterConfig->Ip6Addr[1] = *((__IO uint32_t *)(&(heth->Instance->MACL3A1R0R) + Filter));
-    pL3FilterConfig->Ip6Addr[2] = *((__IO uint32_t *)(&(heth->Instance->MACL3A2R0R) + Filter));
-    pL3FilterConfig->Ip6Addr[3] = *((__IO uint32_t *)(&(heth->Instance->MACL3A3R0R) + Filter));
+    if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+    {
+      WRITE_REG(pL3FilterConfig->Ip6Addr[0], heth->Instance->MACL3A0R0R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[1], heth->Instance->MACL3A1R0R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[2], heth->Instance->MACL3A2R0R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[3], heth->Instance->MACL3A3R0R);
+    }
+    else
+    {
+      WRITE_REG(pL3FilterConfig->Ip4SrcAddr, heth->Instance->MACL3A0R0R);
+      WRITE_REG(pL3FilterConfig->Ip4DestAddr, heth->Instance->MACL3A1R0R);
+    }
   }
-  else
+  else /* ETH_L3_FILTER_1 */
   {
-    pL3FilterConfig->Ip4SrcAddr = *((__IO uint32_t *)(&(heth->Instance->MACL3A0R0R) + Filter));
-    pL3FilterConfig->Ip4DestAddr = *((__IO uint32_t *)(&(heth->Instance->MACL3A1R0R) + Filter));
+    if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+    {
+      WRITE_REG(pL3FilterConfig->Ip6Addr[0], heth->Instance->MACL3A0R1R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[1], heth->Instance->MACL3A1R1R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[2], heth->Instance->MACL3A2R1R);
+      WRITE_REG(pL3FilterConfig->Ip6Addr[3], heth->Instance->MACL3A3R1R);
+    }
+    else
+    {
+      WRITE_REG(pL3FilterConfig->Ip4SrcAddr, heth->Instance->MACL3A0R1R);
+      WRITE_REG(pL3FilterConfig->Ip4DestAddr, heth->Instance->MACL3A1R1R);
+    }
   }
 
   return HAL_OK;
@@ -330,7 +413,7 @@ void HAL_ETHEx_DisableL3L4Filtering(ETH_HandleTypeDef *heth)
   *         that will contain the VLAN filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig)
+HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(const ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig)
 {
   if (pVlanConfig == NULL)
   {
@@ -340,12 +423,14 @@ HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANC
   pVlanConfig->InnerVLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR,
                                                  ETH_MACVTR_EIVLRXS) >> 31) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->StripInnerVLANTag  = READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EIVLS);
-  pVlanConfig->InnerVLANTag = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_ERIVLT) >> 27) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->InnerVLANTag = ((READ_BIT(heth->Instance->MACVTR,
+                                         ETH_MACVTR_ERIVLT) >> 27) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->DoubleVLANProcessing = ((READ_BIT(heth->Instance->MACVTR,
                                                  ETH_MACVTR_EDVLP) >> 26) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->VLANTagHashTableMatch = ((READ_BIT(heth->Instance->MACVTR,
                                                   ETH_MACVTR_VTHM) >> 25) == 0U) ? DISABLE : ENABLE;
-  pVlanConfig->VLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EVLRXS) >> 24) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->VLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR,
+                                            ETH_MACVTR_EVLRXS) >> 24) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->StripVLANTag = READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EVLS);
   pVlanConfig->VLANTypeCheck = READ_BIT(heth->Instance->MACVTR,
                                         (ETH_MACVTR_DOVLTC | ETH_MACVTR_ERSVLM | ETH_MACVTR_ESVL));
@@ -407,7 +492,7 @@ void HAL_ETHEx_SetVLANHashTable(ETH_HandleTypeDef *heth, uint32_t VLANHashTable)
   *         that will contain the Tx VLAN filter configuration.
   * @retval HAL Status.
   */
-HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(const ETH_HandleTypeDef *heth, uint32_t VLANTag,
                                             ETH_TxVLANConfigTypeDef *pVlanConfig)
 {
   if (pVlanConfig == NULL)
@@ -443,7 +528,7 @@ HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VL
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
-                                            ETH_TxVLANConfigTypeDef *pVlanConfig)
+                                            const ETH_TxVLANConfigTypeDef *pVlanConfig)
 {
   if (VLANTag == ETH_INNER_TX_VLANTAG)
   {
@@ -543,7 +628,6 @@ void HAL_ETHEx_ExitLPIMode(ETH_HandleTypeDef *heth)
   /* Enable LPI Interrupts */
   __HAL_ETH_MAC_DISABLE_IT(heth, ETH_MACIER_LPIIE);
 }
-
 
 /**
   * @brief  Returns the ETH MAC LPI event

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_eth_ex.h
@@ -314,25 +314,25 @@ void              HAL_ETHEx_SetARPAddressMatch(ETH_HandleTypeDef *heth, uint32_t
 /* MAC L3 L4 Filtering APIs ***************************************************/
 void              HAL_ETHEx_EnableL3L4Filtering(ETH_HandleTypeDef *heth);
 void              HAL_ETHEx_DisableL3L4Filtering(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(const ETH_HandleTypeDef *heth, uint32_t Filter,
                                               ETH_L3FilterConfigTypeDef *pL3FilterConfig);
-HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(const ETH_HandleTypeDef *heth, uint32_t Filter,
                                               ETH_L4FilterConfigTypeDef *pL4FilterConfig);
 HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
-                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig);
+                                              const ETH_L3FilterConfigTypeDef *pL3FilterConfig);
 HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
-                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig);
+                                              const ETH_L4FilterConfigTypeDef *pL4FilterConfig);
 
 /* MAC VLAN Processing APIs    ************************************************/
 void              HAL_ETHEx_EnableVLANProcessing(ETH_HandleTypeDef *heth);
 void              HAL_ETHEx_DisableVLANProcessing(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig);
+HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(const ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig);
 HAL_StatusTypeDef HAL_ETHEx_SetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig);
 void              HAL_ETHEx_SetVLANHashTable(ETH_HandleTypeDef *heth, uint32_t VLANHashTable);
-HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(const ETH_HandleTypeDef *heth, uint32_t VLANTag,
                                             ETH_TxVLANConfigTypeDef *pVlanConfig);
 HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
-                                            ETH_TxVLANConfigTypeDef *pVlanConfig);
+                                            const ETH_TxVLANConfigTypeDef *pVlanConfig);
 void              HAL_ETHEx_SetTxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t VLANTag, uint32_t VLANIdentifier);
 
 /* Energy Efficient Ethernet APIs *********************************************/
@@ -364,5 +364,3 @@ uint32_t          HAL_ETHEx_GetMACLPIEvent(const ETH_HandleTypeDef *heth);
 #endif
 
 #endif /* STM32H5xx_HAL_ETH_EX_H */
-
-

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_exti.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_exti.h
@@ -105,49 +105,91 @@ typedef struct
 #define EXTI_LINE_15                        (EXTI_GPIO     | EXTI_REG1 | 0x0FU)
 #define EXTI_LINE_16                        (EXTI_CONFIG   | EXTI_REG1 | 0x10U)
 #define EXTI_LINE_17                        (EXTI_DIRECT   | EXTI_REG1 | 0x11U)
+#if defined(EXTI_IMR1_IM18)
 #define EXTI_LINE_18                        (EXTI_DIRECT   | EXTI_REG1 | 0x12U)
+#endif /* EXTI_IMR1_IM18 */
 #define EXTI_LINE_19                        (EXTI_DIRECT   | EXTI_REG1 | 0x13U)
+#if defined(EXTI_IMR1_IM20)
 #define EXTI_LINE_20                        (EXTI_DIRECT   | EXTI_REG1 | 0x14U)
+#endif /* EXTI_IMR1_IM20 */
 #define EXTI_LINE_21                        (EXTI_DIRECT   | EXTI_REG1 | 0x15U)
 #define EXTI_LINE_22                        (EXTI_DIRECT   | EXTI_REG1 | 0x16U)
+#if defined(EXTI_IMR1_IM23)
 #define EXTI_LINE_23                        (EXTI_DIRECT   | EXTI_REG1 | 0x17U)
+#endif /* EXTI_IMR1_IM23 */
 #define EXTI_LINE_24                        (EXTI_DIRECT   | EXTI_REG1 | 0x18U)
 #define EXTI_LINE_25                        (EXTI_DIRECT   | EXTI_REG1 | 0x19U)
 #define EXTI_LINE_26                        (EXTI_DIRECT   | EXTI_REG1 | 0x1AU)
 #define EXTI_LINE_27                        (EXTI_DIRECT   | EXTI_REG1 | 0x1BU)
 #define EXTI_LINE_28                        (EXTI_DIRECT   | EXTI_REG1 | 0x1CU)
 #define EXTI_LINE_29                        (EXTI_DIRECT   | EXTI_REG1 | 0x1DU)
+#if defined(EXTI_IMR1_IM30)
 #define EXTI_LINE_30                        (EXTI_DIRECT   | EXTI_REG1 | 0x1EU)
+#endif /* EXTI_IMR1_IM30 */
 #define EXTI_LINE_31                        (EXTI_DIRECT   | EXTI_REG1 | 0x1FU)
+#if defined(EXTI_IMR2_IM32)
 #define EXTI_LINE_32                        (EXTI_DIRECT   | EXTI_REG2 | 0x00U)
+#endif /* EXTI_IMR2_IM32 */
+#if defined(EXTI_IMR2_IM33)
 #define EXTI_LINE_33                        (EXTI_DIRECT   | EXTI_REG2 | 0x01U)
+#endif /* EXTI_IMR2_IM33 */
+#if defined(EXTI_IMR2_IM34)
 #define EXTI_LINE_34                        (EXTI_DIRECT   | EXTI_REG2 | 0x02U)
+#endif /* EXTI_IMR2_IM34 */
+#if defined(EXTI_IMR2_IM35)
 #define EXTI_LINE_35                        (EXTI_DIRECT   | EXTI_REG2 | 0x03U)
+#endif /* EXTI_IMR2_IM35 */
+#if defined(EXTI_IMR2_IM36)
 #define EXTI_LINE_36                        (EXTI_DIRECT   | EXTI_REG2 | 0x04U)
+#endif /* EXTI_IMR2_IM36 */
 #define EXTI_LINE_37                        (EXTI_DIRECT   | EXTI_REG2 | 0x05U)
 #define EXTI_LINE_38                        (EXTI_DIRECT   | EXTI_REG2 | 0x06U)
 #define EXTI_LINE_39                        (EXTI_DIRECT   | EXTI_REG2 | 0x07U)
 #define EXTI_LINE_40                        (EXTI_DIRECT   | EXTI_REG2 | 0x08U)
 #define EXTI_LINE_41                        (EXTI_DIRECT   | EXTI_REG2 | 0x09U)
 #define EXTI_LINE_42                        (EXTI_DIRECT   | EXTI_REG2 | 0x0AU)
+#if defined(EXTI_IMR2_IM43)
 #define EXTI_LINE_43                        (EXTI_DIRECT   | EXTI_REG2 | 0x0BU)
+#endif /* EXTI_IMR2_IM43 */
+#if defined(EXTI_IMR2_IM44)
 #define EXTI_LINE_44                        (EXTI_DIRECT   | EXTI_REG2 | 0x0CU)
+#endif /* EXTI_IMR2_IM44 */
+#if defined(EXTI_IMR2_IM45)
+#endif /* EXTI_IMR2_IM45 */
 #define EXTI_LINE_45                        (EXTI_DIRECT   | EXTI_REG2 | 0x0DU)
 #if defined(ETH)
 #define EXTI_LINE_46                        (EXTI_CONFIG   | EXTI_REG2 | 0x0EU)
 #endif /* ETH */
 #define EXTI_LINE_47                        (EXTI_DIRECT   | EXTI_REG2 | 0x0FU)
+#if defined(EXTI_IMR2_IM48)
 #define EXTI_LINE_48                        (EXTI_DIRECT   | EXTI_REG2 | 0x10U)
+#endif /* EXTI_IMR2_IM48 */
 #define EXTI_LINE_49                        (EXTI_DIRECT   | EXTI_REG2 | 0x11U)
 #define EXTI_LINE_50                        (EXTI_CONFIG   | EXTI_REG2 | 0x12U)
+#if defined(EXTI_IMR2_IM51)
 #define EXTI_LINE_51                        (EXTI_DIRECT   | EXTI_REG2 | 0x13U)
+#endif /* EXTI_IMR2_IM51 */
+#if defined(EXTI_IMR2_IM52)
 #define EXTI_LINE_52                        (EXTI_DIRECT   | EXTI_REG2 | 0x14U)
+#endif /* EXTI_IMR2_IM52 */
 #define EXTI_LINE_53                        (EXTI_CONFIG   | EXTI_REG2 | 0x15U)
+#if defined(EXTI_IMR2_IM54)
 #define EXTI_LINE_54                        (EXTI_DIRECT   | EXTI_REG2 | 0x16U)
+#endif /* EXTI_IMR2_IM54 */
+#if defined(EXTI_IMR2_IM55)
 #define EXTI_LINE_55                        (EXTI_DIRECT   | EXTI_REG2 | 0x17U)
+#endif /* EXTI_IMR2_IM55 */
+#if defined(EXTI_IMR2_IM56)
 #define EXTI_LINE_56                        (EXTI_DIRECT   | EXTI_REG2 | 0x18U)
+#endif /* EXTI_IMR2_IM56 */
+#if defined(EXTI_IMR2_IM57)
 #define EXTI_LINE_57                        (EXTI_DIRECT   | EXTI_REG2 | 0x19U)
-
+#endif /* EXTI_IMR2_IM57 */
+#if defined(EXTI_IMR2_IM58)
+#if defined(I3C2)
+#define EXTI_LINE_58                        (EXTI_DIRECT   | EXTI_REG2 | 0x1AU)
+#endif /* I3C2 */
+#endif /* EXTI_IMR2_IM58 */
 /**
   * @}
   */
@@ -181,11 +223,19 @@ typedef struct
 #define EXTI_GPIOB                          0x00000001U
 #define EXTI_GPIOC                          0x00000002U
 #define EXTI_GPIOD                          0x00000003U
+#if defined(GPIOE)
 #define EXTI_GPIOE                          0x00000004U
+#endif /* GPIOE */
+#if defined(GPIOF)
 #define EXTI_GPIOF                          0x00000005U
+#endif /* GPIOF */
+#if defined(GPIOG)
 #define EXTI_GPIOG                          0x00000006U
+#endif /* GPIOG */
 #define EXTI_GPIOH                          0x00000007U
+#if defined(GPIOI)
 #define EXTI_GPIOI                          0x00000008U
+#endif /* GPIOI */
 /**
   * @}
   */
@@ -271,7 +321,13 @@ typedef struct
 /**
   * @brief  EXTI Line number
   */
+#if defined(EXTI_IMR2_IM58)
+#define EXTI_LINE_NB                        59U
+#elif defined(EXTI_IMR2_IM57)
 #define EXTI_LINE_NB                        58U
+#else
+#define EXTI_LINE_NB                        54U
+#endif /* EXTI_IMR2_IM58 */
 
 /**
   * @brief  EXTI Mask for secure & privilege attributes
@@ -304,6 +360,7 @@ typedef struct
 
 #define IS_EXTI_CONFIG_LINE(__EXTI_LINE__)   (((__EXTI_LINE__) & EXTI_CONFIG) != 0x00U)
 
+#if defined(GPIOI)
 #define IS_EXTI_GPIO_PORT(__PORT__)     (((__PORT__) == EXTI_GPIOA) || \
                                          ((__PORT__) == EXTI_GPIOB) || \
                                          ((__PORT__) == EXTI_GPIOC) || \
@@ -313,6 +370,22 @@ typedef struct
                                          ((__PORT__) == EXTI_GPIOG) || \
                                          ((__PORT__) == EXTI_GPIOH) || \
                                          ((__PORT__) == EXTI_GPIOI))
+#elif defined(GPIOE)
+#define IS_EXTI_GPIO_PORT(__PORT__)     (((__PORT__) == EXTI_GPIOA) || \
+                                         ((__PORT__) == EXTI_GPIOB) || \
+                                         ((__PORT__) == EXTI_GPIOC) || \
+                                         ((__PORT__) == EXTI_GPIOD) || \
+                                         ((__PORT__) == EXTI_GPIOE) || \
+                                         ((__PORT__) == EXTI_GPIOF) || \
+                                         ((__PORT__) == EXTI_GPIOG) || \
+                                         ((__PORT__) == EXTI_GPIOH))
+#else
+#define IS_EXTI_GPIO_PORT(__PORT__)     (((__PORT__) == EXTI_GPIOA) || \
+                                         ((__PORT__) == EXTI_GPIOB) || \
+                                         ((__PORT__) == EXTI_GPIOC) || \
+                                         ((__PORT__) == EXTI_GPIOD) || \
+                                         ((__PORT__) == EXTI_GPIOH))
+#endif /* GPIOI */
 
 #define IS_EXTI_GPIO_PIN(__PIN__)        ((__PIN__) < 16U)
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fdcan.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fdcan.c
@@ -253,7 +253,7 @@ static const uint8_t DLCtoBytes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 
   * @{
   */
 static void FDCAN_CalcultateRamBlockAddresses(FDCAN_HandleTypeDef *hfdcan);
-static void FDCAN_CopyMessageToRAM(FDCAN_HandleTypeDef *hfdcan, const FDCAN_TxHeaderTypeDef *pTxHeader,
+static void FDCAN_CopyMessageToRAM(const FDCAN_HandleTypeDef *hfdcan, const FDCAN_TxHeaderTypeDef *pTxHeader,
                                    const uint8_t *pTxData, uint32_t BufferIndex);
 /**
   * @}
@@ -3474,7 +3474,7 @@ static void FDCAN_CalcultateRamBlockAddresses(FDCAN_HandleTypeDef *hfdcan)
   * @param  BufferIndex index of the buffer to be configured.
   * @retval none
  */
-static void FDCAN_CopyMessageToRAM(FDCAN_HandleTypeDef *hfdcan, const FDCAN_TxHeaderTypeDef *pTxHeader,
+static void FDCAN_CopyMessageToRAM(const FDCAN_HandleTypeDef *hfdcan, const FDCAN_TxHeaderTypeDef *pTxHeader,
                                    const uint8_t *pTxData, uint32_t BufferIndex)
 {
   uint32_t TxElementW1;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fdcan.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fdcan.h
@@ -517,8 +517,8 @@ typedef  void (*pFDCAN_ErrorStatusCallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, 
 #define HAL_FDCAN_ERROR_PARAM           ((uint32_t)0x00000020U) /*!< Parameter error                                                        */
 #define HAL_FDCAN_ERROR_PENDING         ((uint32_t)0x00000040U) /*!< Pending operation                                                      */
 #define HAL_FDCAN_ERROR_RAM_ACCESS      ((uint32_t)0x00000080U) /*!< Message RAM Access Failure                                             */
-#define HAL_FDCAN_ERROR_FIFO_EMPTY      ((uint32_t)0x00000100U) /*!< Put element in full FIFO                                               */
-#define HAL_FDCAN_ERROR_FIFO_FULL       ((uint32_t)0x00000200U) /*!< Get element from empty FIFO                                            */
+#define HAL_FDCAN_ERROR_FIFO_EMPTY      ((uint32_t)0x00000100U) /*!< Get element from empty FIFO                                            */
+#define HAL_FDCAN_ERROR_FIFO_FULL       ((uint32_t)0x00000200U) /*!< Put element in full FIFO                                               */
 #define HAL_FDCAN_ERROR_LOG_OVERFLOW    FDCAN_IR_ELO            /*!< Overflow of CAN Error Logging Counter                                  */
 #define HAL_FDCAN_ERROR_RAM_WDG         FDCAN_IR_WDI            /*!< Message RAM Watchdog event occurred                                    */
 #define HAL_FDCAN_ERROR_PROTOCOL_ARBT   FDCAN_IR_PEA            /*!< Protocol Error in Arbitration Phase (Nominal Bit Time is used)         */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash.c
@@ -362,6 +362,7 @@ void HAL_FLASH_IRQHandler(void)
   __IO uint32_t *reg_cr;
   __IO uint32_t *reg_ccr;
   const __IO uint32_t *reg_sr;
+  const __IO uint32_t *reg_ecccorr;
 
   /* Access to CR, CCR and SR registers depends on operation type */
 #if defined (FLASH_OPTSR2_TZEN)
@@ -373,6 +374,7 @@ void HAL_FLASH_IRQHandler(void)
   reg_ccr = &(FLASH_NS->NSCCR);
   reg_sr = &(FLASH_NS->NSSR);
 #endif /* FLASH_OPTSR2_TZEN */
+  reg_ecccorr = &(FLASH->ECCCORR);
 
   /* Save Flash errors */
   errorflag = (*reg_sr) & FLASH_FLAG_SR_ERRORS;
@@ -458,6 +460,16 @@ void HAL_FLASH_IRQHandler(void)
 
     /* FLASH EOP interrupt user callback */
     HAL_FLASH_EndOfOperationCallback(param);
+  }
+
+  /* Check FLASH ECC correction flag */
+  if ((*reg_ecccorr & FLASH_ECCR_ECCC) != 0U)
+  {
+    /* Call User callback */
+    HAL_FLASHEx_EccCorrectionCallback();
+
+    /* Clear ECC correction flag in order to allow new ECC error record */
+    FLASH->ECCCORR |= FLASH_ECCR_ECCC;
   }
 
   if (pFlash.ProcedureOnGoing == 0U)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash.h
@@ -251,7 +251,7 @@ typedef struct
 #define FLASH_SECTOR_5             5U       /*!< Sector Number 5   */
 #define FLASH_SECTOR_6             6U       /*!< Sector Number 6   */
 #define FLASH_SECTOR_7             7U       /*!< Sector Number 7   */
-#if (FLASH_SECTOR_NB == 128)
+#if (FLASH_SECTOR_NB >= 32)
 #define FLASH_SECTOR_8             8U       /*!< Sector Number 8   */
 #define FLASH_SECTOR_9             9U       /*!< Sector Number 9   */
 #define FLASH_SECTOR_10            10U      /*!< Sector Number 10  */
@@ -276,6 +276,8 @@ typedef struct
 #define FLASH_SECTOR_29            29U      /*!< Sector Number 29  */
 #define FLASH_SECTOR_30            30U      /*!< Sector Number 30  */
 #define FLASH_SECTOR_31            31U      /*!< Sector Number 31  */
+#endif /* (FLASH_SECTOR_NB >= 32) */
+#if (FLASH_SECTOR_NB >= 128)
 #define FLASH_SECTOR_32            32U      /*!< Sector Number 32  */
 #define FLASH_SECTOR_33            33U      /*!< Sector Number 33  */
 #define FLASH_SECTOR_34            34U      /*!< Sector Number 34  */
@@ -372,7 +374,7 @@ typedef struct
 #define FLASH_SECTOR_125           125U     /*!< Sector Number 125 */
 #define FLASH_SECTOR_126           126U     /*!< Sector Number 126 */
 #define FLASH_SECTOR_127           127U     /*!< Sector Number 127 */
-#endif /* (FLASH_SECTOR_NB == 128) */
+#endif /* (FLASH_SECTOR_NB >= 128) */
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_flash_ex.h
@@ -89,7 +89,7 @@ typedef struct
                                 @ref FLASH_OB_USER_SRAM2_RST, @ref FLASH_OB_USER_BKPRAM_ECC,
                                 @ref FLASH_OB_USER_SRAM3_ECC, @ref FLASH_OB_USER_SRAM2_ECC,
                                 @ref FLASH_OB_USER_SRAM1_RST, @ref FLASH_OB_USER_SRAM1_ECC,
-                                @ref FLASH_OB_USER_TZEN */
+                                @ref FLASH_OB_USER_USBPD_DIS, @ref FLASH_OB_USER_TZEN */
 
   uint32_t Banks;          /*!< Select banks for WRP , HDP and secure area configuration.
                                 This parameter must be a value of @ref FLASH_Banks */
@@ -172,6 +172,19 @@ typedef struct
 } FLASH_HDPExtensionTypeDef;
 
 /**
+  * @brief  ECC Info Structure definition
+  */
+typedef struct
+{
+  uint32_t               Area;             /*!< Area from which an ECC was detected.
+                                                This parameter can be a value of @ref FLASHEx_ECC_Area  */
+
+  uint32_t               Address;          /*!< ECC error address */
+
+  uint32_t               Data;             /*!< ECC failing data */
+} FLASH_EccInfoTypeDef;
+
+/**
   * @}
   */
 /* Exported constants --------------------------------------------------------*/
@@ -206,6 +219,25 @@ typedef struct
                                                                                                   activation */
 #endif /* FLASH_SR_OBKERR */
 #endif /* __ARM_FEATURE_CMSE */
+
+/** @defgroup FLASH_ECC_Area FLASH ECC Area
+  * @brief    FLASH ECC Area
+  * @{
+  */
+#define FLASH_ECC_AREA_USER_BANK1         0x00000000U               /*!< FLASH bank 1 area                */
+#define FLASH_ECC_AREA_USER_BANK2         FLASH_ECCR_BK_ECC         /*!< FLASH bank 2 area                */
+#define FLASH_ECC_AREA_SYSTEM             FLASH_ECCR_SYSF_ECC       /*!< System FLASH area                */
+#if defined (FLASH_SR_OBKERR)
+#define FLASH_ECC_AREA_OBK                FLASH_ECCR_OBK_ECC        /*!< FLASH OBK area                   */
+#endif /* FLASH_SR_OBKERR */
+#define FLASH_ECC_AREA_OTP                FLASH_ECCR_OTP_ECC        /*!< FLASH OTP area                   */
+#if defined (FLASH_EDATAR_EDATA_EN)
+#define FLASH_ECC_AREA_EDATA              FLASH_ECCR_DATA_ECC       /*!< FLASH high-cycle data area       */
+#endif /* FLASH_EDATAR_EDATA_EN */
+/**
+  * @}
+  */
+
 /**
   * @}
   */
@@ -276,24 +308,28 @@ byte configuration */
 #define OB_USER_SRAM3_ECC         0x00008000U     /*!< SRAM3 ECC detection and correction enable */
 #define OB_USER_SRAM2_ECC         0x00010000U     /*!< SRAM2 ECC detection and correction enable */
 #define OB_USER_SRAM1_ECC         0x00020000U     /*!< SRAM1 ECC detection and correction enable */
+#if defined (FLASH_OPTSR2_USBPD_DIS)
+#define OB_USER_USBPD_DIS         0x00040000U     /*!< USB power delivery configuration enable */
+#endif /*FLASH_OPTSR2_USBPD_DIS*/
 #if defined (FLASH_OPTSR2_TZEN)
 #define OB_USER_TZEN              0x00080000U     /*!< Global TrustZone security enable */
 #endif /* FLASH_OPTSR2_TZEN */
 
-#if defined (FLASH_OPTSR2_SRAM1_3_RST) && defined (FLASH_OPTSR_BOOT_UBE)
+#if defined (FLASH_OPTSR2_SRAM1_3_RST) && defined (FLASH_OPTSR_BOOT_UBE) && defined (FLASH_OPTSR2_USBPD_DIS)
 #define OB_USER_ALL (OB_USER_BOR_LEV        | OB_USER_BORH_EN        | OB_USER_IWDG_SW     |\
                      OB_USER_WWDG_SW        | OB_USER_NRST_STOP      | OB_USER_NRST_STDBY  |\
                      OB_USER_IO_VDD_HSLV    | OB_USER_IO_VDDIO2_HSLV | OB_USER_IWDG_STOP   |\
                      OB_USER_IWDG_STDBY     | OB_USER_BOOT_UBE       | OB_USER_SWAP_BANK   |\
                      OB_USER_SRAM1_3_RST    | OB_USER_SRAM2_RST      | OB_USER_BKPRAM_ECC  |\
-                     OB_USER_SRAM3_ECC      | OB_USER_SRAM2_ECC      | OB_USER_TZEN)
+                     OB_USER_SRAM3_ECC      | OB_USER_SRAM2_ECC      | OB_USER_USBPD_DIS   |\
+                     OB_USER_TZEN)
 #else
 #define OB_USER_ALL (OB_USER_BOR_LEV        | OB_USER_BORH_EN        | OB_USER_IWDG_SW     |\
                      OB_USER_WWDG_SW        | OB_USER_NRST_STOP      | OB_USER_NRST_STDBY  |\
                      OB_USER_IO_VDD_HSLV    | OB_USER_IO_VDDIO2_HSLV | OB_USER_IWDG_STOP   |\
                      OB_USER_IWDG_STDBY     | OB_USER_SWAP_BANK      | OB_USER_SRAM1_RST   |\
                      OB_USER_SRAM2_RST      | OB_USER_BKPRAM_ECC     | OB_USER_SRAM3_ECC   |\
-                     OB_USER_SRAM2_ECC      |  OB_USER_SRAM1_ECC)
+                     OB_USER_SRAM2_ECC      | OB_USER_SRAM1_ECC)
 #endif /* FLASH_OPTSR2_SRAM1_3_RST && FLASH_OPTSR_BOOT_UBE */
 /**
   * @}
@@ -302,9 +338,9 @@ byte configuration */
 /** @defgroup FLASH_OB_USER_BOR_LEVEL FLASH BOR Reset Level
   * @{
   */
-#define OB_BOR_LEVEL_1        FLASH_OPTSR_BOR_LEV_0                            /*!< Reset level 1 threshold */
-#define OB_BOR_LEVEL_2        FLASH_OPTSR_BOR_LEV_1                            /*!< Reset level 2 threshold */
-#define OB_BOR_LEVEL_3        (FLASH_OPTSR_BOR_LEV_1 | FLASH_OPTSR_BOR_LEV_0)  /*!< Reset level 3 threshold */
+#define OB_BOR_LEVEL_1        0U                                               /*!< Reset level 1 threshold */
+#define OB_BOR_LEVEL_2        FLASH_OPTSR_BOR_LEV_0                            /*!< Reset level 2 threshold */
+#define OB_BOR_LEVEL_3        FLASH_OPTSR_BOR_LEV_1                            /*!< Reset level 3 threshold */
 /**
   * @}
   */
@@ -500,6 +536,16 @@ byte configuration */
   * @}
   */
 
+/** @defgroup OB_USER_USBPD_DIS FLASH Option Bytes USB power delivery configuration
+  * @{
+  */
+#if defined (FLASH_OPTSR2_USBPD_DIS)
+#define OB_USBPD_DIS_ENABLE       0x00000000U            /*!< USB power delivery check enable  */
+#define OB_USBPD_DIS_DISABLE      FLASH_OPTSR2_USBPD_DIS /*!< USB power delivery check disable */
+#endif /* FLASH_OPTSR2_USBPD_DIS */
+/**
+  * @}
+  */
 /** @defgroup FLASH_OB_USER_TZEN FLASH Option Bytes Global TrustZone
   * @{
   */
@@ -558,6 +604,16 @@ byte configuration */
 #define OB_WRP_SECTOR_120TO123   0x40000000U /*!< Write protection of Sector120 to Sector123 */
 #define OB_WRP_SECTOR_124TO127   0x80000000U /*!< Write protection of Sector124 to Sector127 */
 #define OB_WRP_SECTOR_ALL        0xFFFFFFFFU /*!< Write protection of all Sectors            */
+#elif (FLASH_SECTOR_NB == 32)
+#define OB_WRP_SECTOR_0TO3       0x00000001U /*!< Write protection of Sector0  to Sector3    */
+#define OB_WRP_SECTOR_4TO7       0x00000002U /*!< Write protection of Sector4  to Sector7    */
+#define OB_WRP_SECTOR_8TO11      0x00000004U /*!< Write protection of Sector8  to Sector11   */
+#define OB_WRP_SECTOR_12TO15     0x00000008U /*!< Write protection of Sector12 to Sector15   */
+#define OB_WRP_SECTOR_16TO19     0x00000010U /*!< Write protection of Sector16 to Sector19   */
+#define OB_WRP_SECTOR_20TO23     0x00000020U /*!< Write protection of Sector20 to Sector23   */
+#define OB_WRP_SECTOR_24TO27     0x00000040U /*!< Write protection of Sector24 to Sector27   */
+#define OB_WRP_SECTOR_28TO31     0x00000080U /*!< Write protection of Sector28 to Sector31   */
+#define OB_WRP_SECTOR_ALL        0x000000FFU /*!< Write protection of all Sectors            */
 #else
 #define OB_WRP_SECTOR_0          0x00000001U /*!< Write protection of Sector0                */
 #define OB_WRP_SECTOR_1          0x00000002U /*!< Write protection of Sector1                */
@@ -576,13 +632,12 @@ byte configuration */
 /** @defgroup FLASH_Programming_Delay FLASH Programming Delay
   * @{
   */
-#define FLASH_PROGRAMMING_DELAY_0   0x00000000U            /*!< programming delay set for Flash running at 70 MHz or
+#define FLASH_PROGRAMMING_DELAY_0   0x00000000U            /*!< programming delay set for Flash running at 84 MHz or
                                                                 below */
-#define FLASH_PROGRAMMING_DELAY_1   FLASH_ACR_WRHIGHFREQ_0 /*!< programming delay set for Flash running between 70 MHz
-                                                                and 185 MHz */
-#define FLASH_PROGRAMMING_DELAY_2   FLASH_ACR_WRHIGHFREQ_1 /*!< programming delay set for Flash running between 185 MHz
-                                                                and 225 MHz */
-#define FLASH_PROGRAMMING_DELAY_3   FLASH_ACR_WRHIGHFREQ   /*!< programming delay set for Flash at startup */
+#define FLASH_PROGRAMMING_DELAY_1   FLASH_ACR_WRHIGHFREQ_0 /*!< programming delay set for Flash running between 84 MHz
+                                                                and 168 MHz */
+#define FLASH_PROGRAMMING_DELAY_2   FLASH_ACR_WRHIGHFREQ_1 /*!< programming delay set for Flash running between 168 MHz
+                                                                and 250 MHz */
 /**
   * @}
   */
@@ -838,6 +893,19 @@ HAL_StatusTypeDef HAL_FLASHEx_ConfigHDPExtension(const FLASH_HDPExtensionTypeDef
 /**
   * @}
   */
+
+/** @addtogroup FLASHEx_Exported_Functions_Group3
+  * @{
+  */
+void              HAL_FLASHEx_EnableEccCorrectionInterrupt(void);
+void              HAL_FLASHEx_DisableEccCorrectionInterrupt(void);
+void              HAL_FLASHEx_GetEccInfo(FLASH_EccInfoTypeDef *pData);
+void              HAL_FLASHEx_ECCD_IRQHandler(void);
+__weak void       HAL_FLASHEx_EccDetectionCallback(void);
+__weak void       HAL_FLASHEx_EccCorrectionCallback(void);
+/**
+  * @}
+  */
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
@@ -845,6 +913,8 @@ HAL_StatusTypeDef HAL_FLASHEx_ConfigHDPExtension(const FLASH_HDPExtensionTypeDef
   * @{
   */
 #define FLASH_TYPEPROGRAM_OB (0x00008000U | FLASH_NON_SECURE_MASK) /*!< Program Option Bytes operation type */
+#define FLASH_ADDRESS_OFFSET_OTP       (0x00000600U)               /*!< Flash address offset of OTP area */
+#define FLASH_ADDRESS_OFFSET_EDATA     (0x0000F000U)               /*!< Flash address offset of EDATA area */
 /**
   * @}
   */
@@ -937,6 +1007,9 @@ HAL_StatusTypeDef HAL_FLASHEx_ConfigHDPExtension(const FLASH_HDPExtensionTypeDef
 
 #define IS_OB_USER_SRAM2_ECC(VALUE)      (((VALUE) == OB_SRAM2_ECC_ENABLE) || ((VALUE) == OB_SRAM2_ECC_DISABLE))
 
+#if defined(FLASH_OPTSR2_USBPD_DIS)
+#define IS_OB_USER_USBPD_DIS(VALUE)      (((VALUE) == OB_USBPD_DIS_ENABLE) || ((VALUE) == OB_USBPD_DIS_DISABLE))
+#endif /* FLASH_OPTSR2_USBPD_DIS */
 #define IS_OB_USER_TZEN(VALUE)           (((VALUE) == OB_TZEN_DISABLE) || ((VALUE) == OB_TZEN_ENABLE))
 
 #define IS_OB_USER_TYPE(TYPE)           ((((TYPE) & OB_USER_ALL) != 0U) && \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fmac.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fmac.c
@@ -166,7 +166,7 @@
 
     [..]
       Use function HAL_FMAC_UnRegisterCallback() to reset a callback to the default
-      weak (surcharged) function.
+      weak function.
       HAL_FMAC_UnRegisterCallback() takes as parameters the HAL peripheral handle
       and the Callback ID.
       This function allows to reset following callbacks:
@@ -182,10 +182,10 @@
 
     [..]
       By default, after the HAL_FMAC_Init() and when the state is HAL_FMAC_STATE_RESET
-      all callbacks are set to the corresponding weak (surcharged) functions:
+      all callbacks are set to the corresponding weak functions:
       examples GetDataCallback(), OutputDataReadyCallback().
       Exception done for MspInit and MspDeInit functions that are respectively
-      reset to the legacy weak (surcharged) functions in the HAL_FMAC_Init()
+      reset to the legacy weak functions in the HAL_FMAC_Init()
       and HAL_FMAC_DeInit() only when these callbacks are null (not registered beforehand).
       If not, MspInit or MspDeInit are not null, the HAL_FMAC_Init() and HAL_FMAC_DeInit()
       keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
@@ -202,8 +202,7 @@
     [..]
       When the compilation define USE_HAL_FMAC_REGISTER_CALLBACKS is set to 0 or
       not defined, the callback registration feature is not available
-      and weak (surcharged) callbacks are used.
-
+      and weak callbacks are used.
 
   @endverbatim
   *
@@ -229,7 +228,6 @@
 /** @defgroup  FMAC_Private_Constants   FMAC Private Constants
   * @{
   */
-
 #define MAX_FILTER_DATA_SIZE_TO_HANDLE ((uint16_t) 0xFFU)
 #define MAX_PRELOAD_INDEX      0xFFU
 #define PRELOAD_ACCESS_DMA     0x00U
@@ -322,7 +320,6 @@
 /* Private variables ---------------------------------------------------------*/
 /* Global variables ----------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-
 static HAL_StatusTypeDef FMAC_Reset(FMAC_HandleTypeDef *hfmac);
 static void FMAC_ResetDataPointers(FMAC_HandleTypeDef *hfmac);
 static void FMAC_ResetOutputStateAndDataPointers(FMAC_HandleTypeDef *hfmac);
@@ -348,7 +345,6 @@ static void FMAC_DMAFilterPreload(DMA_HandleTypeDef *hdma);
 static void FMAC_DMAError(DMA_HandleTypeDef *hdma);
 
 /* Functions Definition ------------------------------------------------------*/
-
 /** @defgroup FMAC_Exported_Functions FMAC Exported Functions
   * @{
   */
@@ -2576,7 +2572,6 @@ static void FMAC_DMAFilterConfig(DMA_HandleTypeDef *hdma)
 #else
   HAL_FMAC_ErrorCallback(hfmac);
 #endif /* USE_HAL_FMAC_REGISTER_CALLBACKS */
-
 }
 
 /**
@@ -2708,10 +2703,10 @@ static void FMAC_DMAError(DMA_HandleTypeDef *hdma)
   HAL_FMAC_ErrorCallback(hfmac);
 #endif /* USE_HAL_FMAC_REGISTER_CALLBACKS */
 }
+
 /**
   * @}
   */
-
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fmac.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_fmac.h
@@ -243,10 +243,7 @@ typedef struct
   * @}
   */
 
-
 /* Exported constants --------------------------------------------------------*/
-
-
 /** @defgroup FMAC_Exported_Constants FMAC Exported Constants
   * @{
   */
@@ -356,7 +353,6 @@ typedef struct
 /**
   * @}
   */
-
 
 /* Exported variables --------------------------------------------------------*/
 /** @defgroup FMAC_Exported_variables FMAC Exported variables
@@ -499,7 +495,7 @@ typedef struct
   * @}
   */
 
-/* Private Macros-----------------------------------------------------------*/
+/* Private Macros-------------------------------------------------------------*/
 /** @addtogroup  FMAC_Private_Macros FMAC Private Macros
   * @{
   */
@@ -578,9 +574,9 @@ typedef struct
   * @param  __FUNCTION__ ID of the filter function.
   * @retval SET (__Q__ is a valid value) or RESET (__Q__ is invalid)
   */
-#define IS_FMAC_PARAM_Q(__FUNCTION__, __Q__) ( ((__FUNCTION__) == FMAC_FUNC_CONVO_FIR)                || \
-                                               (((__FUNCTION__) == FMAC_FUNC_IIR_DIRECT_FORM_1)       && \
-                                                (((__Q__) >= FMAC_PARAM_Q_MIN) && ((__Q__) <= FMAC_PARAM_Q_MAX))) )
+#define IS_FMAC_PARAM_Q(__FUNCTION__, __Q__) (((__FUNCTION__) == FMAC_FUNC_CONVO_FIR)                || \
+                                              (((__FUNCTION__) == FMAC_FUNC_IIR_DIRECT_FORM_1)       && \
+                                               (((__Q__) >= FMAC_PARAM_Q_MIN) && ((__Q__) <= FMAC_PARAM_Q_MAX))))
 
 /**
   * @brief  Verify the FMAC filter parameter R.

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio.c
@@ -206,15 +206,15 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, const GPIO_InitTypeDef *pGPIO_Init)
 
         /* Configure Alternate function mapped with the current IO */
         tmp = GPIOx->AFR[position >> 3U];
-        tmp &= ~(0x0FUL << ((position & 0x07U) * 4U));
-        tmp |= ((pGPIO_Init->Alternate & 0x0FUL) << ((position & 0x07U) * 4U));
+        tmp &= ~(0x0FUL << ((position & 0x07U) * GPIO_AFRL_AFSEL1_Pos));
+        tmp |= ((pGPIO_Init->Alternate & 0x0FUL) << ((position & 0x07U) * GPIO_AFRL_AFSEL1_Pos));
         GPIOx->AFR[position >> 3U] = tmp;
       }
 
       /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
       tmp = GPIOx->MODER;
-      tmp &= ~(GPIO_MODER_MODE0 << (position * 2U));
-      tmp |= ((pGPIO_Init->Mode & GPIO_MODE) << (position * 2U));
+      tmp &= ~(GPIO_MODER_MODE0 << (position * GPIO_MODER_MODE1_Pos));
+      tmp |= ((pGPIO_Init->Mode & GPIO_MODE) << (position * GPIO_MODER_MODE1_Pos));
       GPIOx->MODER = tmp;
 
       /* In case of Output or Alternate function mode selection */
@@ -226,8 +226,8 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, const GPIO_InitTypeDef *pGPIO_Init)
 
         /* Configure the IO Speed */
         tmp = GPIOx->OSPEEDR;
-        tmp &= ~(GPIO_OSPEEDR_OSPEED0 << (position * 2U));
-        tmp |= (pGPIO_Init->Speed << (position * 2U));
+        tmp &= ~(GPIO_OSPEEDR_OSPEED0 << (position * GPIO_OSPEEDR_OSPEED1_Pos));
+        tmp |= (pGPIO_Init->Speed << (position * GPIO_OSPEEDR_OSPEED1_Pos));
         GPIOx->OSPEEDR = tmp;
 
         /* Configure the IO Output Type */
@@ -244,8 +244,8 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, const GPIO_InitTypeDef *pGPIO_Init)
 
         /* Activate the Pull-up or Pull down resistor for the current IO */
         tmp = GPIOx->PUPDR;
-        tmp &= ~(GPIO_PUPDR_PUPD0 << (position * 2U));
-        tmp |= ((pGPIO_Init->Pull) << (position * 2U));
+        tmp &= ~(GPIO_PUPDR_PUPD0 << (position * GPIO_PUPDR_PUPD1_Pos));
+        tmp |= ((pGPIO_Init->Pull) << (position * GPIO_PUPDR_PUPD1_Pos));
         GPIOx->PUPDR = tmp;
       }
 
@@ -254,8 +254,8 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, const GPIO_InitTypeDef *pGPIO_Init)
       if ((pGPIO_Init->Mode & EXTI_MODE) == EXTI_MODE)
       {
         tmp = EXTI->EXTICR[position >> 2U];
-        tmp &= ~((0x0FUL) << (8U * (position & 0x03U)));
-        tmp |= (GPIO_GET_INDEX(GPIOx) << (8U * (position & 0x03U)));
+        tmp &= ~((0x0FUL) << ((position & 0x03U) * EXTI_EXTICR1_EXTI1_Pos));
+        tmp |= (GPIO_GET_INDEX(GPIOx) << ((position & 0x03U) * EXTI_EXTICR1_EXTI1_Pos));
         EXTI->EXTICR[position >> 2U] = tmp;
 
         /* Clear Rising Falling edge configuration */
@@ -327,8 +327,8 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
       /*------------------------- EXTI Mode Configuration --------------------*/
       /* Clear the External Interrupt or Event for the current IO */
       tmp = EXTI->EXTICR[position >> 2U];
-      tmp &= ((0x0FUL) << (8U * (position & 0x03U)));
-      if (tmp == (GPIO_GET_INDEX(GPIOx) << (8U * (position & 0x03U))))
+      tmp &= ((0x0FUL) << ((position & 0x03U) * EXTI_EXTICR1_EXTI1_Pos));
+      if (tmp == (GPIO_GET_INDEX(GPIOx) << ((position & 0x03U) * EXTI_EXTICR1_EXTI1_Pos)))
       {
         /* Clear EXTI line configuration */
         EXTI->IMR1 &= ~(iocurrent);
@@ -338,25 +338,25 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
         EXTI->RTSR1 &= ~(iocurrent);
         EXTI->FTSR1 &= ~(iocurrent);
 
-        tmp = (0x0FUL) << (8U * (position & 0x03U));
+        tmp = (0x0FUL) << ((position & 0x03U) * EXTI_EXTICR1_EXTI1_Pos);
         EXTI->EXTICR[position >> 2U] &= ~tmp;
       }
 
       /*------------------------- GPIO Mode Configuration --------------------*/
       /* Configure IO in Analog Mode */
-      GPIOx->MODER |= (GPIO_MODER_MODE0 << (position * 2U));
+      GPIOx->MODER |= (GPIO_MODER_MODE0 << (position * GPIO_MODER_MODE1_Pos));
 
       /* Configure the default Alternate Function in current IO */
-      GPIOx->AFR[position >> 3U] &= ~(0x0FUL << ((position & 0x07U) * 4U));
+      GPIOx->AFR[position >> 3U] &= ~(0x0FUL << ((position & 0x07U) * GPIO_AFRL_AFSEL1_Pos));
 
       /* Configure the default value for IO Speed */
-      GPIOx->OSPEEDR &= ~(GPIO_OSPEEDR_OSPEED0 << (position * 2U));
+      GPIOx->OSPEEDR &= ~(GPIO_OSPEEDR_OSPEED0 << (position * GPIO_OSPEEDR_OSPEED1_Pos));
 
       /* Configure the default value IO Output Type */
       GPIOx->OTYPER  &= ~(GPIO_OTYPER_OT0 << position);
 
       /* Deactivate the Pull-up and Pull-down resistor for the current IO */
-      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPD0 << (position * 2U));
+      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPD0 << (position * GPIO_PUPDR_PUPD1_Pos));
     }
 
     position++;
@@ -704,7 +704,7 @@ HAL_StatusTypeDef HAL_GPIO_GetConfigPinAttributes(const GPIO_TypeDef *GPIOx, uin
 
   /* Check the parameters */
   assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
-  assert_param(IS_GPIO_PIN(GPIO_Pin) && (GPIO_Pin != GPIO_PIN_ALL));
+  assert_param(IS_GPIO_SINGLE_PIN(GPIO_Pin));
 
   /* Get secure attribute of the port pin */
   while ((GPIO_Pin >> position) != 0U)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio.h
@@ -278,6 +278,23 @@ typedef enum
 #define IS_GPIO_PIN(__PIN__)        ((((uint32_t)(__PIN__) & GPIO_PIN_MASK) != 0x00U) &&\
                                      (((uint32_t)(__PIN__) & ~GPIO_PIN_MASK) == 0x00U))
 
+#define IS_GPIO_SINGLE_PIN(__PIN__) (((__PIN__) == GPIO_PIN_0)   ||\
+                                     ((__PIN__) == GPIO_PIN_1)   ||\
+                                     ((__PIN__) == GPIO_PIN_2)   ||\
+                                     ((__PIN__) == GPIO_PIN_3)   ||\
+                                     ((__PIN__) == GPIO_PIN_4)   ||\
+                                     ((__PIN__) == GPIO_PIN_5)   ||\
+                                     ((__PIN__) == GPIO_PIN_6)   ||\
+                                     ((__PIN__) == GPIO_PIN_7)   ||\
+                                     ((__PIN__) == GPIO_PIN_8)   ||\
+                                     ((__PIN__) == GPIO_PIN_9)   ||\
+                                     ((__PIN__) == GPIO_PIN_10)  ||\
+                                     ((__PIN__) == GPIO_PIN_11)  ||\
+                                     ((__PIN__) == GPIO_PIN_12)  ||\
+                                     ((__PIN__) == GPIO_PIN_13)  ||\
+                                     ((__PIN__) == GPIO_PIN_14)  ||\
+                                     ((__PIN__) == GPIO_PIN_15))
+
 #define IS_GPIO_COMMON_PIN(__RESETMASK__, __SETMASK__)  \
   (((uint32_t)(__RESETMASK__) & (uint32_t)(__SETMASK__)) == 0x00u)
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gpio_ex.h
@@ -56,6 +56,12 @@ extern "C" {
 #define GPIO_AF0_CSLEEP        ((uint8_t)0x00)  /* CSLEEP Alternate Function mapping                         */
 #define GPIO_AF0_CSTOP         ((uint8_t)0x00)  /* CSTOP Alternate Function mapping                          */
 #define GPIO_AF0_CRS           ((uint8_t)0x00)  /* CRS Alternate Function mapping                            */
+#if defined(DMA2D)
+#define GPIO_AF0_DMA2D         ((uint8_t)0x00)  /* DMA2D Alternate Function mapping                          */
+#endif /* DMA2D */
+#if defined(GFXTIM)
+#define GPIO_AF0_GFXTIM        ((uint8_t)0x00)  /* GFXTIM Alternate Function mapping                         */
+#endif /* GFXTIM */
 
 /**
   * @brief   AF 1 selection
@@ -68,9 +74,12 @@ extern "C" {
 #if defined(TIM17)
 #define GPIO_AF1_TIM17         ((uint8_t)0x01)  /* TIM17 Alternate Function mapping                          */
 #endif /* TIM17 */
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx))
+#if !defined(STM32H503xx)
 #define GPIO_AF1_LPTIM1        ((uint8_t)0x01)  /* LPTIM1 Alternate Function mapping                         */
-#endif /* defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) */
+#endif /* STM32H503xx */
+#if defined(ADF1)
+#define GPIO_AF1_ADF1         ((uint8_t)0x01)   /* ADF1 Alternate Function mapping                            */
+#endif /* ADF1 */
 
 /**
   * @brief   AF 2 selection
@@ -91,12 +100,20 @@ extern "C" {
 #if defined(TIM5)
 #define GPIO_AF2_TIM5          ((uint8_t)0x02)  /* TIM5 Alternate Function mapping                           */
 #endif /* TIM5 */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF2_TIM8          ((uint8_t)0x02)  /* TIM8 Alternate Function mapping                           */
+#endif /* STM32H533xx || STM32H523xx */
 #if defined(TIM12)
 #define GPIO_AF2_TIM12         ((uint8_t)0x02)  /* TIM12 Alternate Function mapping                          */
 #endif /* TIM12 */
 #if defined(TIM15)
 #define GPIO_AF2_TIM15         ((uint8_t)0x02)  /* TIM15 Alternate Function mapping                          */
 #endif /* TIM15 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF2_TIM13         ((uint8_t)0x02)  /* TIM13 Alternate Function mapping                          */
+#define GPIO_AF2_TIM14         ((uint8_t)0x02)  /* TIM14 Alternate Function mapping                          */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+
 /**
   * @brief   AF 3 selection
   */
@@ -112,12 +129,22 @@ extern "C" {
 #if defined(OCTOSPI1)
 #define GPIO_AF3_OCTOSPI1      ((uint8_t)0x03)  /* OCTOSPI1 Alternate Function mapping                       */
 #endif /* OCTOSPI1 */
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx))
+#if !defined(STM32H503xx)
 #define GPIO_AF3_TIM1          ((uint8_t)0x03)  /* TIM1 Alternate Function mapping                           */
-#endif /* defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) */
+#endif /* STM32H503xx */
 #if defined(TIM8)
 #define GPIO_AF3_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping                           */
 #endif /* TIM8 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF3_COMP1         ((uint8_t)0x03)  /* COMP1 Alternate Function mapping                          */
+#define GPIO_AF3_COMP2         ((uint8_t)0x03)  /* COMP2 Alternate Function mapping                          */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+#if defined(ADF1)
+#define GPIO_AF3_ADF1          ((uint8_t)0x03)  /* ADF1 Alternate Function mapping                           */
+#endif /* ADF1 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF3_I2C3          ((uint8_t)0x03)  /* I2C3 Alternate Function mapping                           */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 
 /**
   * @brief   AF 4 selection
@@ -125,10 +152,14 @@ extern "C" {
 #if defined(CEC)
 #define GPIO_AF4_CEC           ((uint8_t)0x04)  /* CEC Alternate Function mapping                            */
 #endif /* CEC */
+#if !defined(STM32H5F5xx) || !defined(STM32H5F4xx) || !defined(STM32H5E5xx) || !defined(STM32H5E4xx)
 #if defined(DCMI)
 #define GPIO_AF4_DCMI          ((uint8_t)0x04)  /* DCMI Alternate Function mapping                           */
-#define GPIO_AF4_PSSI          ((uint8_t)0x04)  /* PSSI Alternate Function mapping                           */
 #endif /* DCMI */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+#if defined(PSSI)
+#define GPIO_AF4_PSSI          ((uint8_t)0x04)  /* PSSI Alternate Function mapping                           */
+#endif /* PSSI */
 #define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping                           */
 #define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping                           */
 #if defined(I2C3)
@@ -140,6 +171,9 @@ extern "C" {
 #define GPIO_AF4_LPTIM1        ((uint8_t)0x04)  /* LPTIM1 Alternate Function mapping                         */
 #define GPIO_AF4_LPTIM2        ((uint8_t)0x04)  /* LPTIM2 Alternate Function mapping                         */
 #define GPIO_AF4_SPI1          ((uint8_t)0x04)  /* SPI1 Alternate Function mapping                           */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF4_SPI3          ((uint8_t)0x04)  /* SPI3 Alternate Function mapping                           */
+#endif /* STM32H533xx || STM32H523xx */
 #if defined(TIM15)
 #define GPIO_AF4_TIM15         ((uint8_t)0x04)  /* TIM15 Alternate Function mapping                          */
 #endif /* TIM15 */
@@ -147,6 +181,15 @@ extern "C" {
 #if defined(STM32H503xx)
 #define GPIO_AF4_USART2        ((uint8_t)0x04)  /* USART2 Alternate Function mapping                         */
 #endif /* STM32H503xx */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF4_SAI1          ((uint8_t)0x04)  /* SAI1 Alternate Function mapping                           */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+#if defined(MDF1)
+#define GPIO_AF4_MDF1          ((uint8_t)0x04)  /* MDF1 Alternate Function mapping                           */
+#endif /* MDF1 */
+#if defined(ADF1)
+#define GPIO_AF4_ADF1          ((uint8_t)0x04)  /* ADF1 Alternate Function mapping                           */
+#endif /* ADF1 */
 
 /**
   * @brief   AF 5 selection
@@ -154,10 +197,10 @@ extern "C" {
 #if defined(CEC)
 #define GPIO_AF5_CEC           ((uint8_t)0x05)  /* CEC Alternate Function mapping                            */
 #endif /* CEC */
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx))
+#if !defined(STM32H503xx)
 #define GPIO_AF5_I3C1          ((uint8_t)0x05)  /* I3C1 Alternate Function mapping                           */
 #define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3 Alternate Function mapping                           */
-#endif /* defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) */
+#endif /* STM32H503xx */
 #define GPIO_AF5_LPTIM1        ((uint8_t)0x05)  /* LPTIM1 Alternate Function mapping                         */
 #define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping                           */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2 Alternate Function mapping                           */
@@ -170,6 +213,14 @@ extern "C" {
 #if defined(SPI6)
 #define GPIO_AF5_SPI6          ((uint8_t)0x05)  /* SPI6 Alternate Function mapping                           */
 #endif /* SPI6 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF5_I3C2          ((uint8_t)0x05)  /* I3C2 Alternate Function mapping                           */
+#if defined(GFXTIM)
+#define GPIO_AF5_GFXTIM        ((uint8_t)0x05)  /* GFXTIM Alternate Function mapping                         */
+#endif /* GFXTIM */
+#define GPIO_AF5_AUDIOCLK      ((uint8_t)0x05)  /* AUDIOCLK Alternate Function mapping                       */
+#define GPIO_AF5_USART2        ((uint8_t)0x05)  /* USART2 Alternate Function mapping                         */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 
 /**
   * @brief   AF 6 selection
@@ -183,10 +234,10 @@ extern "C" {
 #if defined(SAI1)
 #define GPIO_AF6_SAI1          ((uint8_t)0x06)  /* SAI1 Alternate Function mapping                           */
 #endif /* SAI1 */
-#if defined(STM32H503xx)
+#if (defined(STM32H503xx) || defined(STM32H533xx) || defined(STM32H523xx))
 #define GPIO_AF6_SPI1          ((uint8_t)0x06)  /* SPI1 Alternate Function mapping                           */
 #define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* SPI2 Alternate Function mapping                           */
-#endif /* STM32H503xx */
+#endif /* STM32H503xx || STM32H533xx || STM32H523xx */
 #define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3 Alternate Function mapping                           */
 #if defined(SPI4)
 #define GPIO_AF6_SPI4          ((uint8_t)0x06)  /* SPI4 Alternate Function mapping                           */
@@ -194,6 +245,9 @@ extern "C" {
 #if defined(UART4)
 #define GPIO_AF6_UART4         ((uint8_t)0x06)  /* UART4 Alternate Function mapping                          */
 #endif /* UART4 */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF6_USART6        ((uint8_t)0x06)  /* USART6 Alternate Function mapping                         */
+#endif /* STM32H533xx || STM32H523xx */
 #if defined(UART12)
 #define GPIO_AF6_UART12        ((uint8_t)0x06)  /* UART12 Alternate Function mapping                         */
 #endif /* UART12 */
@@ -203,6 +257,12 @@ extern "C" {
 #if defined(UCPD1)
 #define GPIO_AF6_UCPD1         ((uint8_t)0x06)  /* UCPD1 Alternate Function mapping                          */
 #endif /* UCPD1 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /* I2C2 Alternate Function mapping                           */
+#define GPIO_AF6_ETH           ((uint8_t)0x06)  /* ETH Alternate Function mapping                            */
+#define GPIO_AF6_I2C1          ((uint8_t)0x06)  /* I2C1 Alternate Function mapping                           */
+#define GPIO_AF6_USART12       ((uint8_t)0x06)  /* USART12 Alternate Function mapping                        */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 
 /**
   * @brief   AF 7 selection
@@ -221,9 +281,11 @@ extern "C" {
 #if defined(UART8)
 #define GPIO_AF7_UART8         ((uint8_t)0x07)  /* UART8 Alternate Function mapping                          */
 #endif /* UART8 */
+#if !defined(STM32H5F5xx) || !defined(STM32H5F4xx) || !defined(STM32H5E5xx) || !defined(STM32H5E4xx)
 #if defined(UART12)
 #define GPIO_AF7_UART12        ((uint8_t)0x07)  /* UART12 Alternate Function mapping                         */
 #endif /* UART12 */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 #define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping                         */
 #define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping                         */
 #define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping                         */
@@ -236,7 +298,9 @@ extern "C" {
 #if defined(USART11)
 #define GPIO_AF7_USART11       ((uint8_t)0x07)  /* USART11 Alternate Function mapping                        */
 #endif /* USART11 */
-
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF7_ETH           ((uint8_t)0x07)  /* ETH Alternate Function mapping                         */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 /**
   * @brief   AF 8 selection
   */
@@ -264,6 +328,18 @@ extern "C" {
 #if defined(UART8)
 #define GPIO_AF8_UART8         ((uint8_t)0x08)  /* UART8 Alternate Function mapping                          */
 #endif /* UART8 */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF8_ETH           ((uint8_t)0x08)  /* ETH Alternate Function mapping                            */
+#define GPIO_AF8_FMC           ((uint8_t)0x08)  /* FMC Alternate Function mapping                            */
+#define GPIO_AF8_I3C2          ((uint8_t)0x08)  /* I3C2 Alternate Function mapping                           */
+#define GPIO_AF8_OCTOSPI1      ((uint8_t)0x08)  /* OCTOSPI1 Alternate Function mapping                       */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+#if defined(OCTOSPI2)
+#define GPIO_AF8_OCTOSPI2      ((uint8_t)0x08)  /* OCTOSPI2 Alternate Function mapping                       */
+#endif /* OCTOSPI2 */
+#if defined(MDF1)
+#define GPIO_AF8_MDF1          ((uint8_t)0x08)  /* MDF1 Alternate Function mapping                           */
+#endif /* MDF1 */
 
 /**
   * @brief   AF 9 selection
@@ -291,6 +367,16 @@ extern "C" {
 #define GPIO_AF9_USART2        ((uint8_t)0x09)  /* USART2 Alternate Function mapping                         */
 #define GPIO_AF9_USART3        ((uint8_t)0x09)  /* USART3 Alternate Function mapping                         */
 #endif /* STM32H503xx */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF9_I2C3          ((uint8_t)0x09)  /* I2C3 Alternate Function mapping                           */
+#define GPIO_AF9_I3C2          ((uint8_t)0x09)  /* I3C2 Alternate Function mapping                           */
+#endif /* STM32H533xx || STM32H523xx */
+#if defined(OCTOSPI2)
+#define GPIO_AF9_OCTOSPI2      ((uint8_t)0x09)  /* OCTOSPI2 Alternate Function mapping                       */
+#endif /* OCTOSPI2 */
+#if defined(FDCAN3)
+#define GPIO_AF9_FDCAN3        ((uint8_t)0x09)  /* FDCAN3 Alternate Function mapping                         */
+#endif /* FDCAN3 */
 
 /**
   * @brief   AF 10 selection
@@ -298,9 +384,11 @@ extern "C" {
 #define GPIO_AF10_CRS          ((uint8_t)0x0A)  /* CRS Alternate Function mapping                            */
 #if defined(STM32H503xx)
 #define GPIO_AF10_I3C1         ((uint8_t)0x0A)  /* I3C1 Alternate Function mapping                           */
-#define GPIO_AF10_I3C2         ((uint8_t)0x0A)  /* I3C2 Alternate Function mapping                           */
 #define GPIO_AF10_SPI3         ((uint8_t)0x0A)  /* SPI3 Alternate Function mapping                           */
 #endif /* STM32H503xx */
+#if (defined(STM32H503xx) || defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF10_I3C2         ((uint8_t)0x0A)  /* I3C2 Alternate Function mapping                           */
+#endif /* STM32H503xx || STM32H533xx || STM32H523xx */
 #if defined(FMC_BANK1)
 #define GPIO_AF10_FMC          ((uint8_t)0x0A)  /* FMC Alternate Function mapping                            */
 #endif /* FMC_BANK1 */
@@ -310,13 +398,33 @@ extern "C" {
 #if defined(SAI2)
 #define GPIO_AF10_SAI2         ((uint8_t)0x0A)  /* SAI2 Alternate Function mapping                           */
 #endif /* SAI2 */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF10_SDMMC1       ((uint8_t)0x0A)  /* SDMMC1 Alternate Function mapping                         */
+#endif /* STM32H533xx || STM32H523xx */
 #if defined(SDMMC2)
 #define GPIO_AF10_SDMMC2       ((uint8_t)0x0A)  /* SDMMC2 Alternate Function mapping                         */
 #endif /* SDMMC2 */
 #if defined(TIM8)
 #define GPIO_AF10_TIM8         ((uint8_t)0x0A)  /* TIM8 Alternate Function mapping                           */
 #endif /* TIM8 */
+#if defined(USB_DRD_FS)
 #define GPIO_AF10_USB          ((uint8_t)0x0A)  /* USB Alternate Function mapping                            */
+#endif /* USB_DRD_FS */
+#if defined(LCD)
+#define GPIO_AF10_LCD          ((uint8_t)0x0A)  /* LCD Alternate Function mapping                            */
+#endif /* LCD */
+#if defined(ETH)
+#define GPIO_AF10_ETH          ((uint8_t)0x0A)  /* ETH Alternate Function mapping                            */
+#endif /* ETH */
+#if defined(OCTOSPI2)
+#define GPIO_AF10_OCTOSPI2     ((uint8_t)0x0A)  /* OCTOSPI2 Alternate Function mapping                       */
+#endif /* OCTOSPI2 */
+#if defined(USB_OTG_FS)
+#define GPIO_AF10_OTG_FS       ((uint8_t)0x0A)  /* USB OTG FS Alternate Function mapping                     */
+#endif /* USB_OTG_FS */
+#if defined(USB_OTG_HS)
+#define GPIO_AF10_OTG_HS       ((uint8_t)0x0A)  /* USB OTG HS Alternate Function mapping                    */
+#endif /* USB_OTG_HS */
 
 /**
   * @brief   AF 11 selection
@@ -330,6 +438,9 @@ extern "C" {
 #if defined(OCTOSPI1)
 #define GPIO_AF11_OCTOSPI1     ((uint8_t)0x0B)  /* OCTOSPI1 Alternate Function mapping                       */
 #endif /* OCTOSPI1 */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF11_SDMMC1       ((uint8_t)0x0B)  /* SDMMC1 Alternate Function mapping                         */
+#endif /* STM32H533xx || STM32H523xx */
 #if defined(SDMMC2)
 #define GPIO_AF11_SDMMC2       ((uint8_t)0x0B)  /* SDMMC2 Alternate Function mapping                         */
 #endif /* SDMMC2 */
@@ -348,6 +459,9 @@ extern "C" {
 #define GPIO_AF11_SPI2         ((uint8_t)0x0B)  /* SPI2 Alternate Function mapping                           */
 #define GPIO_AF11_USART2       ((uint8_t)0x0B)  /* USART2 Alternate Function mapping                         */
 #endif /* STM32H503xx */
+#if defined(LCD)
+#define GPIO_AF11_LCD          ((uint8_t)0x0B)  /* LCD Alternate Function mapping                            */
+#endif /* LCD */
 
 /**
   * @brief   AF 12 selection
@@ -362,6 +476,9 @@ extern "C" {
 #define GPIO_AF12_COMP1        ((uint8_t)0x0C)  /* COMP1 Alternate Function mapping                          */
 #define GPIO_AF12_SPI1         ((uint8_t)0x0C)  /* SPI1 Alternate Function mapping                           */
 #endif /* STM32H503xx */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF12_ETH          ((uint8_t)0x0C)  /* ETH Alternate Function mapping                            */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
 
 /**
   * @brief   AF 13 selection
@@ -380,6 +497,12 @@ extern "C" {
 #define GPIO_AF13_USART2       ((uint8_t)0x0D)  /* USART2 Alternate Function mapping                         */
 #define GPIO_AF13_USART3       ((uint8_t)0x0D)  /* USART3 Alternate Function mapping                         */
 #endif /* STM32H503xx */
+#if defined(STM32H5F5xx) || defined(STM32H5F4xx) || defined(STM32H5E5xx) || defined(STM32H5E4xx)
+#define GPIO_AF13_LPTIM6       ((uint8_t)0x0D)  /* LPTIM6 Alternate Function mapping                         */
+#endif /* STM32H5F5xx || STM32H5F4xx || STM32H5E5xx || STM32H5E4xx */
+#if defined(LCD)
+#define GPIO_AF13_LCD          ((uint8_t)0x0D)  /* LCD Alternate Function mapping                            */
+#endif /* LCD */
 
 /**
   * @brief   AF 14 selection
@@ -403,12 +526,22 @@ extern "C" {
 #if defined(LPTIM6)
 #define GPIO_AF14_LPTIM6       ((uint8_t)0x0E)  /* LPTIM6 Alternate Function mapping                         */
 #endif /* LPTIM6 */
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx))
+#if defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) || defined(STM32H533xx) || defined(STM32H523xx)
 #define GPIO_AF14_TIM2         ((uint8_t)0x0E)  /* TIM2 Alternate Function mapping                           */
-#endif /* defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) */
+#endif /* STM32H573xx || STM32H563xx || STM32H562xx || STM32H533xx || STM32H523xx */
 #if defined(UART5)
 #define GPIO_AF14_UART5        ((uint8_t)0x0E)  /* UART5 Alternate Function mapping                          */
 #endif /* UART5 */
+#if (defined(STM32H533xx) || defined(STM32H523xx))
+#define GPIO_AF14_USART6       ((uint8_t)0x0E)  /* USART6 Alternate Function mapping                         */
+#endif /* STM32H533xx || STM32H523xx */
+#if defined(LCD)
+#define GPIO_AF14_LCD          ((uint8_t)0x0E)  /* LCD Alternate Function mapping                            */
+#endif /* LCD */
+#if defined(PLAY1)
+#define GPIO_AF14_PLAY1_IN     ((uint8_t)0x0E)  /* PLAY1_IN Alternate Function mapping                       */
+#define GPIO_AF14_PLAY1_OUT    ((uint8_t)0x0E)  /* PLAY1_OUT Alternate Function mapping                      */
+#endif /* PLAY1 */
 
 /**
   * @brief   AF 15 selection
@@ -438,11 +571,13 @@ extern "C" {
 
 /* GPIO_Peripheral_Memory_Mapping Peripheral Memory Mapping */
 
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) || defined(STM32H503xx))
+#if defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) || defined(STM32H533xx) || \
+    defined(STM32H523xx) || defined(STM32H503xx) || defined(STM32H5F5xx) || defined(STM32H5F4xx) || \
+    defined(STM32H5E5xx) || defined(STM32H5E4xx)
 #define GPIO_GET_INDEX(__GPIOx__)           (((uint32_t )(__GPIOx__) & (~GPIOA_BASE)) >> 10)
-#endif /* (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) || defined(STM32H503xx)) */
-
-
+#endif /* (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) || defined(STM32H533xx) || \
+          defined(STM32H523xx) || defined(STM32H503xx) || defined(STM32H5F5xx) || defined(STM32H5F4xx) || \
+          defined(STM32H5E5xx) || defined(STM32H5E4xx)*/
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gtzc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gtzc.c
@@ -134,33 +134,42 @@
 #define GTZC_TZSC_MPCWM4_SDRAM_MEM_SIZE   0x10000000U    /* 256MB max size */
 #endif /* defined(FMC_SDRAM_BANK_2) */
 
-/* Definitions for GTZC TZSC & TZIC ALL register values */
-#if defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-#define TZSC1_SECCFGR1_ALL       (0xFFFFFFFFUL)
-#define TZSC1_SECCFGR2_ALL       (0xFF0FFF07UL)
-#define TZSC1_SECCFGR3_ALL       (0x05FFFF03UL)
-#endif /* defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
-
-#if defined (GTZC_TZIC1)
-#define TZSC1_PRIVCFGR1_ALL      (0xFFFFFFFFUL)
-#define TZSC1_PRIVCFGR2_ALL      (0xFF0FFF07UL)
-#define TZSC1_PRIVCFGR3_ALL      (0x05FFFF03UL)
+/* Definitions for GTZC TZSC & TZIC Crypto peripherals */
+#if defined(STM32H573xx) || defined(STM32H533xx)
+#define GTZC_CRYP_CFG3_MSK               0x00190000U
+#define GTZC_CRYP_CFG4_MSK               0x00000010U
 #else
-#define TZSC1_PRIVCFGR1_ALL      (0xC21E7E33UL)
-#define TZSC1_PRIVCFGR2_ALL      (0x12080B19UL)
-#define TZSC1_PRIVCFGR3_ALL      (0x04065106UL)
-#endif /* defined (GTZC_TZIC1) */
+#define GTZC_CRYP_CFG3_MSK               0U
+#define GTZC_CRYP_CFG4_MSK               0U
+#endif /* defined(STM32H573xx) || defined(STM32H533xx) */
+
+/* Definitions for GTZC TZSC & TZIC ALL register values */
+#if defined(STM32H573xx) || defined(STM32H563xx)
+#define GTZC_CFGR1_MSK                   0xFFFFFFFFU
+#define GTZC_CFGR2_MSK                   0xFF0FFF07U
+#define GTZC_CFGR3_MSK                   (0x05E6FF03U | GTZC_CRYP_CFG3_MSK)
+#define GTZC_CFGR4_MSK                   (0x3F1F0FDFU | GTZC_CRYP_CFG4_MSK)
+#elif defined(STM32H533xx) || defined(STM32H523xx)
+#define GTZC_CFGR1_MSK                   0xC33FFE7FU
+#define GTZC_CFGR2_MSK                   0x16089F07U
+#define GTZC_CFGR3_MSK                   (0x05A6F106U | GTZC_CRYP_CFG3_MSK)
+#define GTZC_CFGR4_MSK                   (0x3F1F0FDFU | GTZC_CRYP_CFG4_MSK)
+#elif defined(STM32H562xx)
+#define GTZC_CFGR1_MSK                   0xFFFFFFFFU
+#define GTZC_CFGR2_MSK                   0xFF0FFF05U
+#define GTZC_CFGR3_MSK                   0x05A6FF03U
+#define GTZC_CFGR4_MSK                   0x3F1F0FDFU
+#elif defined(STM32H503xx)
+#define GTZC_CFGR1_MSK                   0xC21E7E33U
+#define GTZC_CFGR2_MSK                   0x12080B19U
+#define GTZC_CFGR3_MSK                   0x04065104U
+#define GTZC_CFGR4_MSK                   0x00000000U
+#endif /* (STM32H533xx) || defined(STM32H523xx) */
 
 #if defined (GTZC_TZIC1)
-#define TZIC1_IER1_ALL           (0xFFFFFFFFUL)
-#define TZIC1_IER2_ALL           (0xFF0FFF07UL)
-#define TZIC1_IER3_ALL           (0x05FFFF03UL)
-#define TZIC1_IER4_ALL           (0x3F3F0FFFUL)
-
-#define TZIC1_FCR1_ALL           (0xFFFFFFFFUL)
-#define TZIC1_FCR2_ALL           (0xFF0FFF07UL)
-#define TZIC1_FCR3_ALL           (0x05FFFF03UL)
-#define TZIC1_FCR4_ALL           (0x3F3F0FFFUL)
+#define GTZC_SEC_PRIV_MSK       (GTZC_TZSC_PERIPH_PRIV | GTZC_TZSC_PERIPH_SEC)
+#else
+#define GTZC_SEC_PRIV_MSK       GTZC_TZSC_PERIPH_PRIV
 #endif /* defined (GTZC_TZIC1) */
 /**
   * @}
@@ -189,6 +198,15 @@
 #define GTZC_BASE_ADDRESS(mem)\
   ( mem ## _BASE )
 
+#if defined(GTZC_MPCBB_CR_INVSECSTATE_Pos)
+#define MPCBB_PARAMETERS_CHECK()                                                \
+  ((pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_ENABLE)            \
+   && (pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_DISABLE))       \
+  || ((pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_NOT_INVERTED)   \
+      && (pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_INVERTED))
+#else
+#define MPCBB_PARAMETERS_CHECK() (0U == 1U)
+#endif /* defined(GTZC_MPCBB_CR_INVSECSTATE_Pos) */
 /**
   * @}
   */
@@ -235,17 +253,10 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_ConfigPeriphAttributes(uint32_t PeriphId,
   uint32_t register_address;
 
   /* check entry parameters */
-#if defined (GTZC_TZIC1)
-  if ((PeriphAttributes > (GTZC_TZSC_PERIPH_SEC | GTZC_TZSC_PERIPH_PRIV))
+  if (((PeriphAttributes & ~(GTZC_SEC_PRIV_MSK)) != 0U)
       || (HAL_GTZC_GET_ARRAY_INDEX(PeriphId) >= GTZC_TZSC_PERIPH_NUMBER)
       || (((PeriphId & GTZC_PERIPH_ALL) != 0U)
           && (HAL_GTZC_GET_ARRAY_INDEX(PeriphId) != 0U)))
-#else
-  if ((PeriphAttributes > GTZC_TZSC_PERIPH_PRIV)
-      || (HAL_GTZC_GET_ARRAY_INDEX(PeriphId) >= GTZC_TZSC_PERIPH_NUMBER)
-      || (((PeriphId & GTZC_PERIPH_ALL) != 0U)
-          && (HAL_GTZC_GET_ARRAY_INDEX(PeriphId) != 0U)))
-#endif /* defined (GTZC_TZIC1) */
   {
     return HAL_ERROR;
   }
@@ -258,15 +269,15 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_ConfigPeriphAttributes(uint32_t PeriphId,
     /* secure configuration */
     if ((PeriphAttributes & GTZC_TZSC_PERIPH_SEC) == GTZC_TZSC_PERIPH_SEC)
     {
-      SET_BIT(GTZC_TZSC1->SECCFGR1, TZSC1_SECCFGR1_ALL);
-      SET_BIT(GTZC_TZSC1->SECCFGR2, TZSC1_SECCFGR2_ALL);
-      SET_BIT(GTZC_TZSC1->SECCFGR3, TZSC1_SECCFGR3_ALL);
+      SET_BIT(GTZC_TZSC1->SECCFGR1, GTZC_CFGR1_MSK);
+      SET_BIT(GTZC_TZSC1->SECCFGR2, GTZC_CFGR2_MSK);
+      SET_BIT(GTZC_TZSC1->SECCFGR3, GTZC_CFGR3_MSK);
     }
     else if ((PeriphAttributes & GTZC_TZSC_PERIPH_NSEC) == GTZC_TZSC_PERIPH_NSEC)
     {
-      CLEAR_BIT(GTZC_TZSC1->SECCFGR1, TZSC1_SECCFGR1_ALL);
-      CLEAR_BIT(GTZC_TZSC1->SECCFGR2, TZSC1_SECCFGR2_ALL);
-      CLEAR_BIT(GTZC_TZSC1->SECCFGR3, TZSC1_SECCFGR3_ALL);
+      CLEAR_BIT(GTZC_TZSC1->SECCFGR1, GTZC_CFGR1_MSK);
+      CLEAR_BIT(GTZC_TZSC1->SECCFGR2, GTZC_CFGR2_MSK);
+      CLEAR_BIT(GTZC_TZSC1->SECCFGR3, GTZC_CFGR3_MSK);
     }
     else
     {
@@ -277,15 +288,15 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_ConfigPeriphAttributes(uint32_t PeriphId,
     /* privilege configuration */
     if ((PeriphAttributes & GTZC_TZSC_PERIPH_PRIV) == GTZC_TZSC_PERIPH_PRIV)
     {
-      SET_BIT(GTZC_TZSC1->PRIVCFGR1, TZSC1_PRIVCFGR1_ALL);
-      SET_BIT(GTZC_TZSC1->PRIVCFGR2, TZSC1_PRIVCFGR2_ALL);
-      SET_BIT(GTZC_TZSC1->PRIVCFGR3, TZSC1_PRIVCFGR3_ALL);
+      SET_BIT(GTZC_TZSC1->PRIVCFGR1, GTZC_CFGR1_MSK);
+      SET_BIT(GTZC_TZSC1->PRIVCFGR2, GTZC_CFGR2_MSK);
+      SET_BIT(GTZC_TZSC1->PRIVCFGR3, GTZC_CFGR3_MSK);
     }
     else if ((PeriphAttributes & GTZC_TZSC_PERIPH_NPRIV) == GTZC_TZSC_PERIPH_NPRIV)
     {
-      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR1, TZSC1_PRIVCFGR1_ALL);
-      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR2, TZSC1_PRIVCFGR2_ALL);
-      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR3, TZSC1_PRIVCFGR3_ALL);
+      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR1, GTZC_CFGR1_MSK);
+      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR2, GTZC_CFGR2_MSK);
+      CLEAR_BIT(GTZC_TZSC1->PRIVCFGR3, GTZC_CFGR3_MSK);
     }
     else
     {
@@ -363,6 +374,47 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_GetConfigPeriphAttributes(uint32_t PeriphId,
 
   if ((PeriphId & GTZC_PERIPH_ALL) != 0U)
   {
+    /* get privilege configuration: read each register and deploy each bit value
+     * of corresponding index in the destination array
+     */
+    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR1);
+    for (i = 0U; i < 32U; i++)
+    {
+      if (((reg_value & (1UL << i)) >> i) != 0U)
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_PRIV;
+      }
+      else
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NPRIV;
+      }
+    }
+
+    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR2);
+    for (i = 32U; i < 64U; i++)
+    {
+      if (((reg_value & (1UL << (i - 32U))) >> (i - 32U)) != 0U)
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_PRIV;
+      }
+      else
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NPRIV;
+      }
+    }
+
+    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR3);
+    for (i = 64U; i < GTZC_TZSC_PERIPH_NUMBER; i++)
+    {
+      if (((reg_value & (1UL << (i - 64U))) >> (i - 64U)) != 0U)
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_PRIV;
+      }
+      else
+      {
+        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NPRIV;
+      }
+    }
 #if defined (GTZC_TZIC1)
     /* get secure configuration: read each register and deploy each bit value
      * of corresponding index in the destination array
@@ -372,11 +424,11 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_GetConfigPeriphAttributes(uint32_t PeriphId,
     {
       if (((reg_value & (1UL << i)) >> i) != 0U)
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_SEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_SEC;
       }
       else
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NSEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NSEC;
       }
     }
 
@@ -385,11 +437,11 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_GetConfigPeriphAttributes(uint32_t PeriphId,
     {
       if (((reg_value & (1UL << (i - 32U))) >> (i - 32U)) != 0U)
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_SEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_SEC;
       }
       else
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NSEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NSEC;
       }
     }
 
@@ -398,60 +450,34 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_GetConfigPeriphAttributes(uint32_t PeriphId,
     {
       if (((reg_value & (1UL << (i - 64U))) >> (i - 64U)) != 0U)
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_SEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_SEC;
       }
       else
       {
-        PeriphAttributes[i] = GTZC_TZSC_PERIPH_NSEC;
+        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NSEC;
       }
     }
+
 #endif /* defined (GTZC_TZIC1) */
-
-    /* get privilege configuration: read each register and deploy each bit value
-     * of corresponding index in the destination array
-     */
-    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR1);
-    for (i = 0U; i < 32U; i++)
-    {
-      if (((reg_value & (1UL << i)) >> i) != 0U)
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_PRIV;
-      }
-      else
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NPRIV;
-      }
-    }
-
-    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR2);
-    for (i = 32U; i < 64U; i++)
-    {
-      if (((reg_value & (1UL << (i - 32U))) >> (i - 32U)) != 0U)
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_PRIV;
-      }
-      else
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NPRIV;
-      }
-    }
-
-    reg_value = READ_REG(GTZC_TZSC1->PRIVCFGR3);
-    for (i = 64U; i < GTZC_TZSC_PERIPH_NUMBER; i++)
-    {
-      if (((reg_value & (1UL << (i - 64U))) >> (i - 64U)) != 0U)
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_PRIV;
-      }
-      else
-      {
-        PeriphAttributes[i] |= GTZC_TZSC_PERIPH_NPRIV;
-      }
-    }
   }
   else
   {
-    /* common case where only one peripheral is configured */
+    /* privilege configuration */
+    register_address = (uint32_t) &(GTZC_TZSC1->PRIVCFGR1)
+                        + (4U * GTZC_GET_REG_INDEX(PeriphId));
+
+    if (((READ_BIT(*(__IO uint32_t *)register_address,
+                    1UL << GTZC_GET_PERIPH_POS(PeriphId))) >> GTZC_GET_PERIPH_POS(PeriphId))
+        != 0U)
+    {
+      *PeriphAttributes = GTZC_TZSC_PERIPH_PRIV;
+    }
+    else
+    {
+      *PeriphAttributes = GTZC_TZSC_PERIPH_NPRIV;
+    }
+
+  /* common case where only one peripheral is configured */
 #if defined (GTZC_TZIC1)
     /* secure configuration */
     register_address = (uint32_t) &(GTZC_TZSC1->SECCFGR1)
@@ -461,28 +487,13 @@ HAL_StatusTypeDef HAL_GTZC_TZSC_GetConfigPeriphAttributes(uint32_t PeriphId,
                    1UL << GTZC_GET_PERIPH_POS(PeriphId))) >> GTZC_GET_PERIPH_POS(PeriphId))
         != 0U)
     {
-      *PeriphAttributes = GTZC_TZSC_PERIPH_SEC;
+      *PeriphAttributes |= GTZC_TZSC_PERIPH_SEC;
     }
     else
     {
-      *PeriphAttributes = GTZC_TZSC_PERIPH_NSEC;
+      *PeriphAttributes |= GTZC_TZSC_PERIPH_NSEC;
     }
 #endif /* defined (GTZC_TZIC1) */
-
-    /* privilege configuration */
-    register_address = (uint32_t) &(GTZC_TZSC1->PRIVCFGR1)
-                       + (4U * GTZC_GET_REG_INDEX(PeriphId));
-
-    if (((READ_BIT(*(__IO uint32_t *)register_address,
-                   1UL << GTZC_GET_PERIPH_POS(PeriphId))) >> GTZC_GET_PERIPH_POS(PeriphId))
-        != 0U)
-    {
-      *PeriphAttributes |= GTZC_TZSC_PERIPH_PRIV;
-    }
-    else
-    {
-      *PeriphAttributes |= GTZC_TZSC_PERIPH_NPRIV;
-    }
   }
   return HAL_OK;
 }
@@ -834,17 +845,11 @@ HAL_StatusTypeDef HAL_GTZC_MPCBB_ConfigMem(uint32_t MemBaseAddress,
   if ((!(IS_GTZC_BASE_ADDRESS(SRAM1, MemBaseAddress))
        &&  !(IS_GTZC_BASE_ADDRESS(SRAM2, MemBaseAddress))
        &&  !(IS_GTZC_BASE_ADDRESS(SRAM3, MemBaseAddress)))
-      || ((pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_ENABLE)
-          && (pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_DISABLE))
-      || ((pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_NOT_INVERTED)
-          && (pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_INVERTED)))
+      ||  MPCBB_PARAMETERS_CHECK())
 #else
   if ((!(IS_GTZC_BASE_ADDRESS(SRAM1, MemBaseAddress))
        &&  !(IS_GTZC_BASE_ADDRESS(SRAM2, MemBaseAddress)))
-      || ((pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_ENABLE)
-          && (pMPCBB_desc->SecureRWIllegalMode != GTZC_MPCBB_SRWILADIS_DISABLE))
-      || ((pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_NOT_INVERTED)
-          && (pMPCBB_desc->InvertSecureState != GTZC_MPCBB_INVSECSTATE_INVERTED)))
+      ||  MPCBB_PARAMETERS_CHECK())
 #endif /* defined (GTZC_MPCBB3) */
   {
     return HAL_ERROR;
@@ -1569,10 +1574,10 @@ HAL_StatusTypeDef HAL_GTZC_TZIC_EnableIT(uint32_t PeriphId)
   if ((PeriphId & GTZC_PERIPH_ALL) != 0U)
   {
     /* same configuration is applied to all peripherals */
-    WRITE_REG(GTZC_TZIC1->IER1, TZIC1_IER1_ALL);
-    WRITE_REG(GTZC_TZIC1->IER2, TZIC1_IER2_ALL);
-    WRITE_REG(GTZC_TZIC1->IER3, TZIC1_IER3_ALL);
-    WRITE_REG(GTZC_TZIC1->IER4, TZIC1_IER4_ALL);
+    WRITE_REG(GTZC_TZIC1->IER1, GTZC_CFGR1_MSK);
+    WRITE_REG(GTZC_TZIC1->IER2, GTZC_CFGR2_MSK);
+    WRITE_REG(GTZC_TZIC1->IER3, GTZC_CFGR3_MSK);
+    WRITE_REG(GTZC_TZIC1->IER4, GTZC_CFGR4_MSK);
   }
   else
   {
@@ -1634,7 +1639,7 @@ HAL_StatusTypeDef HAL_GTZC_TZIC_GetFlag(uint32_t PeriphId, uint32_t *pFlag)
     }
 
     reg_value = READ_REG(GTZC_TZIC1->SR4);
-    for (i = 96U; i < 128U; i++)
+    for (i = 96U; i < GTZC_TZIC_PERIPH_NUMBER; i++)
     {
       pFlag[i] = (reg_value & (1UL << (i - 96U))) >> (i - 96U);
     }
@@ -1673,10 +1678,10 @@ HAL_StatusTypeDef HAL_GTZC_TZIC_ClearFlag(uint32_t PeriphId)
   if ((PeriphId & GTZC_PERIPH_ALL) != 0U)
   {
     /* same configuration is applied to all peripherals */
-    WRITE_REG(GTZC_TZIC1->FCR1, TZIC1_FCR1_ALL);
-    WRITE_REG(GTZC_TZIC1->FCR2, TZIC1_FCR2_ALL);
-    WRITE_REG(GTZC_TZIC1->FCR3, TZIC1_FCR3_ALL);
-    WRITE_REG(GTZC_TZIC1->FCR4, TZIC1_FCR4_ALL);
+    WRITE_REG(GTZC_TZIC1->FCR1, GTZC_CFGR1_MSK);
+    WRITE_REG(GTZC_TZIC1->FCR2, GTZC_CFGR2_MSK);
+    WRITE_REG(GTZC_TZIC1->FCR3, GTZC_CFGR3_MSK);
+    WRITE_REG(GTZC_TZIC1->FCR4, GTZC_CFGR4_MSK);
   }
   else
   {
@@ -1849,4 +1854,3 @@ __weak void HAL_GTZC_TZIC_Callback(uint32_t PeriphId)
 /**
   * @}
   */
-

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gtzc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_gtzc.h
@@ -147,10 +147,10 @@ typedef struct
 /** @defgroup GTZC_MPCBB_SecureRWIllegalMode GTZC MPCBB SRWILADIS values
   * @{
   */
-
+#if defined(GTZC_MPCBB_CR_SRWILADIS_Pos)
 #define GTZC_MPCBB_SRWILADIS_ENABLE  (0U)
 #define GTZC_MPCBB_SRWILADIS_DISABLE (GTZC_MPCBB_CR_SRWILADIS_Msk)
-
+#endif /* GTZC_MPCBB_CR_SRWILADIS_Pos */
 /**
   * @}
   */
@@ -158,10 +158,10 @@ typedef struct
 /** @defgroup GTZC_MPCBB_InvertSecureState GTZC MPCBB INVSECSTATE values
   * @{
   */
-
+#if defined(GTZC_MPCBB_CR_INVSECSTATE_Pos)
 #define GTZC_MPCBB_INVSECSTATE_NOT_INVERTED  (0U)
 #define GTZC_MPCBB_INVSECSTATE_INVERTED      (GTZC_MPCBB_CR_INVSECSTATE_Msk)
-
+#endif /* GTZC_MPCBB_CR_INVSECSTATE_Pos */
 /**
   * @}
   */
@@ -693,4 +693,3 @@ void HAL_GTZC_TZIC_Callback(uint32_t PeriphId);
 #endif
 
 #endif /* STM32H5xx_HAL_GTZC_H */
-

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hash.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hash.h
@@ -298,11 +298,13 @@ typedef  void (*pHASH_CallbackTypeDef)(HASH_HandleTypeDef *hhash);  /*!< pointer
   *            @arg @ref HASH_FLAG_DMAS DMA interface is enabled (DMAE=1) or a transfer is ongoing.
   *            @arg @ref HASH_FLAG_BUSY The hash core is Busy : processing a block of data.
   *            @arg @ref HASH_FLAG_DINNE DIN not empty : the input buffer contains at least one word of data.
-  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  * @retval The new state of __FLAG__ (SET or RESET).
   */
-#define __HAL_HASH_GET_FLAG(__HANDLE__, __FLAG__)  (((__FLAG__) > 8U)  ?                    \
-                                                    (((__HANDLE__)->Instance->CR & (__FLAG__)) == (__FLAG__)) :\
-                                                    (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__)) )
+#define __HAL_HASH_GET_FLAG(__HANDLE__, __FLAG__)  (((__FLAG__) > 8U)  ?                           \
+                                                    ((((__HANDLE__)->Instance->CR & (__FLAG__)) == \
+                                                      (__FLAG__)) ? SET : RESET) :                     \
+                                                    ((((__HANDLE__)->Instance->SR & (__FLAG__)) == \
+                                                      (__FLAG__)) ? SET : RESET) )
 
 /** @brief  Clear the specified HASH flag.
   * @param  __HANDLE__ specifies the HASH handle.

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c
@@ -169,9 +169,6 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
   /* Init Host */
   (void)USB_HostInit(hhcd->Instance, hhcd->Init);
 
-  /* Deactivate the power down */
-  hhcd->Instance->CNTR &= ~USB_CNTR_PDWN;
-
   hhcd->State = HAL_HCD_STATE_READY;
 
   /* Host Port State */
@@ -219,6 +216,27 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
   __HAL_LOCK(hhcd);
 
+  if (ch_num > 16U)
+  {
+    __HAL_UNLOCK(hhcd);
+    return HAL_ERROR;
+  }
+
+  if (((epnum & 0xFU)== 0U) && ((hhcd->ep0_PmaAllocState & 0xF000U) != 0U))
+  {
+    hhcd->hc[ch_num & 0xFU].pmaadress = hhcd->hc[0U].pmaadress;
+    hhcd->hc[ch_num & 0xFU].pmaaddr0 = hhcd->hc[0U].pmaaddr0;
+    hhcd->hc[ch_num & 0xFU].pmaaddr1 = hhcd->hc[0U].pmaaddr1;
+
+    hhcd->phy_chin_state[0U] = (((uint16_t)ch_num + 1U) << 4U) |
+                               ((uint16_t)ep_type + 1U) |
+                               (((uint16_t)epnum & 0x0FU) << 8U);
+
+    hhcd->phy_chout_state[0U] = (((uint16_t)ch_num + 1U) << 4U) |
+                                ((uint16_t)ep_type + 1U) |
+                                (((uint16_t)epnum & 0x0FU) << 8U);
+  }
+
   /* Check if the logical channel are already allocated */
   used_channel = HAL_HCD_Check_usedChannel(hhcd, ch_num);
 
@@ -231,6 +249,7 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
     /* No free Channel available, return error */
     if (hhcd->hc[ch_num & 0xFU].phy_ch_num == HCD_FREE_CH_NOT_FOUND)
     {
+      __HAL_UNLOCK(hhcd);
       return HAL_ERROR;
     }
   }
@@ -267,6 +286,7 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
       if (status == HAL_ERROR)
       {
+        __HAL_UNLOCK(hhcd);
         return HAL_ERROR;
       }
 
@@ -285,6 +305,7 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
         if (status == HAL_ERROR)
         {
+          __HAL_UNLOCK(hhcd);
           return HAL_ERROR;
         }
       }
@@ -302,22 +323,28 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
               if (status == HAL_ERROR)
               {
+                __HAL_UNLOCK(hhcd);
                 return HAL_ERROR;
               }
             }
             else
             {
+              __HAL_UNLOCK(hhcd);
               return HAL_ERROR;
             }
           }
           else
           {
+            /* This is a dual EP0 PMA allocation */
+            hhcd->ep0_PmaAllocState |= (0x1U << 12);
+
             /* PMA Dynamic Allocation for EP0 OUT direction */
             hhcd->hc[ch_num & 0xFU].ch_dir = CH_OUT_DIR;
             status = HAL_HCD_PMAlloc(hhcd, ch_num, HCD_SNG_BUF, 64U);
 
             if (status == HAL_ERROR)
             {
+              __HAL_UNLOCK(hhcd);
               return HAL_ERROR;
             }
 
@@ -327,6 +354,7 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
             if (status == HAL_ERROR)
             {
+              __HAL_UNLOCK(hhcd);
               return HAL_ERROR;
             }
           }
@@ -352,6 +380,7 @@ HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
             if (status == HAL_ERROR)
             {
+              __HAL_UNLOCK(hhcd);
               return HAL_ERROR;
             }
           }
@@ -730,8 +759,7 @@ HAL_StatusTypeDef HAL_HCD_HC_SubmitRequest(HCD_HandleTypeDef *hhcd, uint8_t ch_n
 void HAL_HCD_IRQHandler(HCD_HandleTypeDef *hhcd)
 {
   uint8_t phy_chnum;
-  uint8_t chnum;
-  uint32_t epch_reg;
+  uint8_t ch_dir;
   uint32_t wIstr = USB_ReadInterrupts(hhcd->Instance);
 
   /* Port Change Detected (Connection/Disconnection) */
@@ -749,50 +777,21 @@ void HAL_HCD_IRQHandler(HCD_HandleTypeDef *hhcd)
   /* Correct Transaction Detected -------*/
   if ((wIstr & USB_ISTR_CTR) == USB_ISTR_CTR)
   {
-    /* Handle Host channel Interrupt */
-    for (phy_chnum = 0U; phy_chnum < hhcd->Init.Host_channels; phy_chnum++)
+    /* Get Physical channel */
+    phy_chnum = (uint8_t)__HAL_HCD_GET_CHNUM(hhcd);
+
+    /* Get channel direction */
+    ch_dir = (uint8_t)__HAL_HCD_GET_CHDIR(hhcd);
+
+    if (ch_dir == CH_OUT_DIR)
     {
-      if ((HCD_GET_CHANNEL(hhcd->Instance, phy_chnum) & USB_CH_VTRX) != 0U)
-      {
-        /* Get Logical channel to check if the channel is already opened */
-        chnum = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 1U);
-
-        if (chnum != HCD_LOGICAL_CH_NOT_OPENED)
-        {
-          /* Call Channel_IN_IRQ() */
-          HCD_HC_IN_IRQHandler(hhcd, chnum);
-        }
-        else
-        {
-          /*Channel was not closed correctly still have interrupt */
-          epch_reg = HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
-          epch_reg = (epch_reg & (USB_CHEP_REG_MASK & (~USB_CH_ERRRX) & (~USB_CH_VTRX))) |
-                     (USB_CH_VTTX | USB_CH_ERRTX);
-
-          HCD_SET_CHANNEL(hhcd->Instance, phy_chnum, epch_reg);
-        }
-      }
-
-      if ((HCD_GET_CHANNEL(hhcd->Instance, phy_chnum) & USB_CH_VTTX) != 0U)
-      {
-        /* Get Logical channel to check if the channel is already opened */
-        chnum = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 0U);
-
-        if (chnum != HCD_LOGICAL_CH_NOT_OPENED)
-        {
-          /*Call Channel_OUT_IRQ()*/
-          HCD_HC_OUT_IRQHandler(hhcd, chnum);
-        }
-        else
-        {
-          /* Clear Error & unwanted VTTX or Channel was not closed correctly */
-          epch_reg = HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
-          epch_reg = (epch_reg & (USB_CHEP_REG_MASK & (~USB_CH_ERRTX) & (~USB_CH_VTTX))) |
-                     (USB_CH_VTRX | USB_CH_ERRRX);
-
-          HCD_SET_CHANNEL(hhcd->Instance, phy_chnum, epch_reg);
-        }
-      }
+      /* Call Channel_OUT_IRQ() */
+      HCD_HC_OUT_IRQHandler(hhcd, phy_chnum);
+    }
+    else
+    {
+      /* Call Channel_IN_IRQ() */
+      HCD_HC_IN_IRQHandler(hhcd, phy_chnum);
     }
 
     return;
@@ -1292,16 +1291,21 @@ transfers.
   */
 HAL_StatusTypeDef HAL_HCD_Start(HCD_HandleTypeDef *hhcd)
 {
+  __IO uint32_t count = HCD_PDWN_EXIT_CNT;
+
   __HAL_LOCK(hhcd);
 
-  /*Set the PullDown on the PHY */
-  hhcd->Instance->BCDR |= USB_BCDR_DPPD;
-
-  /* Clear Reset  */
-  hhcd->Instance->CNTR &= ~USB_CNTR_USBRST;
-
-  /*Remove PowerDown */
+  /* Remove PowerDown */
   hhcd->Instance->CNTR &= ~USB_CNTR_PDWN;
+
+  /* Few cycles to ensure exit from powerdown */
+  while (count > 0U)
+  {
+    count--;
+  }
+
+  /* Clear Reset */
+  hhcd->Instance->CNTR &= ~USB_CNTR_USBRST;
 
   __HAL_UNLOCK(hhcd);
 
@@ -1347,7 +1351,7 @@ HAL_StatusTypeDef HAL_HCD_Suspend(HCD_HandleTypeDef *hhcd)
   /* wait for Suspend Ready */
   while ((hhcd->Instance->CNTR & USB_CNTR_SUSPRDY) == 0U)
   {
-    if (++count > 0xFFFFFFU)
+    if (++count > HAL_USB_TIMEOUT)
     {
       return HAL_TIMEOUT;
     }
@@ -1581,7 +1585,7 @@ static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
     if (hhcd->hc[ch_num & 0xFU].xfer_len != 0U)
     {
       /* manage multiple Xfer */
-      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
 
       /* check if we need to free user buffer */
       if ((regvalue & USB_CH_DTOG_RX) != 0U)
@@ -1620,7 +1624,7 @@ static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
     else
     {
       /* Transfer complete state */
-      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
       hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
       hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
       hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
@@ -1642,7 +1646,7 @@ static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
     if (hhcd->hc[ch_num & 0xFU].xfer_len != 0U)
     {
       /* manage multiple Xfer */
-      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
 
       /* check if we need to free user buffer */
       if ((regvalue & USB_CH_DTOG_RX) == 0U)
@@ -1683,7 +1687,7 @@ static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
     else
     {
       /* Transfer complete state */
-      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
       hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
       hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
       hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
@@ -1857,16 +1861,17 @@ static void inline HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 /**
   * @brief  Handle Host Channel IN interrupt requests.
   * @param  hhcd HCD handle
-  * @param  ch_num Channel number
-  *         This parameter can be a value from 1 to 15
+  * @param  chnum Channel number
+  *         This parameter can be a value from 1 to 8
   * @retval none
   */
-static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
+static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
 {
   uint16_t received_bytes;
-  uint8_t phy_chnum = (uint8_t)__HAL_HCD_GET_CHNUM(hhcd);
+  uint8_t phy_chnum = chnum;
+  uint8_t ch_num = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 1U);
 
-  /*Take a Flag snapshot from the CHEP register, due to STRX bits are used for both control and status */
+  /* Take a Flag snapshot from the CHEP register, due to STRX bits are used for both control and status */
   uint32_t ch_reg =  HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
 
   /* Manage Correct Transaction */
@@ -1908,8 +1913,8 @@ static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
         if ((hhcd->hc[ch_num & 0xFU].xfer_len == 0U) ||
             ((received_bytes < hhcd->hc[ch_num & 0xFU].max_packet)))
         {
-          hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
-          hhcd->hc[ch_num & 0xFU].state  = HC_XFRC;
+          hhcd->hc[ch_num & 0xFU].urb_state = URB_DONE;
+          hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
         }
         else
         {
@@ -1922,18 +1927,24 @@ static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
         if ((hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_BULK) ||
             (hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_INTR))
         {
-          hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
+          hhcd->hc[ch_num & 0xFU].toggle_in ^= 1U;
         }
       }
-      /* manage NACK Response */
+      /* Manage NACK Response */
       else if (((ch_reg & USB_CH_RX_STRX) == USB_CH_RX_NAK)
                && (hhcd->hc[ch_num & 0xFU].urb_state != URB_DONE))
       {
         hhcd->hc[ch_num & 0xFU].urb_state = URB_NOTREADY;
         hhcd->hc[ch_num & 0xFU].ErrCnt = 0U;
         hhcd->hc[ch_num & 0xFU].state = HC_NAK;
+
+        if (hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_INTR)
+        {
+          /* Close the channel */
+          HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_DIS);
+        }
       }
-      /* manage STALL Response */
+      /* Manage STALL Response */
       else if ((ch_reg & USB_CH_RX_STRX) == USB_CH_RX_STALL)
       {
         (void)HAL_HCD_HC_Halt(hhcd, ch_num);
@@ -2001,16 +2012,17 @@ static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
   * @brief  Handle Host Channel OUT interrupt requests.
   * @param  hhcd  HCD handle
   * @param  chnum Channel number
-  *         This parameter can be a value from 1 to 15
+  *         This parameter can be a value from 1 to 8
   * @retval none
   */
 static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
 {
-  uint16_t data_xfr;
   __IO uint32_t WregCh;
+  uint16_t data_xfr;
+  uint8_t phy_chnum = chnum;
 
-  /* Get Physical Channel number */
-  uint32_t phy_chnum = (uint8_t)__HAL_HCD_GET_CHNUM(hhcd);
+  /* Get Virtual Channel number */
+  uint8_t ch_num = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 0U);
 
   /* Take a Flag snapshot from the CHEP register, due to STRX bits are used for both control &status */
   uint32_t ch_reg =  *(__IO uint32_t *)(&(hhcd->Instance->CHEP0R) + phy_chnum);
@@ -2021,7 +2033,7 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
     /* Handle Isochronous channel */
     if ((ch_reg & USB_CH_UTYPE) == USB_EP_ISOCHRONOUS)
     {
-      /* correct transaction */
+      /* Correct transaction */
       if ((hhcd->Instance->ISTR & USB_ISTR_ERR) == 0U)
       {
         /* Double buffer isochronous out */
@@ -2030,7 +2042,7 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
           HCD_SET_CH_TX_CNT(hhcd->Instance, phy_chnum, 0U);
         }
 #if (USE_USB_DOUBLE_BUFFER == 1U)
-        else /* double buffer isochronous out */
+        else /* Double buffer isochronous out */
         {
           /* Odd Transaction */
           if ((ch_reg & USB_CH_DTOG_TX) != 0U)
@@ -2048,8 +2060,8 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
 #endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
         /* Transfer complete state */
-        hhcd->hc[chnum & 0xFU].state = HC_XFRC;
-        hhcd->hc[chnum & 0xFU].urb_state = URB_DONE;
+        hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_DONE;
       }
 
       /*Clear Correct Transfer */
@@ -2057,9 +2069,9 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
 
       /*TX COMPLETE*/
 #if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
-      hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+      hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #else
-      HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+      HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
 
     }
@@ -2070,37 +2082,37 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
       {
         data_xfr = (uint16_t)(((USB_DRD_PMA_BUFF + phy_chnum)->TXBD & 0x03FF0000U) >> 16U);
 
-        if (hhcd->hc[chnum & 0xFU].xfer_len >= data_xfr)
+        if (hhcd->hc[ch_num & 0xFU].xfer_len >= data_xfr)
         {
-          hhcd->hc[chnum & 0xFU].xfer_len -= data_xfr;
+          hhcd->hc[ch_num & 0xFU].xfer_len -= data_xfr;
         }
         else
         {
-          hhcd->hc[chnum & 0xFU].xfer_len = 0U;
+          hhcd->hc[ch_num & 0xFU].xfer_len = 0U;
+        }
+
+        if ((hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_BULK) ||
+            (hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_INTR))
+        {
+          hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
         }
 
         /* Transfer no yet finished only one packet of mps is transferred and ACKed from device */
-        if (hhcd->hc[chnum & 0xFU].xfer_len != 0U)
+        if (hhcd->hc[ch_num & 0xFU].xfer_len != 0U)
         {
-          /* manage multiple Xfer */
-          hhcd->hc[chnum & 0xFU].xfer_buff += data_xfr;
-          hhcd->hc[chnum & 0xFU].xfer_count  += data_xfr;
+          /* Manage multiple Xfer */
+          hhcd->hc[ch_num & 0xFU].xfer_buff += data_xfr;
+          hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
 
-          /* start a new transfer */
-          (void) USB_HC_StartXfer(hhcd->Instance, &hhcd->hc[chnum & 0xFU]);
+          /* Start a new transfer */
+          (void) USB_HC_StartXfer(hhcd->Instance, &hhcd->hc[ch_num & 0xFU]);
         }
         else
         {
           /* Transfer complete */
-          hhcd->hc[chnum & 0xFU].xfer_count += data_xfr;
-          hhcd->hc[chnum & 0xFU].state = HC_XFRC;
-          hhcd->hc[chnum & 0xFU].urb_state = URB_DONE;
-
-          if ((hhcd->hc[chnum & 0xFU].ep_type == EP_TYPE_BULK) ||
-              (hhcd->hc[chnum & 0xFU].ep_type == EP_TYPE_INTR))
-          {
-            hhcd->hc[chnum & 0xFU].toggle_out ^= 1U;
-          }
+          hhcd->hc[ch_num & 0xFU].xfer_count += data_xfr;
+          hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
+          hhcd->hc[ch_num & 0xFU].urb_state = URB_DONE;
         }
       }
       /* Check NACK Response */
@@ -2108,41 +2120,41 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
                ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_NAK))
       {
         /* Update Channel status */
-        hhcd->hc[chnum & 0xFU].state = HC_NAK;
-        hhcd->hc[chnum & 0xFU].urb_state = URB_NOTREADY;
-        hhcd->hc[chnum & 0xFU].ErrCnt = 0U;
+        hhcd->hc[ch_num & 0xFU].state = HC_NAK;
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_NOTREADY;
+        hhcd->hc[ch_num & 0xFU].ErrCnt = 0U;
 
         /* Get Channel register value */
         WregCh = *(__IO uint32_t *)(&(hhcd->Instance->CHEP0R) + phy_chnum);
 
-        /*clear NAK status*/
+        /* Clear NAK status */
         WregCh &= ~USB_CHEP_NAK & USB_CHEP_REG_MASK;
 
         /* Update channel register Value */
         HCD_SET_CHANNEL(hhcd->Instance, phy_chnum, WregCh);
 
-        if (hhcd->hc[chnum & 0xFU].doublebuffer == 0U)
+        if (hhcd->hc[ch_num & 0xFU].doublebuffer == 0U)
         {
 #if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
-          hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+          hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #else
-          HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+          HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
         }
       }
       /* Check STALL Response */
       else if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_STALL)
       {
-        (void) HAL_HCD_HC_Halt(hhcd, (uint8_t)chnum);
-        hhcd->hc[chnum & 0xFU].state = HC_STALL;
-        hhcd->hc[chnum & 0xFU].urb_state = URB_STALL;
+        (void) HAL_HCD_HC_Halt(hhcd, (uint8_t)ch_num);
+        hhcd->hc[ch_num & 0xFU].state = HC_STALL;
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_STALL;
       }
 #if (USE_USB_DOUBLE_BUFFER == 1U)
       /* Check double buffer ACK in case of bulk transaction */
       else if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_ACK_DBUF)
       {
         /* Double buffer management Bulk Out */
-        (void) HCD_HC_OUT_BulkDb(hhcd, chnum, (uint8_t)phy_chnum, ch_reg);
+        (void) HCD_HC_OUT_BulkDb(hhcd, ch_num, (uint8_t)phy_chnum, ch_reg);
       }
 #endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
       else
@@ -2153,38 +2165,38 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
       if ((ch_reg & USB_CH_TX_STTX) != USB_CH_TX_NAK)
       {
 #if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
-        hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+        hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #else
-        HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+        HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
       }
 
       HCD_CLEAR_TX_CH_CTR(hhcd->Instance, phy_chnum);
-    }  /* end no isochronous */
+    }  /* End no isochronous */
   }
   /*------ Manage Transaction Error------*/
   else
   {
-    hhcd->hc[chnum & 0xFU].ErrCnt++;
-    if (hhcd->hc[chnum & 0xFU].ErrCnt > 3U)
+    hhcd->hc[ch_num & 0xFU].ErrCnt++;
+    if (hhcd->hc[ch_num & 0xFU].ErrCnt > 3U)
     {
       HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_DIS);
-      hhcd->hc[chnum & 0xFU].urb_state = URB_ERROR;
+      hhcd->hc[ch_num & 0xFU].urb_state = URB_ERROR;
     }
     else
     {
-      hhcd->hc[chnum & 0xFU].urb_state = URB_NOTREADY;
+      hhcd->hc[ch_num & 0xFU].urb_state = URB_NOTREADY;
     }
 
-    hhcd->hc[chnum & 0xFU].state = HC_XACTERR;
+    hhcd->hc[ch_num & 0xFU].state = HC_XACTERR;
 
-    /*Clear ERR_TX*/
+    /* Clear ERR_TX */
     HCD_CLEAR_TX_CH_ERR(hhcd->Instance, phy_chnum);
 
 #if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
-    hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+    hhcd->HC_NotifyURBChangeCallback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #else
-    HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum, hhcd->hc[chnum & 0xFU].urb_state);
+    HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num, hhcd->hc[ch_num & 0xFU].urb_state);
 #endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
   }
 }
@@ -2206,13 +2218,13 @@ static void HCD_Port_IRQHandler(HCD_HandleTypeDef *hhcd)
     /* Host Port State */
     hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
 
-    /* clear all allocated virtual channel */
+    /* Clear all allocated virtual channel */
     HAL_HCD_ClearPhyChannel(hhcd);
 
     /* Reset the PMA current pointer */
     (void)HAL_HCD_PMAReset(hhcd);
 
-    /* reset Ep0 Pma allocation state */
+    /* Reset Ep0 Pma allocation state */
     hhcd->ep0_PmaAllocState = 0U;
 
     /* Disconnection Callback */
@@ -2620,7 +2632,7 @@ HAL_StatusTypeDef  HAL_HCD_PMAlloc(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
   /* Get a FreePMA Address */
   pma_addr0 = HAL_HCD_GetFreePMA(hhcd, mps);
 
-  /* if there is no free space to allocate */
+  /* If there is no free space to allocate */
   if (pma_addr0 == 0xFFFFU)
   {
     return HAL_ERROR;
@@ -2635,7 +2647,8 @@ HAL_StatusTypeDef  HAL_HCD_PMAlloc(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
 
       if (hc->ep_num == 0U)
       {
-        hhcd->ep0_PmaAllocState = ch_num;
+        hhcd->ep0_PmaAllocState &= 0xFFF0U;
+        hhcd->ep0_PmaAllocState |= ch_num;
         hhcd->ep0_PmaAllocState |= (1U << 8);
       }
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.c
@@ -88,7 +88,8 @@ static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t p
 
 static uint16_t HAL_HCD_GetFreePMA(HCD_HandleTypeDef *hhcd, uint16_t mps);
 static HAL_StatusTypeDef  HAL_HCD_PMAFree(HCD_HandleTypeDef *hhcd, uint32_t pma_base, uint16_t mps);
-static void inline HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue);
+// Mbed: moved inline ahead of void
+static inline void HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue);
 /**
   * @}
   */
@@ -1797,7 +1798,8 @@ static void HCD_HC_IN_BulkDb(HCD_HandleTypeDef *hhcd,
   * @param  regvalue contain Snapshot of the EPCHn register when ISR is detected
   * @retval none
   */
-static void inline HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+// Mbed: moved inline ahead of void
+static inline void HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
                                  uint8_t phy_chnum, uint32_t regvalue)
 {
   /* Check if Double buffer isochronous */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_hcd.h
@@ -359,11 +359,14 @@ HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd);
 /** @defgroup HCD_ENDP_Kind HCD Endpoint Kind
   * @{
   */
-#define HCD_SNG_BUF                            0U
-#define HCD_DBL_BUF                            1U
+#define HCD_SNG_BUF                              0U
+#define HCD_DBL_BUF                              1U
 /**
   * @}
   */
+
+/* Powerdown exit count */
+#define HCD_PDWN_EXIT_CNT                    0x100U
 
 /* Set Channel */
 #define HCD_SET_CHANNEL                        USB_DRD_SET_CHEP
@@ -495,15 +498,16 @@ HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd);
 __STATIC_INLINE uint16_t HCD_GET_CH_RX_CNT(HCD_TypeDef *Instance, uint16_t bChNum)
 {
   uint32_t HostCoreSpeed;
+  uint32_t ep_reg = USB_DRD_GET_CHEP(Instance, bChNum);
   __IO uint32_t count = 10U;
 
   /* Get Host core Speed */
   HostCoreSpeed = USB_GetHostSpeed(Instance);
 
   /* Count depends on device LS */
-  if (HostCoreSpeed == USB_DRD_SPEED_LS)
+  if ((HostCoreSpeed == USB_DRD_SPEED_LS) || ((ep_reg & USB_CHEP_LSEP) == USB_CHEP_LSEP))
   {
-    count = (63U * (HAL_RCC_GetHCLKFreq() / 1000000U)) / 100U;
+    count = (70U * (HAL_RCC_GetHCLKFreq() / 1000000U)) / 100U;
   }
 
   if (count > 15U)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2c.c
@@ -90,7 +90,7 @@
            add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
       (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
            add their own code by customization of function pointer HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
@@ -156,7 +156,7 @@
             HAL_I2C_Master_Seq_Receive_IT() or using HAL_I2C_Master_Seq_Receive_DMA()
       (+++) At reception end of current frame transfer, HAL_I2C_MasterRxCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
-      (++) Abort a master IT or DMA I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (++) Abort a master or memory IT or DMA I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+++) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (++) Enable/disable the Address listen mode in slave I2C mode using HAL_I2C_EnableListen_IT()
@@ -214,7 +214,7 @@
            add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
       (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
            add their own code by customization of function pointer HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
@@ -1363,6 +1363,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
                                          uint32_t Timeout)
 {
   uint32_t tickstart;
+  uint16_t tmpXferCount;
+  HAL_StatusTypeDef error;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1389,14 +1391,6 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     /* Enable Address Acknowledge */
     hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
 
-    /* Wait until ADDR flag is set */
-    if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
-    {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
-      return HAL_ERROR;
-    }
-
     /* Preload TX data if no stretch enable */
     if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
     {
@@ -1410,6 +1404,18 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
       hi2c->XferCount--;
     }
 
+    /* Wait until ADDR flag is set */
+    if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
+      return HAL_ERROR;
+    }
+
     /* Clear ADDR flag */
     __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
 
@@ -1421,6 +1427,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
       {
         /* Disable Address Acknowledge */
         hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
         return HAL_ERROR;
       }
 
@@ -1433,6 +1443,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     {
       /* Disable Address Acknowledge */
       hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
       return HAL_ERROR;
     }
 
@@ -1456,30 +1470,47 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     }
 
     /* Wait until AF flag is set */
-    if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_AF, RESET, Timeout, tickstart) != HAL_OK)
+    error = I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_AF, RESET, Timeout, tickstart);
+
+    if (error != HAL_OK)
     {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
-      return HAL_ERROR;
+      /* Check that I2C transfer finished */
+      /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+      /* Mean XferCount == 0 */
+
+      tmpXferCount = hi2c->XferCount;
+      if ((hi2c->ErrorCode == HAL_I2C_ERROR_AF) && (tmpXferCount == 0U))
+      {
+        /* Reset ErrorCode to NONE */
+        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      }
+      else
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_ERROR;
+      }
     }
-
-    /* Flush TX register */
-    I2C_Flush_TXDR(hi2c);
-
-    /* Clear AF flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
-
-    /* Wait until STOP flag is set */
-    if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    else
     {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
 
-      return HAL_ERROR;
+      /* Clear AF flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Wait until STOP flag is set */
+      if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        return HAL_ERROR;
+      }
+
+      /* Clear STOP flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
     }
-
-    /* Clear STOP flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
 
     /* Wait until BUSY flag is reset */
     if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout, tickstart) != HAL_OK)
@@ -4785,7 +4816,7 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
 }
 
 /**
-  * @brief  Abort a master I2C IT or DMA process communication with Interrupt.
+  * @brief  Abort a master or memory I2C IT or DMA process communication with Interrupt.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  DevAddress Target device address: The device 7 bits address value
@@ -4794,7 +4825,9 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
   */
 HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
-  if (hi2c->Mode == HAL_I2C_MODE_MASTER)
+  HAL_I2C_ModeTypeDef tmp_mode = hi2c->Mode;
+
+  if ((tmp_mode == HAL_I2C_MODE_MASTER) || (tmp_mode == HAL_I2C_MODE_MEM))
   {
     /* Process Locked */
     __HAL_LOCK(hi2c);
@@ -5460,9 +5493,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, tmpITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
-      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -5891,9 +5923,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, ITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
-      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -6495,6 +6526,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 {
   uint32_t tmpcr1value = READ_REG(hi2c->Instance->CR1);
   uint32_t tmpITFlags = ITFlags;
+  uint32_t tmpoptions = hi2c->XferOptions;
   HAL_I2C_StateTypeDef tmpstate = hi2c->State;
 
   /* Clear STOP Flag */
@@ -6582,6 +6614,57 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
   {
     /* Set ErrorCode corresponding to a Non-Acknowledge */
     hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+  }
+
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_IT_NACKI) != RESET))
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if (hi2c->XferCount == 0U)
+    {
+      if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME))
+        /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for
+           Warning[Pa134]: left and right operands are identical */
+      {
+        /* Call I2C Listen complete process */
+        I2C_ITListenCplt(hi2c, tmpITFlags);
+      }
+      else if ((hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN) && (tmpoptions != I2C_NO_OPTION_FRAME))
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
+        /* Last Byte is Transmitted */
+        /* Call I2C Slave Sequential complete process */
+        I2C_ITSlaveSeqCplt(hi2c);
+      }
+      else
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+      }
+    }
+    else
+    {
+      /* if no, error use case, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      if ((tmpoptions == I2C_FIRST_FRAME) || (tmpoptions == I2C_NEXT_FRAME))
+      {
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        I2C_ITError(hi2c, hi2c->ErrorCode);
+      }
+    }
   }
 
   hi2c->Mode = HAL_I2C_MODE_NONE;
@@ -7172,6 +7255,12 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
 {
   while (__HAL_I2C_GET_FLAG(hi2c, Flag) == Status)
   {
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
@@ -7283,16 +7372,18 @@ static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
 static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
                                                         uint32_t Tickstart)
 {
-  while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  HAL_StatusTypeDef status = HAL_OK;
+
+  while ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET) && (status == HAL_OK))
   {
     /* Check if an error is detected */
     if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
     {
-      return HAL_ERROR;
+      status = HAL_ERROR;
     }
 
     /* Check if a STOPF is detected */
-    if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) && (status == HAL_OK))
     {
       /* Check if an RXNE is pending */
       /* Store Last receive data if any */
@@ -7300,19 +7391,14 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
       {
         /* Return HAL_OK */
         /* The Reading of data from RXDR will be done in caller function */
-        return HAL_OK;
+        status = HAL_OK;
       }
-      else
+
+      /* Check a no-acknowledge have been detected */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
       {
-        if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
-        {
-          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
-          hi2c->ErrorCode = HAL_I2C_ERROR_AF;
-        }
-        else
-        {
-          hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
-        }
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+        hi2c->ErrorCode = HAL_I2C_ERROR_AF;
 
         /* Clear STOP Flag */
         __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
@@ -7326,12 +7412,16 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
         /* Process Unlocked */
         __HAL_UNLOCK(hi2c);
 
-        return HAL_ERROR;
+        status = HAL_ERROR;
+      }
+      else
+      {
+        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
       }
     }
 
     /* Check for the Timeout */
-    if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+    if ((((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U)) && (status == HAL_OK))
     {
       if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET))
       {
@@ -7341,11 +7431,11 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
         /* Process Unlocked */
         __HAL_UNLOCK(hi2c);
 
-        return HAL_ERROR;
+        status = HAL_ERROR;
       }
     }
   }
-  return HAL_OK;
+  return status;
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2c.h
@@ -118,8 +118,6 @@ typedef enum
   HAL_I2C_STATE_BUSY_RX_LISTEN    = 0x2AU,   /*!< Address Listen Mode and Data Reception
                                                  process is ongoing                         */
   HAL_I2C_STATE_ABORT             = 0x60U,   /*!< Abort user request ongoing                */
-  HAL_I2C_STATE_TIMEOUT           = 0xA0U,   /*!< Timeout state                             */
-  HAL_I2C_STATE_ERROR             = 0xE0U    /*!< Error                                     */
 
 } HAL_I2C_StateTypeDef;
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2s.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i2s.c
@@ -170,7 +170,7 @@
 
        When The compilation define USE_HAL_I2S_REGISTER_CALLBACKS is set to 0 or
        not defined, the callback registering feature is not available
-       and weak (surcharged) callbacks are used.
+       and weak callbacks are used.
 
 
   @endverbatim
@@ -540,6 +540,8 @@ __weak void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s)
   *                the configuration information for the specified I2S.
   * @param  CallbackID ID of the callback to be registered
   * @param  pCallback pointer to the Callback function
+  * @note   The HAL_I2S_RegisterCallback() may be called before HAL_I2S_Init() in HAL_I2S_STATE_RESET
+  *         to register callbacks for HAL_I2S_MSPINIT_CB_ID and HAL_I2S_MSPDEINIT_CB_ID
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID,
@@ -554,8 +556,6 @@ HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_Call
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hi2s);
 
   if (HAL_I2S_STATE_READY == hi2s->State)
   {
@@ -637,8 +637,6 @@ HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_Call
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2s);
   return status;
 }
 
@@ -648,14 +646,13 @@ HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_Call
   * @param  hi2s Pointer to a I2S_HandleTypeDef structure that contains
   *                the configuration information for the specified I2S.
   * @param  CallbackID ID of the callback to be unregistered
+  * @note   The HAL_I2S_UnRegisterCallback() may be called before HAL_I2S_Init() in HAL_I2S_STATE_RESET
+  *         to un-register callbacks for HAL_I2S_MSPINIT_CB_ID and HAL_I2S_MSPDEINIT_CB_ID
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_I2S_UnRegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-
-  /* Process locked */
-  __HAL_LOCK(hi2s);
 
   if (HAL_I2S_STATE_READY == hi2s->State)
   {
@@ -736,8 +733,6 @@ HAL_StatusTypeDef HAL_I2S_UnRegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_Ca
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2s);
   return status;
 }
 #endif /* USE_HAL_I2S_REGISTER_CALLBACKS */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i3c.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i3c.c
@@ -112,6 +112,8 @@
         And then application must send a associated dynamic address through HAL_I3C_Ctrl_SetDynAddr().
         This procedure in loop automatically in hardware side until a target respond to repeated ENTDAA sequence.
         The application is informed of the end of the procedure at reception of HAL_I3C_CtrlDAACpltCallback().
+        Then application can easily retrieve ENTDAA payload information through HAL_I3C_Get_ENTDAA_Payload_Info()
+        function.
         At the end of procedure, the function HAL_I3C_Ctrl_ConfigBusDevices() must be called to store in hardware
         register part the target capabilities as Dynamic address, IBI support with or without additional data byte,
         Controller role request support, Controller stop transfer after IBI through I3C_DeviceConfTypeDef structure.
@@ -131,6 +133,18 @@
     (#) To check if I3C target device is ready for communication, use the function HAL_I3C_Ctrl_IsDeviceI3C_Ready()
 
     (#) To check if I2C target device is ready for communication, use the function HAL_I3C_Ctrl_IsDeviceI2C_Ready()
+
+    (#) To send a message header {S + 0x7E + W + STOP}, use the function HAL_I3C_Ctrl_GenerateArbitration().
+    (#) To insert a target reset pattern before the STOP of a transmitted frame containing a RSTACT CCC command,
+        the application must enable the reset pattern configuration using HAL_I3C_Ctrl_SetConfigResetPattern()
+        before calling HAL_I3C_Ctrl_TransmitCCC() or HAL_I3C_Ctrl_ReceiveCCC() interfaces.
+
+        To have a standard STOP emitted at the end of a frame containing a RSTACT CCC command, the application must
+        disable the reset pattern configuration using HAL_I3C_Ctrl_SetConfigResetPattern() before calling
+        HAL_I3C_Ctrl_TransmitCCC() or HAL_I3C_Ctrl_ReceiveCCC() interfaces.
+
+        Use HAL_I3C_Ctrl_SetConfigResetPattern() function to configure the insertion of the reset pattern at
+        the end of a Frame, and HAL_I3C_Ctrl_GetConfigResetPattern() to retrieve reset pattern configuration.
 
     (#) For I3C IO operations, three operation modes are available within this driver :
 
@@ -313,7 +327,8 @@
 /* Includes ----------------------------------------------------------------------------------------------------------*/
 #include "stm32h5xx_hal.h"
 
-#if defined(DEVICE_I3C)
+// Mbed: added include
+#include "stm32h5xx_hal_i3c.h"
 
 /** @addtogroup STM32H5xx_HAL_Driver
   * @{
@@ -355,11 +370,129 @@
 #define I3C_BROADCAST_RSTDAA          (0x00000006U)
 #define I3C_BROADCAST_ENTDAA          (0x00000007U)
 
+/* Private define to split ENTDAA payload */
+#define I3C_DCR_IN_PAYLOAD_SHIFT       56
+#define I3C_PID_IN_PAYLOAD_MASK        0xFFFFFFFFFFFFU
+
+/* Private define to split PID */
+/* Bits[47:33]: MIPI Manufacturer ID */
+#define I3C_MIPIMID_PID_SHIFT          33
+#define I3C_MIPIMID_PID_MASK           0x7FFFU
+
+/* Bit[32]: Provisioned ID Type Selector */
+#define I3C_IDTSEL_PID_SHIFT           32
+#define I3C_IDTSEL_PID_MASK            0x01U
+
+/* Bits[31:16]: Part ID */
+#define I3C_PART_ID_PID_SHIFT          16
+#define I3C_PART_ID_PID_MASK           0xFFFFU
+
+/* Bits[15:12]: MIPI Instance ID */
+#define I3C_MIPIID_PID_SHIFT           12
+#define I3C_MIPIID_PID_MASK            0xFU
 /**
   * @}
   */
 
 /* Private macro -----------------------------------------------------------------------------------------------------*/
+
+/** @brief  Get Provisioned ID in payload (64bits) receive during ENTDAA procedure.
+  * @param  __PAYLOAD__ specifies the Device Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFFFFFF.
+  * @retval The value of PID Return value between Min_Data=0x00 and Max_Data=0xFFFFFFFFFFFF.
+  */
+#define I3C_GET_PID(__PAYLOAD__) ((uint64_t)(__PAYLOAD__) & I3C_PID_IN_PAYLOAD_MASK)
+
+/** @brief  Get MIPI Manufacturer ID in PID (48bits).
+  * @param  __PID__ specifies the Provisioned ID retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFF.
+  * @retval The value of MIPI ID Return value between Min_Data=0x00 and Max_Data=0x7FFF.
+  */
+#define I3C_GET_MIPIMID(__PID__) ((uint16_t)((uint64_t)(__PID__) >> I3C_MIPIMID_PID_SHIFT) & \
+                                  I3C_MIPIMID_PID_MASK)
+
+/** @brief  Get Type Selector in PID (48bits).
+  * @param  __PID__ specifies the Provisioned ID retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFF.
+  * @retval The value of Type Selector Return 0 or 1.
+  */
+#define I3C_GET_IDTSEL(__PID__) ((uint8_t)((uint64_t)(__PID__) >> I3C_IDTSEL_PID_SHIFT) & \
+                                 I3C_IDTSEL_PID_MASK)
+
+/** @brief  Get Part ID in PID (48bits).
+  * @param  __PID__ specifies the Provisioned ID retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFF.
+  * @retval The value of Part ID Return value between Min_Data=0x00 and Max_Data=0xFFFF.
+  */
+#define I3C_GET_PART_ID(__PID__) ((uint16_t)((uint64_t)(__PID__) >> I3C_PART_ID_PID_SHIFT) & \
+                                  I3C_PART_ID_PID_MASK)
+
+/** @brief  Get Instance ID in PID (48bits).
+  * @param  __PID__ specifies the Provisioned ID retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFF.
+  * @retval The value of Instance ID Return value between Min_Data=0x00 and Max_Data=0xF.
+  */
+#define I3C_GET_MIPIID(__PID__) ((uint8_t)((uint64_t)(__PID__) >> I3C_MIPIID_PID_SHIFT) & \
+                                 I3C_MIPIID_PID_MASK)
+
+/** @brief  Get Device Characterics in payload (64bits) receive during ENTDAA procedure.
+  * @param  __PAYLOAD__ specifies the Device Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00(uint64_t) and Max_Data=0xFFFFFFFFFFFFFFFFFF.
+  * @retval The value of BCR Return value between Min_Data=0x00 and Max_Data=0xFF.
+  */
+#define I3C_GET_DCR(__PAYLOAD__) (((uint32_t)((uint64_t)(__PAYLOAD__) >> I3C_DCR_IN_PAYLOAD_SHIFT)) & \
+                                  I3C_DCR_DCR)
+
+/** @brief  Get Advanced Capabilities.
+  * @param  __BCR__ specifies the Bus Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00 and Max_Data=0xFF.
+  * @retval The value of advanced capabilities:
+  *           ENABLE: supports optional advanced capabilities.
+  *           DISABLE: not supports optional advanced capabilities.
+  */
+#define I3C_GET_ADVANCED_CAPABLE(__BCR__) (((((__BCR__) & I3C_BCR_BCR5_Msk) >> \
+                                             I3C_BCR_BCR5_Pos) == 1U) ? ENABLE : DISABLE)
+
+/** @brief  Get virtual target support.
+  * @param  __BCR__ specifies the Bus Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00 and Max_Data=0xFF.
+  * @retval The value of offline capable:
+  *           ENABLE: is a Virtual Target
+  *           DISABLE: is not a Virtual Target
+  */
+#define I3C_GET_VIRTUAL_TGT(__BCR__) (((((__BCR__) & I3C_BCR_BCR4_Msk) >> \
+                                        I3C_BCR_BCR4_Pos) == 1U) ? ENABLE : DISABLE)
+
+/** @brief  Get offline capable.
+  * @param  __BCR__ specifies the Bus Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00 and Max_Data=0xFF.
+  * @retval The value of offline capable
+  *           ENABLE: Device will not always respond to I3C Bus commands
+  *           DISABLE: Device will always respond to I3C Bus commands
+  */
+#define I3C_GET_OFFLINE_CAPABLE(__BCR__) (((((__BCR__) & I3C_BCR_BCR3_Msk) >> \
+                                            I3C_BCR_BCR3_Pos) == 1U) ? ENABLE : DISABLE)
+
+/** @brief  Get Max data speed limitation.
+  * @param  __BCR__ specifies the Bus Characteristics capabilities retrieve during ENTDAA procedure.
+  *         This parameter must be a number between Min_Data=0x00 and Max_Data=0xFF.
+  * @retval The value of offline capable:
+  *           ENABLE: Limitation
+  *           DISABLE: No Limitation
+  */
+#define I3C_GET_MAX_DATA_SPEED_LIMIT(__BCR__) (((((__BCR__) & I3C_BCR_BCR0_Msk) >> \
+                                                 I3C_BCR_BCR0_Pos) == 1U) ? ENABLE : DISABLE)
+
+/** @brief  Change uint32_t variable form big endian to little endian.
+  * @param  __DATA__ .uint32_t variable in big endian.
+  *         This parameter must be a number between Min_Data=0x00(uint32_t) and Max_Data=0xFFFFFFFF.
+  * @retval uint32_t variable in little endian.
+  */
+#define I3C_BIG_TO_LITTLE_ENDIAN(__DATA__) ((uint32_t)((((__DATA__) & 0xff000000U) >> 24) | \
+                                                       (((__DATA__) & 0x00ff0000U) >> 8)  | \
+                                                       (((__DATA__) & 0x0000ff00U) << 8)  | \
+                                                       (((__DATA__) & 0x000000ffU) << 24)))
+
 /* Private variables -------------------------------------------------------------------------------------------------*/
 /** @addtogroup  I3C_Private_Variables
   * @{
@@ -379,31 +512,31 @@ typedef struct
 /** @addtogroup I3C_Private_Functions
   * @{
   */
-static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
+static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
 #if defined(HAL_DMA_MODULE_ENABLED)
-static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
+static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
 #endif /* HAL_DMA_MODULE_ENABLED */
-static HAL_StatusTypeDef I3C_Tgt_HotJoin_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Tgt_CtrlRole_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Tgt_IBI_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *hi3c,
-                                                    uint32_t itFlags,
-                                                    uint32_t itSources);
+static HAL_StatusTypeDef I3C_Tgt_HotJoin_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Tgt_CtrlRole_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Tgt_IBI_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Tx_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Rx_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
 #if defined(HAL_DMA_MODULE_ENABLED)
-static HAL_StatusTypeDef I3C_Ctrl_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_DMA_ISR(struct __I3C_HandleTypeDef *hi3c,
-                                                        uint32_t itFlags,
-                                                        uint32_t itSources);
+static HAL_StatusTypeDef I3C_Ctrl_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
 #endif /* HAL_DMA_MODULE_ENABLED */
-static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
-static HAL_StatusTypeDef I3C_Abort_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources);
+static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+static HAL_StatusTypeDef I3C_Abort_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks);
+
 static HAL_StatusTypeDef I3C_WaitOnDAAUntilTimeout(I3C_HandleTypeDef *hi3c, uint32_t timeout, uint32_t tickstart);
 static HAL_StatusTypeDef I3C_WaitOnFlagUntilTimeout(I3C_HandleTypeDef *hi3c, uint32_t flag, FlagStatus flagstatus,
                                                     uint32_t timeout, uint32_t tickstart);
@@ -1488,10 +1621,12 @@ void HAL_I3C_EV_IRQHandler(I3C_HandleTypeDef *hi3c) /* Derogation MISRAC2012-Rul
   uint32_t it_flags   = READ_REG(hi3c->Instance->EVR);
   uint32_t it_sources = READ_REG(hi3c->Instance->IER);
 
+  uint32_t it_masks   = (uint32_t)(it_flags & it_sources);
+
   /* I3C events treatment */
   if (hi3c->XferISR != NULL)
   {
-    hi3c->XferISR(hi3c, it_flags, it_sources);
+    hi3c->XferISR(hi3c, it_masks);
   }
 }
 /**
@@ -1532,6 +1667,10 @@ void HAL_I3C_EV_IRQHandler(I3C_HandleTypeDef *hi3c) /* Derogation MISRAC2012-Rul
          (+) Call the function HAL_I3C_AddDescToFrame() to prepare the full transfer usecase in a transfer descriptor
              which contained different buffer pointers and their associated size through I3C_XferTypeDef.
              This function must be called before initiate any communication transfer.
+         (+) Call the function HAL_I3C_Ctrl_SetConfigResetPattern() to configure the insertion of the reset pattern
+             at the end of a Frame.
+         (+) Call the function HAL_I3C_Ctrl_GetConfigResetPattern() to get the current reset pattern configuration
+
      [..]
        (@) Users must call all above functions after I3C initialization.
 
@@ -2103,6 +2242,110 @@ HAL_StatusTypeDef HAL_I3C_AddDescToFrame(I3C_HandleTypeDef         *hi3c,
 }
 
 /**
+  * @brief Set the configuration of the inserted reset pattern at the end of a Frame.
+  * @note  When the transfer descriptor contains multiple frames with RESTART option, the reset pattern at the end of
+  *        RSTACT CCC frame is not possible.
+  * @param  hi3c         : [IN] Pointer to an I3C_HandleTypeDef structure that contains
+  *                             the configuration information for the specified I3C.
+  * @param  resetPattern : [IN] Specifies the reset pattern configuration.
+  *                             It can be a value of @ref I3C_RESET_PATTERN
+  * @retval HAL Status   :      Value from HAL_StatusTypeDef enumeration.
+  */
+HAL_StatusTypeDef HAL_I3C_Ctrl_SetConfigResetPattern(I3C_HandleTypeDef *hi3c, uint32_t resetPattern)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  HAL_I3C_StateTypeDef handle_state;
+
+  /* check on the handle */
+  if (hi3c == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the instance and the mode parameters */
+    assert_param(IS_I3C_ALL_INSTANCE(hi3c->Instance));
+    assert_param(IS_I3C_MODE(hi3c->Mode));
+    assert_param(IS_I3C_RESET_PATTERN(resetPattern));
+
+    /* Get I3C handle state */
+    handle_state = hi3c->State;
+
+    /* check on the Mode */
+    if (hi3c->Mode != HAL_I3C_MODE_CONTROLLER)
+    {
+      hi3c->ErrorCode = HAL_I3C_ERROR_NOT_ALLOWED;
+      status = HAL_ERROR;
+    }
+    /* check on the State */
+    else if ((handle_state != HAL_I3C_STATE_READY) && (handle_state != HAL_I3C_STATE_LISTEN))
+    {
+      status = HAL_BUSY;
+    }
+    else
+    {
+      hi3c->State = HAL_I3C_STATE_BUSY;
+
+      if (resetPattern == HAL_I3C_RESET_PATTERN_ENABLE)
+      {
+        LL_I3C_EnableResetPattern(hi3c->Instance);
+      }
+      else
+      {
+        LL_I3C_DisableResetPattern(hi3c->Instance);
+      }
+
+      /* At the end of process update state to Previous state */
+      I3C_StateUpdate(hi3c);
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief Get the configuration of the inserted reset pattern at the end of a Frame.
+  * @param  hi3c          : [IN] Pointer to an I3C_HandleTypeDef structure that contains
+  *                              the configuration information for the specified I3C.
+  * @param  pResetPattern : [OUT] Pointer to the current reset pattern configuration.
+  *                               It can be a value of @ref I3C_RESET_PATTERN
+  * @retval HAL Status    :       Value from HAL_StatusTypeDef enumeration.
+  */
+HAL_StatusTypeDef HAL_I3C_Ctrl_GetConfigResetPattern(I3C_HandleTypeDef *hi3c, uint32_t *pResetPattern)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check on the handle */
+  if (hi3c == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  /* Check on user parameters */
+  else if (pResetPattern == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the instance and the mode parameters */
+    assert_param(IS_I3C_ALL_INSTANCE(hi3c->Instance));
+    assert_param(IS_I3C_MODE(hi3c->Mode));
+
+    /* Check if the reset pattern configuration is enabled */
+    if (LL_I3C_IsEnabledResetPattern(hi3c->Instance) == 1U)
+    {
+      *pResetPattern     = HAL_I3C_RESET_PATTERN_ENABLE;
+    }
+    else
+    {
+      *pResetPattern     = HAL_I3C_RESET_PATTERN_DISABLE;
+    }
+  }
+
+  return status;
+}
+
+/**
   * @}
   */
 
@@ -2476,6 +2719,8 @@ HAL_StatusTypeDef HAL_I3C_GetConfigFifo(I3C_HandleTypeDef *hi3c, I3C_FifoConfTyp
              during the Dynamic Address Assignment processus.
          (+) Call the function HAL_I3C_Ctrl_IsDeviceI3C_Ready() to check if I3C target device is ready.
          (+) Call the function HAL_I3C_Ctrl_IsDeviceI2C_Ready() to check if I2C target device is ready.
+         (+) Call the function HAL_I3C_Ctrl_GenerateArbitration to send arbitration
+            (message header {S + 0x7E + W + STOP}) in polling mode
 
          (+) Those functions are called only when mode is Controller.
 
@@ -2521,7 +2766,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_TransmitCCC(I3C_HandleTypeDef *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -2681,7 +2926,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_TransmitCCC_IT(I3C_HandleTypeDef *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -2701,9 +2946,19 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_TransmitCCC_IT(I3C_HandleTypeDef *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode = HAL_I3C_ERROR_NONE;
-      hi3c->State     = HAL_I3C_STATE_BUSY_TX;
+
+      if (handle_state == HAL_I3C_STATE_LISTEN)
+      {
+        hi3c->XferISR = I3C_Ctrl_Tx_Listen_Event_ISR;
+      }
+      else
+      {
+        hi3c->XferISR = I3C_Ctrl_Tx_ISR;
+      }
+
       hi3c->pXferData = pXferData;
-      hi3c->XferISR   = I3C_Ctrl_Tx_ISR;
+      hi3c->State     = HAL_I3C_STATE_BUSY_TX;
+
 
       /* Check on the Tx threshold to know the Tx treatment process : byte or word */
       if (LL_I3C_GetTxFIFOThreshold(hi3c->Instance) == LL_I3C_TXFIFO_THRESHOLD_1_4)
@@ -2769,7 +3024,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_TransmitCCC_DMA(I3C_HandleTypeDef *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -2794,10 +3049,10 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_TransmitCCC_DMA(I3C_HandleTypeDef *hi3c,
     else
     {
       /* Set handle transfer parameters */
-      hi3c->ErrorCode = HAL_I3C_ERROR_NONE;
-      hi3c->State     = HAL_I3C_STATE_BUSY_TX;
-      hi3c->pXferData = pXferData;
-      hi3c->XferISR   = I3C_Ctrl_Tx_DMA_ISR;
+      hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
+      hi3c->XferISR       = I3C_Ctrl_Tx_DMA_ISR;
+      hi3c->pXferData     = pXferData;
+      hi3c->State         = HAL_I3C_STATE_BUSY_TX;
 
       /*------------------------------------ I3C DMA channel for Control Data ----------------------------------------*/
       /* Set the I3C DMA transfer complete callback */
@@ -2952,7 +3207,6 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_ReceiveCCC(I3C_HandleTypeDef *hi3c,
   }
   else
   {
-
     /* Check the instance and the mode parameters */
     assert_param(IS_I3C_ALL_INSTANCE(hi3c->Instance));
     assert_param(IS_I3C_MODE(hi3c->Mode));
@@ -3135,7 +3389,6 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_ReceiveCCC_IT(I3C_HandleTypeDef *hi3c,
   }
   else
   {
-
     /* Check the instance and the mode parameters */
     assert_param(IS_I3C_ALL_INSTANCE(hi3c->Instance));
     assert_param(IS_I3C_MODE(hi3c->Mode));
@@ -3166,10 +3419,17 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_ReceiveCCC_IT(I3C_HandleTypeDef *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode   = HAL_I3C_ERROR_NONE;
-      hi3c->State       = HAL_I3C_STATE_BUSY_RX;
+      if (handle_state == HAL_I3C_STATE_LISTEN)
+      {
+        hi3c->XferISR   = I3C_Ctrl_Rx_Listen_Event_ISR;
+      }
+      else
+      {
+        hi3c->XferISR   = I3C_Ctrl_Rx_ISR;
+      }
       hi3c->pXferData   = pXferData;
       hi3c->RxXferCount = pXferData->RxBuf.Size;
-      hi3c->XferISR     = I3C_Ctrl_Rx_ISR;
+      hi3c->State       = HAL_I3C_STATE_BUSY_RX;
 
       /* Check on CCC defining byte */
       if (hi3c->TxXferCount != 0U)
@@ -3283,10 +3543,10 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_ReceiveCCC_DMA(I3C_HandleTypeDef *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode   = HAL_I3C_ERROR_NONE;
-      hi3c->State       = HAL_I3C_STATE_BUSY_RX;
+      hi3c->XferISR     = I3C_Ctrl_Rx_DMA_ISR;
       hi3c->pXferData   = pXferData;
       hi3c->RxXferCount = hi3c->pXferData->RxBuf.Size;
-      hi3c->XferISR     = I3C_Ctrl_Rx_DMA_ISR;
+      hi3c->State       = HAL_I3C_STATE_BUSY_RX;
 
       /*------------------------------------ I3C DMA channel for Control Data ----------------------------------------*/
       /* Set the I3C DMA transfer complete callback */
@@ -3508,7 +3768,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit(I3C_HandleTypeDef   *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -3530,7 +3790,6 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit(I3C_HandleTypeDef   *hi3c,
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
       hi3c->State         = HAL_I3C_STATE_BUSY_TX;
       hi3c->pXferData     = pXferData;
-      hi3c->TxXferCount   = hi3c->pXferData->TxBuf.Size;
 
       /* Check on the Tx threshold to know the Tx treatment process : byte or word */
       if (LL_I3C_GetTxFIFOThreshold(hi3c->Instance) == LL_I3C_TXFIFO_THRESHOLD_1_4)
@@ -3669,7 +3928,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit_IT(I3C_HandleTypeDef   *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -3689,10 +3948,16 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit_IT(I3C_HandleTypeDef   *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
-      hi3c->State         = HAL_I3C_STATE_BUSY_TX;
+      if (handle_state == HAL_I3C_STATE_LISTEN)
+      {
+        hi3c->XferISR     = I3C_Ctrl_Tx_Listen_Event_ISR;
+      }
+      else
+      {
+        hi3c->XferISR     = I3C_Ctrl_Tx_ISR;
+      }
       hi3c->pXferData     = pXferData;
-      hi3c->TxXferCount   = hi3c->pXferData->TxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Tx_ISR;
+      hi3c->State         = HAL_I3C_STATE_BUSY_TX;
 
       /* Check on the Tx threshold to know the Tx treatment process : byte or word */
       if (LL_I3C_GetTxFIFOThreshold(hi3c->Instance) == LL_I3C_TXFIFO_THRESHOLD_1_4)
@@ -3759,7 +4024,7 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit_DMA(I3C_HandleTypeDef   *hi3c,
 
     /* Check on user parameters */
     if ((pXferData == NULL) ||
-        ((pXferData->TxBuf.pBuffer == NULL) && (hi3c->TxXferCount != 0U)))
+        ((hi3c->TxXferCount != 0U) && (pXferData->TxBuf.pBuffer == NULL)))
     {
       hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
       status = HAL_ERROR;
@@ -3785,10 +4050,9 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Transmit_DMA(I3C_HandleTypeDef   *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
+      hi3c->XferISR       = I3C_Ctrl_Tx_DMA_ISR;
       hi3c->State         = HAL_I3C_STATE_BUSY_TX;
       hi3c->pXferData     = pXferData;
-      hi3c->TxXferCount   = hi3c->pXferData->TxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Tx_DMA_ISR;
 
       /*------------------------------------ I3C DMA channel for Control Data ----------------------------------------*/
       /* Set the I3C DMA transfer complete callback */
@@ -4129,10 +4393,17 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Receive_IT(I3C_HandleTypeDef   *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
-      hi3c->State         = HAL_I3C_STATE_BUSY_RX;
+      if (handle_state == HAL_I3C_STATE_LISTEN)
+      {
+        hi3c->XferISR     = I3C_Ctrl_Rx_Listen_Event_ISR;
+      }
+      else
+      {
+        hi3c->XferISR     = I3C_Ctrl_Rx_ISR;
+      }
       hi3c->pXferData     = pXferData;
       hi3c->RxXferCount   = hi3c->pXferData->RxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Rx_ISR;
+      hi3c->State         = HAL_I3C_STATE_BUSY_RX;
 
       /* Check on the Rx threshold to know the Rx treatment process : byte or word */
       if (LL_I3C_GetRxFIFOThreshold(hi3c->Instance) == LL_I3C_RXFIFO_THRESHOLD_1_4)
@@ -4222,10 +4493,10 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_Receive_DMA(I3C_HandleTypeDef   *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
-      hi3c->State         = HAL_I3C_STATE_BUSY_RX;
+      hi3c->XferISR       = I3C_Ctrl_Rx_DMA_ISR;
       hi3c->pXferData     = pXferData;
       hi3c->RxXferCount   = hi3c->pXferData->RxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Rx_DMA_ISR;
+      hi3c->State         = HAL_I3C_STATE_BUSY_RX;
 
       /*------------------------------------ I3C DMA channel for Control Data ----------------------------------------*/
       /* Set the I3C DMA transfer complete callback */
@@ -4411,11 +4682,18 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_MultipleTransfer_IT(I3C_HandleTypeDef   *hi3c,
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
-      hi3c->State         = HAL_I3C_STATE_BUSY_TX_RX;
+      if (handle_state == HAL_I3C_STATE_LISTEN)
+      {
+        hi3c->XferISR     = I3C_Ctrl_Multiple_Xfer_Listen_Event_ISR;
+      }
+      else
+      {
+        hi3c->XferISR     = I3C_Ctrl_Multiple_Xfer_ISR;
+      }
       hi3c->pXferData     = pXferData;
       hi3c->TxXferCount   = hi3c->pXferData->TxBuf.Size;
       hi3c->RxXferCount   = hi3c->pXferData->RxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Multiple_Xfer_ISR;
+      hi3c->State         = HAL_I3C_STATE_BUSY_TX_RX;
 
       /* Check on the Tx threshold to know the Tx treatment process : byte or word */
       if (LL_I3C_GetTxFIFOThreshold(hi3c->Instance) == LL_I3C_TXFIFO_THRESHOLD_1_4)
@@ -4522,11 +4800,11 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_MultipleTransfer_DMA(I3C_HandleTypeDef   *hi3c, I
     {
       /* Set handle transfer parameters */
       hi3c->ErrorCode     = HAL_I3C_ERROR_NONE;
-      hi3c->State         = HAL_I3C_STATE_BUSY_TX_RX;
+      hi3c->XferISR       = I3C_Ctrl_Multiple_Xfer_DMA_ISR;
       hi3c->pXferData     = pXferData;
       hi3c->RxXferCount   = hi3c->pXferData->RxBuf.Size;
       hi3c->TxXferCount   = hi3c->pXferData->TxBuf.Size;
-      hi3c->XferISR       = I3C_Ctrl_Multiple_Xfer_DMA_ISR;
+      hi3c->State         = HAL_I3C_STATE_BUSY_TX_RX;
 
       /*------------------------------------ I3C DMA channel for Control Data -------------------------------------*/
       /* Set the I3C DMA transfer complete callback */
@@ -5077,6 +5355,109 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_IsDeviceI2C_Ready(I3C_HandleTypeDef *hi3c,
 
   return status;
 }
+
+/**
+  * @brief Controller generates arbitration (message header {S/Sr + 0x7E addr + W}) in polling mode.
+  * @param  hi3c       : [IN] Pointer to an I3C_HandleTypeDef structure that contains
+  *                           the configuration information for the specified I3C.
+  * @param  timeout    : [IN] Timeout duration
+  * @retval HAL Status :      Value from HAL_StatusTypeDef enumeration.
+  */
+HAL_StatusTypeDef HAL_I3C_Ctrl_GenerateArbitration(I3C_HandleTypeDef *hi3c, uint32_t timeout)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  HAL_I3C_StateTypeDef handle_state;
+  __IO uint32_t exit_condition;
+  uint32_t tickstart;
+
+  /* check on the handle */
+  if (hi3c == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the instance and the mode parameters */
+    assert_param(IS_I3C_ALL_INSTANCE(hi3c->Instance));
+    assert_param(IS_I3C_MODE(hi3c->Mode));
+
+    /* Get I3C handle state */
+    handle_state = hi3c->State;
+
+    /* check on the Mode */
+    if (hi3c->Mode != HAL_I3C_MODE_CONTROLLER)
+    {
+      hi3c->ErrorCode = HAL_I3C_ERROR_NOT_ALLOWED;
+      status = HAL_ERROR;
+    }
+    /* check on the State */
+    else if ((handle_state != HAL_I3C_STATE_READY) && (handle_state != HAL_I3C_STATE_LISTEN))
+    {
+      status = HAL_BUSY;
+    }
+    else
+    {
+      hi3c->State = HAL_I3C_STATE_BUSY;
+
+      /* Disable exit pattern */
+      LL_I3C_DisableExitPattern(hi3c->Instance);
+      /* Disable reset pattern */
+      LL_I3C_DisableResetPattern(hi3c->Instance);
+
+      /* Write message control register */
+      WRITE_REG(hi3c->Instance->CR, LL_I3C_CONTROLLER_MTYPE_HEADER | LL_I3C_GENERATE_STOP);
+
+      /* Calculate exit_condition value based on Frame complete and error flags */
+      exit_condition = (READ_REG(hi3c->Instance->EVR) & (I3C_EVR_FCF | I3C_EVR_ERRF));
+
+      tickstart = HAL_GetTick();
+
+      while (exit_condition == 0U)
+      {
+        if (timeout != HAL_MAX_DELAY)
+        {
+          if (((HAL_GetTick() - tickstart) > timeout) || (timeout == 0U))
+          {
+            /* Update I3C error code */
+            hi3c->ErrorCode |= HAL_I3C_ERROR_TIMEOUT;
+            status = HAL_TIMEOUT;
+
+            break;
+          }
+        }
+        /* Calculate exit_condition value based on Frame complete and error flags */
+        exit_condition = (READ_REG(hi3c->Instance->EVR) & (I3C_EVR_FCF | I3C_EVR_ERRF));
+      }
+
+      if (status == HAL_OK)
+      {
+        /* Check if the FCF flag has been set */
+        if (__HAL_I3C_GET_FLAG(hi3c, I3C_EVR_FCF) == SET)
+        {
+          /* Clear frame complete flag */
+          LL_I3C_ClearFlag_FC(hi3c->Instance);
+        }
+        else
+        {
+          /* Clear error flag */
+          LL_I3C_ClearFlag_ERR(hi3c->Instance);
+
+          /* Update handle error code parameter */
+          I3C_GetErrorSources(hi3c);
+
+          /* Update returned status value */
+          status = HAL_ERROR;
+        }
+      }
+
+      /* At the end of Rx process update state to Previous state */
+      I3C_StateUpdate(hi3c);
+    }
+  }
+
+  return status;
+}
+
 /**
   * @}
   */
@@ -6504,6 +6885,7 @@ HAL_StatusTypeDef HAL_I3C_Tgt_IBIReq_IT(I3C_HandleTypeDef *hi3c, const uint8_t *
          (+) Call the function HAL_I3C_GetState() to get the I3C handle state.
          (+) Call the function HAL_I3C_GetMode() to get the I3C handle mode.
          (+) Call the function HAL_I3C_GetError() to get the error code.
+         (+) Call the function HAL_I3C_Get_ENTDAA_Payload_Info() to get BCR, DCR and PID information after ENTDAA.
 
 @endverbatim
   * @{
@@ -6624,7 +7006,7 @@ uint32_t HAL_I3C_GetError(const I3C_HandleTypeDef *hi3c)
   *                         It can be a combination of value of @ref HAL_I3C_Notification_ID_definition.
   * @param  pCCCInfo : [IN/OUT] Pointer to an I3C_CCCInfoTypeDef structure that contains the CCC information
   *                             updated after CCC event.
-  * @retval None
+  * @retval HAL Status : Value from HAL_StatusTypeDef enumeration.
   */
 HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
                                      uint32_t notifyId,
@@ -6712,6 +7094,73 @@ HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
 
   return status;
 }
+
+/**
+  * @brief  Get BCR, DCR and PID information after ENTDAA.
+  * @param  hi3c     : [IN] Pointer to an I3C_HandleTypeDef structure that contains the configuration information
+  *                         for the specified I3C.
+  * @param  ENTDAA_payload  :[IN] Payload received after ENTDAA
+  * @param  pENTDAA_payload :[OUT] Pointer to an I3C_ENTDAAPayloadTypeDef structure that contains the BCR, DCR and PID
+  *                          information.
+  * @retval HAL Status : Value from HAL_StatusTypeDef enumeration.
+  */
+HAL_StatusTypeDef HAL_I3C_Get_ENTDAA_Payload_Info(I3C_HandleTypeDef *hi3c,
+                                                  uint64_t ENTDAA_payload,
+                                                  I3C_ENTDAAPayloadTypeDef *pENTDAA_payload)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t BCR;
+  uint64_t PID;
+
+  /* check on the handle */
+  if (hi3c == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check on user parameters */
+    if (pENTDAA_payload == NULL)
+    {
+      /* Update handle error code parameter */
+      hi3c->ErrorCode = HAL_I3C_ERROR_INVALID_PARAM;
+      status = HAL_ERROR;
+    }
+    else
+    {
+      /* Get Bus Characterics */
+      BCR = __HAL_I3C_GET_BCR(ENTDAA_payload);
+
+      /* Retrieve BCR information */
+      pENTDAA_payload->BCR.IBIPayload = __HAL_I3C_GET_IBI_PAYLOAD(BCR);
+      pENTDAA_payload->BCR.IBIRequestCapable = __HAL_I3C_GET_IBI_CAPABLE(BCR);
+      pENTDAA_payload->BCR.DeviceRole = __HAL_I3C_GET_CR_CAPABLE(BCR);
+      pENTDAA_payload->BCR.AdvancedCapabilities = I3C_GET_ADVANCED_CAPABLE(BCR);
+      pENTDAA_payload->BCR.OfflineCapable = I3C_GET_OFFLINE_CAPABLE(BCR);
+      pENTDAA_payload->BCR.VirtualTargetSupport = I3C_GET_VIRTUAL_TGT(BCR);
+      pENTDAA_payload->BCR.MaxDataSpeedLimitation = I3C_GET_MAX_DATA_SPEED_LIMIT(BCR);
+
+      /* Get Device Characterics */
+      pENTDAA_payload->DCR = I3C_GET_DCR(ENTDAA_payload);
+
+      /* Get Provisioned ID */
+      PID = I3C_GET_PID(ENTDAA_payload);
+
+      /* Change PID from BigEndian to litlleEndian */
+      PID = (uint64_t)((((uint64_t)I3C_BIG_TO_LITTLE_ENDIAN((uint32_t) PID) << 32)   |
+                        ((uint64_t)I3C_BIG_TO_LITTLE_ENDIAN((uint32_t)(PID >> 32)))) >> 16);
+
+      /* Retrieve PID information*/
+      pENTDAA_payload->PID.MIPIMID = I3C_GET_MIPIMID(PID);
+      pENTDAA_payload->PID.IDTSEL = I3C_GET_IDTSEL(PID);
+      pENTDAA_payload->PID.PartID = I3C_GET_PART_ID(PID);
+      pENTDAA_payload->PID.MIPIID = I3C_GET_MIPIID(PID);
+    }
+  }
+
+  return status;
+}
+
 /**
   * @}
   */
@@ -6729,24 +7178,22 @@ HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
   * @brief  Interrupt Sub-Routine which handles target received events.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   uint32_t tmpevent = 0U;
 
   /* I3C Rx FIFO not empty interrupt Check */
-  if ((I3C_CHECK_FLAG(itFlags, HAL_I3C_FLAG_RXFNEF) != RESET) &&
-      (I3C_CHECK_IT_SOURCE(itSources, HAL_I3C_IT_RXFNEIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, HAL_I3C_FLAG_RXFNEF) != RESET)
   {
     /* Call receive treatment function */
     hi3c->ptrRxFunc(hi3c);
   }
 
   /* I3C target complete controller-role hand-off procedure (direct GETACCR CCC) event management --------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CRUPDF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CRUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRUPDF) != RESET)
   {
     /* Clear controller-role update flag */
     LL_I3C_ClearFlag_CRUPD(hi3c->Instance);
@@ -6756,7 +7203,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive any direct GETxxx CCC event management -------------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_GETF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_GETIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_GETF) != RESET)
   {
     /* Clear GETxxx CCC flag */
     LL_I3C_ClearFlag_GET(hi3c->Instance);
@@ -6766,7 +7213,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive get status command (direct GETSTATUS CCC) event management -----------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_STAF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_STAIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_STAF) != RESET)
   {
     /* Clear GETSTATUS CCC flag */
     LL_I3C_ClearFlag_STA(hi3c->Instance);
@@ -6776,7 +7223,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive a dynamic address update (ENTDAA/RSTDAA/SETNEWDA CCC) event management -----------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_DAUPDF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_DAUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_DAUPDF) != RESET)
   {
     /* Clear dynamic address update flag */
     LL_I3C_ClearFlag_DAUPD(hi3c->Instance);
@@ -6786,8 +7233,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive maximum write length update (direct SETMWL CCC) event management -----------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_MWLUPDF) != RESET) &&
-      (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_MWLUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_MWLUPDF) != RESET)
   {
     /* Clear SETMWL CCC flag */
     LL_I3C_ClearFlag_MWLUPD(hi3c->Instance);
@@ -6797,8 +7243,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive maximum read length update(direct SETMRL CCC) event management -------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_MRLUPDF) != RESET) &&
-      (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_MRLUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_MRLUPDF) != RESET)
   {
     /* Clear SETMRL CCC flag */
     LL_I3C_ClearFlag_MRLUPD(hi3c->Instance);
@@ -6808,7 +7253,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target detect reset pattern (broadcast or direct RSTACT CCC) event management -------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_RSTF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_RSTIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_RSTF) != RESET)
   {
     /* Clear reset pattern flag */
     LL_I3C_ClearFlag_RST(hi3c->Instance);
@@ -6818,7 +7263,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive activity state update (direct or broadcast ENTASx) CCC event management ----------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_ASUPDF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_ASUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_ASUPDF) != RESET)
   {
     /* Clear ENTASx CCC flag */
     LL_I3C_ClearFlag_ASUPD(hi3c->Instance);
@@ -6828,8 +7273,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive a direct or broadcast ENEC/DISEC CCC event management ----------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_INTUPDF) != RESET) &&
-      (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_INTUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_INTUPDF) != RESET)
   {
     /* Clear ENEC/DISEC CCC flag */
     LL_I3C_ClearFlag_INTUPD(hi3c->Instance);
@@ -6839,7 +7283,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive a broadcast DEFTGTS CCC event management -----------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_DEFF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_DEFIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_DEFF) != RESET)
   {
     /* Clear DEFTGTS CCC flag */
     LL_I3C_ClearFlag_DEF(hi3c->Instance);
@@ -6849,7 +7293,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target receive a group addressing (broadcast DEFGRPA CCC) event management ----------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_GRPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_GRPIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_GRPF) != RESET)
   {
     /* Clear DEFGRPA CCC flag */
     LL_I3C_ClearFlag_GRP(hi3c->Instance);
@@ -6859,7 +7303,7 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   }
 
   /* I3C target wakeup event management ----------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_WKPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_WKPIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_WKPF) != RESET)
   {
     /* Clear WKP flag */
     LL_I3C_ClearFlag_WKP(hi3c->Instance);
@@ -6889,14 +7333,13 @@ static HAL_StatusTypeDef I3C_Tgt_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uin
   * @brief  Interrupt Sub-Routine which handles Controller received events.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* I3C controller receive IBI event management ---------------------------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_IBIF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_IBIIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_IBIF) != RESET)
   {
     /* Clear IBI request flag */
     LL_I3C_ClearFlag_IBI(hi3c->Instance);
@@ -6911,7 +7354,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, ui
   }
 
   /* I3C controller controller-role request event management ---------------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CRF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CRIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRF) != RESET)
   {
     /* Clear controller-role request flag */
     LL_I3C_ClearFlag_CR(hi3c->Instance);
@@ -6926,7 +7369,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, ui
   }
 
   /* I3C controller hot-join event management ------------------------------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_HJF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_HJIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_HJF) != RESET)
   {
     /* Clear hot-join flag */
     LL_I3C_ClearFlag_HJ(hi3c->Instance);
@@ -6950,14 +7393,13 @@ static HAL_StatusTypeDef I3C_Ctrl_Event_ISR(struct __I3C_HandleTypeDef *hi3c, ui
   * @brief  Interrupt Sub-Routine which handles target hot join event.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_HotJoin_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_HotJoin_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* I3C target receive a dynamic address update event management */
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_DAUPDF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_DAUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_DAUPDF) != RESET)
   {
     /* Clear dynamic address update flag */
     LL_I3C_ClearFlag_DAUPD(hi3c->Instance);
@@ -6996,14 +7438,13 @@ static HAL_StatusTypeDef I3C_Tgt_HotJoin_ISR(struct __I3C_HandleTypeDef *hi3c, u
   * @brief  Interrupt Sub-Routine which handles target control role event.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_CtrlRole_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_CtrlRole_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* I3C target complete controller-role hand-off procedure (direct GETACCR CCC) event management -------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CRUPDF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CRUPDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRUPDF) != RESET)
   {
     /* Clear controller-role update flag */
     LL_I3C_ClearFlag_CRUPD(hi3c->Instance);
@@ -7031,15 +7472,13 @@ static HAL_StatusTypeDef I3C_Tgt_CtrlRole_ISR(struct __I3C_HandleTypeDef *hi3c, 
   * @brief  Interrupt Sub-Routine which handles target IBI event.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_IBI_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_IBI_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* I3C target IBI end process event management ---------------------------------------------------------------------*/
-  if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_IBIENDF) != RESET) &&
-      (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_IBIENDIE) != RESET))
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_IBIENDF) != RESET)
   {
     /* Clear IBI end flag */
     LL_I3C_ClearFlag_IBIEND(hi3c->Instance);
@@ -7067,18 +7506,16 @@ static HAL_StatusTypeDef I3C_Tgt_IBI_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
   * @brief  Interrupt Sub-Routine which handles target transmit data in Interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Tx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX)
   {
     /* I3C Tx FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_TXFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_TXFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_TXFNFF) != RESET)
     {
       if (hi3c->TxXferCount > 0U)
       {
@@ -7088,7 +7525,7 @@ static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
     }
 
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7121,7 +7558,7 @@ static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
     }
 
     /* I3C target wakeup event management ----------------------------------*/
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_WKPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_WKPIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_WKPF) != RESET)
     {
       /* Clear WKP flag */
       LL_I3C_ClearFlag_WKP(hi3c->Instance);
@@ -7143,18 +7580,16 @@ static HAL_StatusTypeDef I3C_Tgt_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
   * @brief  Interrupt Sub-Routine which handles target receive data in Interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that an Rx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_RX)
   {
     /* I3C Rx FIFO not empty interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, HAL_I3C_FLAG_RXFNEF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, HAL_I3C_IT_RXFNEIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, HAL_I3C_FLAG_RXFNEF) != RESET)
     {
       if (hi3c->RxXferCount > 0U)
       {
@@ -7164,7 +7599,7 @@ static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
     }
 
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7197,7 +7632,7 @@ static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
     }
 
     /* I3C target wakeup event management ----------------------------------*/
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_WKPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_WKPIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_WKPF) != RESET)
     {
       /* Clear WKP flag */
       LL_I3C_ClearFlag_WKP(hi3c->Instance);
@@ -7220,17 +7655,16 @@ static HAL_StatusTypeDef I3C_Tgt_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32
   * @brief  Interrupt Sub-Routine which handles target transmit data in DMA mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Tx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX)
   {
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7266,7 +7700,7 @@ static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, ui
     }
 
     /* I3C target wakeup event management ----------------------------------*/
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_WKPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_WKPIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_WKPF) != RESET)
     {
       /* Clear WKP flag */
       LL_I3C_ClearFlag_WKP(hi3c->Instance);
@@ -7288,17 +7722,16 @@ static HAL_StatusTypeDef I3C_Tgt_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, ui
   * @brief  Interrupt Sub-Routine which handles target receive data in DMA mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Rx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_RX)
   {
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7334,7 +7767,7 @@ static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, ui
     }
 
     /* I3C target wakeup event management ----------------------------------*/
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_WKPF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_WKPIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_WKPF) != RESET)
     {
       /* Clear WKP flag */
       LL_I3C_ClearFlag_WKP(hi3c->Instance);
@@ -7357,18 +7790,16 @@ static HAL_StatusTypeDef I3C_Tgt_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, ui
   * @brief  Interrupt Sub-Routine which handles controller transmission in interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Tx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX)
   {
     /* Check if Control FIFO requests data */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CFNFF) != RESET)
     {
       if (hi3c->ControlXferCount > 0U)
       {
@@ -7378,8 +7809,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
     }
 
     /* I3C Tx FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_TXFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_TXFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_TXFNFF) != RESET)
     {
       if (hi3c->TxXferCount > 0U)
       {
@@ -7389,7 +7819,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
     }
 
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7435,18 +7865,16 @@ static HAL_StatusTypeDef I3C_Ctrl_Tx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
   * @brief  Interrupt Sub-Routine which handles controller reception in interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that an Rx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_RX)
   {
     /* Check if Control FIFO requests data */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CFNFF) != RESET)
     {
       if (hi3c->ControlXferCount > 0U)
       {
@@ -7456,8 +7884,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
     }
 
     /* I3C Rx FIFO not empty interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, HAL_I3C_FLAG_RXFNEF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, HAL_I3C_IT_RXFNEIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, HAL_I3C_FLAG_RXFNEF) != RESET)
     {
       if (hi3c->RxXferCount > 0U)
       {
@@ -7467,8 +7894,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
     }
 
     /* I3C Tx FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_TXFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_TXFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_TXFNFF) != RESET)
     {
       if (hi3c->TxXferCount > 0U)
       {
@@ -7478,7 +7904,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
     }
 
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7523,20 +7949,16 @@ static HAL_StatusTypeDef I3C_Ctrl_Rx_ISR(struct __I3C_HandleTypeDef *hi3c, uint3
   * @brief  Interrupt Sub-Routine which handles controller multiple transmission/reception in interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *hi3c,
-                                                    uint32_t itFlags,
-                                                    uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Tx/Rx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX_RX)
   {
     /* Check if Control FIFO requests data */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CFNFF) != RESET)
     {
       if (hi3c->ControlXferCount > 0U)
       {
@@ -7546,8 +7968,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *
     }
 
     /* I3C Tx FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_TXFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_TXFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_TXFNFF) != RESET)
     {
       if (hi3c->TxXferCount > 0U)
       {
@@ -7557,8 +7978,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *
     }
 
     /* I3C Rx FIFO not empty interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, HAL_I3C_FLAG_RXFNEF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, HAL_I3C_IT_RXFNEIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, HAL_I3C_FLAG_RXFNEF) != RESET)
     {
       if (hi3c->RxXferCount > 0U)
       {
@@ -7568,7 +7988,7 @@ static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *
     }
 
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7606,14 +8026,188 @@ static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_ISR(struct __I3C_HandleTypeDef *
 }
 
 /**
+  * @brief  Interrupt Sub-Routine which handles controller transmission and Controller received events
+  *         in interrupt mode.
+  * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
+  *                            for the specified I3C.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
+  * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
+  */
+static HAL_StatusTypeDef I3C_Ctrl_Tx_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
+{
+  /* I3C controller receive IBI event management ---------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_IBIF) != RESET)
+  {
+    /* Clear IBI request flag */
+    LL_I3C_ClearFlag_IBI(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_IBI);
+#else
+    /* Asynchronous IBI event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_IBI);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller controller-role request event management ---------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRF) != RESET)
+  {
+    /* Clear controller-role request flag */
+    LL_I3C_ClearFlag_CR(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_CR);
+#else
+    /* Asynchronous controller-role event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_CR);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller hot-join event management ------------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_HJF) != RESET)
+  {
+    /* Clear hot-join flag */
+    LL_I3C_ClearFlag_HJ(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_HJ);
+#else
+    /* Asynchronous hot-join event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_HJ);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* ISR controller transmission */
+  return (I3C_Ctrl_Tx_ISR(hi3c, itMasks));
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handles controller reception and Controller received events in interrupt mode.
+  * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
+  *                            for the specified I3C.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
+  * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
+  */
+static HAL_StatusTypeDef I3C_Ctrl_Rx_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
+{
+  /* I3C controller receive IBI event management ---------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_IBIF) != RESET)
+  {
+    /* Clear IBI request flag */
+    LL_I3C_ClearFlag_IBI(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_IBI);
+#else
+    /* Asynchronous IBI event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_IBI);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller controller-role request event management ---------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRF) != RESET)
+  {
+    /* Clear controller-role request flag */
+    LL_I3C_ClearFlag_CR(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_CR);
+#else
+    /* Asynchronous controller-role event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_CR);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller hot-join event management ------------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_HJF) != RESET)
+  {
+    /* Clear hot-join flag */
+    LL_I3C_ClearFlag_HJ(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_HJ);
+#else
+    /* Asynchronous hot-join event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_HJ);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* ISR controller reception */
+  return (I3C_Ctrl_Rx_ISR(hi3c, itMasks));
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handles controller multiple transmission/reception  and
+  *         Controller received eventsin interrupt mode.
+  * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
+  *                            for the specified I3C.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
+  * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
+  */
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_Listen_Event_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
+{
+  /* I3C controller receive IBI event management ---------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_IBIF) != RESET)
+  {
+    /* Clear IBI request flag */
+    LL_I3C_ClearFlag_IBI(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_IBI);
+#else
+    /* Asynchronous IBI event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_IBI);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller controller-role request event management ---------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CRF) != RESET)
+  {
+    /* Clear controller-role request flag */
+    LL_I3C_ClearFlag_CR(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_CR);
+#else
+    /* Asynchronous controller-role event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_CR);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* I3C controller hot-join event management ------------------------------------------------------------------------*/
+  if (I3C_CHECK_FLAG(itMasks, I3C_EVR_HJF) != RESET)
+  {
+    /* Clear hot-join flag */
+    LL_I3C_ClearFlag_HJ(hi3c->Instance);
+
+#if (USE_HAL_I3C_REGISTER_CALLBACKS == 1U)
+    /* Call registered callback */
+    hi3c->NotifyCallback(hi3c, EVENT_ID_HJ);
+#else
+    /* Asynchronous hot-join event Callback */
+    HAL_I3C_NotifyCallback(hi3c, EVENT_ID_HJ);
+#endif /* USE_HAL_I3C_REGISTER_CALLBACKS == 1U */
+  }
+
+  /* ISR controller transmission/reception */
+  return (I3C_Ctrl_Multiple_Xfer_ISR(hi3c, itMasks));
+}
+/**
   * @brief  Interrupt Sub-Routine which handles controller CCC Dynamic Address Assignment command in interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   uint64_t target_payload = 0U;
 
@@ -7621,16 +8215,14 @@ static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint
   if (hi3c->State == HAL_I3C_STATE_BUSY_DAA)
   {
     /* I3C Control FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_CFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_CFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_CFNFF) != RESET)
     {
       /* Write ENTDAA CCC information in the control register */
       LL_I3C_ControllerHandleCCC(hi3c->Instance, I3C_BROADCAST_ENTDAA, 0U, LL_I3C_GENERATE_STOP);
     }
 
     /* I3C Tx FIFO not full interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_TXFNFF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_TXFNFIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_TXFNFF) != RESET)
     {
       /* Check on the Rx FIFO threshold to know the Dynamic Address Assignment treatment process : byte or word */
       if (LL_I3C_GetRxFIFOThreshold(hi3c->Instance) == LL_I3C_RXFIFO_THRESHOLD_1_4)
@@ -7660,7 +8252,7 @@ static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint
     }
 
     /* I3C frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7689,17 +8281,16 @@ static HAL_StatusTypeDef I3C_Ctrl_DAA_ISR(struct __I3C_HandleTypeDef *hi3c, uint
   * @brief  Interrupt Sub-Routine which handles controller transmit data in DMA mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that a Tx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX)
   {
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7758,17 +8349,16 @@ static HAL_StatusTypeDef I3C_Ctrl_Tx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, u
   * @brief  Interrupt Sub-Routine which handles controller receive data in DMA mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that an Rx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_RX)
   {
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7827,19 +8417,16 @@ static HAL_StatusTypeDef I3C_Ctrl_Rx_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, u
   * @brief  Interrupt Sub-Routine which handles controller multiple receive and transmit data in DMA mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_DMA_ISR(struct __I3C_HandleTypeDef *hi3c,
-                                                        uint32_t itFlags,
-                                                        uint32_t itSources)
+static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_DMA_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that an Rx or Tx process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_BUSY_TX_RX)
   {
     /* I3C target frame complete event Check */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -7905,18 +8492,16 @@ static HAL_StatusTypeDef I3C_Ctrl_Multiple_Xfer_DMA_ISR(struct __I3C_HandleTypeD
   * @brief  Interrupt Sub-Routine which handles abort process in interrupt mode.
   * @param  hi3c       : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration information
   *                            for the specified I3C.
-  * @param  itFlags    : [IN]  Interrupt flags to handle.
-  * @param  itSources  : [IN]  Interrupt sources enabled.
+  * @param  itMasks    : [IN]  Flag Interrupt Masks flags to handle.
   * @retval HAL Status :       Value from HAL_StatusTypeDef enumeration.
   */
-static HAL_StatusTypeDef I3C_Abort_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itFlags, uint32_t itSources)
+static HAL_StatusTypeDef I3C_Abort_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_t itMasks)
 {
   /* Check that an Abort process is ongoing */
   if (hi3c->State == HAL_I3C_STATE_ABORT)
   {
     /* I3C Rx FIFO not empty interrupt Check */
-    if ((I3C_CHECK_FLAG(itFlags, HAL_I3C_FLAG_RXFNEF) != RESET) &&
-        (I3C_CHECK_IT_SOURCE(itSources, HAL_I3C_IT_RXFNEIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, HAL_I3C_FLAG_RXFNEF) != RESET)
     {
       if (LL_I3C_IsActiveFlag_DOVR(hi3c->Instance) == 1U)
       {
@@ -7928,7 +8513,7 @@ static HAL_StatusTypeDef I3C_Abort_ISR(struct __I3C_HandleTypeDef *hi3c, uint32_
     /* I3C Abort frame complete event Check */
     /* Evenif abort is called, the Frame completion can arrive if abort is requested at the end of the processus */
     /* Evenif completion occurs, treat this end of processus as abort completion process */
-    if ((I3C_CHECK_FLAG(itFlags, I3C_EVR_FCF) != RESET) && (I3C_CHECK_IT_SOURCE(itSources, I3C_IER_FCIE) != RESET))
+    if (I3C_CHECK_FLAG(itMasks, I3C_EVR_FCF) != RESET)
     {
       /* Clear frame complete flag */
       LL_I3C_ClearFlag_FC(hi3c->Instance);
@@ -8370,7 +8955,7 @@ static HAL_StatusTypeDef I3C_Xfer_PriorPreparation(I3C_HandleTypeDef *hi3c, uint
   uint32_t current_tx_index = 0U;
   uint32_t global_tx_size   = 0U;
   uint32_t global_rx_size   = 0U;
-  uint32_t nb_tx_frame     = 0U;
+  uint32_t nb_tx_frame      = 0U;
   uint32_t direction;
 
   for (uint32_t descr_index = 0U; descr_index < counter; descr_index++)
@@ -8550,12 +9135,12 @@ static HAL_StatusTypeDef I3C_Xfer_PriorPreparation(I3C_HandleTypeDef *hi3c, uint
 
 /**
   * @brief  I3C fill Tx Buffer with data from CCC Descriptor.
-  * @param  hi3c        : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration
-  *                            information for the specified I3C.
-  * @param  indexDesc    : [IN]  Index of descriptor.
-  * @param  txSize       : [IN]  Size of Tx data.
+  * @param  hi3c           : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration
+  *                                information for the specified I3C.
+  * @param  indexDesc      : [IN]  Index of descriptor.
+  * @param  txSize         : [IN]  Size of Tx data.
   * @param  txCurrentIndex : [IN]  Current Index of TxBuffer.
-  * @retval index_tx      : [OUT] New current Index of TxBuffer.
+  * @retval index_tx       : [OUT] New current Index of TxBuffer.
   */
 static uint32_t I3C_FillTxBuffer_CCC(I3C_HandleTypeDef *hi3c,
                                      uint32_t           indexDesc,
@@ -8576,12 +9161,12 @@ static uint32_t I3C_FillTxBuffer_CCC(I3C_HandleTypeDef *hi3c,
 
 /**
   * @brief  I3C fill Tx Buffer with data from Private Descriptor.
-  * @param  hi3c        : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration
-  *                            information for the specified I3C.
-  * @param  indexDesc    : [IN]  Index of descriptor.
-  * @param  txSize       : [IN]  Size of Tx data.
+  * @param  hi3c           : [IN]  Pointer to an I3C_HandleTypeDef structure that contains the configuration
+  *                                information for the specified I3C.
+  * @param  indexDesc      : [IN]  Index of descriptor.
+  * @param  txSize         : [IN]  Size of Tx data.
   * @param  txCurrentIndex : [IN]  Current Index of TxBuffer.
-  * @retval index_tx      : [OUT] New current Index of TxBuffer.
+  * @retval index_tx       : [OUT] New current Index of TxBuffer.
   */
 static uint32_t I3C_FillTxBuffer_Private(I3C_HandleTypeDef *hi3c,
                                          uint32_t           indexDesc,
@@ -9255,8 +9840,6 @@ static void I3C_TreatErrorCallback(I3C_HandleTypeDef *hi3c)
   */
 
 #endif /* HAL_I3C_MODULE_ENABLED */
-
-#endif /* DEVICE_I3C */
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i3c.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_i3c.h
@@ -24,7 +24,6 @@
 extern "C" {
 #endif
 
-#if defined(DEVICE_I3C)
 
 /* Includes ----------------------------------------------------------------------------------------------------------*/
 #include "stm32h5xx_hal_def.h"
@@ -339,6 +338,56 @@ typedef struct
   * @}
   */
 
+/** @defgroup I3C_BCRTypeDef_Structure_definition I3C BCRTypeDef Structure definition
+  * @brief    I3C BCRTypeDef Structure definition
+  * @{
+  */
+typedef struct
+{
+  FunctionalState         MaxDataSpeedLimitation;  /*!< Max data speed limitation */
+  FunctionalState         IBIRequestCapable;       /*!< IBI request capable */
+  FunctionalState         IBIPayload;              /*!< IBI payload data */
+  FunctionalState         OfflineCapable;          /*!< Offline capable */
+  FunctionalState         VirtualTargetSupport;    /*!< Virtual target support */
+  FunctionalState         AdvancedCapabilities;    /*!< Advanced capabilities */
+  FunctionalState         DeviceRole;              /*!< Device role */
+
+} I3C_BCRTypeDef;
+/**
+  * @}
+  */
+
+/** @defgroup I3C_PIDTypeDef_Structure_definition I3C PIDTypeDef Structure definition
+  * @brief    I3C_PIDTypeDef Structure definition
+  * @{
+  */
+typedef struct
+{
+  uint16_t  MIPIMID;         /*!< MIPI Manufacturer ID */
+  uint8_t   IDTSEL;          /*!< Provisioned ID Type Selector */
+  uint16_t  PartID;          /*!< Part ID device vendor to define */
+  uint8_t   MIPIID;          /*!< Instance ID */
+
+} I3C_PIDTypeDef;
+/**
+  * @}
+  */
+
+/** @defgroup I3C_ENTDAAPayloadTypeDef_Structure_definition I3C ENTDAAPayloadTypeDef Structure definition
+  * @brief    I3C ENTDAAPayloadTypeDef Structure definition
+  * @{
+  */
+typedef struct
+{
+  I3C_BCRTypeDef   BCR;             /*!< Bus Characteristics Register */
+  uint32_t         DCR;             /*!< Device Characteristics Register */
+  I3C_PIDTypeDef   PID;             /*!< Provisioned ID */
+
+} I3C_ENTDAAPayloadTypeDef;
+/**
+  * @}
+  */
+
 /** @defgroup I3C_PrivateTypeDef_Structure_definition I3C PrivateTypeDef Structure definition
   * @brief    I3C PrivateTypeDef Structure definition
   * @{
@@ -420,8 +469,7 @@ typedef struct __I3C_HandleTypeDef
   __IO uint32_t              ErrorCode;                           /*!< I3C Error code                            */
 
   HAL_StatusTypeDef(*XferISR)(struct __I3C_HandleTypeDef *hi3c,
-                              uint32_t itFlags,
-                              uint32_t itSources);                /*!< I3C transfer IRQ handler function pointer */
+                              uint32_t itMasks);                  /*!< I3C transfer IRQ handler function pointer */
 
   void(*ptrTxFunc)(struct __I3C_HandleTypeDef *hi3c);             /*!< I3C transmit function pointer             */
 
@@ -915,7 +963,27 @@ typedef  void (*pI3C_TgtReqDynamicAddrCallbackTypeDef)(I3C_HandleTypeDef *hi3c, 
 /** @defgroup I3C_BCR_IN_PAYLOAD I3C BCR IN PAYLOAD
   * @{
   */
-#define HAL_I3C_BCR_IN_PAYLOAD_SHIFT    48  /*!< BCR field in target payload */
+#define HAL_I3C_BCR_IN_PAYLOAD_SHIFT             48                  /*!< BCR field in target payload */
+/**
+  * @}
+  */
+
+/** @defgroup I3C_PATTERN_CONFIGURATION I3C PATTERN CONFIGURATION
+  * @{
+  */
+#define HAL_I3C_TARGET_RESET_PATTERN             0x00000001U        /*!< Target reset pattern */
+#define HAL_I3C_HDR_EXIT_PATTERN                 0x00000002U        /*!< HDR exit pattern */
+/**
+  * @}
+  */
+
+/** @defgroup I3C_RESET_PATTERN RESET PATTERN
+  * @{
+  */
+#define HAL_I3C_RESET_PATTERN_DISABLE            0x00000000U
+/*!< Standard STOP condition emitted at the end of a frame */
+#define HAL_I3C_RESET_PATTERN_ENABLE             I3C_CFGR_RSTPTRN
+/*!< Reset pattern is inserted before the STOP condition of any emitted frame */
 /**
   * @}
   */
@@ -1081,6 +1149,8 @@ HAL_StatusTypeDef HAL_I3C_AddDescToFrame(I3C_HandleTypeDef         *hi3c,
                                          I3C_XferTypeDef           *pXferData,
                                          uint8_t                   nbFrame,
                                          uint32_t                  option);
+HAL_StatusTypeDef HAL_I3C_Ctrl_SetConfigResetPattern(I3C_HandleTypeDef *hi3c, uint32_t resetPattern);
+HAL_StatusTypeDef HAL_I3C_Ctrl_GetConfigResetPattern(I3C_HandleTypeDef *hi3c, uint32_t *pResetPattern);
 /**
   * @}
   */
@@ -1160,6 +1230,9 @@ HAL_StatusTypeDef HAL_I3C_Ctrl_IsDeviceI2C_Ready(I3C_HandleTypeDef *hi3c,
                                                  uint8_t            devAddress,
                                                  uint32_t           trials,
                                                  uint32_t           timeout);
+/* Controller arbitration APIs */
+HAL_StatusTypeDef HAL_I3C_Ctrl_GenerateArbitration(I3C_HandleTypeDef *hi3c, uint32_t timeout);
+
 /**
   * @}
   */
@@ -1194,6 +1267,9 @@ uint32_t HAL_I3C_GetError(const I3C_HandleTypeDef *hi3c);
 HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
                                      uint32_t notifyId,
                                      I3C_CCCInfoTypeDef *pCCCInfo);
+HAL_StatusTypeDef HAL_I3C_Get_ENTDAA_Payload_Info(I3C_HandleTypeDef *hi3c,
+                                                  uint64_t ENTDAA_payload,
+                                                  I3C_ENTDAAPayloadTypeDef *pENTDAA_payload);
 /**
   * @}
   */
@@ -1291,7 +1367,8 @@ HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
 #define IS_I3C_DMADESTINATIONWORD_VALUE(__VALUE__) ((__VALUE__) == DMA_DEST_DATAWIDTH_WORD)
 
 #define I3C_GET_DMA_REMAIN_DATA(__HANDLE__) (__HAL_DMA_GET_COUNTER(__HANDLE__) + HAL_DMAEx_GetFifoLevel(__HANDLE__))
-
+#define IS_I3C_RESET_PATTERN(__RSTPTRN__) (((__RSTPTRN__) == HAL_I3C_RESET_PATTERN_ENABLE)   || \
+                                           ((__RSTPTRN__) == HAL_I3C_RESET_PATTERN_DISABLE))
 /**
   * @}
   */
@@ -1312,7 +1389,6 @@ HAL_StatusTypeDef HAL_I3C_GetCCCInfo(I3C_HandleTypeDef *hi3c,
 /**
   * @}
   */
-#endif /* DEVICE_I3C */
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_irda_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_irda_ex.h
@@ -401,6 +401,176 @@ extern "C" {
       (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;          \
     }                                                          \
   } while(0U)
+#elif (defined(STM32H523xx) || defined(STM32H533xx))
+#define IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)        \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
+        case RCC_USART1CLKSOURCE_PCLK2:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK2;          \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;          \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART3)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                    \
+      {                                                        \
+        case RCC_USART3CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;          \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == UART4)                   \
+    {                                                          \
+      switch(__HAL_RCC_GET_UART4_SOURCE())                     \
+      {                                                        \
+        case RCC_UART4CLKSOURCE_PCLK1:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;          \
+          break;                                               \
+        case RCC_UART4CLKSOURCE_HSI:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_UART4CLKSOURCE_CSI:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_UART4CLKSOURCE_LSE:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_UART4CLKSOURCE_PLL2Q:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_UART4CLKSOURCE_PLL3Q:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == UART5)                   \
+    {                                                          \
+      switch(__HAL_RCC_GET_UART5_SOURCE())                     \
+      {                                                        \
+        case RCC_UART5CLKSOURCE_PCLK1:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;          \
+          break;                                               \
+        case RCC_UART5CLKSOURCE_HSI:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_UART5CLKSOURCE_CSI:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_UART5CLKSOURCE_LSE:                           \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_UART5CLKSOURCE_PLL2Q:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_UART5CLKSOURCE_PLL3Q:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART6)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART6_SOURCE())                    \
+      {                                                        \
+        case RCC_USART6CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;          \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_CSI;            \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;            \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;            \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL2Q;          \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PLL3Q;          \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else                                                       \
+    {                                                          \
+      (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;          \
+    }                                                          \
+  } while(0U)
 #else
 #define IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)        \
   do {                                                         \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_lptim.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_lptim.h
@@ -1125,7 +1125,7 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
     (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||       \
      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1) ||      \
      ((__SOURCE__) == LPTIM_INPUT1SOURCE_LPTIM1_CH2))))
-#else
+#elif defined(LPTIM3) && defined(LPTIM4) && defined(LPTIM5) && defined(LPTIM6)
 #define IS_LPTIM_INPUT1_SOURCE(__INSTANCE__, __SOURCE__) \
   ((((__INSTANCE__) == LPTIM1) || \
     ((__INSTANCE__) == LPTIM2) || \
@@ -1134,6 +1134,11 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
     ((__INSTANCE__) == LPTIM5) || \
     ((__INSTANCE__) == LPTIM6)) && \
    (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO)))
+#else
+#define IS_LPTIM_INPUT1_SOURCE(__INSTANCE__, __SOURCE__) \
+  ((((__INSTANCE__) == LPTIM1) || \
+    ((__INSTANCE__) == LPTIM2)) && \
+   (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO)))
 #endif /* STM32H503xx */
 
 #if defined(STM32H503xx)
@@ -1141,13 +1146,18 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
   ((((__INSTANCE__) == LPTIM1)  || \
     ((__INSTANCE__) == LPTIM2)) && \
    (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO)))
-#else
+#elif defined(LPTIM3) && defined(LPTIM5) && defined(LPTIM6)
 #define IS_LPTIM_INPUT2_SOURCE(__INSTANCE__, __SOURCE__) \
   ((((__INSTANCE__) == LPTIM1) || \
     ((__INSTANCE__) == LPTIM2) || \
     ((__INSTANCE__) == LPTIM3) || \
     ((__INSTANCE__) == LPTIM5) || \
     ((__INSTANCE__) == LPTIM6)) && \
+   (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO)))
+#else
+#define IS_LPTIM_INPUT2_SOURCE(__INSTANCE__, __SOURCE__) \
+  ((((__INSTANCE__) == LPTIM1) || \
+    ((__INSTANCE__) == LPTIM2)) && \
    (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO)))
 #endif /* STM32H503xx */
 
@@ -1177,7 +1187,7 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
      ((__SOURCE__) == LPTIM_IC2SOURCE_HSI_1024) || \
      ((__SOURCE__) == LPTIM_IC2SOURCE_CSI_128)  || \
      ((__SOURCE__) == LPTIM_IC2SOURCE_HSI_8))))
-#else
+#elif defined(LPTIM3) && defined(LPTIM5) && defined(LPTIM6)
 #define IS_LPTIM_IC1_SOURCE(__INSTANCE__, __SOURCE__) \
   ((((__INSTANCE__) == LPTIM1) ||                  \
     ((__INSTANCE__) == LPTIM2) ||                  \
@@ -1206,6 +1216,23 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
    ||                                              \
    (((__INSTANCE__) == LPTIM6) &&                  \
     ((__SOURCE__) == LPTIM_IC2SOURCE_GPIO)))
+#else
+#define IS_LPTIM_IC1_SOURCE(__INSTANCE__, __SOURCE__) \
+  ((((__INSTANCE__) == LPTIM1) ||                  \
+    ((__INSTANCE__) == LPTIM2)) &&                 \
+   (((__SOURCE__) == LPTIM_IC1SOURCE_GPIO)))
+
+#define IS_LPTIM_IC2_SOURCE(__INSTANCE__, __SOURCE__) \
+  ((((__INSTANCE__) == LPTIM1) &&                   \
+    (((__SOURCE__) == LPTIM_IC2SOURCE_GPIO) ||      \
+     ((__SOURCE__) == LPTIM_IC2SOURCE_LSI)  ||     \
+     ((__SOURCE__) == LPTIM_IC2SOURCE_LSE)))       \
+   ||                                              \
+   (((__INSTANCE__) == LPTIM2) &&                  \
+    (((__SOURCE__) == LPTIM_IC2SOURCE_GPIO)     || \
+     ((__SOURCE__) == LPTIM_IC2SOURCE_HSI_1024) || \
+     ((__SOURCE__) == LPTIM_IC2SOURCE_CSI_128)  || \
+     ((__SOURCE__) == LPTIM_IC2SOURCE_HSI_8))))
 #endif /* STM32H503xx */
 
 #define LPTIM_CHANNEL_STATE_GET(__INSTANCE__, __CHANNEL__)\
@@ -1232,7 +1259,7 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
    (((__INSTANCE__) == LPTIM2_NS)  && \
     (((__CHANNEL__)  == LPTIM_CHANNEL_1) ||  \
      ((__CHANNEL__)  == LPTIM_CHANNEL_2))))
-#else
+#elif defined(LPTIM3) && defined(LPTIM4) && defined(LPTIM5) && defined(LPTIM6)
 #define IS_LPTIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) \
   (((((__INSTANCE__) == LPTIM1_NS)  || ((__INSTANCE__) == LPTIM1_S))  && \
     (((__CHANNEL__)  == LPTIM_CHANNEL_1) ||  \
@@ -1254,6 +1281,15 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
      ((__CHANNEL__)  == LPTIM_CHANNEL_2)))   \
    ||                                        \
    ((((__INSTANCE__) == LPTIM6_NS)  || ((__INSTANCE__) == LPTIM6_S))  && \
+    (((__CHANNEL__)  == LPTIM_CHANNEL_1) ||  \
+     ((__CHANNEL__)  == LPTIM_CHANNEL_2))))
+#else
+#define IS_LPTIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) \
+  (((((__INSTANCE__) == LPTIM1_NS)  || ((__INSTANCE__) == LPTIM1_S))  && \
+    (((__CHANNEL__)  == LPTIM_CHANNEL_1) ||  \
+     ((__CHANNEL__)  == LPTIM_CHANNEL_2)))   \
+   ||                                        \
+   ((((__INSTANCE__) == LPTIM2_NS)  || ((__INSTANCE__) == LPTIM2_S))  && \
     (((__CHANNEL__)  == LPTIM_CHANNEL_1) ||  \
      ((__CHANNEL__)  == LPTIM_CHANNEL_2))))
 #endif /* STM32H503xx */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_mmc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_mmc.c
@@ -56,7 +56,6 @@
 
     (#) At this stage, you can perform MMC read/write/erase operations after MMC card initialization
 
-
   *** MMC Card Initialization and configuration ***
   ================================================
   [..]
@@ -548,7 +547,6 @@ HAL_StatusTypeDef HAL_MMC_DeInit(MMC_HandleTypeDef *hmmc)
 
   return HAL_OK;
 }
-
 
 /**
   * @brief  Initializes the MMC MSP.
@@ -3537,7 +3535,6 @@ HAL_StatusTypeDef HAL_MMC_AwakeDevice(MMC_HandleTypeDef *hmmc)
   * @{
   */
 
-
 /**
   * @brief  Initializes the mmc card.
   * @param  hmmc: Pointer to MMC handle
@@ -3620,7 +3617,6 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
   {
     hmmc->ErrorCode |= errorstate;
   }
-
 
   /* Get Extended CSD parameters */
   if (HAL_MMC_GetCardExtCSD(hmmc, hmmc->Ext_CSD, SDMMC_DATATIMEOUT) != HAL_OK)
@@ -3870,7 +3866,6 @@ static void MMC_Read_IT(MMC_HandleTypeDef *hmmc)
   uint8_t *tmp;
 
   tmp = hmmc->pRxBuffPtr;
-
 
   if (hmmc->RxXferSize >= SDMMC_FIFO_SIZE)
   {

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nand.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nand.c
@@ -9,7 +9,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -495,7 +495,7 @@ HAL_StatusTypeDef HAL_NAND_Reset(NAND_HandleTypeDef *hnand)
   * @param  pDeviceConfig  pointer to NAND_DeviceConfigTypeDef structure
   * @retval HAL status
   */
-HAL_StatusTypeDef  HAL_NAND_ConfigDevice(NAND_HandleTypeDef *hnand, NAND_DeviceConfigTypeDef *pDeviceConfig)
+HAL_StatusTypeDef  HAL_NAND_ConfigDevice(NAND_HandleTypeDef *hnand, const NAND_DeviceConfigTypeDef *pDeviceConfig)
 {
   hnand->Config.PageSize           = pDeviceConfig->PageSize;
   hnand->Config.SpareAreaSize      = pDeviceConfig->SpareAreaSize;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nand.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nand.h
@@ -6,7 +6,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -194,7 +194,7 @@ HAL_StatusTypeDef  HAL_NAND_Init(NAND_HandleTypeDef *hnand, FMC_NAND_PCC_TimingT
                                  FMC_NAND_PCC_TimingTypeDef *AttSpace_Timing);
 HAL_StatusTypeDef  HAL_NAND_DeInit(NAND_HandleTypeDef *hnand);
 
-HAL_StatusTypeDef  HAL_NAND_ConfigDevice(NAND_HandleTypeDef *hnand, NAND_DeviceConfigTypeDef *pDeviceConfig);
+HAL_StatusTypeDef  HAL_NAND_ConfigDevice(NAND_HandleTypeDef *hnand, const NAND_DeviceConfigTypeDef *pDeviceConfig);
 
 HAL_StatusTypeDef  HAL_NAND_Read_ID(NAND_HandleTypeDef *hnand, NAND_IDTypeDef *pNAND_ID);
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nor.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nor.c
@@ -9,7 +9,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nor.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_nor.h
@@ -6,7 +6,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd.h
@@ -330,7 +330,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
 HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
 HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
-HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef const *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd_ex.c
@@ -242,7 +242,6 @@ void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd)
   }
 }
 
-
 /**
   * @brief  Activate LPM feature.
   * @param  hpcd PCD handle
@@ -277,7 +276,6 @@ HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd)
 
   return HAL_OK;
 }
-
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pcd_ex.h
@@ -47,7 +47,6 @@ extern "C" {
   */
 
 
-
 HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, uint16_t ep_addr,
                                        uint16_t ep_kind, uint32_t pmaadress);
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pka.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pka.c
@@ -309,6 +309,7 @@ HAL_StatusTypeDef PKA_Process_IT(PKA_HandleTypeDef *hpka, uint32_t mode);
 void PKA_ModExp_Set(PKA_HandleTypeDef *hpka, PKA_ModExpInTypeDef *in);
 void PKA_ModExpFastMode_Set(PKA_HandleTypeDef *hpka, PKA_ModExpFastModeInTypeDef *in);
 void PKA_ModExpProtectMode_Set(PKA_HandleTypeDef *hpka, PKA_ModExpProtectModeInTypeDef *in);
+void PKA_ECCMulEx_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in);
 void PKA_ECDSASign_Set(PKA_HandleTypeDef *hpka, PKA_ECDSASignInTypeDef *in);
 void PKA_ECDSAVerif_Set(PKA_HandleTypeDef *hpka, PKA_ECDSAVerifInTypeDef *in);
 void PKA_RSACRTExp_Set(PKA_HandleTypeDef *hpka, PKA_RSACRTExpInTypeDef *in);
@@ -727,6 +728,7 @@ HAL_StatusTypeDef HAL_PKA_UnRegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_Ca
         (++) HAL_PKA_ECCMulFastMode()
         (++) HAL_PKA_ECCMul_GetResult();
 
+        (++) HAL_PKA_ECCMulEx()
         (++) HAL_PKA_ECCDoubleBaseLadder()
         (++) HAL_PKA_ECCDoubleBaseLadder_GetResult();
         (++) HAL_PKA_ECCProjective2Affine()
@@ -771,6 +773,7 @@ HAL_StatusTypeDef HAL_PKA_UnRegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_Ca
         (++) HAL_PKA_ECCMulFastMode_IT();
         (++) HAL_PKA_ECCMul_GetResult();
 
+        (++) HAL_PKA_ECCMulEx_IT();
         (++) HAL_PKA_ECCDoubleBaseLadder_IT()
         (++) HAL_PKA_ECCDoubleBaseLadder_GetResult();
         (++) HAL_PKA_ECCProjective2Affine_IT()
@@ -808,9 +811,7 @@ HAL_StatusTypeDef HAL_PKA_ModExp(PKA_HandleTypeDef *hpka, PKA_ModExpInTypeDef *i
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExp_Set(hpka, in);
-
   opsize = in->OpSize;
-
   /* Start the operation */
   return PKA_Process(hpka, PKA_MODE_MODULAR_EXP, Timeout);
 }
@@ -825,9 +826,7 @@ HAL_StatusTypeDef HAL_PKA_ModExp_IT(PKA_HandleTypeDef *hpka, PKA_ModExpInTypeDef
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExp_Set(hpka, in);
-
   opsize = in->OpSize;
-
   /* Start the operation */
   return PKA_Process_IT(hpka, PKA_MODE_MODULAR_EXP);
 }
@@ -843,9 +842,7 @@ HAL_StatusTypeDef HAL_PKA_ModExpFastMode(PKA_HandleTypeDef *hpka, PKA_ModExpFast
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExpFastMode_Set(hpka, in);
-
   opsize = in->OpSize;
-
   /* Start the operation */
   return PKA_Process(hpka, PKA_MODE_MODULAR_EXP_FAST_MODE, Timeout);
 }
@@ -860,9 +857,7 @@ HAL_StatusTypeDef HAL_PKA_ModExpFastMode_IT(PKA_HandleTypeDef *hpka, PKA_ModExpF
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExpFastMode_Set(hpka, in);
-
   opsize = in->OpSize;
-
   /* Start the operation */
   return PKA_Process_IT(hpka, PKA_MODE_MODULAR_EXP_FAST_MODE);
 }
@@ -880,9 +875,7 @@ HAL_StatusTypeDef HAL_PKA_ModExpProtectMode(PKA_HandleTypeDef *hpka, PKA_ModExpP
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExpProtectMode_Set(hpka, in);
-
   opsize = in->OpSize;
-
   return PKA_Process(hpka, PKA_MODE_MODULAR_EXP_PROTECT, Timeout);
 }
 
@@ -897,11 +890,10 @@ HAL_StatusTypeDef HAL_PKA_ModExpProtectMode_IT(PKA_HandleTypeDef *hpka, PKA_ModE
 {
   /* Set input parameter in PKA RAM */
   PKA_ModExpProtectMode_Set(hpka, in);
-
   opsize = in->OpSize;
-
   return PKA_Process_IT(hpka, PKA_MODE_MODULAR_EXP_PROTECT);
 }
+
 
 /**
   * @brief  Retrieve operation result.
@@ -931,9 +923,7 @@ HAL_StatusTypeDef HAL_PKA_ECDSASign(PKA_HandleTypeDef *hpka, PKA_ECDSASignInType
 {
   /* Set input parameter in PKA RAM */
   PKA_ECDSASign_Set(hpka, in);
-
   primeordersize = in->primeOrderSize;
-
   /* Start the operation */
   return PKA_Process(hpka, PKA_MODE_ECDSA_SIGNATURE, Timeout);
 }
@@ -948,9 +938,7 @@ HAL_StatusTypeDef HAL_PKA_ECDSASign_IT(PKA_HandleTypeDef *hpka, PKA_ECDSASignInT
 {
   /* Set input parameter in PKA RAM */
   PKA_ECDSASign_Set(hpka, in);
-
   primeordersize = in->primeOrderSize;
-
   /* Start the operation */
   return PKA_Process_IT(hpka, PKA_MODE_ECDSA_SIGNATURE);
 }
@@ -1128,9 +1116,7 @@ HAL_StatusTypeDef HAL_PKA_ECCMul(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef *i
 {
   /* Set input parameter in PKA RAM */
   PKA_ECCMul_Set(hpka, in);
-
   modulussize = in->modulusSize;
-
   /* Start the operation */
   return PKA_Process(hpka, PKA_MODE_ECC_MUL, Timeout);
 }
@@ -1145,9 +1131,37 @@ HAL_StatusTypeDef HAL_PKA_ECCMul_IT(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef
 {
   /* Set input parameter in PKA RAM */
   PKA_ECCMul_Set(hpka, in);
-
   modulussize = in->modulusSize;
+  /* Start the operation */
+  return PKA_Process_IT(hpka, PKA_MODE_ECC_MUL);
+}
+/**
+  * @brief  ECC scalar multiplication extended in blocking mode.
+  * @param  hpka PKA handle
+  * @param  in Input information
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PKA_ECCMulEx(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in, uint32_t Timeout)
+{
+  /* Set input parameter in PKA RAM */
+  PKA_ECCMulEx_Set(hpka, in);
+  modulussize = in->modulusSize;
+  /* Start the operation */
+  return PKA_Process(hpka, PKA_MODE_ECC_MUL, Timeout);
+}
 
+/**
+  * @brief  ECC scalar multiplication extended in non-blocking mode with Interrupt.
+  * @param  hpka PKA handle
+  * @param  in Input information
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PKA_ECCMulEx_IT(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in)
+{
+  /* Set input parameter in PKA RAM */
+  PKA_ECCMulEx_Set(hpka, in);
+  modulussize = in->modulusSize;
   /* Start the operation */
   return PKA_Process_IT(hpka, PKA_MODE_ECC_MUL);
 }
@@ -1704,13 +1718,11 @@ void HAL_PKA_RAMReset(PKA_HandleTypeDef *hpka)
 void HAL_PKA_IRQHandler(PKA_HandleTypeDef *hpka)
 {
   uint32_t mode = PKA_GetMode(hpka);
-  FlagStatus addErrFlag = __HAL_PKA_GET_FLAG(hpka, PKA_FLAG_ADDRERR);
-  FlagStatus ramErrFlag = __HAL_PKA_GET_FLAG(hpka, PKA_FLAG_RAMERR);
-  FlagStatus procEndFlag = __HAL_PKA_GET_FLAG(hpka, PKA_FLAG_PROCEND);
-  FlagStatus operErrFlag = __HAL_PKA_GET_FLAG(hpka, PKA_FLAG_OPERR);
+  uint32_t itsource = READ_REG(hpka->Instance->CR);
+  uint32_t flag  =   READ_REG(hpka->Instance->SR);
 
   /* Address error interrupt occurred */
-  if ((__HAL_PKA_GET_IT_SOURCE(hpka, PKA_IT_ADDRERR) == SET) && (addErrFlag == SET))
+  if (((itsource & PKA_IT_ADDRERR) == PKA_IT_ADDRERR) && ((flag & PKA_FLAG_ADDRERR) == PKA_FLAG_ADDRERR))
   {
     hpka->ErrorCode |= HAL_PKA_ERROR_ADDRERR;
 
@@ -1719,7 +1731,7 @@ void HAL_PKA_IRQHandler(PKA_HandleTypeDef *hpka)
   }
 
   /* RAM access error interrupt occurred */
-  if ((__HAL_PKA_GET_IT_SOURCE(hpka, PKA_IT_RAMERR) == SET) && (ramErrFlag == SET))
+  if (((itsource & PKA_IT_RAMERR) == PKA_IT_RAMERR) && ((flag & PKA_FLAG_RAMERR) == PKA_FLAG_RAMERR))
   {
     hpka->ErrorCode |= HAL_PKA_ERROR_RAMERR;
 
@@ -1728,7 +1740,7 @@ void HAL_PKA_IRQHandler(PKA_HandleTypeDef *hpka)
   }
 
   /* OPERATION access error interrupt occurred */
-  if ((__HAL_PKA_GET_IT_SOURCE(hpka, PKA_FLAG_OPERR) == SET) && (operErrFlag == SET))
+  if (((itsource & PKA_IT_OPERR) == PKA_IT_OPERR) && ((flag & PKA_FLAG_OPERR) == PKA_FLAG_OPERR))
   {
     hpka->ErrorCode |= HAL_PKA_ERROR_OPERATION;
 
@@ -1792,7 +1804,7 @@ void HAL_PKA_IRQHandler(PKA_HandleTypeDef *hpka)
   }
 
   /* End Of Operation interrupt occurred */
-  if ((__HAL_PKA_GET_IT_SOURCE(hpka, PKA_IT_PROCEND) == SET) && (procEndFlag == SET))
+  if (((itsource & PKA_IT_PROCEND) == PKA_IT_PROCEND) && ((flag & PKA_FLAG_PROCEND) == PKA_FLAG_PROCEND))
   {
     /* Clear PROCEND flag */
     __HAL_PKA_CLEAR_FLAG(hpka, PKA_FLAG_PROCEND);
@@ -2591,7 +2603,50 @@ void PKA_ECCMul_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef *in)
   PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER], in->primeOrder, in->modulusSize);
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER + ((in->modulusSize + 3UL) / 4UL));
 }
+/**
+  * @brief  Set input parameters.
+  * @param  hpka PKA handle
+  * @param  in Input information
+  */
+void PKA_ECCMulEx_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in)
+{
+  /* Get the prime order n length */
+  hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS] = PKA_GetOptBitSize_u8(in->primeOrderSize, *(in->primeOrder));
 
+  /* Get the modulus length */
+  hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS] = PKA_GetOptBitSize_u8(in->modulusSize, *(in->modulus));
+
+  /* Get the coefficient a sign */
+  hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN] = in->coefSign;
+
+  /* Move the input parameters coefficient |a| to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_A_COEFF], in->coefA, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_A_COEFF + ((in->modulusSize + 3UL) / 4UL));
+
+  /* Move the input parameters coefficient b to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_B_COEFF], in->coefB, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_B_COEFF + ((in->modulusSize + 3UL) / 4UL));
+
+  /* Move the input parameters modulus value p to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_MOD_GF], in->modulus, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_MOD_GF + ((in->modulusSize + 3UL) / 4UL));
+
+  /* Move the input parameters scalar multiplier k to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_K], in->scalarMul, in->scalarMulSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_K + ((in->scalarMulSize + 3UL) / 4UL));
+
+  /* Move the input parameters Point P coordinate x to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X], in->pointX, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X + ((in->modulusSize + 3UL) / 4UL));
+
+  /* Move the input parameters Point P coordinate y to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y], in->pointY, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
+
+  /* Move the input parameters curve prime order N to PKA RAM */
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER], in->primeOrder, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER + ((in->modulusSize + 3UL) / 4UL));
+}
 
 /**
   * @brief  Set input parameters.

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pka.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pka.h
@@ -149,6 +149,21 @@ typedef struct
 
 typedef struct
 {
+  uint32_t primeOrderSize;             /*!< Number of element in primeOrder array */
+  uint32_t scalarMulSize;              /*!< Number of element in scalarMul array */
+  uint32_t modulusSize;                /*!< Number of element in modulus, coefA, pointX and pointY arrays */
+  uint32_t coefSign;                   /*!< Curve coefficient a sign */
+  const uint8_t *coefA;                /*!< Pointer to curve coefficient |a| (Array of modulusSize elements) */
+  const uint8_t *coefB;                /*!< pointer to curve coefficient b */
+  const uint8_t *modulus;              /*!< Pointer to curve modulus value p (Array of modulusSize elements) */
+  const uint8_t *pointX;               /*!< Pointer to point P coordinate xP (Array of modulusSize elements) */
+  const uint8_t *pointY;               /*!< Pointer to point P coordinate yP (Array of modulusSize elements) */
+  const uint8_t *scalarMul;            /*!< Pointer to scalar multiplier k   (Array of scalarMulSize elements) */
+  const uint8_t *primeOrder;           /*!< pointer to order of the curve */
+} PKA_ECCMulExInTypeDef;
+
+typedef struct
+{
   uint32_t modulusSize;                /*!< Number of element in coefA, coefB, modulus, pointX and pointY arrays */
   uint32_t coefSign;                   /*!< Curve coefficient a sign */
   const uint8_t *coefA;                /*!< Pointer to curve coefficient |a| (Array of modulusSize elements) */
@@ -572,6 +587,8 @@ uint32_t HAL_PKA_PointCheck_IsOnCurve(PKA_HandleTypeDef const *const hpka);
 
 HAL_StatusTypeDef HAL_PKA_ECCMul(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef *in, uint32_t Timeout);
 HAL_StatusTypeDef HAL_PKA_ECCMul_IT(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef *in);
+HAL_StatusTypeDef HAL_PKA_ECCMulEx(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in, uint32_t Timeout);
+HAL_StatusTypeDef HAL_PKA_ECCMulEx_IT(PKA_HandleTypeDef *hpka, PKA_ECCMulExInTypeDef *in);
 void HAL_PKA_ECCMul_GetResult(PKA_HandleTypeDef *hpka, PKA_ECCMulOutTypeDef *out);
 
 HAL_StatusTypeDef HAL_PKA_Add(PKA_HandleTypeDef *hpka, PKA_AddInTypeDef *in, uint32_t Timeout);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pssi.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pssi.c
@@ -53,7 +53,6 @@
     (#) Initialize the PSSI registers by calling the @ref HAL_PSSI_Init(), configure also the low level Hardware
         (GPIO, CLOCK, NVIC...etc) by calling the customized @ref HAL_PSSI_MspInit(&hpssi) API.
 
-
     (#) For PSSI IO operations, two operation modes are available within this driver :
 
     *** Polling mode IO operation ***
@@ -164,7 +163,6 @@
 /** @defgroup PSSI_Private_Define PSSI Private Define
   * @{
   */
-
 
 
 /**
@@ -651,8 +649,8 @@ HAL_StatusTypeDef HAL_PSSI_Transmit(PSSI_HandleTypeDef *hpssi, uint8_t *pData, u
     HAL_PSSI_DISABLE(hpssi);
 
     /* Configure transfer parameters */
-    hpssi->Instance->CR |= PSSI_CR_OUTEN_OUTPUT |
-                           ((hpssi->Init.ClockPolarity == HAL_PSSI_RISING_EDGE) ? 0U : PSSI_CR_CKPOL);
+    MODIFY_REG(hpssi->Instance->CR, (PSSI_CR_OUTEN | PSSI_CR_CKPOL),
+               (PSSI_CR_OUTEN_OUTPUT | ((hpssi->Init.ClockPolarity == HAL_PSSI_RISING_EDGE) ? 0U : PSSI_CR_CKPOL)));
 
 #if defined(HAL_DMA_MODULE_ENABLED)
     /* DMA Disable */
@@ -804,8 +802,8 @@ HAL_StatusTypeDef HAL_PSSI_Receive(PSSI_HandleTypeDef *hpssi, uint8_t *pData, ui
     /* Disable the selected PSSI peripheral */
     HAL_PSSI_DISABLE(hpssi);
     /* Configure transfer parameters */
-    hpssi->Instance->CR |= PSSI_CR_OUTEN_INPUT |
-                           ((hpssi->Init.ClockPolarity == HAL_PSSI_FALLING_EDGE) ? 0U : PSSI_CR_CKPOL);
+    MODIFY_REG(hpssi->Instance->CR, (PSSI_CR_OUTEN | PSSI_CR_CKPOL),
+               (PSSI_CR_OUTEN_INPUT | ((hpssi->Init.ClockPolarity == HAL_PSSI_FALLING_EDGE) ? 0U : PSSI_CR_CKPOL)));
 
 #if defined(HAL_DMA_MODULE_ENABLED)
     /* DMA Disable */
@@ -1122,7 +1120,7 @@ HAL_StatusTypeDef HAL_PSSI_Receive_DMA(PSSI_HandleTypeDef *hpssi, uint32_t *pDat
       if (hpssi->hdmarx != NULL)
       {
         /* Configure BusWidth */
-        if (hpssi->hdmatx->Init.SrcDataWidth == DMA_SRC_DATAWIDTH_BYTE)
+        if (hpssi->hdmarx->Init.SrcDataWidth == DMA_SRC_DATAWIDTH_BYTE)
         {
           MODIFY_REG(hpssi->Instance->CR, PSSI_CR_DMAEN | PSSI_CR_OUTEN | PSSI_CR_CKPOL, PSSI_CR_DMA_ENABLE |
                      ((hpssi->Init.ClockPolarity == HAL_PSSI_RISING_EDGE) ? PSSI_CR_CKPOL : 0U));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pssi.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pssi.h
@@ -53,12 +53,18 @@ extern "C" {
   */
 typedef struct
 {
-  uint32_t  DataWidth;          /* !< Configures the parallel bus width 8 lines or 16 lines */
-  uint32_t  BusWidth;           /* !< Configures the parallel bus width 8 lines or 16 lines */
-  uint32_t  ControlSignal;      /* !< Configures Data enable and Data ready */
-  uint32_t  ClockPolarity;      /* !< Configures the PSSI Input Clock polarity */
-  uint32_t  DataEnablePolarity; /* !< Configures the PSSI Data Enable polarity */
-  uint32_t  ReadyPolarity;      /* !< Configures the PSSI Ready polarity */
+  uint32_t  DataWidth;          /* !< Configures the data width.
+                                      This parameter can be a value of @ref PSSI_DATA_WIDTH. */
+  uint32_t  BusWidth;           /* !< Configures the parallel bus width.
+                                      This parameter can be a value of @ref PSSI_BUS_WIDTH. */
+  uint32_t  ControlSignal;      /* !< Configures Data enable and Data ready.
+                                      This parameter can be a value of @ref ControlSignal_Configuration. */
+  uint32_t  ClockPolarity;      /* !< Configures the PSSI Input Clock polarity.
+                                      This parameter can be a value of @ref Clock_Polarity. */
+  uint32_t  DataEnablePolarity; /* !< Configures the PSSI Data Enable polarity.
+                                      This parameter can be a value of @ref Data_Enable_Polarity. */
+  uint32_t  ReadyPolarity;      /* !< Configures the PSSI Ready polarity.
+                                      This parameter can be a value of @ref Ready_Polarity. */
 
 } PSSI_InitTypeDef;
 
@@ -216,7 +222,7 @@ typedef enum
 /**
   * @}
   */
-/** @defgroup Reday_Polarity Reday Polarity
+/** @defgroup Ready_Polarity Ready Polarity
   * @{
   */
 #define HAL_PSSI_RDYPOL_ACTIVE_LOW        0x0U            /*!< Active Low */
@@ -230,8 +236,6 @@ typedef enum
   */
 #define HAL_PSSI_FALLING_EDGE             0x0U            /*!< Fallling Edge */
 #define HAL_PSSI_RISING_EDGE              0x1U            /*!< Rising Edge */
-
-
 /**
   * @}
   */
@@ -257,7 +261,6 @@ typedef enum
 #define PSSI_FLAG_RTT4B             PSSI_SR_RTT4B    /*!< 4 Bytes Fifo Flag*/
 
 
-
 /**
   * @}
   */
@@ -272,7 +275,6 @@ typedef enum
 /**
   * @}
   */
-
 
 
 /**
@@ -323,7 +325,6 @@ typedef enum
   */
 
 #define HAL_PSSI_GET_STATUS(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR & (__FLAG__))
-
 
 
 /* Interrupt & Flag management */
@@ -394,7 +395,6 @@ typedef enum
                                              ((__CONTROL__) == HAL_PSSI_MAP_DE_BIDIR_ENABLE   ))
 
 
-
 /**
   * @brief  Check whether the PSSI Bus Width is valid.
   * @param  __BUSWIDTH__ PSSI Bush width
@@ -432,6 +432,7 @@ typedef enum
 
 #define IS_PSSI_RDY_POLARITY(__RDYPOL__) (((__RDYPOL__) == HAL_PSSI_RDYPOL_ACTIVE_LOW   ) || \
                                           ((__RDYPOL__) == HAL_PSSI_RDYPOL_ACTIVE_HIGH   ))
+
 /**
   * @}
   */
@@ -486,7 +487,7 @@ HAL_StatusTypeDef HAL_PSSI_Abort_DMA(PSSI_HandleTypeDef *hpssi);
 
 /* Peripheral State functions ***************************************************/
 HAL_PSSI_StateTypeDef HAL_PSSI_GetState(const PSSI_HandleTypeDef *hpssi);
-uint32_t               HAL_PSSI_GetError(const PSSI_HandleTypeDef *hpssi);
+uint32_t              HAL_PSSI_GetError(const PSSI_HandleTypeDef *hpssi);
 
 /**
   * @}
@@ -505,7 +506,6 @@ void HAL_PSSI_AbortCpltCallback(PSSI_HandleTypeDef *hpssi);
 /**
   * @}
   */
-
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr.c
@@ -392,10 +392,11 @@ void HAL_PWR_EnterSTANDBYMode(void)
   /* Set SLEEPDEEP bit of Cortex System Control Register */
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
-  /* This option is used to ensure that store operations are completed */
-#if defined ( __CC_ARM)
-  __force_stores();
-#endif /* __CC_ARM */
+  /* Wait For all memory accesses to complete before continuing */
+  __DSB();
+
+  /* Ensure that the processor pipeline is flushed */
+  __ISB();
 
   /* Wait For Interrupt Request */
   __WFI();

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr_ex.c
@@ -672,13 +672,23 @@ void HAL_PWREx_DisableFlashPowerDown(void)
   *         content. The user can select which memory is discarded during STOP
   *         mode by means of xxSO bits.
   * @param  MemoryBlock : Specifies the memory block to shut-off during Stop mode.
-  *          This parameter can be one of the following values:
-  *            @arg PWR_ETHERNET_MEMORY_BLOCK PWR_PMCR_ETHERNETSO    : Ethernet shut-off control in Stop mode
-  *            @arg PWR_RAM3_MEMORY_BLOCK     PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
-  *            @arg PWR_RAM2_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16SO    : RAM2 16k byte shut-off control in Stop mode
-  *            @arg PWR_RAM2_48_MEMORY_BLOCK  PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
-  *            @arg PWR_RAM1_MEMORY_BLOCK     PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
-  * @note   The PWR_ETHERNET_MEMORY_BLOCK is not available for STM32H503xx devices.
+  *          This parameter can be one of the following values for STM32H573xx/STM32H563xx/STM32H562xx :
+  *            @arg PWR_ETHERNET_MEMORY_BLOCK      PWR_PMCR_ETHERNETSO    : Ethernet shut-off control in Stop mode
+  *            @arg PWR_RAM3_MEMORY_BLOCK          PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
+  *            @arg PWR_RAM2_16_MEMORY_BLOCK       PWR_PMCR_SRAM2_16SO    : RAM2 16k byte shut-off control in Stop mode
+  *            @arg PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
+  *          This parameter can be one of the following values for STM32H533xx/STM32H523xx :
+  *            @arg PWR_RAM3_MEMORY_BLOCK          PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
+  *            @arg PWR_RAM2_LOW_16_MEMORY_BLOCK   PWR_PMCR_SRAM2_16LSO   : RAM2 Low 16k byte shut-off control
+  *            in Stop mode
+  *            @arg PWR_RAM2_HIGH_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16HSO   : RAM2 High 16k byte shut-off control
+  *            in Stop mode
+  *            @arg PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
+  *          This parameter can be one of the following values for STM32H503xx :
+  *            @arg PWR_RAM2_MEMORY_BLOCK          PWR_PMCR_SRAM2SO       : RAM2 shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
   * @retval None.
   */
 void HAL_PWREx_EnableMemoryShutOff(uint32_t MemoryBlock)
@@ -694,13 +704,23 @@ void HAL_PWREx_EnableMemoryShutOff(uint32_t MemoryBlock)
   * @brief Disable memory block shut-off in Stop mode
   * @param  MemoryBlock : Specifies the memory block to keep content during
   *                       Stop mode.
-  *          This parameter can be one of the following values:
-  *            @arg PWR_ETHERNET_MEMORY_BLOCK PWR_PMCR_ETHERNETSO    : Ethernet shut-off control in Stop mode
-  *            @arg PWR_RAM3_MEMORY_BLOCK     PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
-  *            @arg PWR_RAM2_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16SO    : RAM2 16k byte shut-off control in Stop mode
-  *            @arg PWR_RAM2_48_MEMORY_BLOCK  PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
-  *            @arg PWR_RAM1_MEMORY_BLOCK     PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
-  * @note   The PWR_ETHERNET_MEMORY_BLOCK is not available for STM32H503xx devices.
+  *          This parameter can be one of the following values for STM32H573xx/STM32H563xx/STM32H562xx :
+  *            @arg PWR_ETHERNET_MEMORY_BLOCK      PWR_PMCR_ETHERNETSO    : Ethernet shut-off control in Stop mode
+  *            @arg PWR_RAM3_MEMORY_BLOCK          PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
+  *            @arg PWR_RAM2_16_MEMORY_BLOCK       PWR_PMCR_SRAM2_16SO    : RAM2 16k byte shut-off control in Stop mode
+  *            @arg PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
+  *          This parameter can be one of the following values for STM32H533xx/STM32H523xx :
+  *            @arg PWR_RAM3_MEMORY_BLOCK          PWR_PMCR_SRAM3SO       : RAM3 shut-off control in Stop mode
+  *            @arg PWR_RAM2_LOW_16_MEMORY_BLOCK   PWR_PMCR_SRAM2_16LSO   : RAM2 Low 16k byte shut-off control
+  *            in Stop mode
+  *            @arg PWR_RAM2_HIGH_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16HSO   : RAM2 High 16k byte shut-off control
+  *            in Stop mode
+  *            @arg PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    : RAM2 48k byte shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
+  *          This parameter can be one of the following values for STM32H503xx :
+  *            @arg PWR_RAM2_MEMORY_BLOCK          PWR_PMCR_SRAM2SO       : RAM2 shut-off control in Stop mode
+  *            @arg PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       : RAM1 shut-off control in Stop mode
   * @retval None.
   */
 void HAL_PWREx_DisableMemoryShutOff(uint32_t MemoryBlock)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_pwr_ex.h
@@ -181,15 +181,23 @@ typedef struct
 /** @defgroup PWREx_Memory_Shut_Off Memory shut-off block selection
   * @{
   */
+#define PWR_RAM1_MEMORY_BLOCK          PWR_PMCR_SRAM1SO       /*!< RAM1 shut-off control in Stop mode                   */
 #if defined (PWR_PMCR_SRAM2_16SO)
-#define PWR_ETHERNET_MEMORY_BLOCK PWR_PMCR_ETHERNETSO   /*!< Ethernet shut-off control in Stop mode               */
-#define PWR_RAM3_MEMORY_BLOCK     PWR_PMCR_SRAM3SO      /*!< RAM3 shut-off control in Stop mode                   */
-#define PWR_RAM2_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16SO   /*!< RAM2 16k byte shut-off control in Stop mode          */
-#define PWR_RAM2_48_MEMORY_BLOCK  PWR_PMCR_SRAM2_48SO   /*!< RAM2 48k byte shut-off control in Stop mode          */
+#define PWR_RAM2_16_MEMORY_BLOCK       PWR_PMCR_SRAM2_16SO    /*!< RAM2 16k byte shut-off control in Stop mode          */
+#define PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    /*!< RAM2 48k byte shut-off control in Stop mode          */
+#elif defined (PWR_PMCR_SRAM2_16LSO)
+#define PWR_RAM2_LOW_16_MEMORY_BLOCK   PWR_PMCR_SRAM2_16LSO   /*!< RAM2 low 16k byte shut-off control in Stop mode      */
+#define PWR_RAM2_HIGH_16_MEMORY_BLOCK  PWR_PMCR_SRAM2_16HSO   /*!< RAM2 High 16k byte shut-off control in Stop mode     */
+#define PWR_RAM2_48_MEMORY_BLOCK       PWR_PMCR_SRAM2_48SO    /*!< RAM2 48k byte shut-off control in Stop mode          */
 #else
-#define PWR_RAM2_MEMORY_BLOCK     PWR_PMCR_SRAM2SO      /*!< RAM2 48k byte shut-off control in Stop mode          */
+#define PWR_RAM2_MEMORY_BLOCK          PWR_PMCR_SRAM2SO       /*!< RAM2 shut-off control in Stop mode                   */
 #endif /* PWR_PMCR_SRAM2_16SO */
-#define PWR_RAM1_MEMORY_BLOCK     PWR_PMCR_SRAM1SO      /*!< RAM1 shut-off control in Stop mode                   */
+#if defined (PWR_PMCR_SRAM3SO)
+#define PWR_RAM3_MEMORY_BLOCK          PWR_PMCR_SRAM3SO       /*!< RAM3 shut-off control in Stop mode                   */
+#endif /* PWR_PMCR_SRAM3SO */
+#if defined (PWR_PMCR_ETHERNETSO)
+#define PWR_ETHERNET_MEMORY_BLOCK      PWR_PMCR_ETHERNETSO    /*!< Ethernet shut-off control in Stop mode               */
+#endif /* PWR_PMCR_ETHERNETSO */
 
 /**
   * @}
@@ -413,12 +421,18 @@ typedef struct
 #define IS_PWR_BATTERY_RESISTOR_SELECT(RESISTOR) (((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_5) ||\
                                                   ((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_1_5))
 
-#if defined (PWR_PMCR_SRAM2_16SO)
 /* Check memory block parameter */
+#if defined (PWR_PMCR_SRAM2_16SO)
 #define IS_PWR_MEMORY_BLOCK(BLOCK) (((BLOCK) == PWR_ETHERNET_MEMORY_BLOCK) || \
                                     ((BLOCK) == PWR_RAM3_MEMORY_BLOCK)     || \
                                     ((BLOCK) == PWR_RAM2_16_MEMORY_BLOCK)  || \
                                     ((BLOCK) == PWR_RAM2_48_MEMORY_BLOCK)  || \
+                                    ((BLOCK) == PWR_RAM1_MEMORY_BLOCK))
+#elif defined (PWR_PMCR_SRAM2_16LSO)
+#define IS_PWR_MEMORY_BLOCK(BLOCK) (((BLOCK) == PWR_RAM3_MEMORY_BLOCK)          || \
+                                    ((BLOCK) == PWR_RAM2_LOW_16_MEMORY_BLOCK)   || \
+                                    ((BLOCK) == PWR_RAM2_HIGH_16_MEMORY_BLOCK)  || \
+                                    ((BLOCK) == PWR_RAM2_48_MEMORY_BLOCK)       || \
                                     ((BLOCK) == PWR_RAM1_MEMORY_BLOCK))
 #else
 #define IS_PWR_MEMORY_BLOCK(BLOCK) (((BLOCK) == PWR_RAM2_MEMORY_BLOCK)  || \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_ramcfg.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_ramcfg.h
@@ -152,8 +152,6 @@ typedef struct
 /**
   * @}
   */
-
-
 /**
   * @}
   */
@@ -254,7 +252,6 @@ typedef struct
   * @}
   */
 
-
 /* Exported functions --------------------------------------------------------*/
 
 /** @defgroup RAMCFG_Exported_Functions RAMCFG Exported Functions
@@ -335,6 +332,7 @@ HAL_RAMCFG_StateTypeDef HAL_RAMCFG_GetState(const RAMCFG_HandleTypeDef *hramcfg)
   * @}
   */
 
+
 /**
   * @}
   */
@@ -361,7 +359,11 @@ HAL_RAMCFG_StateTypeDef HAL_RAMCFG_GetState(const RAMCFG_HandleTypeDef *hramcfg)
   (((INTERRUPT) != 0U) && (((INTERRUPT) & ~(RAMCFG_IT_SINGLEERR | RAMCFG_IT_DOUBLEERR | RAMCFG_IT_NMIERR)) == 0U))
 
 
+#if defined (RAMCFG_WPR3_P64WP)
+#define IS_RAMCFG_WRITEPROTECTION_PAGE(PAGE)   ((PAGE) <= 80U)
+#else
 #define IS_RAMCFG_WRITEPROTECTION_PAGE(PAGE)   ((PAGE) <= 64U)
+#endif /* RAMCFG_WPR3_P64WP*/
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc.c
@@ -1697,11 +1697,11 @@ void HAL_RCC_NMI_IRQHandler(void)
   /* Check RCC CSSF interrupt flag  */
   if (__HAL_RCC_GET_IT(RCC_IT_HSECSS))
   {
-    /* RCC Clock Security System interrupt user callback */
-    HAL_RCC_CSSCallback();
-
     /* Clear RCC CSS pending bit */
     __HAL_RCC_CLEAR_IT(RCC_IT_HSECSS);
+
+    /* RCC Clock Security System interrupt user callback */
+    HAL_RCC_CSSCallback();
   }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc.h
@@ -773,13 +773,13 @@ typedef struct
                                                     UNUSED(tmpreg); \
                                                   } while(0)
 
-#define __HAL_RCC_RAMCFG_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_RAMCFG_CLK_ENABLE()          do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
 #define __HAL_RCC_FLASH_CLK_ENABLE()           do { \
                                                     __IO uint32_t tmpreg; \
@@ -790,64 +790,64 @@ typedef struct
                                                   } while(0)
 
 #if defined(ETH)
-#define __HAL_RCC_ETH_CLK_ENABLE()           do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN);\
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN);\
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_ETH_CLK_ENABLE()             do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN);\
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN);\
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
-#define __HAL_RCC_ETHTX_CLK_ENABLE()         do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN);\
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN);\
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_ETHTX_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN);\
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN);\
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
-#define __HAL_RCC_ETHRX_CLK_ENABLE()         do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN);\
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN);\
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_ETHRX_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN);\
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN);\
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 #endif /*ETH*/
 
-#define __HAL_RCC_GTZC1_CLK_ENABLE()         do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN); \
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN); \
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_GTZC1_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
-#define __HAL_RCC_BKPRAM_CLK_ENABLE()        do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN); \
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN); \
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_BKPRAM_CLK_ENABLE()          do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
 #if defined(DCACHE1)
-#define __HAL_RCC_DCACHE1_CLK_ENABLE()       do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN); \
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN); \
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_DCACHE1_CLK_ENABLE()         do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 #endif /* DCACHE1 */
 
-#define __HAL_RCC_SRAM1_CLK_ENABLE()        do { \
-                                                 __IO uint32_t tmpreg; \
-                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN); \
-                                                 /* Delay after an RCC peripheral clock enabling */ \
-                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN); \
-                                                 UNUSED(tmpreg); \
-                                               } while(0)
+#define __HAL_RCC_SRAM1_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
 #define __HAL_RCC_GPDMA1_CLK_DISABLE()         CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPDMA1EN)
 
@@ -984,13 +984,13 @@ typedef struct
                                                     UNUSED(tmpreg); \
                                                   } while(0)
 
-#define __HAL_RCC_DAC1_CLK_ENABLE()              do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DAC1EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DAC1EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_DAC1_CLK_ENABLE()            do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DAC1EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DAC1EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 
 #if defined(DCMI)
 #define __HAL_RCC_DCMI_PSSI_CLK_ENABLE()       do { \
@@ -1016,12 +1016,12 @@ typedef struct
 
 #if defined(HASH)
 #define __HAL_RCC_HASH_CLK_ENABLE()             do { \
-                                                     __IO uint32_t tmpreg; \
-                                                     SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN); \
-                                                     /* Delay after an RCC peripheral clock enabling */ \
-                                                     tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN); \
-                                                     UNUSED(tmpreg); \
-                                                   } while(0)
+                                                      __IO uint32_t tmpreg; \
+                                                      SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN); \
+                                                      /* Delay after an RCC peripheral clock enabling */ \
+                                                      tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN); \
+                                                      UNUSED(tmpreg); \
+                                                    } while(0)
 #endif /* HASH */
 
 #define __HAL_RCC_RNG_CLK_ENABLE()             do { \
@@ -1043,30 +1043,30 @@ typedef struct
 #endif /* PKA */
 
 #if defined(SAES)
-#define __HAL_RCC_SAES_CLK_ENABLE()         do { \
-                                                 __IO uint32_t tmpreg; \
-                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SAESEN); \
-                                                 /* Delay after an RCC peripheral clock enabling */ \
-                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SAESEN); \
-                                                 UNUSED(tmpreg); \
-                                               } while(0)
+#define __HAL_RCC_SAES_CLK_ENABLE()            do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SAESEN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SAESEN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 #endif /* SAES */
 
-#define __HAL_RCC_SRAM2_CLK_ENABLE()         do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM2EN); \
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM2EN); \
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_SRAM2_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM2EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM2EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 #if defined(SRAM3_BASE)
-#define __HAL_RCC_SRAM3_CLK_ENABLE()         do { \
-                                                  __IO uint32_t tmpreg; \
-                                                  SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM3EN); \
-                                                  /* Delay after an RCC peripheral clock enabling */ \
-                                                  tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM3EN); \
-                                                  UNUSED(tmpreg); \
-                                                } while(0)
+#define __HAL_RCC_SRAM3_CLK_ENABLE()           do { \
+                                                    __IO uint32_t tmpreg; \
+                                                    SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM3EN); \
+                                                    /* Delay after an RCC peripheral clock enabling */ \
+                                                    tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_SRAM3EN); \
+                                                    UNUSED(tmpreg); \
+                                                  } while(0)
 #endif /* SRAM3_BASE */
 
 #define __HAL_RCC_GPIOA_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN)
@@ -1149,49 +1149,83 @@ typedef struct
                                                       } while(0)
 #endif /* OTFDEC1 */
 
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_CLK_ENABLE()             do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC2EN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC2EN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
+#endif /* OTFDEC2 */
+
 #if defined(SDMMC1)
-#define __HAL_RCC_SDMMC1_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_SDMMC1_CLK_ENABLE()              do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
 #endif /* SDMMC1 */
 
 #if defined(SDMMC2)
-#define __HAL_RCC_SDMMC2_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_SDMMC2_CLK_ENABLE()              do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
 #endif /* SDMMC2 */
 
 #if defined(FMC_BASE)
-#define __HAL_RCC_FMC_CLK_ENABLE()             do { \
-                                                    __IO uint32_t tmpreg; \
-                                                    SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN); \
-                                                    /* Delay after an RCC peripheral clock enabling */ \
-                                                    tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN); \
-                                                    UNUSED(tmpreg); \
-                                                  } while(0)
+#define __HAL_RCC_FMC_CLK_ENABLE()                 do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
 #endif /* FMC_BASE */
 
 #if defined(OCTOSPI1)
-#define __HAL_RCC_OSPI1_CLK_ENABLE()           do { \
-                                                    __IO uint32_t tmpreg; \
-                                                    SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN); \
-                                                    /* Delay after an RCC peripheral clock enabling */ \
-                                                    tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN); \
-                                                    UNUSED(tmpreg); \
-                                                  } while(0)
+#define __HAL_RCC_OSPI1_CLK_ENABLE()               do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
 #endif /* OCTOSPI1 */
+
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_CLK_ENABLE()               do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI2EN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI2EN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_CLK_ENABLE()               do { \
+                                                        __IO uint32_t tmpreg; \
+                                                        SET_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPIMEN); \
+                                                        /* Delay after an RCC peripheral clock enabling */ \
+                                                        tmpreg = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPIMEN); \
+                                                        UNUSED(tmpreg); \
+                                                      } while(0)
+#endif /* OCTOSPIM */
 
 #if defined(OTFDEC1)
 #define __HAL_RCC_OTFDEC1_CLK_DISABLE()        CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC1EN)
 #endif /* OTFDEC1 */
+
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_CLK_DISABLE()        CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC2EN)
+#endif /* OTFDEC2 */
 
 #if defined(SDMMC1)
 #define __HAL_RCC_SDMMC1_CLK_DISABLE()         CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN)
@@ -1209,6 +1243,13 @@ typedef struct
 #define __HAL_RCC_OSPI1_CLK_DISABLE()          CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN)
 #endif /* OCTOSPI1 */
 
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_CLK_DISABLE()          CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI2EN)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_CLK_DISABLE()          CLEAR_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPIMEN)
+#endif /* OCTOSPIM */
 /**
   * @}
   */
@@ -1275,34 +1316,34 @@ typedef struct
                                                    } while(0)
 
 #if defined(TIM12)
-#define __HAL_RCC_TIM12_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM12EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM12EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM12_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM12EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM12EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
 #endif /* TIM12 */
 
 #if defined(TIM13)
-#define __HAL_RCC_TIM13_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM13EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM13EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM13_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM13EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM13EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* TIM13 */
 
 #if defined(TIM14)
-#define __HAL_RCC_TIM14_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM14EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM14EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM14_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM14EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_TIM14EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* TIM14 */
 
 #define __HAL_RCC_WWDG_CLK_ENABLE()             do { \
@@ -1314,13 +1355,13 @@ typedef struct
                                                    } while(0)
 
 #if defined(OPAMP1)
-#define __HAL_RCC_OPAMP_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_OPAMPEN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_OPAMPEN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_OPAMP_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_OPAMPEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_OPAMPEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* OPAMP1 */
 
 #define __HAL_RCC_SPI2_CLK_ENABLE()             do { \
@@ -1349,177 +1390,177 @@ typedef struct
                                                    } while(0)
 #endif /* COMP1 */
 
-#define __HAL_RCC_USART2_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART2EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART2EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_USART2_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART2EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART2EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define __HAL_RCC_USART3_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART3EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART3EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_USART3_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART3EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART3EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
 #if defined(UART4)
-#define __HAL_RCC_UART4_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART4EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART4EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_UART4_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART4EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART4EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART4 */
 
 #if defined(UART5)
-#define __HAL_RCC_UART5_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART5EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART5EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_UART5_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART5EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART5EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART5 */
 
-#define  __HAL_RCC_I2C1_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C1EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C1EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define  __HAL_RCC_I2C1_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C1EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C1EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define  __HAL_RCC_I2C2_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C2EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C2EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define  __HAL_RCC_I2C2_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C2EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I2C2EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define  __HAL_RCC_I3C1_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I3C1EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I3C1EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define  __HAL_RCC_I3C1_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_I3C1EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_I3C1EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define   __HAL_RCC_CRS_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_CRSEN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_CRSEN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define   __HAL_RCC_CRS_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_CRSEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_CRSEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
 #if defined(USART6)
-#define __HAL_RCC_USART6_CLK_ENABLE()            do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART6EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART6EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_USART6_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART6EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART6EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* USART6 */
 
 #if defined(USART10)
-#define __HAL_RCC_USART10_CLK_ENABLE()           do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART10EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART10EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_USART10_CLK_ENABLE()          do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART10EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART10EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* USART10 */
 
 #if defined(USART11)
-#define __HAL_RCC_USART11_CLK_ENABLE()           do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART11EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART11EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_USART11_CLK_ENABLE()          do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_USART11EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_USART11EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* USART11 */
 
 #if defined(CEC)
-#define __HAL_RCC_CEC_CLK_ENABLE()               do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_CECEN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_CECEN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_CEC_CLK_ENABLE()              do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_CECEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_CECEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* CEC */
 
 #if defined(UART7)
-#define __HAL_RCC_UART7_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART7EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART7EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_UART7_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART7EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART7EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART7 */
 
 #if defined(UART8)
-#define __HAL_RCC_UART8_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART8EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART8EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_UART8_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1LENR, RCC_APB1LENR_UART8EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1LENR, RCC_APB1LENR_UART8EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART8 */
 
 #if defined(UART9)
-#define __HAL_RCC_UART9_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB1HENR, RCC_APB1HENR_UART9EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_UART9EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_UART9_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1HENR, RCC_APB1HENR_UART9EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_UART9EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART9 */
 
 #if defined(UART12)
-#define __HAL_RCC_UART12_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->APB1HENR, RCC_APB1HENR_UART12EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_UART12EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_UART12_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1HENR, RCC_APB1HENR_UART12EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_UART12EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* UART12 */
 
-#define __HAL_RCC_DTS_CLK_ENABLE()             do { \
-                                                    __IO uint32_t tmpreg; \
-                                                    SET_BIT(RCC->APB1HENR, RCC_APB1HENR_DTSEN); \
-                                                    /* Delay after an RCC peripheral clock enabling */ \
-                                                    tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_DTSEN); \
-                                                    UNUSED(tmpreg); \
-                                                  } while(0)
+#define __HAL_RCC_DTS_CLK_ENABLE()              do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1HENR, RCC_APB1HENR_DTSEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_DTSEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define __HAL_RCC_LPTIM2_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->APB1HENR, RCC_APB1HENR_LPTIM2EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_LPTIM2EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_LPTIM2_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1HENR, RCC_APB1HENR_LPTIM2EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_LPTIM2EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
-#define __HAL_RCC_FDCAN_CLK_ENABLE()              do { \
-                                                        __IO uint32_t tmpreg; \
-                                                        SET_BIT(RCC->APB1HENR, RCC_APB1HENR_FDCANEN); \
-                                                        /* Delay after an RCC peripheral clock enabling */ \
-                                                        tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_FDCANEN); \
-                                                        UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_FDCAN_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB1HENR, RCC_APB1HENR_FDCANEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB1HENR, RCC_APB1HENR_FDCANEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_CLK_ENABLE()            do { \
@@ -1673,42 +1714,42 @@ typedef struct
                                                    } while(0)
 #endif /* TIM8 */
 
-#define __HAL_RCC_USART1_CLK_ENABLE()             do { \
-                                                       __IO uint32_t tmpreg; \
-                                                       SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
-                                                       /* Delay after an RCC peripheral clock enabling */ \
-                                                       tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
-                                                       UNUSED(tmpreg); \
-                                                     } while(0)
+#define __HAL_RCC_USART1_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 
 #if defined(TIM15)
-#define __HAL_RCC_TIM15_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM15_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* TIM15 */
 
 #if defined(TIM16)
-#define __HAL_RCC_TIM16_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM16_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* TIM16 */
 
 #if defined(TIM17)
-#define __HAL_RCC_TIM17_CLK_ENABLE()             do { \
-                                                      __IO uint32_t tmpreg; \
-                                                      SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
-                                                      /* Delay after an RCC peripheral clock enabling */ \
-                                                      tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
-                                                      UNUSED(tmpreg); \
-                                                    } while(0)
+#define __HAL_RCC_TIM17_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
 #endif /* TIM17 */
 
 #if defined(SPI4)
@@ -1751,13 +1792,35 @@ typedef struct
                                                    } while(0)
 #endif /* SAI2 */
 
-#define __HAL_RCC_USB_CLK_ENABLE()             do { \
-                                                    __IO uint32_t tmpreg; \
-                                                    SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN); \
-                                                    /* Delay after an RCC peripheral clock enabling */ \
-                                                    tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN); \
-                                                    UNUSED(tmpreg); \
-                                                  } while(0)
+#if defined(USB_DRD_FS)
+#define __HAL_RCC_USB_CLK_ENABLE()              do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
+#endif /*USB_DRD_FS*/
+
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_CLK_ENABLE()             do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
+#endif /*LTDC*/
+
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_CLK_ENABLE()           do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB2ENR, RCC_APB2ENR_GFXTIMEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_GFXTIMEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
+#endif /*GFXTIM*/
 
 #define __HAL_RCC_TIM1_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN)
 
@@ -1797,8 +1860,17 @@ typedef struct
 #define __HAL_RCC_SAI2_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN)
 #endif /* SAI2 */
 
+#if defined(USB_DRD_FS)
 #define __HAL_RCC_USB_CLK_DISABLE()            CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN)
+#endif /* USB_DRD_FS */
 
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN)
+#endif /* LTDC */
+
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_CLK_DISABLE()         CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_GFXTIMEN)
+#endif /* GFXTIM */
 /**
   * @}
   */
@@ -1932,6 +2004,24 @@ typedef struct
                                                     UNUSED(tmpreg); \
                                                   } while(0)
 
+#if defined (PLAY1)
+#define __HAL_RCC_PLAY1_CLK_ENABLE()            do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1EN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1EN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
+
+#define __HAL_RCC_PLAY1APB_CLK_ENABLE()         do { \
+                                                     __IO uint32_t tmpreg; \
+                                                     SET_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1APBEN); \
+                                                     /* Delay after an RCC peripheral clock enabling */ \
+                                                     tmpreg = READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1APBEN); \
+                                                     UNUSED(tmpreg); \
+                                                   } while(0)
+#endif /* PLAY1 */
+
 #define __HAL_RCC_SBS_CLK_DISABLE()            CLEAR_BIT(RCC->APB3ENR, RCC_APB3ENR_SBSEN)
 
 #if defined(SPI5)
@@ -1976,6 +2066,10 @@ typedef struct
 
 #define __HAL_RCC_RTC_CLK_DISABLE()            CLEAR_BIT(RCC->APB3ENR, RCC_APB3ENR_RTCAPBEN)
 
+#if defined (PLAY1)
+#define __HAL_RCC_PLAY1_CLK_DISABLE()          CLEAR_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1EN)
+#define __HAL_RCC_PLAY1APB_CLK_DISABLE()       CLEAR_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1APBEN)
+#endif /* PLAY1 */
 /**
   * @}
   */
@@ -2102,41 +2196,41 @@ typedef struct
 #define __HAL_RCC_SRAM1_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN) != 0U)
 
 
-#define __HAL_RCC_GPDMA1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPDMA1EN) == 0U)
+#define __HAL_RCC_GPDMA1_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPDMA1EN) == 0U)
 
-#define __HAL_RCC_GPDMA2_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPDMA2EN) == 0U)
+#define __HAL_RCC_GPDMA2_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPDMA2EN) == 0U)
 
-#define __HAL_RCC_FLASH_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLITFEN) == 0U)
+#define __HAL_RCC_FLASH_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLITFEN) == 0U)
 
-#define __HAL_RCC_CRC_IS_CLK_DISABLED()          (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN) == 0U)
+#define __HAL_RCC_CRC_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN) == 0U)
 
 #if defined(CORDIC)
-#define __HAL_RCC_CORDIC_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CORDICEN) == 0U)
+#define __HAL_RCC_CORDIC_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CORDICEN) == 0U)
 #endif /* CORDIC */
 
 #if defined(FMAC)
-#define __HAL_RCC_FMAC_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FMACEN) == 0U)
+#define __HAL_RCC_FMAC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FMACEN) == 0U)
 #endif /* FMAC */
 
-#define __HAL_RCC_RAMCFG_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN) == 0U)
+#define __HAL_RCC_RAMCFG_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_RAMCFGEN) == 0U)
 
 #if defined(ETH)
-#define __HAL_RCC_ETH_IS_CLK_DISABLED()          (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN) == 0U)
+#define __HAL_RCC_ETH_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHEN) == 0U)
 
-#define __HAL_RCC_ETHTX_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN) == 0U)
+#define __HAL_RCC_ETHTX_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHTXEN) == 0U)
 
-#define __HAL_RCC_ETHRX_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN) == 0U)
+#define __HAL_RCC_ETHRX_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHRXEN) == 0U)
 #endif /*ETH*/
 
-#define __HAL_RCC_GTZC1_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN) == 0U)
+#define __HAL_RCC_GTZC1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TZSC1EN) == 0U)
 
-#define __HAL_RCC_BKPRAM_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN) == 0U)
+#define __HAL_RCC_BKPRAM_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPRAMEN) == 0U)
 
 #if defined(DCACHE1)
-#define __HAL_RCC_DCACHE1_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN) == 0U)
+#define __HAL_RCC_DCACHE1_IS_CLK_DISABLED()     (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DCACHE1EN) == 0U)
 #endif /* DCACHE1 */
 
-#define __HAL_RCC_SRAM1_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN) == 0U)
+#define __HAL_RCC_SRAM1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_SRAM1EN) == 0U)
 /**
   * @}
   */
@@ -2278,9 +2372,9 @@ typedef struct
 #define __HAL_RCC_OTFDEC1_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC1EN) != 0U)
 #endif /* OTFDEC1 */
 
-#if defined(OCTOSPI1)
-#define __HAL_RCC_OSPI1_IS_CLK_ENABLED()          (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN) != 0U)
-#endif /* OCTOSPI1 */
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC2EN) != 0U)
+#endif /* OTFDEC2 */
 
 #if defined(SDMMC1)
 #define __HAL_RCC_SDMMC1_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN) != 0U)
@@ -2294,26 +2388,49 @@ typedef struct
 #define __HAL_RCC_FMC_IS_CLK_ENABLED()            (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN) != 0U)
 #endif /* FMC_BASE */
 
-
-#if defined(OTFDEC1)
-#define __HAL_RCC_OTFDEC1_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC1EN) == 0U)
-#endif /* OTFDEC1 */
-
 #if defined(OCTOSPI1)
-#define __HAL_RCC_OSPI1_IS_CLK_DISABLED()          (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN) == 0U)
+#define __HAL_RCC_OSPI1_IS_CLK_ENABLED()          (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN) != 0U)
 #endif /* OCTOSPI1 */
 
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_IS_CLK_ENABLED()          (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI2EN) != 0U)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_IS_CLK_ENABLED()          (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPIMEN) != 0U)
+#endif /* OCTOSPIM */
+
+#if defined(OTFDEC1)
+#define __HAL_RCC_OTFDEC1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC1EN) == 0U)
+#endif /* OTFDEC1 */
+
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OTFDEC2EN) == 0U)
+#endif /* OTFDEC2 */
+
 #if defined(SDMMC1)
-#define __HAL_RCC_SDMMC1_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN) == 0U)
+#define __HAL_RCC_SDMMC1_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC1EN) == 0U)
 #endif /* SDMMC1 */
 
 #if defined(SDMMC2)
-#define __HAL_RCC_SDMMC2_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN) == 0U)
+#define __HAL_RCC_SDMMC2_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_SDMMC2EN) == 0U)
 #endif /* SDMMC2 */
 
 #if defined(FMC_BASE)
-#define __HAL_RCC_FMC_IS_CLK_DISABLED()            (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN) == 0U)
+#define __HAL_RCC_FMC_IS_CLK_DISABLED()           (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_FMCEN) == 0U)
 #endif /* FMC_BASE */
+
+#if defined(OCTOSPI1)
+#define __HAL_RCC_OSPI1_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI1EN) == 0U)
+#endif /* OCTOSPI1 */
+
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPI2EN) == 0U)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_IS_CLK_DISABLED()         (READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_OCTOSPIMEN) == 0U)
+#endif /* OCTOSPIM */
 
 /**
   * @}
@@ -2589,48 +2706,67 @@ typedef struct
 #define __HAL_RCC_SAI2_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN) != 0U)
 #endif /* SAI2 */
 
+#if defined(USB_DRD_FS)
 #define __HAL_RCC_USB_IS_CLK_ENABLED()         (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN) != 0U)
+#endif /* USB_DRD_FS */
 
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN) != 0U)
+#endif /* LTDC */
 
-#define __HAL_RCC_TIM1_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN) == 0U)
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_IS_CLK_ENABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_GFXTIMEN) != 0U)
+#endif /* GFXTIM */
 
-#define __HAL_RCC_SPI1_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN) == 0U)
+#define __HAL_RCC_TIM1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN) == 0U)
+
+#define __HAL_RCC_SPI1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN) == 0U)
 
 #if defined(TIM8)
-#define __HAL_RCC_TIM8_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN) == 0U)
+#define __HAL_RCC_TIM8_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN) == 0U)
 #endif /* TIM8 */
 
-#define __HAL_RCC_USART1_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN) == 0U)
+#define __HAL_RCC_USART1_IS_CLK_DISABLED()     (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN) == 0U)
 
 #if defined(TIM15)
-#define __HAL_RCC_TIM15_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN) == 0U)
+#define __HAL_RCC_TIM15_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN) == 0U)
 #endif /* TIM15 */
 
 #if defined(TIM16)
-#define __HAL_RCC_TIM16_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN) == 0U)
+#define __HAL_RCC_TIM16_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN) == 0U)
 #endif /* TIM16 */
 
 #if defined(TIM17)
-#define __HAL_RCC_TIM17_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN) == 0U)
+#define __HAL_RCC_TIM17_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN) == 0U)
 #endif /* TIM17 */
 
 #if defined(SPI4)
-#define __HAL_RCC_SPI4_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI4EN) == 0U)
+#define __HAL_RCC_SPI4_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI4EN) == 0U)
 #endif /* SPI4 */
 
 #if defined(SPI6)
-#define __HAL_RCC_SPI6_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN) == 0U)
+#define __HAL_RCC_SPI6_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN) == 0U)
 #endif /* SPI6 */
 
 #if defined(SAI1)
-#define __HAL_RCC_SAI1_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN) == 0U)
+#define __HAL_RCC_SAI1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN) == 0U)
 #endif /* SAI1 */
 
 #if defined(SAI2)
-#define __HAL_RCC_SAI2_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN) == 0U)
+#define __HAL_RCC_SAI2_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN) == 0U)
 #endif /* SAI2 */
 
+#if defined(USB_DRD_FS)
 #define __HAL_RCC_USB_IS_CLK_DISABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USBEN) == 0U)
+#endif /* USB_DRD_FS */
+
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN) == 0U)
+#endif /* LTDC */
+
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_IS_CLK_DISABLED()     (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_GFXTIMEN) == 0U)
+#endif /* GFXTIM */
 /**
   * @}
   */
@@ -2687,6 +2823,10 @@ typedef struct
 
 #define __HAL_RCC_RTC_IS_CLK_ENABLED()            (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_RTCAPBEN) != 0U)
 
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_IS_CLK_ENABLED()          (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1EN) != 0U)
+#define __HAL_RCC_PLAY1APB_IS_CLK_ENABLED()       (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1APBEN) != 0U)
+#endif /* PLAY1 */
 
 #define __HAL_RCC_SBS_IS_CLK_DISABLED()           (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_SBSEN) == 0U)
 
@@ -2731,6 +2871,11 @@ typedef struct
 #endif /* VREFBUF */
 
 #define __HAL_RCC_RTC_IS_CLK_DISABLED()           (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_RTCAPBEN) == 0U)
+
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_IS_CLK_DISABLED()         (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1EN) == 0U)
+#define __HAL_RCC_PLAY1APB_IS_CLK_DISABLED()      (READ_BIT(RCC->APB3ENR, RCC_APB3ENR_PLAY1APBEN) == 0U)
+#endif /* PLAY1 */
 
 /**
   * @}
@@ -2787,7 +2932,7 @@ typedef struct
 #define __HAL_RCC_RAMCFG_FORCE_RESET()    SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_RAMCFGRST)
 
 #if defined(ETH)
-#define __HAL_RCC_ETH_FORCE_RESET()      SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_ETHRST)
+#define __HAL_RCC_ETH_FORCE_RESET()       SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_ETHRST)
 #endif /* ETH */
 
 #define __HAL_RCC_GTZC1_FORCE_RESET()     SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_TZSC1RST)
@@ -2800,11 +2945,11 @@ typedef struct
 #define __HAL_RCC_GPDMA2_RELEASE_RESET()  CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_GPDMA2RST)
 
 #if defined(CORDIC)
-#define __HAL_RCC_CORDIC_RELEASE_RESET()   CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_CORDICRST)
+#define __HAL_RCC_CORDIC_RELEASE_RESET()  CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_CORDICRST)
 #endif /* CORDIC */
 
 #if defined(FMAC)
-#define __HAL_RCC_FMAC_RELEASE_RESET()     CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_FMACRST)
+#define __HAL_RCC_FMAC_RELEASE_RESET()    CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_FMACRST)
 #endif /* FMAC */
 
 #define __HAL_RCC_CRC_RELEASE_RESET()     CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_CRCRST)
@@ -2864,23 +3009,26 @@ typedef struct
 #endif /* DCMI */
 
 #if defined(AES)
-#define __HAL_RCC_AES_FORCE_RESET()       SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
+#define __HAL_RCC_AES_FORCE_RESET()        SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
 #endif /* AES */
 
 #if defined(HASH)
-#define __HAL_RCC_HASH_FORCE_RESET()      SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_HASHRST)
+#define __HAL_RCC_HASH_FORCE_RESET()       SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_HASHRST)
 #endif /* HASH */
 
-#define __HAL_RCC_RNG_FORCE_RESET()       SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
+#define __HAL_RCC_RNG_FORCE_RESET()        SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
 
 #if defined(PKA)
-#define __HAL_RCC_PKA_FORCE_RESET()       SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_PKARST)
+#define __HAL_RCC_PKA_FORCE_RESET()        SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_PKARST)
 #endif /* PKA */
 
 #if defined(SAES)
-#define __HAL_RCC_SAES_FORCE_RESET()      SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_SAESRST)
+#define __HAL_RCC_SAES_FORCE_RESET()       SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_SAESRST)
 #endif /* SAES*/
 
+#if defined(RCC_AHB2RSTR_OTGHSPHYRST)
+#define __HAL_RCC_OTGPHY_FORCE_RESET()     SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_OTGHSPHYRST)
+#endif /* RCC_AHB2RSTR_OTGHSPHYRST */
 
 #define __HAL_RCC_AHB2_RELEASE_RESET()    WRITE_REG(RCC->AHB2RSTR, 0x00000000U)
 
@@ -2920,22 +3068,26 @@ typedef struct
 #endif /* DCMI */
 
 #if defined(AES)
-#define __HAL_RCC_AES_RELEASE_RESET()     CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
+#define __HAL_RCC_AES_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
 #endif /* AES */
 
 #if defined(HASH)
-#define __HAL_RCC_HASH_RELEASE_RESET()    CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_HASHRST)
+#define __HAL_RCC_HASH_RELEASE_RESET()       CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_HASHRST)
 #endif /* HASH */
 
-#define __HAL_RCC_RNG_RELEASE_RESET()     CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
+#define __HAL_RCC_RNG_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
 
 #if defined(PKA)
-#define __HAL_RCC_PKA_RELEASE_RESET()     CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_PKARST)
+#define __HAL_RCC_PKA_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_PKARST)
 #endif /* PKA */
 
 #if defined(SAES)
-#define __HAL_RCC_SAES_RELEASE_RESET()    CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_SAESRST)
+#define __HAL_RCC_SAES_RELEASE_RESET()       CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_SAESRST)
 #endif /* SAES*/
+
+#if defined(RCC_AHB2RSTR_OTGHSPHYRST)
+#define __HAL_RCC_OTGPHY_RELEASE_RESET()     CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_OTGHSPHYRST)
+#endif /* RCC_AHB2RSTR_OTGHSPHYRST */
 
 /**
   * @}
@@ -2955,11 +3107,11 @@ typedef struct
 #endif /* OTFDEC1 */
 
 #if defined(SDMMC1)
-#define __HAL_RCC_SDMMC1_FORCE_RESET()   SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_SDMMC1RST)
+#define __HAL_RCC_SDMMC1_FORCE_RESET()    SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_SDMMC1RST)
 #endif /* SDMMC1 */
 
 #if defined(SDMMC2)
-#define __HAL_RCC_SDMMC2_FORCE_RESET()   SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_SDMMC2RST)
+#define __HAL_RCC_SDMMC2_FORCE_RESET()    SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_SDMMC2RST)
 #endif /* SDMMC2 */
 
 #if defined(FMC_BASE)
@@ -2970,6 +3122,17 @@ typedef struct
 #define __HAL_RCC_OSPI1_FORCE_RESET()     SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPI1RST)
 #endif /* OCTOSPI1 */
 
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_FORCE_RESET()     SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPI2RST)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_FORCE_RESET()     SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPIMRST)
+#endif /* OCTOSPIM */
+
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_FORCE_RESET()   SET_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OTFDEC2RST)
+#endif /* OTFDEC2 */
 
 #if defined(FMC_BASE)
 #define __HAL_RCC_AHB4_RELEASE_RESET()    WRITE_REG(RCC->AHB4RSTR, 0x00000000U)
@@ -2995,10 +3158,21 @@ typedef struct
 #define __HAL_RCC_OSPI1_RELEASE_RESET()   CLEAR_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPI1RST)
 #endif /* OCTOSPI1 */
 
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_RELEASE_RESET()   CLEAR_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPI2RST)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_RELEASE_RESET()   CLEAR_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OCTOSPIMRST)
+#endif /* OCTOSPIM */
+
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_RELEASE_RESET() CLEAR_BIT(RCC->AHB4RSTR, RCC_AHB4RSTR_OTFDEC2RST)
+#endif /* OTFDEC2 */
+
 /**
   * @}
   */
-
 
 
 /** @defgroup RCC_APB1_Force_Release_Reset APB1 Peripheral Force Release Reset
@@ -3028,19 +3202,19 @@ typedef struct
 #define __HAL_RCC_TIM7_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM7RST)
 
 #if defined(TIM12)
-#define __HAL_RCC_TIM12_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM12RST)
+#define __HAL_RCC_TIM12_FORCE_RESET()    SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM12RST)
 #endif /* TIM12 */
 
 #if defined(TIM13)
-#define __HAL_RCC_TIM13_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM13RST)
+#define __HAL_RCC_TIM13_FORCE_RESET()    SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM13RST)
 #endif /* TIM13 */
 
 #if defined(TIM14)
-#define __HAL_RCC_TIM14_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM14RST)
+#define __HAL_RCC_TIM14_FORCE_RESET()    SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_TIM14RST)
 #endif /* TIM14 */
 
 #if defined(OPAMP1)
-#define __HAL_RCC_OPAMP_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_OPAMPRST)
+#define __HAL_RCC_OPAMP_FORCE_RESET()    SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_OPAMPRST)
 #endif /* OPAMP1 */
 
 #define __HAL_RCC_SPI2_FORCE_RESET()     SET_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_SPI2RST)
@@ -3149,7 +3323,7 @@ typedef struct
 #endif /* TIM14 */
 
 #if defined(OPAMP1)
-#define __HAL_RCC_OPAMP_RELEASE_RESET()    CLEAR_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_OPAMPRST)
+#define __HAL_RCC_OPAMP_RELEASE_RESET()   CLEAR_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_OPAMPRST)
 #endif /* OPAMP1 */
 
 #define __HAL_RCC_SPI2_RELEASE_RESET()    CLEAR_BIT(RCC->APB1LRSTR, RCC_APB1LRSTR_SPI2RST)
@@ -3272,8 +3446,17 @@ typedef struct
 #define __HAL_RCC_SAI2_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI2RST)
 #endif /* SAI2 */
 
-#define __HAL_RCC_USB_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USBRST)
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_LTDCRST)
+#endif /* LTDC */
 
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_FORCE_RESET()        SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_GFXTIMRST)
+#endif /* GFXTIM */
+
+#if defined(USB_DRD_FS)
+#define __HAL_RCC_USB_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USBRST)
+#endif /* USB_DRD_FS */
 
 #define __HAL_RCC_APB2_RELEASE_RESET()        WRITE_REG(RCC->APB2RSTR, 0x00000000U)
 
@@ -3315,7 +3498,17 @@ typedef struct
 #define __HAL_RCC_SAI2_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI2RST)
 #endif /* SAI2 */
 
-#define __HAL_RCC_USB_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USBRST)
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_LTDCRST)
+#endif /* LTDC */
+
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_RELEASE_RESET()      CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_GFXTIMRST)
+#endif /* GFXTIM */
+
+#if defined(USB_DRD_FS)
+#define __HAL_RCC_USB_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USBRST)
+#endif /* USB_DRD_FS */
 
 /**
   * @}
@@ -3368,6 +3561,11 @@ typedef struct
 #define __HAL_RCC_VREF_FORCE_RESET()           SET_BIT(RCC->APB3RSTR, RCC_APB3RSTR_VREFRST)
 #endif /* VREFBUF */
 
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_FORCE_RESET()          SET_BIT(RCC->APB3RSTR, RCC_APB3RSTR_PLAY1RST)
+#define __HAL_RCC_PLAY1POR_FORCE_RESET()       SET_BIT(RCC->APB3RSTR, RCC_APB3RSTR_PLAY1POR)
+#endif /* PLAY1 */
+
 #define __HAL_RCC_APB3_RELEASE_RESET()         WRITE_REG(RCC->APB3RSTR, 0x00000000U)
 
 #if defined(SPI5)
@@ -3410,6 +3608,10 @@ typedef struct
 #define __HAL_RCC_VREF_RELEASE_RESET()         CLEAR_BIT(RCC->APB3RSTR, RCC_APB3RSTR_VREFRST)
 #endif /* VREFBUF */
 
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_RELEASE_RESET()        CLEAR_BIT(RCC->APB3RSTR, RCC_APB3RSTR_PLAY1RST)
+#define __HAL_RCC_PLAY1POR_RELEASE_RESET()     CLEAR_BIT(RCC->APB3RSTR, RCC_APB3RSTR_PLAY1POR)
+#endif /* PLAY1 */
 /**
   * @}
   */
@@ -3445,6 +3647,10 @@ typedef struct
 #define __HAL_RCC_ETHTX_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHTXLPEN)
 
 #define __HAL_RCC_ETHRX_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHRXLPEN)
+
+#if defined(RCC_AHB1LPENR_ETHCKLPEN)
+#define __HAL_RCC_ETHINTERN_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHCKLPEN)
+#endif /* RCC_AHB1LPENR_ETHCKLPEN */
 #endif /* ETH */
 
 #define __HAL_RCC_GTZC1_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_TZSC1LPEN)
@@ -3484,6 +3690,10 @@ typedef struct
 #define __HAL_RCC_ETHTX_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHTXLPEN)
 
 #define __HAL_RCC_ETHRX_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHRXLPEN)
+
+#if defined(RCC_AHB1LPENR_ETHCKLPEN)
+#define __HAL_RCC_ETHINTERN_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_ETHCKLPEN)
+#endif /* RCC_AHB1LPENR_ETHCKLPEN */
 #endif /* ETH */
 
 #define __HAL_RCC_GTZC1_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB1LPENR, RCC_AHB1LPENR_TZSC1LPEN)
@@ -3544,6 +3754,10 @@ typedef struct
 #define __HAL_RCC_DCMI_CLK_SLEEP_ENABLE()   __HAL_RCC_DCMI_PSSI_CLK_SLEEP_ENABLE()  /* for API backward compatibility */
 #endif /* DCMI */
 
+#if defined(RCC_AHB2LPENR_OTGPHYLPEN)
+#define __HAL_RCC_OTGPHY_CLK_SLEEP_ENABLE()         SET_BIT(RCC->AHB2LPENR, RCC_AHB2LPENR_OTGPHYLPEN);
+#endif /* RCC_AHB2LPENR_OTGPHYLPEN */
+
 #if defined(AES)
 #define __HAL_RCC_AES_CLK_SLEEP_ENABLE()            SET_BIT(RCC->AHB2LPENR, RCC_AHB2LPENR_AESLPEN);
 #endif /* AES */
@@ -3603,6 +3817,10 @@ typedef struct
 #define __HAL_RCC_DCMI_CLK_SLEEP_DISABLE()  __HAL_RCC_DCMI_PSSI_CLK_SLEEP_DISABLE() /* for API backward compatibility */
 #endif /* DCMI */
 
+#if defined(RCC_AHB2LPENR_OTGPHYLPEN)
+#define __HAL_RCC_OTGPHY_CLK_SLEEP_DISABLE()        CLEAR_BIT(RCC->AHB2LPENR, RCC_AHB2LPENR_OTGPHYLPEN)
+#endif /* RCC_AHB2LPENR_OTGPHYLPEN */
+
 #if defined(AES)
 #define __HAL_RCC_AES_CLK_SLEEP_DISABLE()           CLEAR_BIT(RCC->AHB2LPENR, RCC_AHB2LPENR_AESLPEN);
 #endif /* AES */
@@ -3639,6 +3857,10 @@ typedef struct
 #define __HAL_RCC_OTFDEC1_CLK_SLEEP_ENABLE()        SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OTFDEC1LPEN)
 #endif /* OTFDEC1 */
 
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_CLK_SLEEP_ENABLE()        SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OTFDEC2LPEN)
+#endif /* OTFDEC2 */
+
 #if defined(SDMMC1)
 #define __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE()         SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_SDMMC1LPEN)
 #endif /* SDMMC1*/
@@ -3655,9 +3877,21 @@ typedef struct
 #define __HAL_RCC_OSPI1_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPI1LPEN)
 #endif /* OCTOSPI1 */
 
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPI2LPEN)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_CLK_SLEEP_ENABLE()          SET_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPIMLPEN)
+#endif /* OCTOSPIM */
+
 #if defined(OTFDEC1)
 #define __HAL_RCC_OTFDEC1_CLK_SLEEP_DISABLE()       CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OTFDEC1LPEN)
 #endif /* OTFDEC1 */
+
+#if defined(OTFDEC2)
+#define __HAL_RCC_OTFDEC2_CLK_SLEEP_DISABLE()       CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OTFDEC2LPEN)
+#endif /* OTFDEC2 */
 
 #if defined(SDMMC1)
 #define __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE()        CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_SDMMC1LPEN)
@@ -3674,6 +3908,14 @@ typedef struct
 #if defined(OCTOSPI1)
 #define __HAL_RCC_OSPI1_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPI1LPEN)
 #endif /* OCTOSPI1 */
+
+#if defined(OCTOSPI2)
+#define __HAL_RCC_OSPI2_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPI2LPEN)
+#endif /* OCTOSPI2 */
+
+#if defined(OCTOSPIM)
+#define __HAL_RCC_OSPIM_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->AHB4LPENR, RCC_AHB4LPENR_OCTOSPIMLPEN)
+#endif /* OCTOSPIM */
 
 /**
   * @}
@@ -3830,7 +4072,7 @@ typedef struct
 #define __HAL_RCC_SPI3_CLK_SLEEP_DISABLE()       CLEAR_BIT(RCC->APB1LLPENR, RCC_APB1LLPENR_SPI3LPEN)
 
 #if defined(COMP1)
-#define __HAL_RCC_COMP_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APB1LLPENR, RCC_APB1LLPENR_COMPLPEN)
+#define __HAL_RCC_COMP_CLK_SLEEP_DISABLE()       CLEAR_BIT(RCC->APB1LLPENR, RCC_APB1LLPENR_COMPLPEN)
 #endif /* COMP1 */
 
 #define __HAL_RCC_USART2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1LLPENR, RCC_APB1LLPENR_USART2LPEN)
@@ -3883,7 +4125,7 @@ typedef struct
 #endif /* UART9 */
 
 #if defined(UART12)
-#define __HAL_RCC_UART12_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APB1HLPENR, RCC_APB1HLPENR_UART12LPEN)
+#define __HAL_RCC_UART12_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1HLPENR, RCC_APB1HLPENR_UART12LPEN)
 #endif /* UART12 */
 
 #define __HAL_RCC_DTS_CLK_SLEEP_DISABLE()        CLEAR_BIT(RCC->APB1HLPENR, RCC_APB1HLPENR_DTSLPEN)
@@ -3944,8 +4186,17 @@ typedef struct
 #define __HAL_RCC_SAI2_CLK_SLEEP_ENABLE()           SET_BIT(RCC->APB2LPENR, RCC_APB2LPENR_SAI2LPEN)
 #endif /* SAI2 */
 
-#define __HAL_RCC_USB_CLK_SLEEP_ENABLE()            SET_BIT(RCC->APB2LPENR, RCC_APB2LPENR_USBLPEN)
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_CLK_SLEEP_ENABLE()           SET_BIT(RCC->APB2LPENR, RCC_APB2LPENR_LTDCLPEN)
+#endif /* LTDC */
 
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_CLK_SLEEP_ENABLE()         SET_BIT(RCC->APB2LPENR, RCC_APB2LPENR_GFXTIMLPEN)
+#endif /* GFXTIM */
+
+#if defined(USB_DRD_FS)
+#define __HAL_RCC_USB_CLK_SLEEP_ENABLE()            SET_BIT(RCC->APB2LPENR, RCC_APB2LPENR_USBLPEN)
+#endif /* USB_DRD_FS */
 
 #define __HAL_RCC_TIM1_CLK_SLEEP_DISABLE()          CLEAR_BIT(RCC->APB2LPENR, RCC_APB2LPENR_TIM1LPEN)
 
@@ -3985,7 +4236,18 @@ typedef struct
 #define __HAL_RCC_SAI2_CLK_SLEEP_DISABLE()          CLEAR_BIT(RCC->APB2LPENR, RCC_APB2LPENR_SAI2LPEN)
 #endif /* SAI2 */
 
+
+#if defined(LTDC)
+#define __HAL_RCC_LTDC_CLK_SLEEP_DISABLE()          CLEAR_BIT(RCC->APB2LPENR, RCC_APB2LPENR_LTDCLPEN)
+#endif /* LTDC */
+
+#if defined(GFXTIM)
+#define __HAL_RCC_GFXTIM_CLK_SLEEP_DISABLE()        CLEAR_BIT(RCC->APB2LPENR, RCC_APB2LPENR_GFXTMLPEN)
+#endif /* GFXTIM */
+
+#if defined(USB_DRD_FS)
 #define __HAL_RCC_USB_CLK_SLEEP_DISABLE()           CLEAR_BIT(RCC->APB2LPENR, RCC_APB2LPENR_USBLPEN)
+#endif /* USB_DRD_FS */
 
 /**
   * @}
@@ -4041,6 +4303,9 @@ typedef struct
 
 #define __HAL_RCC_RTC_CLK_SLEEP_ENABLE()            SET_BIT(RCC->APB3LPENR, RCC_APB3LPENR_RTCAPBLPEN)
 
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_CLK_SLEEP_ENABLE()          SET_BIT(RCC->APB3LPENR, RCC_APB3LPENR_PLAY1LPEN)
+#endif /* PLAY1 */
 
 #define __HAL_RCC_SBS_CLK_SLEEP_DISABLE()           CLEAR_BIT(RCC->APB3LPENR, RCC_APB3LPENR_SBSLPEN)
 
@@ -4086,6 +4351,9 @@ typedef struct
 
 #define __HAL_RCC_RTC_CLK_SLEEP_DISABLE()           CLEAR_BIT(RCC->APB3LPENR, RCC_APB3LPENR_RTCAPBLPEN)
 
+#if defined(PLAY1)
+#define __HAL_RCC_PLAY1_CLK_SLEEP_DISABLE()         CLEAR_BIT(RCC->APB3LPENR, RCC_APB3LPENR_PLAY1LPEN)
+#endif /* PLAY1 */
 /**
   * @}
   */
@@ -5048,10 +5316,16 @@ typedef struct
                             ((DIV) == RCC_MCODIV_13) || ((DIV) == RCC_MCODIV_14)  || \
                             ((DIV) == RCC_MCODIV_15))
 
-#define IS_RCC_LSE_DRIVE(__DRIVE__) (((__DRIVE__) == RCC_LSEDRIVE_LOW)        || \
-                                     ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMLOW)  || \
+#if defined(STM32H5E5xx) || defined(STM32H5E4xx) || defined(STM32H5F5xx) || defined(STM32H5F4xx)
+#define IS_RCC_LSE_DRIVE(__DRIVE__) (((__DRIVE__) == RCC_LSEDRIVE_MEDIUMLOW)  || \
                                      ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMHIGH) || \
                                      ((__DRIVE__) == RCC_LSEDRIVE_HIGH))
+#else
+#define IS_RCC_LSE_DRIVE(__DRIVE__) (((__DRIVE__) == RCC_LSEDRIVE_MEDIUMLOW)  || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_LOW)        || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMHIGH) || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_HIGH))
+#endif /* STM32H5E5xx || STM32H5E4xx || !STM32H5F5xx || STM32H5F4xx */
 
 #define IS_RCC_STOP_WAKEUPCLOCK(__SOURCE__) (((__SOURCE__) == RCC_STOP_WAKEUPCLOCK_CSI) || \
                                              ((__SOURCE__) == RCC_STOP_WAKEUPCLOCK_HSI))

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc_ex.c
@@ -114,7 +114,6 @@ static HAL_StatusTypeDef RCCEx_PLL3_Config(const RCC_PLL3InitTypeDef *Pll3);
   *            @arg @ref RCC_PERIPHCLK_I2C3    I2C3 peripheral clock (*)
   *            @arg @ref RCC_PERIPHCLK_I2C4    I2C4 peripheral clock (*)
   *            @arg @ref RCC_PERIPHCLK_I3C1    I3C1 peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_I3C2    I3C2 peripheral clock (***)
   *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock
   *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock
   *            @arg @ref RCC_PERIPHCLK_SAI1    SAI1 peripheral clock (*)
@@ -1147,14 +1146,20 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
 
     switch (pPeriphClkInit->I3c2ClockSelection)
     {
-      case RCC_I3C2CLKSOURCE_PCLK3:      /* PCLK1 is used as clock source for I3C2*/
+      case RCC_I3C2CLKSOURCE_PCLK3:      /* PCLK3 is used as clock source for I3C2*/
 
         /* I3C2 clock source config set later after clock selection check */
         break;
 
+#if defined(RCC_I3C2CLKSOURCE_PLL3R)
+      case RCC_I3C2CLKSOURCE_PLL3R:  /* PLL3 is used as clock source for I3C2*/
+        /* PLL3  input clock, parameters M, N & R configuration clock output (PLL3ClockOut) */
+        ret = RCCEx_PLL3_Config(&(pPeriphClkInit->PLL3));
+#else
       case RCC_I3C2CLKSOURCE_PLL2R:  /* PLL2 is used as clock source for I3C2*/
         /* PLL2  input clock, parameters M, N & R configuration clock output (PLL2ClockOut) */
         ret = RCCEx_PLL2_Config(&(pPeriphClkInit->PLL2));
+#endif /* RCC_I3C2CLKSOURCE_PLL3R */
         /* I3C2 clock source config set later after clock selection check */
         break;
 
@@ -1166,7 +1171,6 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
         ret = HAL_ERROR;
         break;
     }
-
     if (ret == HAL_OK)
     {
       /* Set the source of I3C2 clock*/
@@ -2367,6 +2371,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
     }
   }
 
+#if defined(USB_DRD_FS)
   /*------------------------------ USB Configuration -------------------------*/
   if (((pPeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USB) == RCC_PERIPHCLK_USB)
   {
@@ -2417,6 +2422,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
     }
 
   }
+#endif /* USB_DRD_FS */
 
 #if defined(CEC)
   /*-------------------------- CEC clock source configuration ----------------*/
@@ -2435,8 +2441,6 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
   return status;
 }
 
-
-
 /**
   * @brief  Get the pPeriphClkInit according to the internal RCC configuration registers.
   * @param  pPeriphClkInit  pointer to an RCC_PeriphCLKInitTypeDef structure that
@@ -2444,7 +2448,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(const RCC_PeriphCLKInitTypeDef  *pPe
   *         clocks (ADC12, DAC, SDMMC1, SDMMC2, OCTOSPI1, TIM, LPTIM1, LPTIM2, LPTIM3, LPTIM4, LPTIM5, LPTIM6,
   *         SPI1, SPI2, SPI3, SPI4, SPI5, SPI6, USART1, USART2, USART3, UART4, UART5, USART6, UART7, UART8,
   *         UART9, USART10, USART11, UART12, LPUART1, I2C1, I2C2, I2C3, I2C4, I3C1, I3C2, CEC, FDCAN, SAI1,
-  *         SAI2, USB,), PLL2 and PLL3.
+  *         SAI2, USB, PLAY1), PLL2 and PLL3.
   * @retval None
   */
 void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphClkInit)
@@ -2455,8 +2459,11 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphClkInit)
                                          RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_ADCDAC  | \
                                          RCC_PERIPHCLK_DAC_LP | RCC_PERIPHCLK_RTC  | RCC_PERIPHCLK_RNG | \
                                          RCC_PERIPHCLK_I3C1 | RCC_PERIPHCLK_SPI1 | RCC_PERIPHCLK_SPI2 | \
-                                         RCC_PERIPHCLK_SPI3 | RCC_PERIPHCLK_CKPER | RCC_PERIPHCLK_USB;
+                                         RCC_PERIPHCLK_SPI3 | RCC_PERIPHCLK_CKPER;
 
+#if defined(USB_DRD_FS)
+  pPeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_USB;
+#endif /* USB_DRD_FS */
 #if defined(UART4)
   pPeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_UART4;
 #endif /* UART4 */
@@ -2737,8 +2744,10 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphClkInit)
   pPeriphClkInit->CecClockSelection = __HAL_RCC_GET_CEC_SOURCE();
 #endif /* CEC */
 
+#if defined(USB_DRD_FS)
   /* Get the USB clock source ------------------------------------------------*/
   pPeriphClkInit->UsbClockSelection = __HAL_RCC_GET_USB_SOURCE();
+#endif /* USB_DRD_FS */
 
   /* Get the TIM Prescaler configuration -------------------------------------*/
   if ((RCC->CFGR1 & RCC_CFGR1_TIMPRE) == 0U)
@@ -2749,6 +2758,61 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphClkInit)
   {
     pPeriphClkInit->TimPresSelection = RCC_TIMPRES_ACTIVATED;
   }
+
+#if defined(PLAY1)
+  /* Get the PLAY1 clock source ------------------------------------------------*/
+  pPeriphClkInit->PLAY1ClockSelection = __HAL_RCC_GET_PLAY1_SOURCE();
+#endif /* PLAY1 */
+
+#if defined(USB_OTG_FS)
+  /* Get the USB_OTG_FS clock source ------------------------------------------------*/
+  pPeriphClkInit->OtgfsClockSelection = __HAL_RCC_GET_OTGFS_SOURCE();
+#endif /* USB_OTG_FS */
+
+#if defined(USB_OTG_HS)
+  /* Get the USB_OTG_HS clock source ------------------------------------------------*/
+  pPeriphClkInit->OtghsClockSelection = __HAL_RCC_GET_OTGHS_SOURCE();
+#endif /* USB_OTG_HS */
+
+#if defined(OCTOSPI2)
+  /* Get the OSPI2 clock source -----------------------------------------------*/
+  pPeriphClkInit->Ospi2ClockSelection = __HAL_RCC_GET_OSPI2_SOURCE();
+#endif /* OCTOSPI2 */
+
+#if defined(LTDC)
+  /* Get the LTDC clock source ------------------------------------------------*/
+  pPeriphClkInit->LtdcClockSelection = __HAL_RCC_GET_LTDC_SOURCE();
+#endif /* LTDC */
+
+#if defined(ADF1)
+  /* Get the ADF1 clock source ------------------------------------------------*/
+  pPeriphClkInit->Adf1ClockSelection = __HAL_RCC_GET_ADF1_SOURCE();
+#endif /* ADF1 */
+
+#if defined(MDF1)
+  /* Get the MDF1 clock source ------------------------------------------------*/
+  pPeriphClkInit->Mdf1ClockSelection = __HAL_RCC_GET_MDF1_SOURCE();
+#endif /* MDF1 */
+
+#if defined(RCC_CCIPR4_ETHCLKSEL)
+  /* Get the ETH clock source ------------------------------------------------*/
+  pPeriphClkInit->EthClockSelection = __HAL_RCC_GET_ETH_SOURCE();
+#endif /* RCC_CCIPR4_ETHCLKSEL */
+
+#if defined(RCC_CCIPR5_ETHPTPCLKSEL)
+  /* Get the ETHPTP clock source ------------------------------------------------*/
+  pPeriphClkInit->EthptpClockSelection = __HAL_RCC_GET_ETHPTP_SOURCE();
+#endif /* RCC_CCIPR5_ETHPTPCLKSEL */
+
+#if defined(RCC_CCIPR5_ETHT1SCLKSEL)
+  /* Get the ETHT1S clock source ------------------------------------------------*/
+  pPeriphClkInit->Etht1sClockSelection = __HAL_RCC_GET_ETHT1S_SOURCE();
+#endif /* RCC_CCIPR5_ETHT1SCLKSEL */
+
+#if defined(RCC_CCIPR5_ETHREFCLKSEL)
+  /* Get the ETHREF clock source ------------------------------------------------*/
+  pPeriphClkInit->EthrefClockSelection = __HAL_RCC_GET_ETHREF_SOURCE();
+#endif /* RCC_CCIPR5_ETHREFCLKSEL */
 }
 
 /**
@@ -3179,7 +3243,6 @@ void HAL_RCCEx_GetPLL3ClockFreq(PLL3_ClocksTypeDef *pPLL3_Clocks)
   *            @arg @ref RCC_PERIPHCLK_I2C3    I2C3 peripheral clock (*)
   *            @arg @ref RCC_PERIPHCLK_I2C4    I2C4 peripheral clock (*)
   *            @arg @ref RCC_PERIPHCLK_I3C1    I3C1 peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_I3C2    I3C2 peripheral clock (***)
   *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock
   *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock
   *            @arg @ref RCC_PERIPHCLK_SAI1    SAI1 peripheral clock (*)
@@ -4180,20 +4243,33 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint64_t PeriphClk)
       case RCC_PERIPHCLK_I3C2:
         /* Get the current I3C2 source */
         srcclk = __HAL_RCC_GET_I3C2_SOURCE();
-
         if (srcclk == RCC_I3C2CLKSOURCE_PCLK3)
         {
           frequency = HAL_RCC_GetPCLK3Freq();
         }
+#if defined(RCC_I3C1CLKSOURCE_PLL3R)
+        else if (srcclk ==  RCC_I3C2CLKSOURCE_PLL3R)
+        {
+          HAL_RCCEx_GetPLL3ClockFreq(&pll3_clocks);
+          frequency = pll3_clocks.PLL3_R_Frequency;
+        }
+#else
         else if (srcclk ==  RCC_I3C2CLKSOURCE_PLL2R)
         {
           HAL_RCCEx_GetPLL2ClockFreq(&pll2_clocks);
           frequency = pll2_clocks.PLL2_R_Frequency;
         }
+#endif /* RCC_I3C1CLKSOURCE_PLL3R */
         else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)) && (srcclk == RCC_I3C2CLKSOURCE_HSI))
         {
           frequency = (HSI_VALUE >> (__HAL_RCC_GET_HSI_DIVIDER() >> RCC_CR_HSIDIV_Pos));
         }
+#if defined(STM32H5E5xx) || defined(STM32H5E4xx) || defined(STM32H5F5xx) || defined(STM32H5F4xx)
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_CSIRDY)) && (srcclk ==  RCC_I3C2CLKSOURCE_CSI))
+        {
+          frequency = CSI_VALUE;
+        }
+#endif /* defined(STM32H5E5xx) || defined(STM32H5E4xx) || defined(STM32H5F5xx) || defined(STM32H5F4xx) */
         /* Clock not enabled for I3C2 */
         else
         {
@@ -5191,6 +5267,7 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint64_t PeriphClk)
         }
         break;
 
+#if defined(USB_DRD_FS)
       case RCC_PERIPHCLK_USB:
         /* Get the current USB kernel source */
         srcclk = __HAL_RCC_GET_USB_SOURCE();
@@ -5230,9 +5307,36 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint64_t PeriphClk)
       default:
         frequency = 0U;
         break;
+#endif /* USB_DRD_FS */
+
+#if defined(RCC_CCIPR4_ETHCLKSEL)
+      case RCC_PERIPHCLK_ETH:
+
+        /* Get the current ETH kernel source */
+        srcclk = __HAL_RCC_GET_ETH_SOURCE();
+        switch (srcclk)
+        {
+          case RCC_ETHCLKSOURCE_PLL1Q:
+          {
+            HAL_RCCEx_GetPLL1ClockFreq(&pll1_clocks);
+            frequency = pll1_clocks.PLL1_Q_Frequency;
+            break;
+          }
+          case RCC_ETHCLKSOURCE_HSE:
+          {
+            frequency = HSE_VALUE;
+            break;
+          }
+          default:
+          {
+            frequency = 0U;
+            break;
+          }
+        }
+        break;
+#endif /* RCC_CCIPR4_ETHCLKSEL */
     }
   }
-
   return (frequency);
 }
 
@@ -6269,5 +6373,3 @@ static HAL_StatusTypeDef RCCEx_PLL3_Config(const RCC_PLL3InitTypeDef *pll3)
 /**
   * @}
   */
-
-

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rcc_ex.h
@@ -346,12 +346,13 @@ typedef struct
                                         This parameter can be a value of @ref RCCEx_CEC_Clock_Source */
 #endif /* CEC */
 
+#if defined(USB_DRD_FS)
   uint32_t UsbClockSelection;      /*!< Specifies USB clock source.
                                         This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+#endif /* USB_DRD_FS */
 
   uint32_t TimPresSelection;       /*!< Specifies TIM Clock Prescalers Selection.
                                        This parameter can be a value of @ref RCCEx_TIM_Prescaler_Selection */
-
 } RCC_PeriphCLKInitTypeDef;
 
 #if defined(CRS)
@@ -507,7 +508,9 @@ typedef struct
 #if defined(CEC)
 #define RCC_PERIPHCLK_CEC              ((uint64_t)0x800000000U)
 #endif /* CEC */
+#if defined(USB_DRD_FS)
 #define RCC_PERIPHCLK_USB              ((uint64_t)0x1000000000U)
+#endif /* USB_DRD_FS */
 #if defined(LPTIM3)
 #define RCC_PERIPHCLK_LPTIM3           ((uint64_t)0x2000000000U)
 #endif /* LPTIM3 */
@@ -528,7 +531,6 @@ typedef struct
 #if defined(I3C2)
 #define RCC_PERIPHCLK_I3C2             ((uint64_t)0x100000000000U)
 #endif /* I3C2 */
-
 /**
   * @}
   */
@@ -892,7 +894,11 @@ typedef struct
   * @{
   */
 #define RCC_I3C2CLKSOURCE_PCLK3        ((uint32_t)0x00000000U)
+#if defined(RCC_CR_PLL3ON)
+#define RCC_I3C2CLKSOURCE_PLL3R        RCC_CCIPR4_I3C2SEL_0
+#else
 #define RCC_I3C2CLKSOURCE_PLL2R        RCC_CCIPR4_I3C2SEL_0
+#endif /* RCC_CR_PLL3ON */
 #define RCC_I3C2CLKSOURCE_HSI          RCC_CCIPR4_I3C2SEL_1
 /**
   * @}
@@ -1205,6 +1211,7 @@ typedef struct
   */
 #endif /* CEC */
 
+#if defined(USB_DRD_FS)
 /** @defgroup RCCEx_USB_Clock_Source  RCCEx USB Clock Source
   * @{
   */
@@ -1218,6 +1225,7 @@ typedef struct
 /**
   * @}
   */
+#endif /* USB_DRD_FS */
 
 /** @defgroup RCCEx_TIM_Prescaler_Selection RCCEx TIM Prescaler Selection
   * @{
@@ -2357,9 +2365,13 @@ typedef struct
   * @param  __I3C2_CLKSOURCE__ specifies the I3C2 clock source.
   *          This parameter can be one of the following values:
   *            @arg @ref RCC_I3C2CLKSOURCE_PCLK3  PCLK3 selected as I3C2 clock
+  *            @arg @ref RCC_I3C2CLKSOURCE_PLL3R  PLL3R selected as I3C2 clock (*)
   *            @arg @ref RCC_I3C2CLKSOURCE_PLL2R  PLL2R selected as I3C2 clock
   *            @arg @ref RCC_I3C2CLKSOURCE_HSI    HSI selected as I3C2 clock
+  *
   * @retval None
+  *
+  *  (*)  : Not available for all stm32h5xxxx family lines.
   */
 #define __HAL_RCC_I3C2_CONFIG(__I3C2_CLKSOURCE__) \
   MODIFY_REG(RCC->CCIPR4, RCC_CCIPR4_I3C2SEL, (uint32_t)(__I3C2_CLKSOURCE__))
@@ -2367,8 +2379,11 @@ typedef struct
 /** @brief  Macro to get the I3C2 clock source.
   * @retval The clock source can be one of the following values:
   *            @arg @ref RCC_I3C2CLKSOURCE_PCLK3  PCLK3 selected as I3C2 clock
+  *            @arg @ref RCC_I3C2CLKSOURCE_PLL3R  PLL3R selected as I3C2 clock (*)
   *            @arg @ref RCC_I3C2CLKSOURCE_PLL2R  PLL2R selected as I3C2 clock
   *            @arg @ref RCC_I3C2CLKSOURCE_HSI    HSI selected as I3C2 clock
+  *
+  *  (*)  : Not available for all stm32h5xxxx family lines.
   */
 #define __HAL_RCC_GET_I3C2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR4, RCC_CCIPR4_I3C2SEL)))
 #endif /* I3C2 */
@@ -2917,6 +2932,7 @@ typedef struct
 #define __HAL_RCC_GET_CEC_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR5, RCC_CCIPR5_CECSEL)))
 #endif /* CEC */
 
+#if defined(USB_DRD_FS)
 /** @brief  Macro to configure the USB clock (USBCLK).
   * @param  __USBCLKSource__ specifies the USB clock source.
   *         This parameter can be one of the following values:
@@ -2942,6 +2958,7 @@ typedef struct
   *  (**) : For stm32h503xx family line.
   */
 #define __HAL_RCC_GET_USB_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR4, RCC_CCIPR4_USBSEL)))
+#endif /* USB_DRD_FS */
 
 /** @brief  Macro to configure the Timers clocks prescalers
   * @param  __PRESC__  specifies the Timers clocks prescalers selection
@@ -3137,11 +3154,11 @@ typedef struct
                                          RCC_PERIPHCLK_LPTIM6 | RCC_PERIPHCLK_SAI1 | RCC_PERIPHCLK_SAI2 | \
                                          RCC_PERIPHCLK_ADCDAC | RCC_PERIPHCLK_DAC_LP | RCC_PERIPHCLK_RNG | \
                                          RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_SDMMC2 | \
-                                         RCC_PERIPHCLK_I3C1 | RCC_PERIPHCLK_SPI1 |  RCC_PERIPHCLK_SPI2 | \
+                                         RCC_PERIPHCLK_SPI1 |  RCC_PERIPHCLK_SPI2 | \
                                          RCC_PERIPHCLK_SPI3 | RCC_PERIPHCLK_SPI4 | RCC_PERIPHCLK_SPI5 | \
                                          RCC_PERIPHCLK_SPI6 | RCC_PERIPHCLK_OSPI | RCC_PERIPHCLK_FDCAN | \
                                          RCC_PERIPHCLK_CEC | RCC_PERIPHCLK_USB | RCC_PERIPHCLK_CKPER)
-#elif defined(RCC_CR_PLL3ON)
+#elif defined(UART7)
 #define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | \
                                          RCC_PERIPHCLK_UART4 | RCC_PERIPHCLK_UART5 |  RCC_PERIPHCLK_USART6 | \
                                          RCC_PERIPHCLK_UART7 | RCC_PERIPHCLK_UART8 |  RCC_PERIPHCLK_UART9 | \
@@ -3152,9 +3169,20 @@ typedef struct
                                          RCC_PERIPHCLK_LPTIM3 | RCC_PERIPHCLK_LPTIM4 | RCC_PERIPHCLK_LPTIM5 | \
                                          RCC_PERIPHCLK_LPTIM6 | RCC_PERIPHCLK_SAI1 | RCC_PERIPHCLK_SAI2 | \
                                          RCC_PERIPHCLK_ADCDAC | RCC_PERIPHCLK_DAC_LP | RCC_PERIPHCLK_RNG | \
-                                         RCC_PERIPHCLK_RTC |  RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_I3C1 | \
-                                         RCC_PERIPHCLK_SPI1 | RCC_PERIPHCLK_SPI2 | RCC_PERIPHCLK_SPI3 | \
-                                         RCC_PERIPHCLK_SPI4 | RCC_PERIPHCLK_SPI5 | RCC_PERIPHCLK_SPI6 | \
+                                         RCC_PERIPHCLK_RTC |  RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_SPI1 | \
+                                         RCC_PERIPHCLK_SPI2 | RCC_PERIPHCLK_SPI3 | RCC_PERIPHCLK_SPI4 | \
+                                         RCC_PERIPHCLK_SPI5 | RCC_PERIPHCLK_SPI6 | RCC_PERIPHCLK_OSPI | \
+                                         RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_CEC | RCC_PERIPHCLK_USB | \
+                                         RCC_PERIPHCLK_CKPER)
+#elif defined(USART6)
+#define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | \
+                                         RCC_PERIPHCLK_UART4 | RCC_PERIPHCLK_UART5 |  RCC_PERIPHCLK_USART6 | \
+                                         RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1 |  RCC_PERIPHCLK_I2C2 | \
+                                         RCC_PERIPHCLK_I2C3 | RCC_PERIPHCLK_I3C1 | RCC_PERIPHCLK_I3C2 | \
+                                         RCC_PERIPHCLK_TIM | RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM2 | \
+                                         RCC_PERIPHCLK_ADCDAC | RCC_PERIPHCLK_DAC_LP | RCC_PERIPHCLK_RNG | \
+                                         RCC_PERIPHCLK_RTC |  RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_SPI1 | \
+                                         RCC_PERIPHCLK_SPI2 | RCC_PERIPHCLK_SPI3 | RCC_PERIPHCLK_SPI4 | \
                                          RCC_PERIPHCLK_OSPI | RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_CEC | \
                                          RCC_PERIPHCLK_USB | RCC_PERIPHCLK_CKPER)
 #else
@@ -3163,9 +3191,8 @@ typedef struct
                                          RCC_PERIPHCLK_I3C1 | RCC_PERIPHCLK_I3C2 | RCC_PERIPHCLK_TIM | \
                                          RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_ADCDAC | \
                                          RCC_PERIPHCLK_DAC_LP | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_RTC | \
-                                         RCC_PERIPHCLK_I3C1 | RCC_PERIPHCLK_SPI1 | RCC_PERIPHCLK_SPI2 | \
-                                         RCC_PERIPHCLK_SPI3 |  RCC_PERIPHCLK_FDCAN |  RCC_PERIPHCLK_USB | \
-                                         RCC_PERIPHCLK_CKPER)
+                                         RCC_PERIPHCLK_SPI1 | RCC_PERIPHCLK_SPI2 | RCC_PERIPHCLK_SPI3 | \
+                                         RCC_PERIPHCLK_FDCAN |  RCC_PERIPHCLK_USB | RCC_PERIPHCLK_CKPER)
 #endif /*FDCAN2 && SDMMC2 */
 /**
   * @}
@@ -3448,10 +3475,17 @@ typedef struct
 #endif /* RCC_CR_PLL3ON */
 
 #if defined(I3C2)
+#if defined(RCC_CR_PLL3ON)
 #define IS_RCC_I3C2CLKSOURCE(__SOURCE__)   \
   (((__SOURCE__) == RCC_I3C2CLKSOURCE_PCLK3) || \
-   ((__SOURCE__) == RCC_I3C2CLKSOURCE_PLL2R)  || \
+   ((__SOURCE__) == RCC_I3C2CLKSOURCE_PLL3R) || \
    ((__SOURCE__) == RCC_I3C2CLKSOURCE_HSI))
+#else
+#define IS_RCC_I3C2CLKSOURCE(__SOURCE__)   \
+  (((__SOURCE__) == RCC_I3C2CLKSOURCE_PCLK3) || \
+   ((__SOURCE__) == RCC_I3C2CLKSOURCE_PLL2R) || \
+   ((__SOURCE__) == RCC_I3C2CLKSOURCE_HSI))
+#endif /* PLL3 */
 #endif /* I3C2 */
 
 #if defined(SAI1)
@@ -3664,6 +3698,7 @@ typedef struct
    ((__SOURCE__) == RCC_SPI6CLKSOURCE_HSE))
 #endif /* SPI6 */
 
+#if defined(USB_DRD_FS)
 #if defined(RCC_CR_PLL3ON)
 #define IS_RCC_USBCLKSOURCE(__SOURCE__) \
   (((__SOURCE__) == RCC_USBCLKSOURCE_PLL1Q) || \
@@ -3675,6 +3710,7 @@ typedef struct
    ((__SOURCE__) == RCC_USBCLKSOURCE_PLL2Q) || \
    ((__SOURCE__) == RCC_USBCLKSOURCE_HSI48))
 #endif /* RCC_CR_PLL3ON */
+#endif /* USB_DRD_FS */
 
 #if defined(CEC)
 #define IS_RCC_CECCLKSOURCE(__SOURCE__) \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng.c
@@ -199,6 +199,17 @@ HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
 
   /* Clock Error Detection Configuration when CONDRT bit is set to 1 */
   MODIFY_REG(hrng->Instance->CR, RNG_CR_CED | RNG_CR_CONDRST, hrng->Init.ClockErrorDetection | RNG_CR_CONDRST);
+#if defined(RNG_CR_NIST_VALUE)
+  /* Recommended value for NIST compliance, refer to application note AN4230 */
+  WRITE_REG(hrng->Instance->CR, RNG_CR_NIST_VALUE);
+#endif /* defined(RNG_CR_NIST_VALUE) */
+#if defined(RNG_HTCR_NIST_VALUE)
+  /* Recommended value for NIST compliance, refer to application note AN4230 */
+  WRITE_REG(hrng->Instance->HTCR, RNG_HTCR_NIST_VALUE);
+#endif /* defined(RNG_HTCR_NIST_VALUE) */
+#if defined(RNG_NSCR_NIST_VALUE)
+  WRITE_REG(hrng->Instance->NSCR, RNG_NSCR_NIST_VALUE);
+#endif /* defined(RNG_NSCR_NIST_VALUE) */
 
   /* Writing bit CONDRST=0 */
   CLEAR_BIT(hrng->Instance->CR, RNG_CR_CONDRST);
@@ -233,12 +244,12 @@ HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
   /* Get tick */
   tickstart = HAL_GetTick();
   /* Check if data register contains valid random data */
-  while (__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_SECS) != RESET)
+  while (__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) != SET)
   {
     if ((HAL_GetTick() - tickstart) > RNG_TIMEOUT_VALUE)
     {
       /* New check to avoid false timeout detection in case of preemption */
-      if (__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_SECS) != RESET)
+      if (__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) != SET)
       {
         hrng->State = HAL_RNG_STATE_ERROR;
         hrng->ErrorCode = HAL_RNG_ERROR_TIMEOUT;
@@ -674,8 +685,6 @@ HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t
       /* Update the error code and status */
       hrng->ErrorCode = HAL_RNG_ERROR_SEED;
       status = HAL_ERROR;
-      /* Clear bit DRDY */
-      CLEAR_BIT(hrng->Instance->SR, RNG_FLAG_DRDY);
     }
     else /* No seed error */
     {

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng_ex.c
@@ -30,7 +30,7 @@
 
 #if defined(RNG)
 
-/** @addtogroup RNG_Ex
+/** @addtogroup RNGEx
   * @brief RNG Extended HAL module driver.
   * @{
   */
@@ -41,7 +41,7 @@
 /* Private defines -----------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
-/** @addtogroup RNG_Ex_Private_Constants
+/** @addtogroup RNGEx_Private_Constants
   * @{
   */
 #define RNG_TIMEOUT_VALUE     2U
@@ -53,11 +53,11 @@
 /* Private functions  --------------------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
-/** @defgroup RNG_Ex_Exported_Functions RNG_Ex Exported Functions
+/** @defgroup RNGEx_Exported_Functions RNGEx Exported Functions
   * @{
   */
 
-/** @defgroup RNG_Ex_Exported_Functions_Group1 Configuration and lock functions
+/** @defgroup RNGEx_Exported_Functions_Group1 Configuration and lock functions
   *  @brief   Configuration functions
   *
 @verbatim
@@ -269,7 +269,7 @@ HAL_StatusTypeDef HAL_RNGEx_LockConfig(RNG_HandleTypeDef *hrng)
   * @}
   */
 
-/** @defgroup RNG_Ex_Exported_Functions_Group2 Recover from seed error function
+/** @defgroup RNGEx_Exported_Functions_Group2 Recover from seed error function
   *  @brief   Recover from seed error function
   *
 @verbatim

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rng_ex.h
@@ -34,19 +34,19 @@ extern "C" {
 #if defined(RNG)
 #if defined(RNG_CR_CONDRST)
 
-/** @defgroup RNG_Ex RNG_Ex
+/** @defgroup RNGEx RNGEx
   * @brief RNG Extension HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
-/** @defgroup RNG_Ex_Exported_Types RNG_Ex Exported Types
-  * @brief RNG_Ex Exported types
+/** @defgroup RNGEx_Exported_Types RNGEx Exported Types
+  * @brief RNGEx Exported types
   * @{
   */
 
 /**
-  * @brief RNG_Ex Configuration Structure definition
+  * @brief RNGEx Configuration Structure definition
   */
 
 typedef struct
@@ -55,11 +55,11 @@ typedef struct
   uint32_t        Config2;           /*!< Config2 must be a value between 0 and 0x7 */
   uint32_t        Config3;           /*!< Config3 must be a value between 0 and 0xF */
   uint32_t        ClockDivider;      /*!< Clock Divider factor.This parameter can
-                                          be a value of @ref RNG_Ex_Clock_Divider_Factor   */
+                                          be a value of @ref RNGEx_Clock_Divider_Factor   */
   uint32_t        NistCompliance;    /*!< NIST compliance.This parameter can be a
-                                          value of @ref RNG_Ex_NIST_Compliance   */
+                                          value of @ref RNGEx_NIST_Compliance   */
   uint32_t        AutoReset;         /*!< automatic reset When a noise source error occurs
-                                          value of @ref RNG_Ex_Auto_Reset   */
+                                          value of @ref RNGEx_Auto_Reset   */
   uint32_t        HealthTest;           /*!< RNG health test control must be a value
                                              between 0x0FFCABFF and 0x00005200 */
 } RNG_ConfigTypeDef;
@@ -69,11 +69,11 @@ typedef struct
   */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup RNG_Ex_Exported_Constants RNG_Ex Exported Constants
+/** @defgroup RNGEx_Exported_Constants RNGEx Exported Constants
   * @{
   */
 
-/** @defgroup RNG_Ex_Clock_Divider_Factor  Value used to configure an internal
+/** @defgroup RNGEx_Clock_Divider_Factor  Value used to configure an internal
   *            programmable divider acting on the incoming RNG clock
   * @{
   */
@@ -112,7 +112,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RNG_Ex_NIST_Compliance  NIST Compliance configuration
+/** @defgroup RNGEx_NIST_Compliance  NIST Compliance configuration
   * @{
   */
 #define RNG_NIST_COMPLIANT     (0x00000000UL) /*!< NIST compliant configuration*/
@@ -121,7 +121,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup RNG_Ex_Auto_Reset  Auto Reset configuration
+/** @defgroup RNGEx_Auto_Reset  Auto Reset configuration
   * @{
   */
 #define RNG_ARDIS_ENABLE     (0x00000000UL) /*!< automatic reset after seed error*/
@@ -136,7 +136,7 @@ typedef struct
   */
 
 /* Private types -------------------------------------------------------------*/
-/** @defgroup RNG_Ex_Private_Types RNG_Ex Private Types
+/** @defgroup RNGEx_Private_Types RNGEx Private Types
   * @{
   */
 
@@ -145,7 +145,7 @@ typedef struct
   */
 
 /* Private variables ---------------------------------------------------------*/
-/** @defgroup RNG_Ex_Private_Variables RNG_Ex Private Variables
+/** @defgroup RNGEx_Private_Variables RNGEx Private Variables
   * @{
   */
 
@@ -154,7 +154,7 @@ typedef struct
   */
 
 /* Private constants ---------------------------------------------------------*/
-/** @defgroup RNG_Ex_Private_Constants RNG_Ex Private Constants
+/** @defgroup RNGEx_Private_Constants RNGEx Private Constants
   * @{
   */
 
@@ -163,7 +163,7 @@ typedef struct
   */
 
 /* Private macros ------------------------------------------------------------*/
-/** @defgroup RNG_Ex_Private_Macros RNG_Ex Private Macros
+/** @defgroup RNGEx_Private_Macros RNGEx Private Macros
   * @{
   */
 
@@ -202,7 +202,7 @@ typedef struct
   */
 
 /* Private functions ---------------------------------------------------------*/
-/** @defgroup RNG_Ex_Private_Functions RNG_Ex Private Functions
+/** @defgroup RNGEx_Private_Functions RNGEx Private Functions
   * @{
   */
 
@@ -211,11 +211,11 @@ typedef struct
   */
 
 /* Exported functions --------------------------------------------------------*/
-/** @addtogroup RNG_Ex_Exported_Functions
+/** @addtogroup RNGEx_Exported_Functions
   * @{
   */
 
-/** @addtogroup RNG_Ex_Exported_Functions_Group1
+/** @addtogroup RNGEx_Exported_Functions_Group1
   * @{
   */
 HAL_StatusTypeDef HAL_RNGEx_SetConfig(RNG_HandleTypeDef *hrng, const RNG_ConfigTypeDef *pConf);
@@ -226,7 +226,7 @@ HAL_StatusTypeDef HAL_RNGEx_LockConfig(RNG_HandleTypeDef *hrng);
   * @}
   */
 
-/** @addtogroup RNG_Ex_Exported_Functions_Group2
+/** @addtogroup RNGEx_Exported_Functions_Group2
   * @{
   */
 HAL_StatusTypeDef HAL_RNGEx_RecoverSeedError(RNG_HandleTypeDef *hrng);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc.c
@@ -1349,14 +1349,8 @@ void HAL_RTC_DST_SetStoreOperation(const RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Set RTC_CR_BKP Bit */
   SET_BIT(RTC->CR, RTC_CR_BKP);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 }
 
 /**
@@ -1369,14 +1363,8 @@ void HAL_RTC_DST_ClearStoreOperation(const RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Clear RTC_CR_BKP Bit */
   CLEAR_BIT(RTC->CR, RTC_CR_BKP);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 }
 
 /**
@@ -1539,9 +1527,6 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     }
   }
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Configure the Alarm register */
   if (sAlarm->Alarm == RTC_ALARM_A)
   {
@@ -1615,9 +1600,6 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     /* Configure the Alarm state: Enable Alarm */
     SET_BIT(RTC->CR, RTC_CR_ALRBE);
   }
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1758,9 +1740,6 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     }
   }
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Configure the Alarm registers */
   if (sAlarm->Alarm == RTC_ALARM_A)
   {
@@ -1833,9 +1812,6 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     SET_BIT(RTC->CR, RTC_CR_ALRBE | RTC_CR_ALRBIE);
   }
 
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
 
@@ -1865,9 +1841,6 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* In case of interrupt mode is used, the interrupt source must disabled */
   if (Alarm == RTC_ALARM_A)
   {
@@ -1883,9 +1856,6 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
     /* AlarmB, Clear SSCLR */
     CLEAR_BIT(RTC->ALRMBSSR, RTC_ALRMBSSR_SSCLR);
   }
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc.h
@@ -503,35 +503,22 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   * @}
   */
 
-/** @defgroup RTC_Flag_Mask    RTC Flag Mask (5bits) for __HAL_RTC_GET_FLAG()
+/** @defgroup RTC_Flags_Definitions RTC Flag Mask (5bits) for __HAL_RTC_GET_FLAG()
   * @{
   */
-#define RTC_FLAG_MASK                       0x001FU            /*!< RTC flags mask (5bits) */
-/**
-  * @}
-  */
-
-/** @defgroup RTC_Flags_Definitions RTC Flags Definitions
-  *        Elements values convention: 000000XX000YYYYYb
-  *           - YYYYY  : Interrupt flag position in the XX register (5bits)
-  *           - XX  : Interrupt status register (2bits)
-  *                 - 01: ICSR register
-  *                 - 10: SR or SCR or MISR or SMISR registers
-  * @{
-  */
-#define RTC_FLAG_RECALPF                    (0x00000100U | RTC_ICSR_RECALPF_Pos) /*!< Recalibration pending flag     */
-#define RTC_FLAG_INITF                      (0x00000100U | RTC_ICSR_INITF_Pos)   /*!< Initialization flag            */
-#define RTC_FLAG_RSF                        (0x00000100U | RTC_ICSR_RSF_Pos)     /*!< Registers synchronization flag */
-#define RTC_FLAG_INITS                      (0x00000100U | RTC_ICSR_INITS_Pos)   /*!< Initialization status flag     */
-#define RTC_FLAG_SHPF                       (0x00000100U | RTC_ICSR_SHPF_Pos)    /*!< Shift operation pending flag   */
-#define RTC_FLAG_WUTWF                      (0x00000100U | RTC_ICSR_WUTWF_Pos)   /*!< Wakeup timer write flag        */
-#define RTC_FLAG_SSRUF                      (0x00000200U | RTC_SR_SSRUF_Pos)     /*!< Clear SSR underflow flag       */
-#define RTC_FLAG_ITSF                       (0x00000200U | RTC_SR_ITSF_Pos)      /*!< Clear Internal Time-stamp flag */
-#define RTC_FLAG_TSOVF                      (0x00000200U | RTC_SR_TSOVF_Pos)     /*!< Clear Time-stamp overflow flag */
-#define RTC_FLAG_TSF                        (0x00000200U | RTC_SR_TSF_Pos)       /*!< Clear Time-stamp flag          */
-#define RTC_FLAG_WUTF                       (0x00000200U | RTC_SR_WUTF_Pos)      /*!< Clear Wakeup timer flag        */
-#define RTC_FLAG_ALRBF                      (0x00000200U | RTC_SR_ALRBF_Pos)     /*!< Clear Alarm B flag             */
-#define RTC_FLAG_ALRAF                      (0x00000200U | RTC_SR_ALRAF_Pos)     /*!< Clear Alarm A flag             */
+#define RTC_FLAG_RECALPF                    (1U)               /*!< Recalibration pending flag     */
+#define RTC_FLAG_INITF                      (2U)               /*!< Initialization flag            */
+#define RTC_FLAG_RSF                        (3U)               /*!< Registers synchronization flag */
+#define RTC_FLAG_INITS                      (4U)               /*!< Initialization status flag     */
+#define RTC_FLAG_SHPF                       (5U)               /*!< Shift operation pending flag   */
+#define RTC_FLAG_WUTWF                      (6U)               /*!< Wakeup timer write flag        */
+#define RTC_FLAG_SSRUF                      (7U)               /*!< Clear SSR underflow flag       */
+#define RTC_FLAG_ITSF                       (8U)               /*!< Clear Internal Time-stamp flag */
+#define RTC_FLAG_TSOVF                      (9U)               /*!< Clear Time-stamp overflow flag */
+#define RTC_FLAG_TSF                        (10U)              /*!< Clear Time-stamp flag          */
+#define RTC_FLAG_WUTF                       (11U)              /*!< Clear Wakeup timer flag        */
+#define RTC_FLAG_ALRBF                      (12U)              /*!< Clear Alarm B flag             */
+#define RTC_FLAG_ALRAF                      (13U)              /*!< Clear Alarm A flag             */
 /**
   * @}
   */
@@ -669,7 +656,12 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *             @arg @ref RTC_IT_ALRB Alarm B interrupt
   * @retval None
   */
-#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (RTC->CR |= (__INTERRUPT__))
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)( \
+                                                              ((__INTERRUPT__) == RTC_IT_ALRA) ?\
+                                                              (SET_BIT(RTC->CR, RTC_CR_ALRAIE)):\
+                                                              ((__INTERRUPT__) == RTC_IT_ALRB) ?\
+                                                              (SET_BIT(RTC->CR, RTC_CR_ALRBIE)):\
+                                                              (0U)) /*!< Dummy action because is an invalid parameter value */
 
 /**
   * @brief  Disable the RTC Alarm interrupt.
@@ -680,7 +672,12 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *            @arg @ref RTC_IT_ALRB Alarm B interrupt
   * @retval None
   */
-#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__) (RTC->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)( \
+                                                               ((__INTERRUPT__) == RTC_IT_ALRA) ?\
+                                                               (CLEAR_BIT(RTC->CR, RTC_CR_ALRAIE)):\
+                                                               ((__INTERRUPT__) == RTC_IT_ALRB) ?\
+                                                               (CLEAR_BIT(RTC->CR, RTC_CR_ALRBIE)):\
+                                                               (0U)) /*!< Dummy action because is an invalid parameter value */
 
 /**
   * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
@@ -689,10 +686,14 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *         This parameter can be:
   *            @arg @ref RTC_IT_ALRA Alarm A interrupt
   *            @arg @ref RTC_IT_ALRB Alarm B interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__) ((((RTC->MISR)& ((__INTERRUPT__)>> 12U)) != 0U) \
-                                                           ? 1UL : 0UL)
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)( \
+                                                           ((__INTERRUPT__) == RTC_IT_ALRA) ?\
+                                                           (READ_BIT(RTC->MISR, RTC_MISR_ALRAMF) == RTC_MISR_ALRAMF):\
+                                                           ((__INTERRUPT__) == RTC_IT_ALRB) ?\
+                                                           (READ_BIT(RTC->MISR, RTC_MISR_ALRBMF) == RTC_MISR_ALRBMF):\
+                                                           (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /**
   * @brief  Check whether the specified RTC Alarm interrupt has been enabled or not.
@@ -701,10 +702,14 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *         This parameter can be:
   *            @arg @ref RTC_IT_ALRA Alarm A interrupt
   *            @arg @ref RTC_IT_ALRB Alarm B interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     ((((RTC->CR) & (__INTERRUPT__)) != 0U) \
-                                                                      ? 1UL : 0UL)
+#define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)( \
+                                                                  ((__INTERRUPT__) == RTC_IT_ALRA) ?\
+                                                                  (READ_BIT(RTC->CR, RTC_CR_ALRAIE) == RTC_CR_ALRAIE):\
+                                                                  ((__INTERRUPT__) == RTC_IT_ALRB) ?\
+                                                                  (READ_BIT(RTC->CR, RTC_CR_ALRBIE) == RTC_CR_ALRBIE):\
+                                                                  (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /**
   * @brief  Get the selected RTC Alarms flag status.
@@ -713,9 +718,14 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *         This parameter can be:
   *            @arg @ref RTC_FLAG_ALRAF
   *            @arg @ref RTC_FLAG_ALRBF
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)   (__HAL_RTC_GET_FLAG((__HANDLE__), (__FLAG__)))
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)( \
+                                                        ((__FLAG__) == RTC_FLAG_ALRAF) ?\
+                                                        (READ_BIT(RTC->SR, RTC_SR_ALRAF) == RTC_SR_ALRAF):\
+                                                        ((__FLAG__) == RTC_FLAG_ALRBF) ?\
+                                                        (READ_BIT(RTC->SR, RTC_SR_ALRBF) == RTC_SR_ALRBF):\
+                                                        (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /**
   * @brief  Clear the RTC Alarms pending flags.
@@ -726,16 +736,19 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to
   *             @arg @ref RTC_FLAG_ALRBF
   * @retval None
   */
-#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)   (((__FLAG__) == RTC_FLAG_ALRAF) \
-                                                            ? ((RTC->SCR = (RTC_CLEAR_ALRAF))) :\
-                                                            (RTC->SCR = (RTC_CLEAR_ALRBF)))
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)( \
+                                                          ((__FLAG__) == RTC_FLAG_ALRAF) ?\
+                                                          (SET_BIT(RTC->SCR, RTC_SCR_CALRAF)):\
+                                                          ((__FLAG__) == RTC_FLAG_ALRBF) ?\
+                                                          (SET_BIT(RTC->SCR, RTC_SCR_CALRBF)):\
+                                                          (0U)) /*!< Dummy action because is an invalid parameter value */
 
 /**
   * @brief  Check whether if the RTC Calendar is initialized.
   * @param  __HANDLE__ specifies the RTC handle.
-  * @retval None
+  * @retval The state of RTC Calendar initialization (TRUE or FALSE).
   */
-#define __HAL_RTC_IS_CALENDAR_INITIALIZED(__HANDLE__)  ((((RTC->ICSR) & (RTC_ICSR_INITS)) == RTC_ICSR_INITS) ? 1U : 0U)
+#define __HAL_RTC_IS_CALENDAR_INITIALIZED(__HANDLE__)  ((((RTC->ICSR) & (RTC_ICSR_INITS)) == RTC_ICSR_INITS))
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc_ex.c
@@ -247,9 +247,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeS
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Get the RTC_CR register and clear the bits to be configured */
 #if defined(RTC_CR_TSEDGE)
   CLEAR_BIT(RTC->CR, (RTC_CR_TSEDGE | RTC_CR_TSE));
@@ -259,9 +256,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeS
 
   /* Configure the Time Stamp TSEDGE and Enable bits */
   SET_BIT(RTC->CR, (uint32_t)TimeStampEdge | RTC_CR_TSE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -306,9 +300,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t Ti
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Get the RTC_CR register and clear the bits to be configured */
 #if defined(RTC_CR_TSEDGE)
   CLEAR_BIT(RTC->CR, (RTC_CR_TSEDGE | RTC_CR_TSE | RTC_CR_TSIE));
@@ -321,9 +312,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t Ti
 
   /* Enable timestamp and IT */
   SET_BIT(RTC->CR, RTC_CR_TSE | RTC_CR_TSIE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -347,18 +335,12 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* In case of interrupt mode is used, the interrupt source must disabled */
 #if defined(RTC_CR_TSEDGE)
   CLEAR_BIT(RTC->CR, (RTC_CR_TSEDGE | RTC_CR_TSE | RTC_CR_TSIE));
 #else
   CLEAR_BIT(RTC->CR, (RTC_CR_TSE | RTC_CR_TSIE));
 #endif /* RTC_CR_TSEDGE */
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -384,14 +366,8 @@ HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Configure the internal Time Stamp Enable bits */
   SET_BIT(RTC->CR, RTC_CR_ITSE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -415,14 +391,8 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Configure the internal Time Stamp Enable bits */
   CLEAR_BIT(RTC->CR, RTC_CR_ITSE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   hrtc->State = HAL_RTC_STATE_READY;
 
@@ -619,9 +589,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t Wak
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Clear WUTE in RTC_CR to disable the wakeup timer */
   CLEAR_BIT(RTC->CR, RTC_CR_WUTE);
 
@@ -639,9 +606,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t Wak
         /* New check to avoid false timeout detection in case of preemption */
         if (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == 0U)
         {
-          /* Enable the write protection for RTC registers */
-          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
           /* Change RTC state */
           hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
@@ -666,9 +630,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t Wak
 
   /* Enable the Wakeup Timer */
   SET_BIT(RTC->CR, RTC_CR_WUTE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -708,9 +669,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Clear WUTE in RTC_CR to disable the wakeup timer */
   CLEAR_BIT(RTC->CR, RTC_CR_WUTE);
 
@@ -730,9 +688,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
         /* New check to avoid false timeout detection in case of preemption */
         if (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == 0U)
         {
-          /* Enable the write protection for RTC registers */
-          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
           /* Change RTC state */
           hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
@@ -758,9 +713,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
   /* Configure the Interrupt in the RTC_CR register and Enable the Wakeup Timer*/
   SET_BIT(RTC->CR, (RTC_CR_WUTIE | RTC_CR_WUTE));
 
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
 
@@ -777,51 +729,15 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
   */
 HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tickstart;
-
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Disable the Wakeup Timer */
   /* In case of interrupt mode is used, the interrupt source must disabled */
   CLEAR_BIT(RTC->CR, (RTC_CR_WUTE | RTC_CR_WUTIE));
-
-  tickstart = HAL_GetTick();
-
-  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
-  while (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == 0U)
-  {
-    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
-    {
-      /* New check to avoid false timeout detection in case of preemption */
-      if (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == 0U)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        /* Change RTC state */
-        hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrtc);
-
-        return HAL_TIMEOUT;
-      }
-      else
-      {
-        break;
-      }
-    }
-  }
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -993,9 +909,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t Smo
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   tickstart = HAL_GetTick();
 
   /* check if a calibration is pending */
@@ -1006,8 +919,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t Smo
       /* New check to avoid false timeout detection in case of preemption */
       if (READ_BIT(RTC->ICSR, RTC_ICSR_RECALPF) != 0U)
       {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
         /* Change RTC state */
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
@@ -1023,6 +934,9 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t Smo
       }
     }
   }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
   /* Configure the Smooth calibration settings */
   MODIFY_REG(RTC->CALR, (RTC_CALR_CALP | RTC_CALR_CALW8 | RTC_CALR_CALW16 | RTC_CALR_CALM),
@@ -1104,9 +1018,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t Sh
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   tickstart = HAL_GetTick();
 
   /* Wait until the shift is completed */
@@ -1117,9 +1028,6 @@ HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t Sh
       /* New check to avoid false timeout detection in case of preemption */
       if (READ_BIT(RTC->ICSR, RTC_ICSR_SHPF) != 0U)
       {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
         /* Change RTC state */
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
@@ -1134,6 +1042,9 @@ HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t Sh
       }
     }
   }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
 #if defined(RTC_CR_REFCKON)
   /* Check if the reference clock detection is disabled */
@@ -1210,17 +1121,11 @@ HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Configure the RTC_CR register */
   MODIFY_REG(RTC->CR, RTC_CR_COSEL, CalibOutput);
 
   /* Enable calibration output */
   SET_BIT(RTC->CR, RTC_CR_COE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1244,14 +1149,8 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Disable calibration output */
   CLEAR_BIT(RTC->CR, RTC_CR_COE);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1368,14 +1267,8 @@ HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Set the BYPSHAD bit */
   SET_BIT(RTC->CR, RTC_CR_BYPSHAD);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1401,14 +1294,8 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Reset the BYPSHAD bit */
   CLEAR_BIT(RTC->CR, RTC_CR_BYPSHAD);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1476,14 +1363,8 @@ HAL_StatusTypeDef HAL_RTCEx_SetSSRU_IT(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* Enable IT SSRU */
   __HAL_RTC_SSRU_ENABLE_IT(hrtc, RTC_IT_SSRU);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1507,14 +1388,8 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateSSRU(RTC_HandleTypeDef *hrtc)
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
   /* In case of interrupt mode is used, the interrupt source must disabled */
   __HAL_RTC_SSRU_DISABLE_IT(hrtc, RTC_IT_SSRU);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1740,13 +1615,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper(const RTC_HandleTypeDef *hrtc, const RTC_T
   /* Timestamp on tamper */
   if (READ_BIT(RTC->CR, RTC_CR_TAMPTS) != sTamper->TimeStampOnTamperDetection)
   {
-    /* Disable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
     MODIFY_REG(RTC->CR, RTC_CR_TAMPTS, sTamper->TimeStampOnTamperDetection);
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
   }
 
   /* Control register 1 */
@@ -1812,13 +1681,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(const RTC_HandleTypeDef *hrtc, const RT
   /* Timestamp on tamper */
   if (READ_BIT(RTC->CR, RTC_CR_TAMPTS) != sTamper->TimeStampOnTamperDetection)
   {
-    /* Disable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
     MODIFY_REG(RTC->CR, RTC_CR_TAMPTS, sTamper->TimeStampOnTamperDetection);
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
   }
 
   /* Interrupt enable register */
@@ -1913,13 +1776,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetActiveTampers(RTC_HandleTypeDef *hrtc, const RTC_
   tmp_cr = READ_REG(RTC->CR);
   if ((tmp_cr & RTC_CR_TAMPTS) != (sAllTamper->TimeStampOnTamperDetection))
   {
-    /* Disable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
     MODIFY_REG(RTC->CR, RTC_CR_TAMPTS, sAllTamper->TimeStampOnTamperDetection);
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
   }
 
   tmp_cr1 = READ_REG(TAMP->CR1);
@@ -2179,13 +2036,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetInternalTamper(const RTC_HandleTypeDef *hrtc,
   /* Timestamp enable on internal tamper */
   if (READ_BIT(RTC->CR, RTC_CR_TAMPTS) != sIntTamper->TimeStampOnTamperDetection)
   {
-    /* Disable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
     MODIFY_REG(RTC->CR, RTC_CR_TAMPTS, sIntTamper->TimeStampOnTamperDetection);
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
   }
 
   /* No Erase Backup register enable for Internal Tamper */
@@ -2226,13 +2077,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetInternalTamper_IT(const RTC_HandleTypeDef *hrtc,
   /* Timestamp enable on internal tamper */
   if (READ_BIT(RTC->CR, RTC_CR_TAMPTS) != sIntTamper->TimeStampOnTamperDetection)
   {
-    /* Disable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
     MODIFY_REG(RTC->CR, RTC_CR_TAMPTS, sIntTamper->TimeStampOnTamperDetection);
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
   }
 
   /* Interrupt enable register */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_rtc_ex.h
@@ -942,11 +942,49 @@ typedef struct
   *            @arg @ref RTC_FLAG_WUTF                Wakeup timer flag
   *            @arg @ref RTC_FLAG_ALRBF               Alarm B flag
   *            @arg @ref RTC_FLAG_ALRAF               Alarm A flag
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_RTC_GET_FLAG(__HANDLE__, __FLAG__)    (((((__FLAG__)) >> 8U) == 1U) ? \
-                                                     (RTC->ICSR & (1U << (((uint16_t)(__FLAG__)) & RTC_FLAG_MASK))) : \
-                                                     (RTC->SR & (1U << (((uint16_t)(__FLAG__)) & RTC_FLAG_MASK))))
+#define __HAL_RTC_GET_FLAG(__HANDLE__, __FLAG__)( \
+                                                  ((__FLAG__) == RTC_FLAG_RECALPF) ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_RECALPF) == \
+                                                   RTC_ICSR_RECALPF) : \
+                                                  ((__FLAG__) == RTC_FLAG_INITF)   ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_INITF) == \
+                                                   RTC_ICSR_INITF) : \
+                                                  ((__FLAG__) == RTC_FLAG_RSF)     ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_RSF) == \
+                                                   RTC_ICSR_RSF) : \
+                                                  ((__FLAG__) == RTC_FLAG_INITS)   ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_INITS) == \
+                                                   RTC_ICSR_INITS) : \
+                                                  ((__FLAG__) == RTC_FLAG_SHPF)    ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_SHPF) == \
+                                                   RTC_ICSR_SHPF) : \
+                                                  ((__FLAG__) == RTC_FLAG_WUTWF)   ? \
+                                                  (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == \
+                                                   RTC_ICSR_WUTWF) : \
+                                                  ((__FLAG__) == RTC_FLAG_SSRUF)   ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_SSRUF) == \
+                                                   RTC_SR_SSRUF) : \
+                                                  ((__FLAG__) == RTC_FLAG_ITSF)    ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_ITSF) == \
+                                                   RTC_SR_ITSF) : \
+                                                  ((__FLAG__) == RTC_FLAG_TSOVF)   ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_TSOVF) == \
+                                                   RTC_SR_TSOVF) : \
+                                                  ((__FLAG__) == RTC_FLAG_TSF)     ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_TSF) == \
+                                                   RTC_SR_TSF): \
+                                                  ((__FLAG__) == RTC_FLAG_WUTF)    ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_WUTF) == \
+                                                   RTC_SR_WUTF): \
+                                                  ((__FLAG__) == RTC_FLAG_ALRBF)   ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_ALRBF) == \
+                                                   RTC_SR_ALRBF) : \
+                                                  ((__FLAG__) == RTC_FLAG_ALRAF)   ? \
+                                                  (READ_BIT(RTC->SR, RTC_SR_ALRAF) == \
+                                                   RTC_SR_ALRAF) : \
+                                                  (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /* ---------------------------------WAKEUPTIMER---------------------------------*/
 /** @defgroup RTCEx_WakeUp_Timer RTC WakeUp Timer
@@ -975,7 +1013,7 @@ typedef struct
   *            @arg @ref RTC_IT_WUT WakeUpTimer interrupt
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR |= (__INTERRUPT__))
+#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR |= (RTC_CR_WUTIE))
 
 /**
   * @brief  Disable the RTC WakeUpTimer interrupt.
@@ -985,7 +1023,7 @@ typedef struct
   *            @arg @ref RTC_IT_WUT WakeUpTimer interrupt
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   (RTC->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   (RTC->CR &= ~(RTC_CR_WUTIE))
 
 /**
   * @brief  Check whether the specified RTC WakeUpTimer interrupt has occurred or not.
@@ -993,10 +1031,9 @@ typedef struct
   * @param  __INTERRUPT__ specifies the RTC WakeUpTimer interrupt to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_WUT  WakeUpTimer interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)       ((((RTC->MISR) & ((__INTERRUPT__)>> 12U)) !=\
-                                                                        0UL) ? 1UL : 0UL)
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)       (((RTC->MISR) & (RTC_MISR_WUTMF)) != 0U)
 
 /**
   * @brief  Check whether the specified RTC Wake Up timer interrupt has been enabled or not.
@@ -1004,10 +1041,9 @@ typedef struct
   * @param  __INTERRUPT__ specifies the RTC Wake Up timer interrupt sources to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_WUT  WakeUpTimer interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   ((((RTC->CR) & (__INTERRUPT__)) != \
-                                                                           0UL) ? 1UL : 0UL)
+#define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   (((RTC->CR) & (RTC_CR_WUTIE)) != 0U)
 
 /**
   * @brief  Get the selected RTC WakeUpTimers flag status.
@@ -1016,9 +1052,14 @@ typedef struct
   *          This parameter can be:
   *             @arg @ref RTC_FLAG_WUTF
   *             @arg @ref RTC_FLAG_WUTWF
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)   (__HAL_RTC_GET_FLAG((__HANDLE__), (__FLAG__)))
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)( \
+                                                              ((__FLAG__) == RTC_FLAG_WUTF)  ?\
+                                                              (READ_BIT(RTC->SR, RTC_SR_WUTF) == RTC_SR_WUTF):\
+                                                              ((__FLAG__) == RTC_FLAG_WUTWF) ?\
+                                                              (READ_BIT(RTC->ICSR, RTC_ICSR_WUTWF) == RTC_ICSR_WUTWF):\
+                                                              (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /**
   * @brief  Clear the RTC Wake Up timers pending flags.
@@ -1028,7 +1069,8 @@ typedef struct
   *            @arg @ref RTC_FLAG_WUTF
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)  (__HAL_RTC_CLEAR_FLAG((__HANDLE__), RTC_CLEAR_WUTF))
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)  (SET_BIT(RTC->SCR, RTC_SCR_CWUTF))
+
 /**
   * @}
   */
@@ -1060,7 +1102,7 @@ typedef struct
   *            @arg @ref RTC_IT_TS TimeStamp interrupt
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)     (RTC->CR |= (__INTERRUPT__))
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)     (RTC->CR |= (RTC_CR_TSIE))
 
 /**
   * @brief  Disable the RTC TimeStamp interrupt.
@@ -1070,7 +1112,7 @@ typedef struct
   *            @arg @ref RTC_IT_TS TimeStamp interrupt
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR &= ~(RTC_CR_TSIE))
 
 /**
   * @brief  Check whether the specified RTC TimeStamp interrupt has occurred or not.
@@ -1078,10 +1120,9 @@ typedef struct
   * @param  __INTERRUPT__ specifies the RTC TimeStamp interrupt to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_TS TimeStamp interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)        ((((RTC->MISR) & ((__INTERRUPT__)>> 12U)) != \
-                                                                       0U) ? 1UL : 0UL)
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)        (((RTC->MISR) & (RTC_MISR_TSMF)) != 0U)
 
 /**
   * @brief  Check whether the specified RTC Time Stamp interrupt has been enabled or not.
@@ -1089,10 +1130,9 @@ typedef struct
   * @param  __INTERRUPT__ specifies the RTC Time Stamp interrupt source to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_TS TimeStamp interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     ((((RTC->CR) & (__INTERRUPT__)) != 0U) ?\
-                                                                          1UL : 0UL)
+#define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  (((RTC->CR) & (RTC_CR_TSIE)) != 0U)
 
 /**
   * @brief  Get the selected RTC TimeStamps flag status.
@@ -1101,9 +1141,14 @@ typedef struct
   *         This parameter can be:
   *            @arg @ref RTC_FLAG_TSF
   *            @arg @ref RTC_FLAG_TSOVF
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE) or 255 if invalid parameter.
   */
-#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)     (__HAL_RTC_GET_FLAG((__HANDLE__),(__FLAG__)))
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)( \
+                                                            ((__FLAG__) == RTC_FLAG_TSF)   ?\
+                                                            (READ_BIT(RTC->SR, RTC_SR_TSF) == RTC_SR_TSF):\
+                                                            ((__FLAG__) == RTC_FLAG_TSOVF) ?\
+                                                            (READ_BIT(RTC->SR, RTC_SR_TSOVF) == RTC_SR_TSOVF):\
+                                                            (0U)) /*!< Return 0 because it is an invalid parameter value */
 
 /**
   * @brief  Clear the RTC Time Stamps pending flags.
@@ -1114,7 +1159,12 @@ typedef struct
   *             @arg @ref RTC_FLAG_TSOVF
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)   (__HAL_RTC_CLEAR_FLAG((__HANDLE__), (__FLAG__)))
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)( \
+                                                              ((__FLAG__) == RTC_FLAG_TSF)   ?\
+                                                              (SET_BIT(RTC->SCR, RTC_SCR_CTSF)):\
+                                                              ((__FLAG__) == RTC_FLAG_TSOVF) ?\
+                                                              (SET_BIT(RTC->SCR, RTC_SCR_CTSOVF)):\
+                                                              (0U)) /*!< Dummy action because is an invalid parameter value */
 
 /**
   * @brief  Enable the RTC internal TimeStamp peripheral.
@@ -1138,8 +1188,7 @@ typedef struct
   *            @arg @ref RTC_FLAG_ITSF
   * @retval None
   */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)     (__HAL_RTC_GET_FLAG((__HANDLE__),\
-                                                                         (__FLAG__)))
+#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)   ((READ_BIT(RTC->SR, RTC_SR_ITSF) == RTC_SR_ITSF))
 
 /**
   * @brief  Clear the RTC Internal Time Stamps pending flags.
@@ -1149,8 +1198,7 @@ typedef struct
   *             @arg @ref RTC_FLAG_ITSF
   * @retval None
   */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)     (__HAL_RTC_CLEAR_FLAG((__HANDLE__),\
-                                                                           RTC_CLEAR_ITSF))
+#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)   (SET_BIT(RTC->SCR, RTC_SCR_CITSF))
 
 /**
   * @brief  Enable the RTC TimeStamp on Tamper detection.
@@ -1207,7 +1255,6 @@ typedef struct
   */
 #define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)              (RTC->CR &= ~(RTC_CR_COE))
 
-
 /**
   * @brief  Enable the clock reference detection.
   * @param  __HANDLE__ specifies the RTC handle.
@@ -1222,20 +1269,18 @@ typedef struct
   */
 #define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)              (RTC->CR &= ~(RTC_CR_REFCKON))
 
-
 /**
   * @brief  Get the selected RTC shift operations flag status.
   * @param  __HANDLE__ specifies the RTC handle.
   * @param  __FLAG__ specifies the RTC shift operation Flag is pending or not.
   *          This parameter can be:
   *             @arg @ref RTC_FLAG_SHPF
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE)
   */
-#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)                (__HAL_RTC_GET_FLAG((__HANDLE__), (__FLAG__)))
+#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)  ((READ_BIT(RTC->ICSR, RTC_ICSR_SHPF) == RTC_ICSR_SHPF))
 /**
   * @}
   */
-
 
 /* ------------------------------Tamper----------------------------------*/
 /** @defgroup RTCEx_Tamper RTCEx tamper
@@ -1409,7 +1454,7 @@ typedef struct
   *             @arg RTC_FLAG_INT_TAMP_12: Internal Tamper12 flag
   *             @arg RTC_FLAG_INT_TAMP_13: Internal Tamper13 flag
   *             @arg RTC_FLAG_INT_TAMP_15: Internal Tamper15 flag
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE)
   */
 #define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)        (((TAMP->SR) & (__FLAG__)) != 0U)
 
@@ -1461,7 +1506,7 @@ typedef struct
   *            @arg @ref RTC_IT_SSRU SSRU interrupt
   * @retval None
   */
-#define __HAL_RTC_SSRU_ENABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR |= (__INTERRUPT__))
+#define __HAL_RTC_SSRU_ENABLE_IT(__HANDLE__, __INTERRUPT__)    (RTC->CR |= (RTC_CR_SSRUIE))
 
 /**
   * @brief  Disable the RTC SSRU interrupt.
@@ -1471,7 +1516,7 @@ typedef struct
   *            @arg @ref RTC_IT_SSRU SSRU interrupt
   * @retval None
   */
-#define __HAL_RTC_SSRU_DISABLE_IT(__HANDLE__, __INTERRUPT__)   (RTC->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_SSRU_DISABLE_IT(__HANDLE__, __INTERRUPT__)   (RTC->CR &= ~(RTC_CR_SSRUIE))
 
 
 /**
@@ -1480,19 +1525,18 @@ typedef struct
   * @param  __INTERRUPT__ specifies the RTC SSRU interrupt to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_SSRU  SSRU interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE)
   */
-#define __HAL_RTC_SSRU_GET_IT(__HANDLE__, __INTERRUPT__)       (((RTC->MISR) & ((__INTERRUPT__) >> 1) != 0U) \
-                                                                ? 1U : 0U)
+#define __HAL_RTC_SSRU_GET_IT(__HANDLE__, __INTERRUPT__)       ((((RTC->MISR) & (RTC_MISR_SSRUMF)) != 0U) ? 1U : 0U)
 /**
   * @brief  Check whether the specified RTC Wake Up timer interrupt has been enabled or not.
   * @param  __HANDLE__ specifies the RTC handle.
   * @param  __INTERRUPT__ specifies the RTC Wake Up timer interrupt sources to check.
   *         This parameter can be:
   *            @arg @ref RTC_IT_SSRU  SSRU interrupt
-  * @retval None
+  * @retval The state of __INTERRUPT__ (TRUE or FALSE)
   */
-#define __HAL_RTC_SSRU_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   ((((RTC->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_SSRU_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   ((((RTC->CR) & (RTC_CR_SSRUIE)) != 0U) ? 1U : 0U)
 
 /**
   * @brief  Get the selected RTC SSRU's flag status.
@@ -1500,9 +1544,9 @@ typedef struct
   * @param  __FLAG__ specifies the RTC SSRU Flag is pending or not.
   *          This parameter can be:
   *             @arg @ref RTC_FLAG_SSRUF
-  * @retval None
+  * @retval The state of __FLAG__ (TRUE or FALSE)
   */
-#define __HAL_RTC_SSRU_GET_FLAG(__HANDLE__, __FLAG__)   (__HAL_RTC_GET_FLAG((__HANDLE__), (__FLAG__)))
+#define __HAL_RTC_SSRU_GET_FLAG(__HANDLE__, __FLAG__)       ((READ_BIT(RTC->SR, RTC_SR_SSRUF) == RTC_SR_SSRUF))
 
 /**
   * @brief  Clear the RTC Wake Up timer's pending flags.
@@ -1512,7 +1556,7 @@ typedef struct
   *            @arg @ref RTC_FLAG_SSRUF
   * @retval None
   */
-#define __HAL_RTC_SSRU_CLEAR_FLAG(__HANDLE__, __FLAG__)     (__HAL_RTC_CLEAR_FLAG((__HANDLE__), RTC_CLEAR_SSRUF))
+#define __HAL_RTC_SSRU_CLEAR_FLAG(__HANDLE__, __FLAG__)     (SET_BIT(RTC->SCR, RTC_SCR_CSSRUF))
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sai.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sai.c
@@ -171,7 +171,7 @@
 
     [..]
     Use function HAL_SAI_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
+    weak function.
     HAL_SAI_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the callback ID.
     [..]
@@ -186,10 +186,10 @@
 
     [..]
     By default, after the HAL_SAI_Init and if the state is HAL_SAI_STATE_RESET
-    all callbacks are reset to the corresponding legacy weak (surcharged) functions:
+    all callbacks are reset to the corresponding legacy weak functions:
     examples HAL_SAI_RxCpltCallback(), HAL_SAI_ErrorCallback().
     Exception done for MspInit and MspDeInit callbacks that are respectively
-    reset to the legacy weak (surcharged) functions in the HAL_SAI_Init
+    reset to the legacy weak functions in the HAL_SAI_Init
     and HAL_SAI_DeInit only when these callbacks are null (not registered beforehand).
     If not, MspInit or MspDeInit are not null, the HAL_SAI_Init and HAL_SAI_DeInit
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
@@ -206,7 +206,7 @@
     [..]
     When the compilation define USE_HAL_SAI_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registering feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak callbacks are used.
 
   @endverbatim
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sd.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sd.c
@@ -56,7 +56,6 @@
 
     (#) At this stage, you can perform SD read/write/erase operations after SD card initialization
 
-
   *** SD Card Initialization and configuration ***
   ================================================
   [..]
@@ -612,7 +611,6 @@ HAL_StatusTypeDef HAL_SD_DeInit(SD_HandleTypeDef *hsd)
 
   return HAL_OK;
 }
-
 
 /**
   * @brief  Initializes the SD MSP.
@@ -1316,7 +1314,6 @@ HAL_StatusTypeDef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint8_t *pData, u
     /* Enable transfer interrupts */
     __HAL_SD_ENABLE_IT(hsd, (SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_RXOVERR | SDMMC_IT_DATAEND));
 
-
     return HAL_OK;
   }
   else
@@ -1382,7 +1379,6 @@ HAL_StatusTypeDef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, const uint8_t *p
     config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
     config.DPSM          = SDMMC_DPSM_DISABLE;
     (void)SDMMC_ConfigData(hsd->Instance, &config);
-
 
     __SDMMC_CMDTRANS_ENABLE(hsd->Instance);
 
@@ -2330,7 +2326,6 @@ HAL_StatusTypeDef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusT
     status = HAL_ERROR;
   }
 
-
   return status;
 }
 
@@ -2371,6 +2366,7 @@ HAL_StatusTypeDef HAL_SD_ConfigWideBusOperation(SD_HandleTypeDef *hsd, uint32_t 
   SDMMC_InitTypeDef Init;
   uint32_t errorstate;
   uint32_t sdmmc_clk;
+
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
@@ -2422,11 +2418,15 @@ HAL_StatusTypeDef HAL_SD_ConfigWideBusOperation(SD_HandleTypeDef *hsd, uint32_t 
       sdmmc_clk = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SDMMC1);
     }
 #if defined(SDMMC2)
-    else
+    else if (hsd->Instance == SDMMC2)
     {
       sdmmc_clk = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SDMMC2);
     }
 #endif /* SDMMC2 */
+    else
+    {
+      sdmmc_clk = 0U;
+    }
     if (sdmmc_clk != 0U)
     {
       /* Configure the SDMMC peripheral */
@@ -2950,7 +2950,6 @@ HAL_StatusTypeDef HAL_SD_Abort(SD_HandleTypeDef *hsd)
   return HAL_OK;
 }
 
-
 /**
   * @brief  Abort the current transfer and disable the SD (IT mode).
   * @param  hsd: pointer to a SD_HandleTypeDef structure that contains
@@ -3007,7 +3006,6 @@ HAL_StatusTypeDef HAL_SD_Abort_IT(SD_HandleTypeDef *hsd)
 /** @addtogroup SD_Private_Functions
   * @{
   */
-
 
 /**
   * @brief  Initializes the sd card.
@@ -3515,7 +3513,6 @@ static uint32_t SD_WideBus_Disable(SD_HandleTypeDef *hsd)
   }
 }
 
-
 /**
   * @brief  Finds the SD card SCR register value.
   * @param  hsd: Pointer to SD handle
@@ -3569,7 +3566,6 @@ static uint32_t SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
       tempscr[1] = SDMMC_ReadFIFO(hsd->Instance);
       index++;
     }
-
 
     if ((HAL_GetTick() - tickstart) >=  SDMMC_SWDATATIMEOUT)
     {
@@ -3727,7 +3723,6 @@ uint32_t SD_SwitchSpeed(SD_HandleTypeDef *hsd, uint32_t SwitchSpeedMode)
 
     (void)SDMMC_ConfigData(hsd->Instance, &sdmmc_datainitstructure);
 
-
     errorstate = SDMMC_CmdSwitch(hsd->Instance, SwitchSpeedMode);
     if (errorstate != HAL_SD_ERROR_NONE)
     {
@@ -3745,7 +3740,6 @@ uint32_t SD_SwitchSpeed(SD_HandleTypeDef *hsd, uint32_t SwitchSpeedMode)
         }
         loop ++;
       }
-
       if ((HAL_GetTick() - Timeout) >=  SDMMC_SWDATATIMEOUT)
       {
         hsd->ErrorCode = HAL_SD_ERROR_TIMEOUT;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sdram.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sdram.c
@@ -9,7 +9,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -1333,7 +1333,7 @@ uint32_t HAL_SDRAM_GetModeStatus(SDRAM_HandleTypeDef *hsdram)
   *                the configuration information for SDRAM module.
   * @retval HAL state
   */
-HAL_SDRAM_StateTypeDef HAL_SDRAM_GetState(SDRAM_HandleTypeDef *hsdram)
+HAL_SDRAM_StateTypeDef HAL_SDRAM_GetState(const SDRAM_HandleTypeDef *hsdram)
 {
   return hsdram->State;
 }
@@ -1356,6 +1356,7 @@ HAL_SDRAM_StateTypeDef HAL_SDRAM_GetState(SDRAM_HandleTypeDef *hsdram)
   */
 static void SDRAM_DMACplt(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SDRAM_HandleTypeDef *hsdram = (SDRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */
@@ -1378,6 +1379,7 @@ static void SDRAM_DMACplt(DMA_HandleTypeDef *hdma)
   */
 static void SDRAM_DMACpltProt(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SDRAM_HandleTypeDef *hsdram = (SDRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */
@@ -1400,6 +1402,7 @@ static void SDRAM_DMACpltProt(DMA_HandleTypeDef *hdma)
   */
 static void SDRAM_DMAError(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SDRAM_HandleTypeDef *hsdram = (SDRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sdram.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sdram.h
@@ -6,7 +6,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -212,7 +212,7 @@ uint32_t          HAL_SDRAM_GetModeStatus(SDRAM_HandleTypeDef *hsdram);
   * @{
   */
 /* SDRAM State functions ********************************************************/
-HAL_SDRAM_StateTypeDef  HAL_SDRAM_GetState(SDRAM_HandleTypeDef *hsdram);
+HAL_SDRAM_StateTypeDef  HAL_SDRAM_GetState(const SDRAM_HandleTypeDef *hsdram);
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smartcard.c
@@ -2494,7 +2494,7 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
     assert_param(IS_SMARTCARD_TIMEOUT_VALUE(hsmartcard->Init.TimeOutValue));
     tmpreg |= (uint32_t) hsmartcard->Init.TimeOutValue;
   }
-  MODIFY_REG(hsmartcard->Instance->RTOR, (USART_RTOR_RTO | USART_RTOR_BLEN), tmpreg);
+  WRITE_REG(hsmartcard->Instance->RTOR, tmpreg);
 
   /*-------------------------- USART BRR Configuration -----------------------*/
   SMARTCARD_GETCLOCKSOURCE(hsmartcard, clocksource);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smartcard.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smartcard.h
@@ -1037,6 +1037,122 @@ typedef enum
       (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED;     \
     }                                                          \
   } while(0U)
+#elif (defined(STM32H523xx) || defined(STM32H533xx))
+#define SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)   \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
+        case RCC_USART1CLKSOURCE_PCLK2:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK2;     \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_CSI;       \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL2Q;     \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL3Q;     \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_CSI;       \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL2Q;     \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL3Q;     \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART3)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                    \
+      {                                                        \
+        case RCC_USART3CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_CSI;       \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL2Q;     \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL3Q;     \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART6)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART6_SOURCE())                    \
+      {                                                        \
+        case RCC_USART6CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_CSI;       \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL2Q;     \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PLL3Q;     \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else                                                       \
+    {                                                          \
+      (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED;     \
+    }                                                          \
+  } while(0U)
 #else
 #define SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)   \
   do {                                                         \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus.c
@@ -2585,8 +2585,11 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
     __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_PECERR);
   }
 
-  /* Flush TX register */
-  SMBUS_Flush_TXDR(hsmbus);
+  if (hsmbus->ErrorCode != HAL_SMBUS_ERROR_NONE)
+  {
+    /* Flush TX register */
+    SMBUS_Flush_TXDR(hsmbus);
+  }
 
   /* Store current volatile hsmbus->ErrorCode, misra rule */
   tmperror = hsmbus->ErrorCode;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus.h
@@ -100,8 +100,6 @@ typedef struct
 #define HAL_SMBUS_STATE_MASTER_BUSY_RX  (0x00000022U)  /*!< Master Data Reception process is ongoing      */
 #define HAL_SMBUS_STATE_SLAVE_BUSY_TX   (0x00000032U)  /*!< Slave Data Transmission process is ongoing    */
 #define HAL_SMBUS_STATE_SLAVE_BUSY_RX   (0x00000042U)  /*!< Slave Data Reception process is ongoing       */
-#define HAL_SMBUS_STATE_TIMEOUT         (0x00000003U)  /*!< Timeout state                                 */
-#define HAL_SMBUS_STATE_ERROR           (0x00000004U)  /*!< Reception process is ongoing                  */
 #define HAL_SMBUS_STATE_LISTEN          (0x00000008U)  /*!< Address Listen Mode is ongoing                */
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_smbus_ex.c
@@ -6,6 +6,8 @@
   *          This file provides firmware functions to manage the following
   *          functionalities of SMBUS Extended peripheral:
   *           + Extended features functions
+  *           + WakeUp Mode Functions
+  *           + FastModePlus Functions
   *
   ******************************************************************************
   * @attention

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_spi.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_spi.c
@@ -111,9 +111,8 @@
        using HAL_SPI_RegisterCallback() before calling HAL_SPI_DeInit()
        or HAL_SPI_Init() function.
 
-       When The compilation define USE_HAL_PPP_REGISTER_CALLBACKS is set to 0 or
-       not defined, the callback registering feature is not available
-       and weak (surcharged) callbacks are used.
+       When The compilation define USE_HAL_PPP_REGISTER_CALLBACKS is set to 0 or not defined,
+       the callback registering feature is not available and weak callbacks are used.
 
        SuspendCallback restriction:
            SuspendCallback is called only when MasterReceiverAutoSusp is enabled and
@@ -152,7 +151,6 @@
   * @{
   */
 #define SPI_DEFAULT_TIMEOUT 100UL
-#define MAX_FIFO_LENGTH     16UL
 /**
   * @}
   */
@@ -570,6 +568,8 @@ __weak void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi)
   *                the configuration information for the specified SPI.
   * @param  CallbackID ID of the callback to be registered
   * @param  pCallback pointer to the Callback function
+  * @note   The HAL_SPI_RegisterCallback() may be called before HAL_SPI_Init() in HAL_SPI_STATE_RESET
+  *         to register callbacks for HAL_SPI_MSPINIT_CB_ID and HAL_SPI_MSPDEINIT_CB_ID
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID,
@@ -584,8 +584,6 @@ HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Call
 
     return HAL_ERROR;
   }
-  /* Lock the process */
-  __HAL_LOCK(hspi);
 
   if (HAL_SPI_STATE_READY == hspi->State)
   {
@@ -674,8 +672,6 @@ HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Call
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hspi);
   return status;
 }
 
@@ -685,14 +681,13 @@ HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Call
   * @param  hspi Pointer to a SPI_HandleTypeDef structure that contains
   *                the configuration information for the specified SPI.
   * @param  CallbackID ID of the callback to be unregistered
+  * @note   The HAL_SPI_UnRegisterCallback() may be called before HAL_SPI_Init() in HAL_SPI_STATE_RESET
+  *         to un-register callbacks for HAL_SPI_MSPINIT_CB_ID and HAL_SPI_MSPDEINIT_CB_ID
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-
-  /* Lock the process */
-  __HAL_LOCK(hspi);
 
   if (HAL_SPI_STATE_READY == hspi->State)
   {
@@ -781,8 +776,6 @@ HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Ca
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hspi);
   return status;
 }
 #endif /* USE_HAL_SPI_REGISTER_CALLBACKS */
@@ -839,30 +832,25 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
 #endif /* __GNUC__ */
 
   uint32_t tickstart;
-  HAL_StatusTypeDef errorcode = HAL_OK;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_TXONLY(hspi->Init.Direction));
-
-  /* Lock the process */
-  __HAL_LOCK(hspi);
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
@@ -921,11 +909,12 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -965,11 +954,12 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -1014,11 +1004,12 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -1034,16 +1025,19 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
   /* Call standard close procedure with error check */
   SPI_CloseTransfer(hspi);
 
+  hspi->State = HAL_SPI_STATE_READY;
+
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
-
-  hspi->State = HAL_SPI_STATE_READY;
 
   if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
   {
     return HAL_ERROR;
   }
-  return errorcode;
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
@@ -1058,7 +1052,6 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData
 HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
-  HAL_StatusTypeDef errorcode = HAL_OK;
 #if defined (__GNUC__)
   __IO uint16_t *prxdr_16bits = (__IO uint16_t *)(&(hspi->Instance->RXDR));
 #endif /* __GNUC__ */
@@ -1066,25 +1059,21 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_RXONLY(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -1143,11 +1132,12 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -1178,11 +1168,12 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -1209,11 +1200,12 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
           /* Call standard close procedure with error check */
           SPI_CloseTransfer(hspi);
 
+          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+          hspi->State = HAL_SPI_STATE_READY;
+
           /* Unlock the process */
           __HAL_UNLOCK(hspi);
 
-          SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-          hspi->State = HAL_SPI_STATE_READY;
           return HAL_TIMEOUT;
         }
       }
@@ -1234,16 +1226,20 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   /* Call standard close procedure with error check */
   SPI_CloseTransfer(hspi);
 
+  hspi->State = HAL_SPI_STATE_READY;
+
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
 
-  hspi->State = HAL_SPI_STATE_READY;
 
   if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
   {
     return HAL_ERROR;
   }
-  return errorcode;
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
@@ -1259,21 +1255,18 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
 HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                           uint16_t Size, uint32_t Timeout)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
 #if defined (__GNUC__)
   __IO uint16_t *ptxdr_16bits = (__IO uint16_t *)(&(hspi->Instance->TXDR));
   __IO uint16_t *prxdr_16bits = (__IO uint16_t *)(&(hspi->Instance->RXDR));
 #endif /* __GNUC__ */
 
   uint32_t   tickstart;
+  uint32_t   fifo_length;
   uint16_t   initial_TxXferCount;
   uint16_t   initial_RxXferCount;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
-
-  /* Lock the process */
-  __HAL_LOCK(hspi);
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
@@ -1283,17 +1276,16 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX_RX;
@@ -1312,6 +1304,16 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
   /* Set Full-Duplex mode */
   SPI_2LINES(hspi);
 
+  /* Initialize FIFO length */
+  if (IS_SPI_FULL_INSTANCE(hspi->Instance))
+  {
+    fifo_length = SPI_HIGHEND_FIFO_SIZE;
+  }
+  else
+  {
+    fifo_length = SPI_LOWEND_FIFO_SIZE;
+  }
+
   /* Set the number of data at current transfer */
   MODIFY_REG(hspi->Instance->CR2, SPI_CR2_TSIZE, Size);
 
@@ -1326,10 +1328,14 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
   /* Transmit and Receive data in 32 Bit mode */
   if ((hspi->Init.DataSize > SPI_DATASIZE_16BIT) && (IS_SPI_FULL_INSTANCE(hspi->Instance)))
   {
+    /* Adapt fifo length to 32bits data width */
+    fifo_length = (fifo_length / 4UL);
+
     while ((initial_TxXferCount > 0UL) || (initial_RxXferCount > 0UL))
     {
       /* Check TXP flag */
-      if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP)) && (initial_TxXferCount > 0UL))
+      if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP)) && (initial_TxXferCount > 0UL) &&
+          (initial_RxXferCount  < (initial_TxXferCount + fifo_length)))
       {
         *((__IO uint32_t *)&hspi->Instance->TXDR) = *((const uint32_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint32_t);
@@ -1352,11 +1358,12 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
         /* Call standard close procedure with error check */
         SPI_CloseTransfer(hspi);
 
+        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+        hspi->State = HAL_SPI_STATE_READY;
+
         /* Unlock the process */
         __HAL_UNLOCK(hspi);
 
-        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-        hspi->State = HAL_SPI_STATE_READY;
         return HAL_TIMEOUT;
       }
     }
@@ -1364,10 +1371,14 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
   /* Transmit and Receive data in 16 Bit mode */
   else if (hspi->Init.DataSize > SPI_DATASIZE_8BIT)
   {
+    /* Adapt fifo length to 16bits data width */
+    fifo_length = (fifo_length / 2UL);
+
     while ((initial_TxXferCount > 0UL) || (initial_RxXferCount > 0UL))
     {
       /* Check the TXP flag */
-      if (__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP) && (initial_TxXferCount > 0UL))
+      if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP)) && (initial_TxXferCount > 0UL) &&
+          (initial_RxXferCount  < (initial_TxXferCount + fifo_length)))
       {
 #if defined (__GNUC__)
         *ptxdr_16bits = *((const uint16_t *)hspi->pTxBuffPtr);
@@ -1398,11 +1409,12 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
         /* Call standard close procedure with error check */
         SPI_CloseTransfer(hspi);
 
+        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+        hspi->State = HAL_SPI_STATE_READY;
+
         /* Unlock the process */
         __HAL_UNLOCK(hspi);
 
-        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-        hspi->State = HAL_SPI_STATE_READY;
         return HAL_TIMEOUT;
       }
     }
@@ -1413,7 +1425,8 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
     while ((initial_TxXferCount > 0UL) || (initial_RxXferCount > 0UL))
     {
       /* Check the TXP flag */
-      if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP)) && (initial_TxXferCount > 0UL))
+      if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXP)) && (initial_TxXferCount > 0UL) &&
+          (initial_RxXferCount  < (initial_TxXferCount + fifo_length)))
       {
         *((__IO uint8_t *)&hspi->Instance->TXDR) = *((const uint8_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint8_t);
@@ -1436,11 +1449,12 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
         /* Call standard close procedure with error check */
         SPI_CloseTransfer(hspi);
 
+        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
+        hspi->State = HAL_SPI_STATE_READY;
+
         /* Unlock the process */
         __HAL_UNLOCK(hspi);
 
-        SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_TIMEOUT);
-        hspi->State = HAL_SPI_STATE_READY;
         return HAL_TIMEOUT;
       }
     }
@@ -1455,16 +1469,19 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
   /* Call standard close procedure with error check */
   SPI_CloseTransfer(hspi);
 
+  hspi->State = HAL_SPI_STATE_READY;
+
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
-
-  hspi->State = HAL_SPI_STATE_READY;
 
   if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
   {
     return HAL_ERROR;
   }
-  return errorcode;
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
@@ -1477,27 +1494,21 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t
   */
 HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
-
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_TXONLY(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
@@ -1542,6 +1553,9 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pD
   /* Enable SPI peripheral */
   __HAL_SPI_ENABLE(hspi);
 
+  /* Unlock the process */
+  __HAL_UNLOCK(hspi);
+
   /* Enable EOT, TXP, FRE, MODF and UDR interrupts */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_EOT | SPI_IT_TXP | SPI_IT_UDR | SPI_IT_FRE | SPI_IT_MODF));
 
@@ -1551,8 +1565,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pD
     SET_BIT(hspi->Instance->CR1, SPI_CR1_CSTART);
   }
 
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 /**
@@ -1565,27 +1578,21 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pD
   */
 HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
-
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_RXONLY(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -1634,6 +1641,9 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
   /* Enable SPI peripheral */
   __HAL_SPI_ENABLE(hspi);
 
+  /* Unlock the process */
+  __HAL_UNLOCK(hspi);
+
   /* Enable EOT, RXP, OVR, FRE and MODF interrupts */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_EOT | SPI_IT_RXP | SPI_IT_OVR | SPI_IT_FRE | SPI_IT_MODF));
 
@@ -1643,9 +1653,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     SET_BIT(hspi->Instance->CR1, SPI_CR1_CSTART);
   }
 
-  /* Unlock the process */
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 /**
@@ -1660,9 +1668,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
 HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                              uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
   uint32_t tmp_TxXferCount;
-
 #if defined (__GNUC__)
   __IO uint16_t *ptxdr_16bits = (__IO uint16_t *)(&(hspi->Instance->TXDR));
 #endif /* __GNUC__ */
@@ -1670,22 +1676,18 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX_RX;
@@ -1757,6 +1759,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint
     }
   }
 
+  /* Unlock the process */
+  __HAL_UNLOCK(hspi);
+
   /* Enable EOT, DXP, UDR, OVR, FRE and MODF interrupts */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_EOT | SPI_IT_DXP | SPI_IT_UDR | SPI_IT_OVR | SPI_IT_FRE | SPI_IT_MODF));
 
@@ -1766,9 +1771,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint
     SET_BIT(hspi->Instance->CR1, SPI_CR1_CSTART);
   }
 
-  /* Unlock the process */
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 
@@ -1785,27 +1788,23 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint
   */
 HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode;
+  HAL_StatusTypeDef status;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_TXONLY(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
@@ -1837,9 +1836,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *p
       ((hspi->Init.DataSize > SPI_DATASIZE_8BIT)  && (hspi->hdmatx->Init.SrcDataWidth ==  DMA_SRC_DATAWIDTH_BYTE)))
   {
     /* Restriction the DMA data received is not allowed in this mode */
-    errorcode = HAL_ERROR;
     __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Adjust XferCount according to DMA alignment / Data size */
@@ -1908,39 +1906,30 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *p
       /* Set DMA destination address */
       hspi->hdmatx->LinkedListQueue->Head->LinkRegisters[NODE_CDAR_DEFAULT_OFFSET] = (uint32_t)&hspi->Instance->TXDR;
 
-      errorcode = HAL_DMAEx_List_Start_IT(hspi->hdmatx);
+      status = HAL_DMAEx_List_Start_IT(hspi->hdmatx);
     }
     else
     {
-      /* Update SPI error code */
-      SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-
-      /* Unlock the process */
-      __HAL_UNLOCK(hspi);
-
-      hspi->State = HAL_SPI_STATE_READY;
-      errorcode = HAL_ERROR;
-      return errorcode;
+      status = HAL_ERROR;
     }
   }
   else
   {
-    errorcode = HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->TXDR,
-                                 hspi->TxXferCount);
+    status = HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->TXDR,
+                              hspi->TxXferCount);
   }
 
   /* Check status */
-  if (errorcode != HAL_OK)
+  if (status != HAL_OK)
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
+    hspi->State = HAL_SPI_STATE_READY;
 
     /* Unlock the process */
     __HAL_UNLOCK(hspi);
 
-    hspi->State = HAL_SPI_STATE_READY;
-    errorcode = HAL_ERROR;
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Set the number of data at current transfer */
@@ -1970,7 +1959,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *p
 
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+
+  return HAL_OK;
 }
 
 /**
@@ -1984,27 +1974,26 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *p
   */
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode;
+  HAL_StatusTypeDef status;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE_2LINES_RXONLY(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
     __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
     __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -2035,9 +2024,8 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
       ((hspi->Init.DataSize > SPI_DATASIZE_8BIT)  && (hspi->hdmarx->Init.DestDataWidth == DMA_DEST_DATAWIDTH_BYTE)))
   {
     /* Restriction the DMA data received is not allowed in this mode */
-    errorcode = HAL_ERROR;
     __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Clear RXDMAEN bit */
@@ -2106,39 +2094,30 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
       /* Set DMA destination address */
       hspi->hdmarx->LinkedListQueue->Head->LinkRegisters[NODE_CDAR_DEFAULT_OFFSET] = (uint32_t)hspi->pRxBuffPtr;
 
-      errorcode = HAL_DMAEx_List_Start_IT(hspi->hdmarx);
+      status = HAL_DMAEx_List_Start_IT(hspi->hdmarx);
     }
     else
     {
-      /* Update SPI error code */
-      SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-
-      /* Unlock the process */
-      __HAL_UNLOCK(hspi);
-
-      hspi->State = HAL_SPI_STATE_READY;
-      errorcode = HAL_ERROR;
-      return errorcode;
+      status = HAL_ERROR;
     }
   }
   else
   {
-    errorcode = HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->RXDR, (uint32_t)hspi->pRxBuffPtr,
-                                 hspi->RxXferCount);
+    status = HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->RXDR, (uint32_t)hspi->pRxBuffPtr,
+                              hspi->RxXferCount);
   }
 
   /* Check status */
-  if (errorcode != HAL_OK)
+  if (status != HAL_OK)
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
+    hspi->State = HAL_SPI_STATE_READY;
 
     /* Unlock the process */
     __HAL_UNLOCK(hspi);
 
-    hspi->State = HAL_SPI_STATE_READY;
-    errorcode = HAL_ERROR;
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Set the number of data at current transfer */
@@ -2168,7 +2147,8 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
 
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+
+  return HAL_OK;
 }
 
 /**
@@ -2184,27 +2164,23 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
 HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                               uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode;
+  HAL_StatusTypeDef status;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
 
-  /* Lock the process */
-  __HAL_LOCK(hspi);
-
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0UL))
   {
-    errorcode = HAL_ERROR;
-    __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
+
+  /* Lock the process */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX_RX;
@@ -2232,10 +2208,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uin
       ((hspi->Init.DataSize > SPI_DATASIZE_8BIT)  && (hspi->hdmarx->Init.DestDataWidth == DMA_DEST_DATAWIDTH_BYTE)))
   {
     /* Restriction the DMA data received is not allowed in this mode */
-    errorcode = HAL_ERROR;
     /* Unlock the process */
     __HAL_UNLOCK(hspi);
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Adjust XferCount according to DMA alignment / Data size */
@@ -2310,39 +2285,30 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uin
       /* Set DMA destination address */
       hspi->hdmarx->LinkedListQueue->Head->LinkRegisters[NODE_CDAR_DEFAULT_OFFSET] = (uint32_t)hspi->pRxBuffPtr;
 
-      errorcode = HAL_DMAEx_List_Start_IT(hspi->hdmarx);
+      status = HAL_DMAEx_List_Start_IT(hspi->hdmarx);
     }
     else
     {
-      /* Update SPI error code */
-      SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-
-      /* Unlock the process */
-      __HAL_UNLOCK(hspi);
-
-      hspi->State = HAL_SPI_STATE_READY;
-      errorcode = HAL_ERROR;
-      return errorcode;
+      status = HAL_ERROR;
     }
   }
   else
   {
-    errorcode = HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->RXDR, (uint32_t)hspi->pRxBuffPtr,
-                                 hspi->RxXferCount);
+    status = HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->RXDR, (uint32_t)hspi->pRxBuffPtr,
+                              hspi->RxXferCount);
   }
 
   /* Check status */
-  if (errorcode != HAL_OK)
+  if (status != HAL_OK)
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
+    hspi->State = HAL_SPI_STATE_READY;
 
     /* Unlock the process */
     __HAL_UNLOCK(hspi);
 
-    hspi->State = HAL_SPI_STATE_READY;
-    errorcode = HAL_ERROR;
-    return errorcode;
+    return HAL_ERROR;
   }
 
   /* Enable Rx DMA Request */
@@ -2384,39 +2350,33 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uin
       /* Set DMA destination address */
       hspi->hdmatx->LinkedListQueue->Head->LinkRegisters[NODE_CDAR_DEFAULT_OFFSET] = (uint32_t)&hspi->Instance->TXDR;
 
-      errorcode = HAL_DMAEx_List_Start_IT(hspi->hdmatx);
+      status = HAL_DMAEx_List_Start_IT(hspi->hdmatx);
     }
     else
     {
-      /* Update SPI error code */
-      SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-
-      /* Unlock the process */
-      __HAL_UNLOCK(hspi);
-
-      hspi->State = HAL_SPI_STATE_READY;
-      errorcode = HAL_ERROR;
-      return errorcode;
+      status = HAL_ERROR;
     }
   }
   else
   {
-    errorcode = HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->TXDR,
-                                 hspi->TxXferCount);
+    status = HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->TXDR,
+                              hspi->TxXferCount);
   }
 
   /* Check status */
-  if (errorcode != HAL_OK)
+  if (status != HAL_OK)
   {
+    /* Abort Rx DMA Channel already started */
+    (void)HAL_DMA_Abort(hspi->hdmarx);
+
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
+    hspi->State = HAL_SPI_STATE_READY;
 
     /* Unlock the process */
     __HAL_UNLOCK(hspi);
 
-    hspi->State = HAL_SPI_STATE_READY;
-    errorcode = HAL_ERROR;
-    return errorcode;
+    return HAL_ERROR;
   }
 
   if ((hspi->hdmarx->Mode == DMA_LINKEDLIST_CIRCULAR) && (hspi->hdmatx->Mode == DMA_LINKEDLIST_CIRCULAR))
@@ -2445,7 +2405,8 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uin
 
   /* Unlock the process */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+
+  return HAL_OK;
 }
 #endif /* HAL_DMA_MODULE_ENABLED */
 
@@ -2573,11 +2534,11 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
     hspi->ErrorCode = HAL_SPI_ERROR_NONE;
   }
 
-  /* Unlock the process */
-  __HAL_UNLOCK(hspi);
-
   /* Restore hspi->state to ready */
   hspi->State = HAL_SPI_STATE_READY;
+
+  /* Unlock the process */
+  __HAL_UNLOCK(hspi);
 
   return errorcode;
 }
@@ -2657,6 +2618,12 @@ HAL_StatusTypeDef HAL_SPI_Abort_IT(SPI_HandleTypeDef *hspi)
   /* If DMA Tx and/or DMA Rx Handles are associated to SPI Handle, DMA Abort complete callbacks should be initialized
      before any call to DMA Abort functions */
 
+  // Mbed OS Patch:
+  // The Tx abort callback calls SPI_AbortTransfer, which clears both the TXDMAEN and RXDMAEN bits.
+  // This causes the flag to be unintentionally cleared when we check to abort Rx later on.
+  // To avoid this issue, store it in a variable.
+  int rxDMAUsed = HAL_IS_BIT_SET(hspi->Instance->CFG1, SPI_CFG1_RXDMAEN);
+
   if (hspi->hdmatx != NULL)
   {
     if (HAL_IS_BIT_SET(hspi->Instance->CFG1, SPI_CFG1_TXDMAEN))
@@ -2684,7 +2651,7 @@ HAL_StatusTypeDef HAL_SPI_Abort_IT(SPI_HandleTypeDef *hspi)
 
   if (hspi->hdmarx != NULL)
   {
-    if (HAL_IS_BIT_SET(hspi->Instance->CFG1, SPI_CFG1_RXDMAEN))
+    if (rxDMAUsed)
     {
       /* Set DMA Abort Complete callback if SPI DMA Rx request if enabled */
       hspi->hdmarx->XferAbortCallback = SPI_DMARxAbortCallback;
@@ -2847,7 +2814,6 @@ void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
     hspi->TxISR(hspi);
     handled = 1UL;
   }
-
 
   if (handled != 0UL)
   {
@@ -3334,7 +3300,8 @@ static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma) /* Derogation MISRAC2012-Rule-8.13 */
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)
+                            ((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
 
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1UL)
   hspi->TxHalfCpltCallback(hspi);
@@ -3351,7 +3318,8 @@ static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma) /* Derogation MISRA
   */
 static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma) /* Derogation MISRAC2012-Rule-8.13 */
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)
+                            ((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
 
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1UL)
   hspi->RxHalfCpltCallback(hspi);
@@ -3368,7 +3336,8 @@ static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma) /* Derogation MISRAC
   */
 static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma) /* Derogation MISRAC2012-Rule-8.13 */
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)
+                            ((DMA_HandleTypeDef *)hdma)->Parent; /* Derogation MISRAC2012-Rule-8.13 */
 
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1UL)
   hspi->TxRxHalfCpltCallback(hspi);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sram.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sram.c
@@ -9,7 +9,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -1162,6 +1162,7 @@ HAL_SRAM_StateTypeDef HAL_SRAM_GetState(const SRAM_HandleTypeDef *hsram)
   */
 static void SRAM_DMACplt(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SRAM_HandleTypeDef *hsram = (SRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */
@@ -1184,6 +1185,7 @@ static void SRAM_DMACplt(DMA_HandleTypeDef *hdma)
   */
 static void SRAM_DMACpltProt(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SRAM_HandleTypeDef *hsram = (SRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */
@@ -1206,6 +1208,7 @@ static void SRAM_DMACpltProt(DMA_HandleTypeDef *hdma)
   */
 static void SRAM_DMAError(DMA_HandleTypeDef *hdma)
 {
+  /* Derogation MISRAC2012-Rule-11.5 */
   SRAM_HandleTypeDef *hsram = (SRAM_HandleTypeDef *)(hdma->Parent);
 
   /* Disable the DMA channel */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sram.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_sram.h
@@ -6,7 +6,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim.c
@@ -3854,7 +3854,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     if ((itsource & (TIM_IT_CC1)) == (TIM_IT_CC1))
     {
       {
-        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC1);
         htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
 
         /* Input capture event */
@@ -3886,7 +3886,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_CC2)) == (TIM_IT_CC2))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC2);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
       /* Input capture event */
       if ((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00U)
@@ -3916,7 +3916,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_CC3)) == (TIM_IT_CC3))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC3);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00U)
@@ -3946,7 +3946,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_CC4)) == (TIM_IT_CC4))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC4);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00U)
@@ -3976,7 +3976,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_UPDATE)) == (TIM_IT_UPDATE))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->PeriodElapsedCallback(htim);
 #else
@@ -3985,11 +3985,12 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Break input event */
-  if ((itflag & (TIM_FLAG_BREAK)) == (TIM_FLAG_BREAK))
+  if (((itflag & (TIM_FLAG_BREAK)) == (TIM_FLAG_BREAK)) || \
+      ((itflag & (TIM_FLAG_SYSTEM_BREAK)) == (TIM_FLAG_SYSTEM_BREAK)))
   {
     if ((itsource & (TIM_IT_BREAK)) == (TIM_IT_BREAK))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_BREAK | TIM_FLAG_SYSTEM_BREAK);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->BreakCallback(htim);
 #else
@@ -4015,7 +4016,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_TRIGGER)) == (TIM_IT_TRIGGER))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_TRIGGER);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->TriggerCallback(htim);
 #else
@@ -4028,7 +4029,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_COM)) == (TIM_IT_COM))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_COM);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_COM);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->CommutationCallback(htim);
 #else
@@ -4041,7 +4042,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_IDX)) == (TIM_IT_IDX))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_IDX);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_IDX);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->EncoderIndexCallback(htim);
 #else
@@ -4054,7 +4055,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_DIR)) == (TIM_IT_DIR))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_DIR);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_DIR);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->DirectionChangeCallback(htim);
 #else
@@ -4067,7 +4068,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_IERR)) == (TIM_IT_IERR))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_IERR);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_IERR);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->IndexErrorCallback(htim);
 #else
@@ -4080,7 +4081,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   {
     if ((itsource & (TIM_IT_TERR)) == (TIM_IT_TERR))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_TERR);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_TERR);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->TransitionErrorCallback(htim);
 #else
@@ -4617,6 +4618,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
   *            @arg TIM_DMABASE_TISEL
   *            @arg TIM_DMABASE_AF1
   *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_OR1
   * @param  BurstRequestSrc TIM DMA Request sources
   *         This parameter can be one of the following values:
   *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
@@ -4633,7 +4635,8 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, const uint32_t *BurstBuffer, uint32_t  BurstLength)
+                                              uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
+                                              uint32_t  BurstLength)
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t BlockDataLength = 0;
@@ -4761,6 +4764,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
   *            @arg TIM_DMABASE_TISEL
   *            @arg TIM_DMABASE_AF1
   *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_OR1
   * @param  BurstRequestSrc TIM DMA Request sources
   *         This parameter can be one of the following values:
   *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
@@ -5070,6 +5074,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t B
   *            @arg TIM_DMABASE_TISEL
   *            @arg TIM_DMABASE_AF1
   *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_OR1
   * @param  BurstRequestSrc TIM DMA Request sources
   *         This parameter can be one of the following values:
   *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
@@ -5214,6 +5219,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
   *            @arg TIM_DMABASE_TISEL
   *            @arg TIM_DMABASE_AF1
   *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_OR1
   * @param  BurstRequestSrc TIM DMA Request sources
   *         This parameter can be one of the following values:
   *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
@@ -5575,12 +5581,22 @@ HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
       CLEAR_BIT(htim->Instance->SMCR, (TIM_SMCR_OCCS | TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP));
       break;
     }
-    case TIM_CLEARINPUTSOURCE_OCREFCLR:
+
+#if defined(COMP1) && defined(COMP2)
+    case TIM_CLEARINPUTSOURCE_COMP1:
+    case TIM_CLEARINPUTSOURCE_COMP2:
     {
+      /* Check the parameters */
+      assert_param(IS_TIM_OCXREF_COMP_CLEARINPUT_INSTANCE(htim->Instance));
+
       /* Clear the OCREF clear selection bit */
       CLEAR_BIT(htim->Instance->SMCR, TIM_SMCR_OCCS);
+
+      /* Set the clear input source */
+      MODIFY_REG(htim->Instance->AF2, TIMx_AF2_OCRSEL, sClearInputConfig->ClearInputSource);
       break;
     }
+#endif /* COMP1 && COMP2 */
 
     case TIM_CLEARINPUTSOURCE_ETR:
     {
@@ -7033,38 +7049,18 @@ static void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else
   {
@@ -7131,42 +7127,18 @@ void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else
   {
@@ -7230,11 +7202,6 @@ static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  if (htim->hdma[TIM_DMA_ID_UPDATE]->Init.Mode == DMA_NORMAL)
-  {
-    htim->State = HAL_TIM_STATE_READY;
-  }
-
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->PeriodElapsedCallback(htim);
 #else
@@ -7266,11 +7233,6 @@ static void TIM_DMAPeriodElapsedHalfCplt(DMA_HandleTypeDef *hdma)
 static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
-
-  if (htim->hdma[TIM_DMA_ID_TRIGGER]->Init.Mode == DMA_NORMAL)
-  {
-    htim->State = HAL_TIM_STATE_READY;
-  }
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->TriggerCallback(htim);
@@ -7341,6 +7303,13 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, const TIM_Base_InitTypeDef *Structure
   /* Generate an update event to reload the Prescaler
      and the repetition counter (only for advanced timer) value immediately */
   TIMx->EGR = TIM_EGR_UG;
+
+  /* Check if the update flag is set after the Update Generation, if so clear the UIF flag */
+  if (HAL_IS_BIT_SET(TIMx->SR, TIM_FLAG_UPDATE))
+  {
+    /* Clear the update flag */
+    CLEAR_BIT(TIMx->SR, TIM_FLAG_UPDATE);
+  }
 }
 
 /**
@@ -7465,7 +7434,6 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
     tmpccer |= (OC_Config->OCNPolarity << 4U);
     /* Reset the Output N State */
     tmpccer &= ~TIM_CCER_CC2NE;
-
   }
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim.h
@@ -416,29 +416,28 @@ typedef struct
   */
 typedef enum
 {
-  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                              */
-  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                            */
-  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                */
-  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                              */
-  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                */
-  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                              */
-  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                               */
-  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                             */
-  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                         */
-  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                       */
-  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                           */
-  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                         */
-  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
-  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
+  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                               */
+  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                             */
+  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                 */
+  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                               */
+  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                 */
+  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                               */
+  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                                */
+  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                              */
+  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                          */
+  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                        */
+  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                            */
+  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                          */
+  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
+  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
   , HAL_TIM_PERIOD_ELAPSED_CB_ID          = 0x0EU   /*!< TIM Period Elapsed Callback ID                             */
   , HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID     = 0x0FU   /*!< TIM Period Elapsed half complete Callback ID               */
   , HAL_TIM_TRIGGER_CB_ID                 = 0x10U   /*!< TIM Trigger Callback ID                                    */
   , HAL_TIM_TRIGGER_HALF_CB_ID            = 0x11U   /*!< TIM Trigger half complete Callback ID                      */
-
   , HAL_TIM_IC_CAPTURE_CB_ID              = 0x12U   /*!< TIM Input Capture Callback ID                              */
   , HAL_TIM_IC_CAPTURE_HALF_CB_ID         = 0x13U   /*!< TIM Input Capture half complete Callback ID                */
   , HAL_TIM_OC_DELAY_ELAPSED_CB_ID        = 0x14U   /*!< TIM Output Compare Delay Elapsed Callback ID               */
-  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID           */
+  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID                         */
   , HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID = 0x16U   /*!< TIM PWM Pulse Finished half complete Callback ID           */
   , HAL_TIM_ERROR_CB_ID                   = 0x17U   /*!< TIM Error Callback ID                                      */
   , HAL_TIM_COMMUTATION_CB_ID             = 0x18U   /*!< TIM Commutation Callback ID                                */
@@ -471,9 +470,12 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 /** @defgroup TIM_ClearInput_Source TIM Clear Input Source
   * @{
   */
-#define TIM_CLEARINPUTSOURCE_NONE           0x00000000U   /*!< OCREF_CLR is disabled */
-#define TIM_CLEARINPUTSOURCE_ETR            0x00000001U   /*!< OCREF_CLR is connected to ETRF input */
-#define TIM_CLEARINPUTSOURCE_OCREFCLR       0x00000002U   /*!< OCREF_CLR is connected to OCREF_CLR_INT */
+#define TIM_CLEARINPUTSOURCE_NONE     0xFFFFFFFFU                               /*!< OCREF_CLR is disabled */
+#define TIM_CLEARINPUTSOURCE_ETR      0x00000001U                               /*!< OCREF_CLR is connected to ETRF input */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_CLEARINPUTSOURCE_COMP1    0x00000000U                               /*!< OCREF_CLR_INT is connected to COMP1 output */
+#define TIM_CLEARINPUTSOURCE_COMP2    TIM1_AF2_OCRSEL_0                         /*!< OCREF_CLR_INT is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -507,6 +509,7 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_DMABASE_TISEL                  0x00000017U
 #define TIM_DMABASE_AF1                    0x00000018U
 #define TIM_DMABASE_AF2                    0x00000019U
+#define TIM_DMABASE_OR1                    0x0000001AU
 /**
   * @}
   */
@@ -1066,8 +1069,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_OCMODE_RETRIGERRABLE_OPM2      (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)                     /*!< Retrigerrable OPM mode 2               */
 #define TIM_OCMODE_COMBINED_PWM1           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)                     /*!< Combined PWM mode 1                    */
 #define TIM_OCMODE_COMBINED_PWM2           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)  /*!< Combined PWM mode 2                    */
-#define TIM_OCMODE_ASSYMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
-#define TIM_OCMODE_ASSYMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
 #define TIM_OCMODE_PULSE_ON_COMPARE        (TIM_CCMR2_OC3M_3 | TIM_CCMR2_OC3M_1)                     /*!< Pulse on compare (CH3&CH4 only)        */
 #define TIM_OCMODE_DIRECTION_OUTPUT        (TIM_CCMR2_OC3M_3 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_0)  /*!< Direction output (CH3&CH4 only)        */
 /**
@@ -1848,9 +1851,15 @@ mode.
 /** @defgroup TIM_Private_Macros TIM Private Macros
   * @{
   */
-#define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_NONE)      || \
-                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)       || \
-                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_OCREFCLR))
+#if defined(COMP1) && defined(COMP2)
+#define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP1)    || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP2)    || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_NONE))
+#else
+#define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_NONE))
+#endif /* COMP1 && COMP2 */
 
 #define IS_TIM_DMA_BASE(__BASE__) (((__BASE__) == TIM_DMABASE_CR1)   || \
                                    ((__BASE__) == TIM_DMABASE_CR2)   || \
@@ -1958,8 +1967,9 @@ mode.
 #define IS_TIM_OPM_CHANNELS(__CHANNEL__)   (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                             ((__CHANNEL__) == TIM_CHANNEL_2))
 
-#define IS_TIM_PERIOD(__HANDLE__, __PERIOD__) \
-  ((IS_TIM_32B_COUNTER_INSTANCE(((__HANDLE__)->Instance)) == 0U) ? (((__PERIOD__) > 0U) && ((__PERIOD__) <= 0x0000FFFFU)) : ((__PERIOD__) > 0U))
+#define IS_TIM_PERIOD(__HANDLE__, __PERIOD__) ((IS_TIM_32B_COUNTER_INSTANCE(((__HANDLE__)->Instance)) == 0U) ? \
+                                               (((__PERIOD__) > 0U) && ((__PERIOD__) <= 0x0000FFFFU)) :        \
+                                               ((__PERIOD__) > 0U))
 
 #define IS_TIM_COMPLEMENTARY_CHANNELS(__CHANNEL__) (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                                     ((__CHANNEL__) == TIM_CHANNEL_2) || \
@@ -2021,7 +2031,6 @@ mode.
                                             ((__LEVEL__) == TIM_LOCKLEVEL_3))
 
 #define IS_TIM_BREAK_FILTER(__BRKFILTER__) ((__BRKFILTER__) <= 0xFUL)
-
 
 #define IS_TIM_BREAK_STATE(__STATE__)      (((__STATE__) == TIM_BREAK_ENABLE) || \
                                             ((__STATE__) == TIM_BREAK_DISABLE))
@@ -2091,8 +2100,8 @@ mode.
                                    ((__MODE__) == TIM_OCMODE_PWM2)               || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM1)      || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM2)      || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM1)    || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM2))
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM1)    || \
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM2))
 
 #define IS_TIM_OC_MODE(__MODE__)  (((__MODE__) == TIM_OCMODE_TIMING)             || \
                                    ((__MODE__) == TIM_OCMODE_ACTIVE)             || \
@@ -2416,7 +2425,8 @@ HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_S
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, const uint32_t  *BurstBuffer, uint32_t  BurstLength);
+                                              uint32_t BurstRequestSrc, const uint32_t  *BurstBuffer,
+                                              uint32_t  BurstLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                                    uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
                                                    uint32_t BurstLength,  uint32_t DataLength);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim_ex.c
@@ -872,7 +872,7 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
 
     /* Disable the TIM Break interrupt (only if no more channel is active) */
     tmpccer = htim->Instance->CCER;
-    if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE  | TIM_CCER_CC4NE)) == (uint32_t)RESET)
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
     {
       __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
     }
@@ -1149,17 +1149,6 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
     (+) Stop the Complementary PWM and disable interrupts.
     (+) Start the Complementary PWM and enable DMA transfers.
     (+) Stop the Complementary PWM and disable DMA transfers.
-    (+) Start the Complementary Input Capture measurement.
-    (+) Stop the Complementary Input Capture.
-    (+) Start the Complementary Input Capture and enable interrupts.
-    (+) Stop the Complementary Input Capture and disable interrupts.
-    (+) Start the Complementary Input Capture and enable DMA transfers.
-    (+) Stop the Complementary Input Capture and disable DMA transfers.
-    (+) Start the Complementary One Pulse generation.
-    (+) Stop the Complementary One Pulse.
-    (+) Start the Complementary One Pulse and enable interrupts.
-    (+) Stop the Complementary One Pulse and disable interrupts.
-
 @endverbatim
   * @{
   */
@@ -1403,7 +1392,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 
     /* Disable the TIM Break interrupt (only if no more channel is active) */
     tmpccer = htim->Instance->CCER;
-    if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE  | TIM_CCER_CC4NE)) == (uint32_t)RESET)
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
     {
       __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
     }
@@ -2196,6 +2185,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
   assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->BreakFilter));
   assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(sBreakDeadTimeConfig->AutomaticOutput));
+  assert_param(IS_TIM_BREAK_AFMODE(sBreakDeadTimeConfig->BreakAFMode));
 
   /* Check input state */
   __HAL_LOCK(htim);
@@ -2212,15 +2202,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKP, sBreakDeadTimeConfig->BreakPolarity);
   MODIFY_REG(tmpbdtr, TIM_BDTR_AOE, sBreakDeadTimeConfig->AutomaticOutput);
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKF, (sBreakDeadTimeConfig->BreakFilter << TIM_BDTR_BKF_Pos));
-
-  if (IS_TIM_ADVANCED_INSTANCE(htim->Instance))
-  {
-    /* Check the parameters */
-    assert_param(IS_TIM_BREAK_AFMODE(sBreakDeadTimeConfig->BreakAFMode));
-
-    /* Set BREAK AF mode */
-    MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, sBreakDeadTimeConfig->BreakAFMode);
-  }
+  MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, sBreakDeadTimeConfig->BreakAFMode);
 
   if (IS_TIM_BKIN2_INSTANCE(htim->Instance))
   {
@@ -2228,20 +2210,13 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
     assert_param(IS_TIM_BREAK2_STATE(sBreakDeadTimeConfig->Break2State));
     assert_param(IS_TIM_BREAK2_POLARITY(sBreakDeadTimeConfig->Break2Polarity));
     assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->Break2Filter));
+    assert_param(IS_TIM_BREAK2_AFMODE(sBreakDeadTimeConfig->Break2AFMode));
 
     /* Set the BREAK2 input related BDTR bits */
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2F, (sBreakDeadTimeConfig->Break2Filter << TIM_BDTR_BK2F_Pos));
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2E, sBreakDeadTimeConfig->Break2State);
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2P, sBreakDeadTimeConfig->Break2Polarity);
-
-    if (IS_TIM_ADVANCED_INSTANCE(htim->Instance))
-    {
-      /* Check the parameters */
-      assert_param(IS_TIM_BREAK2_AFMODE(sBreakDeadTimeConfig->Break2AFMode));
-
-      /* Set BREAK2 AF mode */
-      MODIFY_REG(tmpbdtr, TIM_BDTR_BK2BID, sBreakDeadTimeConfig->Break2AFMode);
-    }
+    MODIFY_REG(tmpbdtr, TIM_BDTR_BK2BID, sBreakDeadTimeConfig->Break2AFMode);
   }
 
   /* Set TIMx_BDTR */
@@ -2265,7 +2240,6 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
                                              uint32_t BreakInput,
                                              const TIMEx_BreakInputConfigTypeDef *sBreakInputConfig)
-
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmporx;
@@ -2366,50 +2340,73 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
   * @param  htim TIM handle.
   * @param  Remap specifies the TIM remapping source.
   *         For TIM1, the parameter can take one of the following values:
-  *            @arg TIM_TIM1_ETR_GPIO           TIM1 ETR is connected to GPIO
-  *            @arg TIM_TIM1_ETR_COMP1          TIM1 ETR is connected to COMP1 output  (*)
-  *            @arg TIM_TIM1_ETR_ADC1_AWD1      TIM1 ETR is connected to ADC1 AWD1
-  *            @arg TIM_TIM1_ETR_ADC1_AWD2      TIM1 ETR is connected to ADC1 AWD2
-  *            @arg TIM_TIM1_ETR_ADC1_AWD3      TIM1 ETR is connected to ADC1 AWD3
+  *            @arg TIM_TIM1_ETR_GPIO            TIM1 ETR is connected to GPIO
+  *            @arg TIM_TIM1_ETR_COMP1           TIM1 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM1_ETR_COMP2           TIM1 ETR is connected to COMP2 output    (*)
+  *            @arg TIM_TIM1_ETR_ADC1_AWD1       TIM1 ETR is connected to ADC1 AWD1
+  *            @arg TIM_TIM1_ETR_ADC1_AWD2       TIM1 ETR is connected to ADC1 AWD2
+  *            @arg TIM_TIM1_ETR_ADC1_AWD3       TIM1 ETR is connected to ADC1 AWD3
   *
   *         For TIM2, the parameter can take one of the following values:
   *            @arg TIM_TIM2_ETR_GPIO            TIM2 ETR is connected to GPIO
-  *            @arg TIM_TIM2_ETR_COMP1           TIM2 ETR is connected to COMP1 output  (*)
+  *            @arg TIM_TIM2_ETR_COMP1           TIM2 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM2_ETR_COMP2           TIM2 ETR is connected to COMP2 output    (*)
   *            @arg TIM_TIM2_ETR_LSE             TIM2 ETR is connected to LSE
-  *            @arg TIM_TIM2_ETR_SAI1_FSA        TIM2 ETR is connected to SAI1 FSA      (*)
-  *            @arg TIM_TIM2_ETR_SAI1_FSB        TIM2 ETR is connected to SAI1 FSB      (*)
+  *            @arg TIM_TIM2_ETR_SAI1_FSA        TIM2 ETR is connected to SAI1 FSA        (*)
+  *            @arg TIM_TIM2_ETR_SAI1_FSB        TIM2 ETR is connected to SAI1 FSB        (*)
   *            @arg TIM_TIM2_ETR_TIM3_ETR        TIM2 ETR is connected to TIM3 ETR pin
-  *            @arg TIM_TIM2_ETR_TIM4_ETR        TIM2 ETR is connected to TIM4 ETR pin  (*)
-  *            @arg TIM_TIM2_ETR_TIM5_ETR        TIM2 ETR is connected to TIM5 ETR pin  (*)
-  *            @arg TIM_TIM2_ETR_ETH_PPS         TIM2 ETR is connected to ETH PPS       (*)
+  *            @arg TIM_TIM2_ETR_TIM4_ETR        TIM2 ETR is connected to TIM4 ETR pin    (*)
+  *            @arg TIM_TIM2_ETR_TIM5_ETR        TIM2 ETR is connected to TIM5 ETR pin    (*)
+  *            @arg TIM_TIM2_ETR_USB_SOF         TIM2 ETR is connected to USB SOF         (*)
+  *            @arg TIM_TIM2_ETR_USBHS_SOF       TIM2 ETR is connected to USBHS OTG SOF   (*)
+  *            @arg TIM_TIM2_ETR_USBFS_SOF       TIM2 ETR is connected to USBFS OTG SOF   (*)
+  *            @arg TIM_TIM2_ETR_ETH_PPS         TIM2 ETR is connected to ETH PPS         (*)
+  *            @arg TIM_TIM2_ETR_PLAY1_OUT0      TIM2 ETR is connected to PLAY1 output 0  (*)
   *
   *         For TIM3, the parameter can take one of the following values:
   *            @arg TIM_TIM3_ETR_GPIO            TIM3 ETR is connected to GPIO
-  *            @arg TIM_TIM3_ETR_COMP1           TIM3 ETR is connected to COMP1 output  (*)
+  *            @arg TIM_TIM3_ETR_COMP1           TIM3 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM3_ETR_COMP2           TIM3 ETR is connected to COMP2 output    (*)
+  *            @arg TIM_TIM3_ETR_ADC2_AWD1       TIM3 ETR is connected to ADC2 AWD1       (*)
+  *            @arg TIM_TIM3_ETR_ADC2_AWD2       TIM3 ETR is connected to ADC2 AWD2       (*)
+  *            @arg TIM_TIM3_ETR_ADC2_AWD3       TIM3 ETR is connected to ADC2 AWD3       (*)
   *            @arg TIM_TIM3_ETR_TIM2_ETR        TIM3 ETR is connected to TIM2 ETR pin
-  *            @arg TIM_TIM3_ETR_TIM4_ETR        TIM3 ETR is connected to TIM4 ETR pin  (*)
-  *            @arg TIM_TIM3_ETR_TIM5_ETR        TIM3 ETR is connected to TIM5 ETR pin  (*)
-  *            @arg TIM_TIM3_ETR_ETH_PPS         TIM3 ETR is connected to ETH PPS       (*)
+  *            @arg TIM_TIM3_ETR_TIM4_ETR        TIM3 ETR is connected to TIM4 ETR pin    (*)
+  *            @arg TIM_TIM3_ETR_TIM5_ETR        TIM3 ETR is connected to TIM5 ETR pin    (*)
+  *            @arg TIM_TIM3_ETR_ETH_PPS         TIM3 ETR is connected to ETH PPS         (*)
+  *            @arg TIM_TIM3_ETR_PLAY1_OUT0      TIM3 ETR is connected to PLAY1 output 0  (*)
   *
   *         For TIM4, the parameter can take one of the following values: (**)
-  *            @arg TIM_TIM4_ETR_GPIO              TIM4 ETR is connected to GPIO
-  *            @arg TIM_TIM4_ETR_TIM2_ETR          TIM4 ETR is connected to TIM2 ETR pin
-  *            @arg TIM_TIM4_ETR_TIM3_ETR          TIM4 ETR is connected to TIM3 ETR pin
-  *            @arg TIM_TIM4_ETR_TIM5_ETR          TIM4 ETR is connected to TIM5 ETR pin
+  *            @arg TIM_TIM4_ETR_GPIO            TIM4 ETR is connected to GPIO
+  *            @arg TIM_TIM4_ETR_COMP1           TIM4 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM4_ETR_COMP2           TIM4 ETR is connected to COMP2 output    (*)
+  *            @arg TIM_TIM4_ETR_TIM2_ETR        TIM4 ETR is connected to TIM2 ETR pin
+  *            @arg TIM_TIM4_ETR_TIM3_ETR        TIM4 ETR is connected to TIM3 ETR pin
+  *            @arg TIM_TIM4_ETR_TIM5_ETR        TIM4 ETR is connected to TIM5 ETR pin
   *
   *         For TIM5, the parameter can take one of the following values: (**)
-  *            @arg TIM_TIM5_ETR_GPIO              TIM5 ETR is connected to GPIO
-  *            @arg TIM_TIM2_ETR_SAI2_FSA        TIM2 ETR is connected to SAI2 FSA
-  *            @arg TIM_TIM2_ETR_SAI2_FSB        TIM2 ETR is connected to SAI2 FSB
-  *            @arg TIM_TIM5_ETR_TIM2_ETR          TIM5 ETR is connected to TIM2 ETR pin
-  *            @arg TIM_TIM5_ETR_TIM3_ETR          TIM5 ETR is connected to TIM3 ETR pin
-  *            @arg TIM_TIM5_ETR_TIM4_ETR          TIM5 ETR is connected to TIM4 ETR pin
+  *            @arg TIM_TIM5_ETR_GPIO            TIM5 ETR is connected to GPIO
+  *            @arg TIM_TIM5_ETR_SAI2_FSA        TIM5 ETR is connected to SAI2 FSA
+  *            @arg TIM_TIM5_ETR_SAI2_FSB        TIM5 ETR is connected to SAI2 FSB
+  *            @arg TIM_TIM5_ETR_COMP1           TIM5 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM5_ETR_COMP2           TIM5 ETR is connected to COMP2 output    (*)
+  *            @arg TIM_TIM5_ETR_TIM2_ETR        TIM5 ETR is connected to TIM2 ETR pin
+  *            @arg TIM_TIM5_ETR_TIM3_ETR        TIM5 ETR is connected to TIM3 ETR pin
+  *            @arg TIM_TIM5_ETR_TIM4_ETR        TIM5 ETR is connected to TIM4 ETR pin
+  *            @arg TIM_TIM5_ETR_USB_SOF         TIM5 ETR is connected to USB SOF         (*)
+  *            @arg TIM_TIM5_ETR_USBHS_SOF       TIM5 ETR is connected to USBHS OTG SOF   (*)
+  *            @arg TIM_TIM5_ETR_USBFS_SOF       TIM5 ETR is connected to USBFS OTG SOF   (*)
   *
   *         For TIM8, the parameter can take one of the following values: (**)
   *            @arg TIM_TIM8_ETR_GPIO            TIM8 ETR is connected to GPIO
+  *            @arg TIM_TIM8_ETR_COMP1           TIM8 ETR is connected to COMP1 output    (*)
+  *            @arg TIM_TIM8_ETR_COMP2           TIM8 ETR is connected to COMP2 output    (*)
   *            @arg TIM_TIM8_ETR_ADC2_AWD1       TIM8 ETR is connected to ADC2 AWD1
   *            @arg TIM_TIM8_ETR_ADC2_AWD2       TIM8 ETR is connected to ADC2 AWD2
   *            @arg TIM_TIM8_ETR_ADC2_AWD3       TIM8 ETR is connected to ADC2 AWD3
+  *            @arg TIM_TIM8_ETR_ADC3_AWD1       TIM8 ETR is connected to ADC3 AWD1       (*)
+  *            @arg TIM_TIM8_ETR_ADC3_AWD2       TIM8 ETR is connected to ADC3 AWD2       (*)
+  *            @arg TIM_TIM8_ETR_ADC3_AWD3       TIM8 ETR is connected to ADC3 AWD3       (*)
   *
   *         (*)  Value not defined in all devices.
   *         (**) Timer instance not available on all devices. \n
@@ -2442,69 +2439,96 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
   * @param  TISelection parameter of the TIM_TISelectionStruct structure is detailed as follows:
   *         For TIM1, the parameter is one of the following values:
   *            @arg TIM_TIM1_TI1_GPIO:                TIM1 TI1 is connected to GPIO
-  *            @arg TIM_TIM1_TI1_COMP1:               TIM1 TI1 is connected to COMP1 output (*)
+  *            @arg TIM_TIM1_TI1_COMP1:               TIM1 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM1_TI1_COMP2:               TIM1 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM1_TI2_GPIO:                TIM1 TI2 is connected to GPIO
   *            @arg TIM_TIM1_TI3_GPIO:                TIM1 TI3 is connected to GPIO
   *            @arg TIM_TIM1_TI4_GPIO:                TIM1 TI4 is connected to GPIO
   *
   *         For TIM2, the parameter is one of the following values:
   *            @arg TIM_TIM2_TI1_GPIO:                TIM2 TI1 is connected to GPIO
-  *            @arg TIM_TIM2_TI1_LSI:                 TIM2 TI1 is connected to LSI          (*)
-  *            @arg TIM_TIM2_TI1_LSE:                 TIM2 TI1 is connected to LSE          (*)
-  *            @arg TIM_TIM2_TI1_ETH_PPS              TIM2 TI1 is connected to ETH PPS      (*)
-  *            @arg TIM_TIM2_TI1_RTC_WKUP:            TIM2 TI2 is connected to RTC_WKUP     (*)
-  *            @arg TIM_TIM2_TI1_TIM3_TI1:            TIM2 TI2 is connected to TIM3_TI1     (*)
+  *            @arg TIM_TIM2_TI1_LSI:                 TIM2 TI1 is connected to LSI             (*)
+  *            @arg TIM_TIM2_TI1_LSE:                 TIM2 TI1 is connected to LSE             (*)
+  *            @arg TIM_TIM2_TI1_RTC_WKUP:            TIM2 TI2 is connected to RTC_WKUP        (*)
+  *            @arg TIM_TIM2_TI1_TIM3_TI1:            TIM2 TI2 is connected to TIM3_TI1        (*)
+  *            @arg TIM_TIM2_TI1_ETH_PPS              TIM2 TI1 is connected to ETH PPS         (*)
+  *            @arg TIM_TIM2_TI1_COMP1                TIM2 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM2_TI1_COMP2                TIM2 TI1 is connected to COMP2 output    (*)
+  *            @arg TIM_TIM2_TI1_PLAY1_OUT3           TIM2 TI1 is connected to PLAY1 output 3  (*)
   *            @arg TIM_TIM2_TI2_GPIO:                TIM2 TI2 is connected to GPIO
-  *            @arg TIM_TIM2_TI2_HSI_1024:            TIM2 TI2 is connected to HSI/1024     (*)
-  *            @arg TIM_TIM2_TI2_CSI_128:             TIM2 TI2 is connected to CSI/128      (*)
-  *            @arg TIM_TIM2_TI2_MCO2:                TIM2 TI2 is connected to MCO1         (*)
-  *            @arg TIM_TIM2_TI2_MCO1:                TIM2 TI2 is connected to MCO1         (*)
+  *            @arg TIM_TIM2_TI2_HSI_1024:            TIM2 TI2 is connected to HSI/1024        (*)
+  *            @arg TIM_TIM2_TI2_CSI_128:             TIM2 TI2 is connected to CSI/128         (*)
+  *            @arg TIM_TIM2_TI2_MCO2:                TIM2 TI2 is connected to MCO2            (*)
+  *            @arg TIM_TIM2_TI2_MCO1:                TIM2 TI2 is connected to MCO1            (*)
+  *            @arg TIM_TIM2_TI2_COMP1:               TIM2 TI2 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM2_TI2_COMP2:               TIM2 TI2 is connected to COMP2 output    (*)
   *            @arg TIM_TIM2_TI3_GPIO:                TIM2 TI3 is connected to GPIO
   *            @arg TIM_TIM2_TI4_GPIO:                TIM2 TI4 is connected to GPIO
-  *            @arg TIM_TIM2_TI4_COMP1:               TIM2 TI4 is connected to COMP1 output (*)
+  *            @arg TIM_TIM2_TI4_COMP1:               TIM2 TI4 is connected to COMP1 output    (*)
   *
   *         For TIM3, the parameter is one of the following values:
   *            @arg TIM_TIM3_TI1_GPIO:                TIM3 TI1 is connected to GPIO
-  *            @arg TIM_TIM3_TI1_COMP1:               TIM3 TI1 is connected to COMP1 output (*)
-  *            @arg TIM_TIM3_TI1_MCO1:                TIM3 TI2 is connected to MCO1         (*)
-  *            @arg TIM_TIM3_TI1_TIM2_TI1:            TIM3 TI2 is connected to TIM2 TI1     (*)
-  *            @arg TIM_TIM3_TI1_HSE_1MHZ:            TIM3 TI2 is connected to HSE_1MHZ     (*)
-  *            @arg TIM_TIM3_TI1_ETH_PPS              TIM3 TI1 is connected to ETH PPS      (*)
+  *            @arg TIM_TIM3_TI1_COMP1:               TIM3 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM3_TI1_MCO1:                TIM3 TI2 is connected to MCO1            (*)
+  *            @arg TIM_TIM3_TI1_TIM2_TI1:            TIM3 TI2 is connected to TIM2 TI1        (*)
+  *            @arg TIM_TIM3_TI1_HSE_1MHZ:            TIM3 TI2 is connected to HSE_1MHZ        (*)
+  *            @arg TIM_TIM3_TI1_ETH_PPS              TIM3 TI1 is connected to ETH PPS         (*)
+  *            @arg TIM_TIM3_TI1_COMP1                TIM3 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM3_TI1_COMP2                TIM3 TI1 is connected to COMP2 output    (*)
+  *            @arg TIM_TIM3_TI1_PLAY1_OUT3           TIM3 TI1 is connected to PLAY1 output 3  (*)
   *            @arg TIM_TIM3_TI2_GPIO:                TIM3 TI2 is connected to GPIO
-  *            @arg TIM_TIM3_TI2_CSI_128:             TIM3 TI2 is connected to CSI_128      (*)
-  *            @arg TIM_TIM3_TI2_MCO2:                TIM3 TI2 is connected to MCO2         (*)
-  *            @arg TIM_TIM3_TI2_HSI_1024:            TIM3 TI2 is connected to HSI_1024     (*)
+  *            @arg TIM_TIM3_TI2_CSI_128:             TIM3 TI2 is connected to CSI_128         (*)
+  *            @arg TIM_TIM3_TI2_MCO2:                TIM3 TI2 is connected to MCO2            (*)
+  *            @arg TIM_TIM3_TI2_HSI_1024:            TIM3 TI2 is connected to HSI_1024        (*)
+  *            @arg TIM_TIM3_TI2_COMP1:               TIM3 TI2 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM3_TI2_COMP2:               TIM3 TI2 is connected to COMP2 output    (*)
   *            @arg TIM_TIM3_TI3_GPIO:                TIM3 TI2 is connected to GPIO
   *            @arg TIM_TIM3_TI4_GPIO:                TIM3 TI2 is connected to GPIO
   *
   *         For TIM4, the parameter is one of the following values: (**)
   *            @arg TIM_TIM4_TI1_GPIO:                TIM4 TI1 is connected to GPIO
+  *            @arg TIM_TIM4_TI1_COMP1                TIM4 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM4_TI1_COMP2                TIM4 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM4_TI2_GPIO:                TIM4 TI2 is connected to GPIO
   *            @arg TIM_TIM4_TI3_GPIO:                TIM4 TI3 is connected to GPIO
   *            @arg TIM_TIM4_TI4_GPIO:                TIM4 TI4 is connected to GPIO
   *
   *         For TIM5, the parameter is one of the following values: (**)
   *            @arg TIM_TIM5_TI1_GPIO:                TIM5 TI1 is connected to GPIO
+  *            @arg TIM_TIM5_TI1_COMP1                TIM5 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM5_TI1_COMP2                TIM5 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM5_TI2_GPIO:                TIM5 TI2 is connected to GPIO
   *            @arg TIM_TIM5_TI3_GPIO:                TIM5 TI3 is connected to GPIO
   *            @arg TIM_TIM5_TI4_GPIO:                TIM5 TI4 is connected to GPIO
   *
   *         For TIM8, the parameter is one of the following values: (**)
   *            @arg TIM_TIM8_TI1_GPIO:                TIM8 TI1 is connected to GPIO
+  *            @arg TIM_TIM8_TI1_COMP1                TIM8 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM8_TI1_COMP2                TIM8 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM8_TI2_GPIO:                TIM8 TI2 is connected to GPIO
   *            @arg TIM_TIM8_TI3_GPIO:                TIM8 TI3 is connected to GPIO
   *            @arg TIM_TIM8_TI4_GPIO:                TIM8 TI4 is connected to GPIO
   *
   *         For TIM12, the parameter is one of the following values: (**)
   *            @arg TIM_TIM12_TI1_GPIO:              TIM12 TI1 is connected to GPIO
+  *            @arg TIM_TIM12_TI1_COMP1              TIM12 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM12_TI1_COMP2              TIM12 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM12_TI1_HSI_1024:          TIM12 TI1 is connected to HSI/1024
   *            @arg TIM_TIM12_TI1_CSI_128:           TIM12 TI1 is connected to CSI/128
+  *            @arg TIM_TIM12_TI2_GPIO:              TIM12 TI2 is connected to GPIO
+  *            @arg TIM_TIM12_TI2_COMP2              TIM12 TI2 is connected to COMP2 output    (*)
   *
   *         For TIM13, the parameter is one of the following values: (**)
-  *            @arg TIM_TIM12_TI1_GPIO:              TIM13 TI1 is connected to GPIO
+  *            @arg TIM_TIM13_TI1_GPIO:              TIM13 TI1 is connected to GPIO
+  *            @arg TIM_TIM13_TI1_I3C1_IBIACK        TIM13 TI1 is connected to I3C1 IBI ACK    (*)
+  *            @arg TIM_TIM13_TI1_COMP1              TIM13 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM13_TI1_COMP2              TIM13 TI1 is connected to COMP2 output    (*)
   *
   *         For TIM14, the parameter is one of the following values: (**)
   *            @arg TIM_TIM14_TI1_GPIO:              TIM14 TI1 is connected to GPIO
+  *            @arg TIM_TIM14_TI1_I3C2_IBIACK        TIM14 TI1 is connected to I3C2 IBI ACK    (*)
+  *            @arg TIM_TIM14_TI1_COMP1              TIM14 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM14_TI1_COMP2              TIM14 TI1 is connected to COMP2 output    (*)
   *
   *         For TIM15, the parameter can have the following values: (**)
   *            @arg TIM_TIM15_TI1_GPIO:              TIM15 TI1 is connected to GPIO
@@ -2513,22 +2537,30 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
   *            @arg TIM_TIM15_TI1_TIM4:              TIM15 TI1 is connected to TIM4
   *            @arg TIM_TIM15_TI1_LSE:               TIM15 TI1 is connected to LSE
   *            @arg TIM_TIM15_TI1_CSI_128:           TIM15 TI1 is connected to CSI/128
-  *            @arg TIM_TIM15_TI1_MCO:               TIM15 TI1 is connected to MCO
+  *            @arg TIM_TIM15_TI1_MCO2:              TIM15 TI1 is connected to MCO2
+  *            @arg TIM_TIM15_TI1_COMP1              TIM15 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM15_TI1_COMP2              TIM15 TI1 is connected to COMP2 output    (*)
   *            @arg TIM_TIM15_TI2_GPIO:              TIM15 TI1 is connected to GPIO
   *            @arg TIM_TIM15_TI2_TIM2:              TIM15 TI1 is connected to TIM2
   *            @arg TIM_TIM15_TI2_TIM3:              TIM15 TI1 is connected to TIM3
   *            @arg TIM_TIM15_TI2_TIM4:              TIM15 TI1 is connected to TIM4
+  *            @arg TIM_TIM15_TI2_COMP1              TIM15 TI2 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM15_TI2_COMP2              TIM15 TI2 is connected to COMP2 output    (*)
   *
   *         For TIM16, the parameter is one of the following values: (**)
   *            @arg TIM_TIM16_TI1_GPIO:              TIM16 TI1 is connected to GPIO
   *            @arg TIM_TIM16_TI1_LSI:               TIM16 TI1 is connected to LSI
   *            @arg TIM_TIM16_TI1_LSE:               TIM16 TI1 is connected to LSE
   *            @arg TIM_TIM16_TI1_RTC_WKUP:          TIM16 TI1 is connected to RTCWKUP
+  *            @arg TIM_TIM16_TI1_COMP1              TIM16 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM16_TI1_COMP2              TIM16 TI1 is connected to COMP2 output    (*)
   *
   *         For TIM17, the parameter can have the following values: (**)
   *            @arg TIM_TIM17_TI1_GPIO:              TIM17 TI1 is connected to GPIO
   *            @arg TIM_TIM17_TI1_HSE_1MHZ:          TIM17 TI1 is connected to HSE_1MHZ
-  *            @arg TIM_TIM17_TI1_MCO:               TIM17 TI1 is connected to MCO
+  *            @arg TIM_TIM17_TI1_MCO1:              TIM17 TI1 is connected to MCO1
+  *            @arg TIM_TIM17_TI1_COMP1              TIM17 TI1 is connected to COMP1 output    (*)
+  *            @arg TIM_TIM17_TI1_COMP2              TIM17 TI1 is connected to COMP2 output    (*)
   *
   *         (*)  Value not defined in all devices. \n
   *         (**) Timer instance not available on all devices. \n
@@ -2548,6 +2580,18 @@ HAL_StatusTypeDef  HAL_TIMEx_TISelection(TIM_HandleTypeDef *htim, uint32_t TISel
   {
     case TIM_CHANNEL_1:
       MODIFY_REG(htim->Instance->TISEL, TIM_TISEL_TI1SEL, TISelection);
+
+#if defined(TIM17)
+      /* If required, set OR1 bit to request HSE 1MHz clock */
+      if ((IS_TIM_RTCPREEN_INSTANCE(htim->Instance)) && (IS_TIM_RTCPREEN_SELECTION(TISelection)))
+      {
+        SET_BIT(htim->Instance->OR1, TIM_OR1_RTCPREEN);
+      }
+      else
+      {
+        CLEAR_BIT(htim->Instance->OR1, TIM_OR1_RTCPREEN);
+      }
+#endif /* TIM17 */
       break;
     case TIM_CHANNEL_2:
       MODIFY_REG(htim->Instance->TISEL, TIM_TISEL_TI2SEL, TISelection);
@@ -2620,7 +2664,7 @@ HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t B
   uint32_t tmpbdtr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
   assert_param(IS_TIM_BREAKINPUT(BreakInput));
 
   switch (BreakInput)
@@ -2637,7 +2681,6 @@ HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t B
       }
       break;
     }
-
     case TIM_BREAKINPUT_BRK2:
     {
       /* Check initial conditions */
@@ -2675,7 +2718,7 @@ HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(const TIM_HandleTypeDef *htim, uint3
   uint32_t tickstart;
 
   /* Check the parameters */
-  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
   assert_param(IS_TIM_BREAKINPUT(BreakInput));
 
   switch (BreakInput)
@@ -3089,7 +3132,7 @@ HAL_StatusTypeDef HAL_TIMEx_DisableEncoderFirstIndex(TIM_HandleTypeDef *htim)
   */
 
 /**
-  * @brief  Hall commutation changed callback in non-blocking mode
+  * @brief  Commutation callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -3103,7 +3146,7 @@ __weak void HAL_TIMEx_CommutCallback(TIM_HandleTypeDef *htim)
    */
 }
 /**
-  * @brief  Hall commutation changed half complete callback in non-blocking mode
+  * @brief  Commutation half complete callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -3118,7 +3161,7 @@ __weak void HAL_TIMEx_CommutHalfCpltCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break detection callback in non-blocking mode
+  * @brief  Break detection callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -3133,7 +3176,7 @@ __weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break2 detection callback in non blocking mode
+  * @brief  Break2 detection callback in non blocking mode
   * @param  htim: TIM handle
   * @retval None
   */
@@ -3322,38 +3365,18 @@ static void TIM_DMADelayPulseNCplt(DMA_HandleTypeDef *hdma)
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-    }
   }
   else
   {
@@ -3393,6 +3416,11 @@ static void TIM_DMAErrorCCxN(DMA_HandleTypeDef *hdma)
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
     TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
   }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+  }
   else
   {
     /* nothing to do */
@@ -3424,13 +3452,13 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
 {
   uint32_t tmp;
 
-  tmp = TIM_CCER_CC1NE << (Channel & 0x1FU); /* 0x1FU = 31 bits max shift */
+  tmp = TIM_CCER_CC1NE << (Channel & 0xFU); /* 0xFU = 15 bits max shift */
 
   /* Reset the CCxNE Bit */
   TIMx->CCER &=  ~tmp;
 
   /* Set or reset the CCxNE Bit */
-  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0x1FU)); /* 0x1FU = 31 bits max shift */
+  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0xFU)); /* 0xFU = 15 bits max shift */
 }
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_tim_ex.h
@@ -106,70 +106,119 @@ typedef struct
 /** @defgroup TIMEx_Remap TIM Extended Remapping
   * @{
   */
-#define TIM_TIM1_ETR_GPIO           0x00000000UL                                                /*!< TIM1_ETR is not connected to I/O      */
+#define TIM_TIM1_ETR_GPIO           0x00000000UL                                                /*!< TIM1_ETR is not connected to I/O         */
 #if defined(COMP1)
-#define TIM_TIM1_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM1_ETR is connected to COMP1 output */
+#define TIM_TIM1_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM1_ETR is connected to COMP1 output    */
 #endif /* COMP1 */
-#define TIM_TIM1_ETR_ADC1_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM1_ETR is connected to ADC1 AWD1    */
-#define TIM_TIM1_ETR_ADC1_AWD2      TIM1_AF1_ETRSEL_2                                           /*!< TIM1_ETR is connected to ADC1 AWD2    */
-#define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM1_ETR is connected to ADC1 AWD3    */
+#if defined(COMP1)
+#define TIM_TIM1_ETR_COMP2          TIM1_AF1_ETRSEL_1                                           /*!< TIM1_ETR is connected to COMP2 output    */
+#endif /* COMP1 */
+#define TIM_TIM1_ETR_ADC1_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM1_ETR is connected to ADC1 AWD1       */
+#define TIM_TIM1_ETR_ADC1_AWD2      TIM1_AF1_ETRSEL_2                                           /*!< TIM1_ETR is connected to ADC1 AWD2       */
+#define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM1_ETR is connected to ADC1 AWD3       */
 
-#define TIM_TIM2_ETR_GPIO           0x00000000UL                                                /*!< TIM2_ETR is not connected to I/O      */
+#define TIM_TIM2_ETR_GPIO           0x00000000UL                                                /*!< TIM2_ETR is not connected to I/O         */
 #if defined(COMP1)
-#define TIM_TIM2_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM2_ETR is connected to COMP1 output */
+#define TIM_TIM2_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM2_ETR is connected to COMP1 output    */
 #endif /* COMP1 */
-#define TIM_TIM2_ETR_LSE            (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_1)                     /*!< TIM2_ETR is connected to LSE          */
+#if defined(COMP2)
+#define TIM_TIM2_ETR_COMP2          TIM1_AF1_ETRSEL_0                                           /*!< TIM2_ETR is connected to COMP2 output    */
+#endif /* COMP2 */
+#define TIM_TIM2_ETR_LSE            (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM2_ETR is connected to LSE             */
 #if defined(SAI1)
-#define TIM_TIM2_ETR_SAI1_FSA       TIM1_AF1_ETRSEL_2                                           /*!< TIM2_ETR is connected to SAI1 FS_A    */
-#define TIM_TIM2_ETR_SAI1_FSB       (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_2)                     /*!< TIM2_ETR is connected to SAI1         */
+#define TIM_TIM2_ETR_SAI1_FSA       TIM1_AF1_ETRSEL_2                                           /*!< TIM2_ETR is connected to SAI1 FS_A       */
+#define TIM_TIM2_ETR_SAI1_FSB       (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM2_ETR is connected to SAI1            */
 #endif /* SAI1 */
-#define TIM_TIM2_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_3)                     /*!< TIM2_ETR is connected to TIM3 ETR     */
+#define TIM_TIM2_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< TIM2_ETR is connected to TIM3 ETR        */
 #if defined(TIM4)
-#define TIM_TIM2_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_3)                     /*!< TIM2_ETR is connected to TIM4 ETR     */
+#define TIM_TIM2_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< TIM2_ETR is connected to TIM4 ETR        */
 #endif /* TIM4 */
 #if defined(TIM5)
-#define TIM_TIM2_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_3 ) /*!< TIM2_ETR is connected to TIM5 ETR     */
+#define TIM_TIM2_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< TIM2_ETR is connected to TIM5 ETR        */
 #endif /* TIM5 */
+#if defined(USB_DRD_FS)
+#define TIM_TIM2_ETR_USB_SOF        (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< TIM2_ETR is connected to USB SOF         */
+#elif defined(USB_OTG_HS)
+#define TIM_TIM2_ETR_USBHS_SOF      (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2)                     /*!< TIM2_ETR is connected to USBHS OTG SOF   */
+#define TIM_TIM2_ETR_USBFS_SOF      (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< TIM2_ETR is connected to USBFS OTG SOF   */
+#endif /* USB_DRD_FS */
 #if defined(ETH_NS)
-#define TIM_TIM2_ETR_ETH_PPS        (TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_3 ) /*!< TIM2_ETR is connected to ETH PPS      */
+#define TIM_TIM2_ETR_ETH_PPS        (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1) /*!< TIM2_ETR is connected to ETH PPS         */
 #endif /* ETH_NS */
+#if defined(PLAY1)
+#define TIM_TIM2_ETR_PLAY1_OUT0     TIM1_AF1_ETRSEL_Msk                                         /*!< TIM2_ETR is connected to PLAY1 output 0  */
+#endif /* PLAY1 */
 
-#define TIM_TIM3_ETR_GPIO           0x00000000UL                                                /*!< TIM3_ETR is not connected to I/O      */
+#define TIM_TIM3_ETR_GPIO           0x00000000UL                                                /*!< TIM3_ETR is not connected to I/O         */
 #if defined(COMP1)
-#define TIM_TIM3_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM3_ETR is connected to COMP1 output */
+#define TIM_TIM3_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM3_ETR is connected to COMP1 output    */
 #endif /* COMP1 */
-#define TIM_TIM3_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM3_ETR is connected to TIM2 ETR     */
+#if defined(COMP2)
+#define TIM_TIM3_ETR_COMP2          TIM1_AF1_ETRSEL_1                                           /*!< TIM3_ETR is connected to COMP2 output    */
+#endif /* COMP2 */
+#if defined(ADC2)
+#define TIM_TIM3_ETR_ADC2_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM3_ETR is connected to ADC2 AWD1       */
+#define TIM_TIM3_ETR_ADC2_AWD2      TIM1_AF1_ETRSEL_2                                           /*!< TIM3_ETR is connected to ADC2 AWD2       */
+#define TIM_TIM3_ETR_ADC2_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM3_ETR is connected to ADC2 AWD3       */
+#endif /* ADC2 */
+#define TIM_TIM3_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM3_ETR is connected to TIM2 ETR        */
 #if defined(TIM4)
-#define TIM_TIM3_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< TIM3_ETR is connected to TIM4 ETR     */
+#define TIM_TIM3_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< TIM3_ETR is connected to TIM4 ETR        */
 #endif /* TIM4 */
 #if defined(TIM5)
-#define TIM_TIM3_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_0)  /*!< TIM3_ETR is connected to TIM5 ETR     */
+#define TIM_TIM3_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_0)  /*!< TIM3_ETR is connected to TIM5 ETR        */
 #endif /* TIM5 */
 #if defined(ETH_NS)
-#define TIM_TIM3_ETR_ETH_PPS        (TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_3 ) /*!< TIM3_ETR is connected to ETH PPS      */
+#define TIM_TIM3_ETR_ETH_PPS        (TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_3 ) /*!< TIM3_ETR is connected to ETH PPS         */
 #endif /* ETH_NS */
+#if defined(PLAY1)
+#define TIM_TIM3_ETR_PLAY1_OUT0     TIM1_AF1_ETRSEL_Msk                                         /*!< TIM3_ETR is connected to PLAY1 output 0  */
+#endif /* PLAY1 */
 
 #if defined(TIM4)
-#define TIM_TIM4_ETR_GPIO           0x00000000UL                                                /*!< TIM4_ETR is not connected to I/O      */
-#define TIM_TIM4_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM4_ETR is connected to TIM2 ETR     */
-#define TIM_TIM4_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< TIM4_ETR is connected to TIM3 ETR     */
-#define TIM_TIM4_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_0)  /*!< TIM4_ETR is connected to TIM5 ETR     */
+#define TIM_TIM4_ETR_GPIO           0x00000000UL                                                /*!< TIM4_ETR is not connected to I/O         */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM4_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM4_ETR is connected to COMP1 output    */
+#define TIM_TIM4_ETR_COMP2          TIM1_AF1_ETRSEL_1                                           /*!< TIM4_ETR is connected to COMP2 output    */
+#endif /* COMP1 && COMP2 */
+#define TIM_TIM4_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM4_ETR is connected to TIM2 ETR        */
+#define TIM_TIM4_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< TIM4_ETR is connected to TIM3 ETR        */
+#define TIM_TIM4_ETR_TIM5_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_0)  /*!< TIM4_ETR is connected to TIM5 ETR        */
 #endif /* TIM4 */
 
 #if defined(TIM5)
-#define TIM_TIM5_ETR_GPIO           0x00000000UL                                                /*!< TIM5_ETR is not connected to I/O      */
-#define TIM_TIM5_ETR_SAI2_FSA       TIM1_AF1_ETRSEL_0                                           /*!< TIM5_ETR is connected to SAI2         */
-#define TIM_TIM5_ETR_SAI2_FSB       TIM1_AF1_ETRSEL_1                                           /*!< TIM5_ETR is connected to SAI2         */
-#define TIM_TIM5_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM5_ETR is connected to TIM2 ETR     */
-#define TIM_TIM5_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< TIM5_ETR is connected to TIM3 ETR     */
-#define TIM_TIM5_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< TIM5_ETR is connected to TIM4 ETR     */
+#define TIM_TIM5_ETR_GPIO           0x00000000UL                                                /*!< TIM5_ETR is not connected to I/O         */
+#define TIM_TIM5_ETR_SAI2_FSA       TIM1_AF1_ETRSEL_0                                           /*!< TIM5_ETR is connected to SAI2            */
+#define TIM_TIM5_ETR_SAI2_FSB       TIM1_AF1_ETRSEL_1                                           /*!< TIM5_ETR is connected to SAI2            */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM5_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM5_ETR is connected to COMP1 output    */
+#define TIM_TIM5_ETR_COMP2          TIM1_AF1_ETRSEL_1                                           /*!< TIM5_ETR is connected to COMP2 output    */
+#endif /* COMP1 && COMP2 */
+#define TIM_TIM5_ETR_TIM2_ETR       TIM1_AF1_ETRSEL_3                                           /*!< TIM5_ETR is connected to TIM2 ETR        */
+#define TIM_TIM5_ETR_TIM3_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< TIM5_ETR is connected to TIM3 ETR        */
+#define TIM_TIM5_ETR_TIM4_ETR       (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< TIM5_ETR is connected to TIM4 ETR        */
+#if defined(USB_DRD_FS)
+#define TIM_TIM5_ETR_USB_SOF        (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< TIM5_ETR is connected to USB SOF         */
+#elif defined(USB_OTG_HS)
+#define TIM_TIM5_ETR_USBHS_SOF      (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2)                     /*!< TIM5_ETR is connected to USBHS OTG SOF   */
+#define TIM_TIM5_ETR_USBFS_SOF      (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< TIM5_ETR is connected to USBFS OTG SOF   */
+#endif /* USB_DRD_FS */
 #endif /* TIM5 */
 
 #if defined(TIM8)
-#define TIM_TIM8_ETR_GPIO           0x00000000UL                                                /*!< TIM8_ETR is not connected to I/O      */
-#define TIM_TIM8_ETR_ADC2_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM8_ETR is connected to ADC1 AWD1    */
-#define TIM_TIM8_ETR_ADC2_AWD2       TIM1_AF1_ETRSEL_2                                          /*!< TIM8_ETR is connected to ADC1 AWD2    */
-#define TIM_TIM8_ETR_ADC2_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM8_ETR is connected to ADC1 AWD3    */
+#define TIM_TIM8_ETR_GPIO           0x00000000UL                                                /*!< TIM8_ETR is not connected to I/O         */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM8_ETR_COMP1          TIM1_AF1_ETRSEL_0                                           /*!< TIM8_ETR is connected to COMP1 output    */
+#define TIM_TIM8_ETR_COMP2          TIM1_AF1_ETRSEL_1                                           /*!< TIM8_ETR is connected to COMP2 output    */
+#endif /* COMP1 && COMP2 */
+#define TIM_TIM8_ETR_ADC2_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< TIM8_ETR is connected to ADC2 AWD1       */
+#define TIM_TIM8_ETR_ADC2_AWD2       TIM1_AF1_ETRSEL_2                                          /*!< TIM8_ETR is connected to ADC2 AWD2       */
+#define TIM_TIM8_ETR_ADC2_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< TIM8_ETR is connected to ADC2 AWD3       */
+#if defined(ADC3)
+#define TIM_TIM8_ETR_ADC3_AWD1      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1)                     /*!< TIM8_ETR is connected to ADC3 AWD1       */
+#define TIM_TIM8_ETR_ADC3_AWD2      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< TIM8_ETR is connected to ADC3 AWD2       */
+#define TIM_TIM8_ETR_ADC3_AWD3      TIM1_AF1_ETRSEL_3                                           /*!< TIM8_ETR is connected to ADC3 AWD3       */
+#endif /* ADC3 */
 #endif /* TIM8 */
 /**
   * @}
@@ -191,6 +240,15 @@ typedef struct
 #if defined(COMP1)
 #define TIM_BREAKINPUTSOURCE_COMP1    0x00000002U                               /*!< The COMP1 output is connected to the break input */
 #endif /* COMP1 */
+#if defined(COMP2)
+#define TIM_BREAKINPUTSOURCE_COMP2    0x00000004U                               /*!< The COMP2 output is connected to the break input */
+#endif /* COMP2 */
+#if defined(PLAY1)
+#define TIM_BREAKINPUTSOURCE_PLAY1    0x00000008U                               /*!< The PLAY1 output is connected to the break input (only for BKIN) */
+#endif /* PLAY1 */
+#if defined(MDF1)
+#define TIM_BREAKINPUTSOURCE_MDF1     0x00000100U                               /*!< The Digital filter break output is connected to the break input */
+#endif /* MDF1 */
 /**
   * @}
   */
@@ -217,9 +275,12 @@ typedef struct
   * @{
   */
 #define TIM_TIM1_TI1_GPIO                         0x00000000UL                                        /*!< TIM1_TI1 is connected to GPIO      */
-#if defined(COMP1)
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM1_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM1_TI1 is connected to COMP1 OUT */
+#define TIM_TIM1_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM1_TI1 is connected to COMP2 OUT */
+#elif defined(COMP1)
 #define TIM_TIM1_TI1_COMP1                        TIM_TISEL_TI1SEL_0                                  /*!< TIM1_TI1 is connected to COMP1 OUT */
-#endif /* COMP1 */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM1_TI2_GPIO                         0x00000000UL                                        /*!< TIM1_TI2 is connected to GPIO */
 #define TIM_TIM1_TI3_GPIO                         0x00000000UL                                        /*!< TIM1_TI3 is connected to GPIO */
 #define TIM_TIM1_TI4_GPIO                         0x00000000UL                                        /*!< TIM1_TI4 is connected to GPIO */
@@ -234,6 +295,11 @@ typedef struct
 #if defined(ETH_NS)
 #define TIM_TIM2_TI1_ETH_PPS                      TIM_TISEL_TI1SEL_0                                  /*!< TIM2_TI1 is connected to ETH PPS  */
 #endif /* ETH_NS */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM2_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM2_TI1 is connected to COMP1 output */
+#define TIM_TIM2_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM2_TI1 is connected to COMP2 output */
+#define TIM_TIM2_TI1_PLAY1_OUT3                   TIM_TISEL_TI1SEL_2                                  /*!< TIM2_TI1 is connected to PLAY1 output 3 */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM2_TI2_GPIO                         0x00000000UL                                        /*!< TIM2_TI2 is connected to GPIO */
 #if defined(STM32H503xx)
 #define TIM_TIM2_TI2_HSI_1024                     TIM_TISEL_TI2SEL_0                                  /*!< TIM2_TI2 is connected to HSI_1024 */
@@ -241,11 +307,15 @@ typedef struct
 #define TIM_TIM2_TI2_MCO2                         (TIM_TISEL_TI2SEL_1 |TIM_TISEL_TI2SEL_0)            /*!< TIM2_TI2 is connected to MCO2     */
 #define TIM_TIM2_TI2_MCO1                         TIM_TISEL_TI2SEL_2                                  /*!< TIM2_TI2 is connected to MCO1     */
 #endif /* STM32H503xx */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM2_TI2_COMP1                        TIM_TISEL_TI2SEL_0                                  /*!< TIM2_TI2 is connected to COMP1 output */
+#define TIM_TIM2_TI2_COMP2                        TIM_TISEL_TI2SEL_1                                  /*!< TIM2_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM2_TI3_GPIO                         0x00000000UL                                        /*!< TIM2_TI3 is connected to GPIO */
 #define TIM_TIM2_TI4_GPIO                         0x00000000UL                                        /*!< TIM2_TI4 is connected to GPIO */
-#if defined(COMP1)
+#if defined(STM32H503xx)
 #define TIM_TIM2_TI4_COMP1                        TIM_TISEL_TI4SEL_0                                  /*!< TIM2_TI4 is connected to COMP1 */
-#endif /* COMP1 */
+#endif /* STM32H503xx */
 
 #define TIM_TIM3_TI1_GPIO                          0x00000000UL                                       /*!< TIM3_TI1 is connected to GPIO */
 #if defined(STM32H503xx)
@@ -257,17 +327,30 @@ typedef struct
 #if defined(ETH_NS)
 #define TIM_TIM3_TI1_ETH_PPS                      TIM_TISEL_TI1SEL_0                                  /*!< TIM3_TI1 is connected to ETH PPS */
 #endif /* ETH_NS */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM3_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM3_TI1 is connected to COMP1 output */
+#define TIM_TIM3_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM3_TI1 is connected to COMP2 output */
+#define TIM_TIM3_TI1_PLAY1_OUT3                   TIM_TISEL_TI1SEL_2                                  /*!< TIM3_TI1 is connected to PLAY1 output 3 */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM3_TI2_GPIO                         0x00000000UL                                        /*!< TIM3_TI2 is connected to GPIO */
 #if defined(STM32H503xx)
 #define TIM_TIM3_TI2_CSI_128                      TIM_TISEL_TI2SEL_0                                  /*!< TIM3_TI2 is connected to CSI 128  */
 #define TIM_TIM3_TI2_MCO2                         TIM_TISEL_TI2SEL_1                                  /*!< TIM3_TI2 is connected to MCO2     */
 #define TIM_TIM3_TI2_HSI_1024                     (TIM_TISEL_TI2SEL_1 |TIM_TISEL_TI2SEL_0)            /*!< TIM3_TI2 is connected to HSI 1024 */
 #endif /* STM32H503xx */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM3_TI2_COMP1                        TIM_TISEL_TI2SEL_0                                  /*!< TIM3_TI2 is connected to COMP1 output */
+#define TIM_TIM3_TI2_COMP2                        TIM_TISEL_TI2SEL_1                                  /*!< TIM3_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM3_TI3_GPIO                         0x00000000UL                                        /*!< TIM3_TI3 is connected to GPIO */
 #define TIM_TIM3_TI4_GPIO                         0x00000000UL                                        /*!< TIM3_TI4 is connected to GPIO */
 
 #if defined(TIM4)
 #define TIM_TIM4_TI1_GPIO                         0x00000000UL                                        /*!< TIM4_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM4_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM4_TI1 is connected to COMP1 output */
+#define TIM_TIM4_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM4_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM4_TI2_GPIO                         0x00000000UL                                        /*!< TIM4_TI2 is connected to GPIO */
 #define TIM_TIM4_TI3_GPIO                         0x00000000UL                                        /*!< TIM4_TI3 is connected to GPIO */
 #define TIM_TIM4_TI4_GPIO                         0x00000000UL                                        /*!< TIM4_TI4 is connected to GPIO */
@@ -275,6 +358,10 @@ typedef struct
 
 #if defined(TIM5)
 #define TIM_TIM5_TI1_GPIO                         0x00000000UL                                        /*!< TIM5_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM5_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM5_TI1 is connected to COMP1 output */
+#define TIM_TIM5_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM5_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM5_TI2_GPIO                         0x00000000UL                                        /*!< TIM5_TI2 is connected to GPIO */
 #define TIM_TIM5_TI3_GPIO                         0x00000000UL                                        /*!< TIM5_TI3 is connected to GPIO */
 #define TIM_TIM5_TI4_GPIO                         0x00000000UL                                        /*!< TIM5_TI4 is connected to GPIO */
@@ -282,6 +369,10 @@ typedef struct
 
 #if defined(TIM8)
 #define TIM_TIM8_TI1_GPIO                         0x00000000UL                                        /*!< TIM8_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM8_TI1_COMP1                        TIM_TISEL_TI1SEL_1                                  /*!< TIM8_TI1 is connected to COMP1 output */
+#define TIM_TIM8_TI1_COMP2                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM8_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM8_TI2_GPIO                         0x00000000UL                                        /*!< TIM8_TI2 is connected to GPIO */
 #define TIM_TIM8_TI3_GPIO                         0x00000000UL                                        /*!< TIM8_TI3 is connected to GPIO */
 #define TIM_TIM8_TI4_GPIO                         0x00000000UL                                        /*!< TIM8_TI4 is connected to GPIO */
@@ -289,16 +380,38 @@ typedef struct
 
 #if defined(TIM12)
 #define TIM_TIM12_TI1_GPIO                        0x00000000UL                                        /*!< TIM12_TI1 is connected to GPIO     */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM12_TI1_COMP1                       TIM_TISEL_TI1SEL_1                                  /*!< TIM12_TI1 is connected to COMP1 output */
+#define TIM_TIM12_TI1_COMP2                       (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM12_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM12_TI1_HSI_1024                    TIM_TISEL_TI1SEL_2                                  /*!< TIM12_TI1 is connected to HSI 1024 */
 #define TIM_TIM12_TI1_CSI_128                     (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_0)            /*!< TIM12_TI1 is connected to CSI 128  */
+#define TIM_TIM12_TI2_GPIO                        0x00000000UL                                        /*!< TIM12_TI2 is connected to GPIO */
+#if defined(COMP2)
+#define TIM_TIM12_TI2_COMP2                       TIM_TISEL_TI2SEL_0                                  /*!< TIM12_TI2 is connected to COMP2 output */
+#endif /* COMP2 */
 #endif /* TIM12 */
 
 #if defined(TIM13)
 #define TIM_TIM13_TI1_GPIO                        0x00000000UL                                        /*!< TIM13_TI1 is connected to GPIO */
+#if defined(I3C1)
+#define TIM_TIM13_TI1_I3C1_IBIACK                 TIM_TISEL_TI1SEL_0                                  /*!< TIM13_TI1 is connected to I3C1 IBI ACK */
+#endif /* I3C1 */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM13_TI1_COMP1                       TIM_TISEL_TI1SEL_1                                  /*!< TIM13_TI1 is connected to COMP1 output */
+#define TIM_TIM13_TI1_COMP2                       (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM13_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #endif /* TIM13 */
 
 #if defined(TIM14)
 #define TIM_TIM14_TI1_GPIO                        0x00000000UL                                        /*!< TIM14_TI1 is connected to GPIO */
+#if defined(I3C2)
+#define TIM_TIM14_TI1_I3C2_IBIACK                 TIM_TISEL_TI1SEL_0                                  /*!< TIM14_TI1 is connected to I3C2 IBI ACK */
+#endif /* I3C1 */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM14_TI1_COMP1                       TIM_TISEL_TI1SEL_1                                  /*!< TIM14_TI1 is connected to COMP1 output */
+#define TIM_TIM14_TI1_COMP2                       (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM14_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #endif /* TIM14 */
 
 #if defined(TIM15)
@@ -309,10 +422,18 @@ typedef struct
 #define TIM_TIM15_TI1_LSE                         TIM_TISEL_TI1SEL_2                                  /*!< TIM15_TI1 is connected to LSE    */
 #define TIM_TIM15_TI1_CSI_128                     (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_0)            /*!< TIM15_TI1 is connected to CSI 128*/
 #define TIM_TIM15_TI1_MCO2                        (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_1)            /*!< TIM15_TI1 is connected to MCO2   */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM15_TI1_COMP1                       TIM_TISEL_TI1SEL_3                                  /*!< TIM15_TI1 is connected to COMP1 output */
+#define TIM_TIM15_TI1_COMP2                       (TIM_TISEL_TI1SEL_3 | TIM_TISEL_TI1SEL_0)           /*!< TIM15_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define TIM_TIM15_TI2_GPIO                        0x00000000UL                                        /*!< TIM15_TI1 is connected to GPIO   */
 #define TIM_TIM15_TI2_TIM2                        TIM_TISEL_TI2SEL_0                                  /*!< TIM15_TI2 is connected to TIM2   */
 #define TIM_TIM15_TI2_TIM3                        TIM_TISEL_TI2SEL_1                                  /*!< TIM15_TI2 is connected to TIM3   */
 #define TIM_TIM15_TI2_TIM4                        (TIM_TISEL_TI2SEL_1 | TIM_TISEL_TI2SEL_0)           /*!< TIM15_TI2 is connected to TIM4   */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM15_TI2_COMP1                       TIM_TISEL_TI2SEL_2                                  /*!< TIM15_TI2 is connected to COMP1 output */
+#define TIM_TIM15_TI2_COMP2                       (TIM_TISEL_TI2SEL_2 | TIM_TISEL_TI2SEL_0)           /*!< TIM15_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #endif /* TIM15 */
 
 #if defined(TIM16)
@@ -320,12 +441,20 @@ typedef struct
 #define TIM_TIM16_TI1_LSI                         TIM_TISEL_TI1SEL_0                                  /*!< TIM16_TI1 is connected to LSI  */
 #define TIM_TIM16_TI1_LSE                         TIM_TISEL_TI1SEL_1                                  /*!< TIM16_TI1 is connected to LSE  */
 #define TIM_TIM16_TI1_RTC_WKUP                    (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM16_TI1 is connected to RTC  */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM16_TI1_COMP1                       TIM_TISEL_TI1SEL_3                                  /*!< TIM16_TI1 is connected to COMP1 output */
+#define TIM_TIM16_TI1_COMP2                       (TIM_TISEL_TI1SEL_3 | TIM_TISEL_TI1SEL_0)           /*!< TIM16_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #endif /* TIM16 */
 
 #if defined(TIM17)
 #define TIM_TIM17_TI1_GPIO                        0x00000000UL                                        /*!< TIM17_TI1 is connected to GPIO     */
 #define TIM_TIM17_TI1_HSE_1MHZ                    TIM_TISEL_TI1SEL_1                                  /*!< TIM17_TI1 is connected to HSE 1MHZ */
 #define TIM_TIM17_TI1_MCO1                        (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM17_TI1 is connected to MCO1     */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM17_TI1_COMP1                       TIM_TISEL_TI1SEL_2                                  /*!< TIM17_TI1 is connected to COMP1 output */
+#define TIM_TIM17_TI1_COMP2                       (TIM_TISEL_TI1SEL_2 | TIM_TISEL_TI1SEL_0)           /*!< TIM17_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #endif /* TIM17 */
 /**
   * @}
@@ -507,12 +636,18 @@ typedef struct
 #define IS_TIM_REMAP(__REMAP__) ((((__REMAP__) & 0xFFFC3FFFU) == 0x00000000U))
 #define IS_TIM_BREAKINPUT(__BREAKINPUT__)  (((__BREAKINPUT__) == TIM_BREAKINPUT_BRK)  || \
                                             ((__BREAKINPUT__) == TIM_BREAKINPUT_BRK2))
-#if defined(COMP1)
+#if defined(COMP1) && defined(COMP2)
+#define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  (((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)  || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP1) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP2) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_PLAY1) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_MDF1))
+#elif defined(COMP1)
 #define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  (((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)  || \
                                               ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP1))
 #else
 #define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  ((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)
-#endif /* COMP1 */
+#endif /* COMP1 && COMP2 */
 
 #define IS_TIM_BREAKINPUTSOURCE_STATE(__STATE__)  (((__STATE__) == TIM_BREAKINPUTSOURCE_DISABLE)  || \
                                                    ((__STATE__) == TIM_BREAKINPUTSOURCE_ENABLE))
@@ -716,7 +851,7 @@ typedef struct
      ((__CLOCK__) == TIM_CLOCKSOURCE_ITR9)      ||          \
      ((__CLOCK__) == TIM_CLOCKSOURCE_ITR10)     ||          \
      ((__CLOCK__) == TIM_CLOCKSOURCE_ITR11)))               \
-   ||                                        \
+   ||                                       \
    (((INSTANCE) == TIM12) &&                \
     (((__CLOCK__) == TIM_CLOCKSOURCE_INTERNAL)  ||          \
      ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE1)  ||          \
@@ -1005,6 +1140,10 @@ typedef struct
      ((__SELECTION__) == TIM_TS_ITR10)||          \
      ((__SELECTION__) == TIM_TS_ITR11)||          \
      ((__SELECTION__) == TIM_TS_NONE))))
+
+#if defined(TIM17)
+#define IS_TIM_RTCPREEN_SELECTION(__SELECTION__) ((__SELECTION__) == TIM_TIM17_TI1_HSE_1MHZ)
+#endif /* TIM17 */
 #endif /* STM32H503xx */
 
 #define IS_TIM_OC_CHANNEL_MODE(__MODE__, __CHANNEL__)   \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart.c
@@ -973,10 +973,7 @@ HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pU
     return HAL_ERROR;
   }
 
-  /* Process locked */
-  __HAL_LOCK(huart);
-
-  if (huart->gState == HAL_UART_STATE_READY)
+  if (huart->RxState == HAL_UART_STATE_READY)
   {
     huart->RxEventCallback = pCallback;
   }
@@ -986,9 +983,6 @@ HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pU
 
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(huart);
 
   return status;
 }
@@ -1003,10 +997,7 @@ HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(huart);
-
-  if (huart->gState == HAL_UART_STATE_READY)
+  if (huart->RxState == HAL_UART_STATE_READY)
   {
     huart->RxEventCallback = HAL_UARTEx_RxEventCallback; /* Legacy weak UART Rx Event Callback  */
   }
@@ -1017,8 +1008,6 @@ HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart)
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(huart);
   return status;
 }
 
@@ -1141,12 +1130,14 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, const uint8_t *pD
       return  HAL_ERROR;
     }
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the UART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
     {
       CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->gState = HAL_UART_STATE_BUSY_TX;
 
@@ -1238,12 +1229,14 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
       return  HAL_ERROR;
     }
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the UART DMA Rx request if enabled */
     if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
     {
       CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
     huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
@@ -1323,12 +1316,14 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, const uint8_t 
       return HAL_ERROR;
     }
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the UART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
     {
       CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     huart->pTxBuffPtr  = pData;
     huart->TxXferSize  = Size;
     huart->TxXferCount = Size;
@@ -1400,12 +1395,14 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
     /* Set Reception type to Standard reception */
     huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the UART DMA Rx request if enabled */
     if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
     {
       CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     if (!(IS_LPUART_INSTANCE(huart->Instance)))
     {
       /* Check that USART RTOEN bit is set */
@@ -1784,6 +1781,11 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Tx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmatx != NULL)
     {
@@ -1807,6 +1809,11 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Rx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmarx != NULL)
     {
@@ -1876,6 +1883,11 @@ HAL_StatusTypeDef HAL_UART_AbortTransmit(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Tx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmatx != NULL)
     {
@@ -1940,6 +1952,11 @@ HAL_StatusTypeDef HAL_UART_AbortReceive(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Rx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmarx != NULL)
     {
@@ -2041,6 +2058,11 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable DMA Tx at UART level */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Tx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmatx != NULL)
     {
@@ -2062,6 +2084,11 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Rx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmarx != NULL)
     {
@@ -2150,6 +2177,11 @@ HAL_StatusTypeDef HAL_UART_AbortTransmit_IT(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Tx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmatx != NULL)
     {
@@ -2246,6 +2278,11 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
   /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the UART DMA Rx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmarx != NULL)
     {
@@ -2427,6 +2464,11 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
         /* Abort the UART DMA Rx channel if enabled */
         if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
         {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+          /* Disable the UART DMA Rx request if enabled */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
           /* Abort the UART DMA Rx channel */
           if (huart->hdmarx != NULL)
           {
@@ -2515,6 +2557,12 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
           ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
           ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
+#if !defined(USART_DMAREQUESTS_SW_WA)
+          /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
+             in the UART CR3 register */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
           /* At end of Rx process, restore huart->RxState to Ready */
           huart->RxState = HAL_UART_STATE_READY;
           huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
@@ -2536,6 +2584,28 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
         /*Call legacy weak Rx Event callback*/
         HAL_UARTEx_RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
 #endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+      }
+      else
+      {
+        /* If DMA is in Circular mode, Idle event is to be reported to user
+           even if occurring after a Transfer Complete event from DMA */
+        if (nb_remaining_rx_data == huart->RxXferSize)
+        {
+          if (huart->hdmarx->Mode == DMA_LINKEDLIST_CIRCULAR)
+          {
+            /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+               In this case, Rx Event type is Idle Event */
+            huart->RxEventType = HAL_UART_RXEVENT_IDLE;
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+            /*Call registered Rx Event callback*/
+            huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+            /*Call legacy weak Rx Event callback*/
+            HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+          }
+        }
       }
       return;
     }
@@ -3433,7 +3503,7 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
         return HAL_TIMEOUT;
       }
 
-      if (READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U)
+      if ((READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U) && (Flag != UART_FLAG_TXE) && (Flag != UART_FLAG_TC))
       {
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) == SET)
         {
@@ -3708,6 +3778,12 @@ static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
   {
     huart->TxXferCount = 0U;
 
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the DMA transfer for transmit request by resetting the DMAT bit
+       in the UART CR3 register */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Enable the UART Transmit Complete Interrupt */
     ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
   }
@@ -3760,6 +3836,12 @@ static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
     ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
     ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
+       in the UART CR3 register */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* At end of Rx process, restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
 
@@ -4558,6 +4640,7 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
           HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
         }
+        break;
       }
     }
 
@@ -4722,6 +4805,7 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
           HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
         }
+        break;
       }
     }
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart.h
@@ -1243,7 +1243,7 @@ typedef  void (*pUART_RxEventCallbackTypeDef)
 /** @defgroup UART_Private_Macros   UART Private Macros
   * @{
   */
-/** @brief  Get UART clok division factor from clock prescaler value.
+/** @brief  Get UART clock division factor from clock prescaler value.
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval UART clock division factor
   */
@@ -1258,8 +1258,7 @@ typedef  void (*pUART_RxEventCallbackTypeDef)
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV16)  ? 16U :      \
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV32)  ? 32U :      \
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV64)  ? 64U :      \
-   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV128) ? 128U :     \
-   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV256) ? 256U : 1U)
+   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV128) ? 128U : 256U)
 
 /** @brief  BRR division operation to set BRR register with LPUART.
   * @param  __PCLK__ LPUART clock.

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart_ex.c
@@ -576,7 +576,7 @@ HAL_StatusTypeDef HAL_UARTEx_DisableFifoMode(UART_HandleTypeDef *huart)
   /* Disable UART */
   __HAL_UART_DISABLE(huart);
 
-  /* Enable FIFO mode */
+  /* Disable FIFO mode */
   CLEAR_BIT(tmpcr1, USART_CR1_FIFOEN);
   huart->FifoMode = UART_FIFOMODE_DISABLE;
 
@@ -726,6 +726,14 @@ HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle(UART_HandleTypeDef *huart, uint8_t *p
       return  HAL_ERROR;
     }
 
+#if defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
+    {
+      CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    }
+
+#endif /* USART_DMAREQUESTS_SW_WA */
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
     huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
@@ -845,6 +853,14 @@ HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_IT(UART_HandleTypeDef *huart, uint8_t
       return HAL_ERROR;
     }
 
+#if defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the UART DMA Rx request if enabled */
+    if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
+    {
+      CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    }
+
+#endif /* USART_DMAREQUESTS_SW_WA */
     /* Set Reception type to reception till IDLE Event*/
     huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
     huart->RxEventType = HAL_UART_RXEVENT_TC;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_uart_ex.h
@@ -261,6 +261,42 @@ HAL_UART_RxEventTypeTypeDef HAL_UARTEx_GetRxEventType(const UART_HandleTypeDef *
       (__CLOCKSOURCE__) = 0U;                                     \
     }                                                             \
   } while(0U)
+#elif (defined(STM32H523xx) || defined(STM32H533xx))
+#define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)           \
+  do {                                                            \
+    if((__HANDLE__)->Instance == USART1)                          \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_USART1;         \
+    }                                                             \
+    else if((__HANDLE__)->Instance == USART2)                     \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_USART2;         \
+    }                                                             \
+    else if((__HANDLE__)->Instance == USART3)                     \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_USART3;         \
+    }                                                             \
+    else if((__HANDLE__)->Instance == UART4)                      \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_UART4;          \
+    }                                                             \
+    else if((__HANDLE__)->Instance == UART5)                      \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_UART5;          \
+    }                                                             \
+    else if((__HANDLE__)->Instance == USART6)                     \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_USART6;         \
+    }                                                             \
+    else if((__HANDLE__)->Instance == LPUART1)                    \
+    {                                                             \
+      (__CLOCKSOURCE__) = (uint32_t)RCC_PERIPHCLK_LPUART1;        \
+    }                                                             \
+    else                                                          \
+    {                                                             \
+      (__CLOCKSOURCE__) = 0U;                                     \
+    }                                                             \
+  } while(0U)
 #else
 #define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)           \
   do {                                                            \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart.c
@@ -144,7 +144,7 @@
   */
 
 /** @defgroup USART USART
-  * @brief HAL USART Synchronous module driver
+  * @brief HAL USART Synchronous SPI module driver
   * @{
   */
 
@@ -227,8 +227,8 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart);
  ===============================================================================
     [..]
     This subsection provides a set of functions allowing to initialize the USART
-    in asynchronous and in synchronous modes.
-      (+) For the asynchronous mode only these parameters can be configured:
+    in synchronous SPI master/slave mode.
+      (+) For the synchronous SPI mode only these parameters can be configured:
         (++) Baud Rate
         (++) Word Length
         (++) Stop Bit
@@ -240,7 +240,7 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart);
         (++) Receiver/transmitter modes
 
     [..]
-    The HAL_USART_Init() function follows the USART  synchronous configuration
+    The HAL_USART_Init() function follows the USART synchronous SPI configuration
     procedure (details for the procedure are available in reference manual).
 
 @endverbatim
@@ -318,7 +318,7 @@ HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
     return HAL_ERROR;
   }
 
-  /* In Synchronous mode, the following bits must be kept cleared:
+  /* In Synchronous SPI mode, the following bits must be kept cleared:
   - LINEN bit in the USART_CR2 register
   - HDSEL, SCEN and IREN bits in the USART_CR3 register.
   */
@@ -659,11 +659,10 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
  ===============================================================================
                       ##### IO operation functions #####
  ===============================================================================
-    [..] This subsection provides a set of functions allowing to manage the USART synchronous
+    [..] This subsection provides a set of functions allowing to manage the USART synchronous SPI
     data transfers.
 
-    [..] The USART supports master mode only: it cannot receive or send data related to an input
-         clock (SCLK is always an output).
+    [..] The USART Synchronous SPI supports master and slave modes (SCLK as output or input).
 
     [..]
 
@@ -760,12 +759,14 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, const uint8_t 
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
     {
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_TX;
 
@@ -864,12 +865,14 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Rx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAR))
     {
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
@@ -986,6 +989,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, const u
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
     {
@@ -998,6 +1002,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, const u
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
@@ -1136,12 +1141,14 @@ HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, const uint8
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
     {
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->pTxBuffPtr  = pTxData;
     husart->TxXferSize  = Size;
     husart->TxXferCount = Size;
@@ -1227,12 +1234,14 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Rx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAR))
     {
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->pRxBuffPtr  = pRxData;
     husart->RxXferSize  = Size;
     husart->RxXferCount = Size;
@@ -1347,6 +1356,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, cons
     /* Process Locked */
     __HAL_LOCK(husart);
 
+#if defined(USART_DMAREQUESTS_SW_WA)
     /* Disable the USART DMA Tx request if enabled */
     if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
     {
@@ -1359,6 +1369,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, cons
       CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
     }
 
+#endif /* USART_DMAREQUESTS_SW_WA */
     husart->pRxBuffPtr = pRxData;
     husart->RxXferSize = Size;
     husart->RxXferCount = Size;
@@ -2175,6 +2186,11 @@ HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
   /* Abort the USART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the USART DMA Tx request if enabled */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the USART DMA Tx channel : use blocking DMA Abort API (no callback) */
     if (husart->hdmatx != NULL)
     {
@@ -2198,6 +2214,11 @@ HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
   /* Abort the USART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the USART DMA Rx request if enabled */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the USART DMA Rx channel : use blocking DMA Abort API (no callback) */
     if (husart->hdmarx != NULL)
     {
@@ -2302,6 +2323,11 @@ HAL_StatusTypeDef HAL_USART_Abort_IT(USART_HandleTypeDef *husart)
   /* Abort the USART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAT))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable DMA Tx at USART level */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the USART DMA Tx channel : use non blocking DMA Abort API (callback) */
     if (husart->hdmatx != NULL)
     {
@@ -2323,6 +2349,11 @@ HAL_StatusTypeDef HAL_USART_Abort_IT(USART_HandleTypeDef *husart)
   /* Abort the USART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAR))
   {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the USART DMA Rx request if enabled */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     /* Abort the USART DMA Rx channel : use non blocking DMA Abort API (callback) */
     if (husart->hdmarx != NULL)
     {
@@ -2505,6 +2536,11 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
         /* Abort the USART DMA Rx channel if enabled */
         if (HAL_IS_BIT_SET(husart->Instance->CR3, USART_CR3_DMAR))
         {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+          /* Disable the USART DMA Rx request if enabled */
+          CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR | USART_CR3_DMAR);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
           /* Abort the USART DMA Tx channel */
           if (husart->hdmatx != NULL)
           {
@@ -2834,6 +2870,12 @@ static void USART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 
     if (husart->State == HAL_USART_STATE_BUSY_TX)
     {
+#if !defined(USART_DMAREQUESTS_SW_WA)
+      /* Disable the DMA transfer for transmit request by resetting the DMAT bit
+         in the USART CR3 register */
+      CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
       /* Enable the USART Transmit Complete Interrupt */
       __HAL_USART_ENABLE_IT(husart, USART_IT_TC);
     }
@@ -2890,6 +2932,15 @@ static void USART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
     CLEAR_BIT(husart->Instance->CR1, USART_CR1_PEIE);
     CLEAR_BIT(husart->Instance->CR3, USART_CR3_EIE);
 
+#if !defined(USART_DMAREQUESTS_SW_WA)
+    /* Disable the DMA RX transfer for the receiver request by resetting the DMAR bit
+       in USART CR3 register */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAR);
+    /* similarly, disable the DMA TX transfer that was started to provide the
+       clock to the slave device */
+    CLEAR_BIT(husart->Instance->CR3, USART_CR3_DMAT);
+
+#endif /* !USART_DMAREQUESTS_SW_WA */
     if (husart->State == HAL_USART_STATE_BUSY_RX)
     {
 #if (USE_HAL_USART_REGISTER_CALLBACKS == 1)
@@ -3176,7 +3227,7 @@ static HAL_StatusTypeDef USART_SetConfig(USART_HandleTypeDef *husart)
   /* Clear and configure the USART Clock, CPOL, CPHA, LBCL STOP and SLVEN bits:
    * set CPOL bit according to husart->Init.CLKPolarity value
    * set CPHA bit according to husart->Init.CLKPhase value
-   * set LBCL bit according to husart->Init.CLKLastBit value (used in SPI master mode only)
+   * set LBCL bit according to husart->Init.CLKLastBit value (used in USART Synchronous SPI master mode only)
    * set STOP[13:12] bits according to husart->Init.StopBits value */
   tmpreg = (uint32_t)(USART_CLOCK_ENABLE);
   tmpreg |= (uint32_t)husart->Init.CLKLastBit;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart.h
@@ -710,8 +710,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
    ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV16)  ? 16U :      \
    ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV32)  ? 32U :      \
    ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV64)  ? 64U :      \
-   ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV128) ? 128U :     \
-   ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV256) ? 256U : 1U)
+   ((__CLOCKPRESCALER__) == USART_PRESCALER_DIV128) ? 128U : 256U)
 
 /** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
   * @param  __PCLK__ USART clock.
@@ -886,6 +885,122 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
           (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL2Q;         \
           break;                                               \
         case RCC_USART11CLKSOURCE_PLL3Q:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL3Q;         \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else                                                       \
+    {                                                          \
+      (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;         \
+    }                                                          \
+  } while(0U)
+#elif (defined(STM32H523xx) || defined(STM32H533xx))
+#define USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
+        case RCC_USART1CLKSOURCE_PCLK2:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK2;         \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_CSI;           \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL2Q;         \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL3Q;         \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_CSI;           \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL2Q;         \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL3Q;         \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART3)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                    \
+      {                                                        \
+        case RCC_USART3CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_CSI;           \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL2Q;         \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_PLL3Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL3Q;         \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART6)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART6_SOURCE())                    \
+      {                                                        \
+        case RCC_USART6CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_CSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_CSI;           \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL2Q:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL2Q;         \
+          break;                                               \
+        case RCC_USART6CLKSOURCE_PLL3Q:                        \
           (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PLL3Q;         \
           break;                                               \
         default:                                               \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_usart_ex.c
@@ -364,7 +364,7 @@ HAL_StatusTypeDef HAL_USARTEx_DisableFifoMode(USART_HandleTypeDef *husart)
   /* Disable USART */
   __HAL_USART_DISABLE(husart);
 
-  /* Enable FIFO mode */
+  /* Disable FIFO mode */
   CLEAR_BIT(tmpcr1, USART_CR1_FIFOEN);
   husart->FifoMode = USART_FIFOMODE_DISABLE;
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_xspi.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_xspi.c
@@ -1134,7 +1134,7 @@ HAL_StatusTypeDef HAL_XSPI_HyperbusCmd(XSPI_HandleTypeDef *hxspi, XSPI_HyperbusC
   * @note   This function is used only in Indirect Write Mode
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_XSPI_Transmit(XSPI_HandleTypeDef *hxspi, uint8_t *const pData, uint32_t Timeout)
+HAL_StatusTypeDef HAL_XSPI_Transmit(XSPI_HandleTypeDef *hxspi, const uint8_t *pData, uint32_t Timeout)
 {
   HAL_StatusTypeDef status;
   uint32_t tickstart = HAL_GetTick();
@@ -1154,7 +1154,7 @@ HAL_StatusTypeDef HAL_XSPI_Transmit(XSPI_HandleTypeDef *hxspi, uint8_t *const pD
       /* Configure counters and size */
       hxspi->XferCount = READ_REG(hxspi->Instance->DLR) + 1U;
       hxspi->XferSize  = hxspi->XferCount;
-      hxspi->pBuffPtr  = pData;
+      hxspi->pBuffPtr  = (uint8_t *)pData;
 
       /* Configure CR register with functional mode as indirect write */
       MODIFY_REG(hxspi->Instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
@@ -1296,7 +1296,7 @@ HAL_StatusTypeDef HAL_XSPI_Receive(XSPI_HandleTypeDef *hxspi, uint8_t *const pDa
   * @note   This function is used only in Indirect Write Mode
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_XSPI_Transmit_IT(XSPI_HandleTypeDef *hxspi, uint8_t *const pData)
+HAL_StatusTypeDef HAL_XSPI_Transmit_IT(XSPI_HandleTypeDef *hxspi, const uint8_t *pData)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -1314,7 +1314,7 @@ HAL_StatusTypeDef HAL_XSPI_Transmit_IT(XSPI_HandleTypeDef *hxspi, uint8_t *const
       /* Configure counters and size */
       hxspi->XferCount = READ_REG(hxspi->Instance->DLR) + 1U;
       hxspi->XferSize  = hxspi->XferCount;
-      hxspi->pBuffPtr  = pData;
+      hxspi->pBuffPtr  = (uint8_t *)pData;
 
       /* Configure CR register with functional mode as indirect write */
       MODIFY_REG(hxspi->Instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
@@ -1417,7 +1417,7 @@ HAL_StatusTypeDef HAL_XSPI_Receive_IT(XSPI_HandleTypeDef *hxspi, uint8_t *const 
   *         of data and the fifo threshold should be aligned on word
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_XSPI_Transmit_DMA(XSPI_HandleTypeDef *hxspi, uint8_t *const pData)
+HAL_StatusTypeDef HAL_XSPI_Transmit_DMA(XSPI_HandleTypeDef *hxspi, const uint8_t *pData)
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t data_size = hxspi->Instance->DLR + 1U;
@@ -1496,7 +1496,7 @@ HAL_StatusTypeDef HAL_XSPI_Transmit_DMA(XSPI_HandleTypeDef *hxspi, uint8_t *cons
       if (status == HAL_OK)
       {
         hxspi->XferSize = hxspi->XferCount;
-        hxspi->pBuffPtr = pData;
+        hxspi->pBuffPtr = (uint8_t *)pData;
 
         /* Configure CR register with functional mode as indirect write */
         MODIFY_REG(hxspi->Instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
@@ -2387,7 +2387,7 @@ HAL_StatusTypeDef HAL_XSPI_UnRegisterCallback(XSPI_HandleTypeDef *hxspi, HAL_XSP
   */
 
 /**
-  * @brief  Abort the current transmission.
+  * @brief  Abort the current operation, return to the indirect mode.
   * @param  hxspi : XSPI handle
   * @retval HAL status
   */
@@ -2440,12 +2440,18 @@ HAL_StatusTypeDef HAL_XSPI_Abort(XSPI_HandleTypeDef *hxspi)
 
         if (status == HAL_OK)
         {
+          /* Return to indirect mode */
+          CLEAR_BIT(hxspi->Instance->CR, XSPI_CR_FMODE);
+
           hxspi->State = HAL_XSPI_STATE_READY;
         }
       }
     }
     else
     {
+      /* Return to indirect mode */
+      CLEAR_BIT(hxspi->Instance->CR, XSPI_CR_FMODE);
+
       hxspi->State = HAL_XSPI_STATE_READY;
     }
   }
@@ -2459,7 +2465,7 @@ HAL_StatusTypeDef HAL_XSPI_Abort(XSPI_HandleTypeDef *hxspi)
 }
 
 /**
-  * @brief  Abort the current transmission (non-blocking function)
+  * @brief  Abort the current operation, return to the indirect mode. (non-blocking function)
   * @param  hxspi : XSPI handle
   * @retval HAL status
   */
@@ -2523,9 +2529,15 @@ HAL_StatusTypeDef HAL_XSPI_Abort_IT(XSPI_HandleTypeDef *hxspi)
 
         /* Perform an abort of the XSPI */
         SET_BIT(hxspi->Instance->CR, XSPI_CR_ABORT);
+
+        /* Return to indirect mode */
+        CLEAR_BIT(hxspi->Instance->CR, XSPI_CR_FMODE);
       }
       else
       {
+        /* Return to indirect mode */
+        CLEAR_BIT(hxspi->Instance->CR, XSPI_CR_FMODE);
+
         hxspi->State = HAL_XSPI_STATE_READY;
 
         /* Abort callback */
@@ -2846,9 +2858,6 @@ static void XSPI_DMACplt(DMA_HandleTypeDef *hdma)
   /* Disable the DMA transfer on the XSPI side */
   CLEAR_BIT(hxspi->Instance->CR, XSPI_CR_DMAEN);
 
-  /* Disable the DMA channel */
-  __HAL_DMA_DISABLE(hdma);
-
   /* Enable the XSPI transfer complete Interrupt */
   HAL_XSPI_ENABLE_IT(hxspi, HAL_XSPI_IT_TC);
 }
@@ -2983,7 +2992,7 @@ static HAL_StatusTypeDef XSPI_WaitFlagStateUntilTimeout(XSPI_HandleTypeDef *hxsp
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        hxspi->State     = HAL_XSPI_STATE_ERROR;
+        hxspi->State     = HAL_XSPI_STATE_READY;
         hxspi->ErrorCode |= HAL_XSPI_ERROR_TIMEOUT;
 
         return HAL_TIMEOUT;

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_xspi.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_hal_xspi.h
@@ -824,12 +824,12 @@ typedef void (*pXSPI_CallbackTypeDef)(XSPI_HandleTypeDef *hxspi);
   */
 
 /* Exported functions --------------------------------------------------------*/
-/** @addtogroup XSPI_Exported_Functions
+/** @addtogroup XSPI_Exported_Functions XSPI Exported Functions
   * @{
   */
 
 /* Initialization/de-initialization functions  ********************************/
-/** @addtogroup XSPI_Exported_Functions_Group1
+/** @addtogroup XSPI_Exported_Functions_Group1 Initialization/de-initialization functions
   * @{
   */
 HAL_StatusTypeDef     HAL_XSPI_Init(XSPI_HandleTypeDef *hxspi);
@@ -842,7 +842,7 @@ void                  HAL_XSPI_MspDeInit(XSPI_HandleTypeDef *hxspi);
   */
 
 /* IO operation functions *****************************************************/
-/** @addtogroup XSPI_Exported_Functions_Group2
+/** @addtogroup XSPI_Exported_Functions_Group2 Input and Output operation functions
   * @{
   */
 /* XSPI IRQ handler function */
@@ -858,11 +858,11 @@ HAL_StatusTypeDef     HAL_XSPI_HyperbusCmd(XSPI_HandleTypeDef *hxspi, XSPI_Hyper
                                            uint32_t Timeout);
 
 /* XSPI indirect mode functions */
-HAL_StatusTypeDef     HAL_XSPI_Transmit(XSPI_HandleTypeDef *hxspi, uint8_t *const pData, uint32_t Timeout);
+HAL_StatusTypeDef     HAL_XSPI_Transmit(XSPI_HandleTypeDef *hxspi, const uint8_t *pData, uint32_t Timeout);
 HAL_StatusTypeDef     HAL_XSPI_Receive(XSPI_HandleTypeDef *hxspi, uint8_t *const pData, uint32_t Timeout);
-HAL_StatusTypeDef     HAL_XSPI_Transmit_IT(XSPI_HandleTypeDef *hxspi, uint8_t *const pData);
+HAL_StatusTypeDef     HAL_XSPI_Transmit_IT(XSPI_HandleTypeDef *hxspi, const uint8_t *pData);
 HAL_StatusTypeDef     HAL_XSPI_Receive_IT(XSPI_HandleTypeDef *hxspi, uint8_t *const pData);
-HAL_StatusTypeDef     HAL_XSPI_Transmit_DMA(XSPI_HandleTypeDef *hxspi, uint8_t *const pData);
+HAL_StatusTypeDef     HAL_XSPI_Transmit_DMA(XSPI_HandleTypeDef *hxspi, const uint8_t *pData);
 HAL_StatusTypeDef     HAL_XSPI_Receive_DMA(XSPI_HandleTypeDef *hxspi, uint8_t *const pData);
 
 /* XSPI status flag polling mode functions */
@@ -903,7 +903,7 @@ HAL_StatusTypeDef     HAL_XSPI_UnRegisterCallback(XSPI_HandleTypeDef *hxspi, HAL
   */
 
 /* Peripheral Control and State functions  ************************************/
-/** @addtogroup XSPI_Exported_Functions_Group3
+/** @addtogroup XSPI_Exported_Functions_Group3 Peripheral Control and State functions
   * @{
   */
 HAL_StatusTypeDef     HAL_XSPI_Abort(XSPI_HandleTypeDef *hxspi);
@@ -1046,7 +1046,6 @@ HAL_StatusTypeDef      HAL_XSPI_DLYB_GetClockPeriod(XSPI_HandleTypeDef *hxspi,
 
 #define IS_XSPI_DLYB_BYPASS(DLYB)                 (((DLYB) == HAL_XSPI_DELAY_BLOCK_ON) || \
                                                    ((DLYB) == HAL_XSPI_DELAY_BLOCK_BYPASS))
-
 
 
 #define IS_XSPI_OPERATION_TYPE(TYPE)              (((TYPE) == HAL_XSPI_OPTYPE_COMMON_CFG) || \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_adc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_adc.c
@@ -517,11 +517,6 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
   /* Disable ADC instance if not already disabled.                            */
   if (LL_ADC_IsEnabled(ADCx) == 1UL)
   {
-    /* Set ADC group regular trigger source to SW start to ensure to not      */
-    /* have an external trigger event occurring during the conversion stop    */
-    /* ADC disable process.                                                   */
-    LL_ADC_REG_SetTriggerSource(ADCx, LL_ADC_REG_TRIG_SOFTWARE);
-
     /* Stop potential ADC conversion on going on ADC group regular.           */
     if (LL_ADC_REG_IsConversionOngoing(ADCx) != 0UL)
     {
@@ -530,11 +525,6 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
         LL_ADC_REG_StopConversion(ADCx);
       }
     }
-
-    /* Set ADC group injected trigger source to SW start to ensure to not     */
-    /* have an external trigger event occurring during the conversion stop    */
-    /* ADC disable process.                                                   */
-    LL_ADC_INJ_SetTriggerSource(ADCx, LL_ADC_INJ_TRIG_SOFTWARE);
 
     /* Stop potential ADC conversion on going on ADC group injected.          */
     if (LL_ADC_INJ_IsConversionOngoing(ADCx) != 0UL)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_adc.h
@@ -81,8 +81,6 @@ extern "C" {
 #define ADC_REG_RANK_15_SQRX_BITOFFSET_POS (ADC_SQR4_SQ15_Pos)
 #define ADC_REG_RANK_16_SQRX_BITOFFSET_POS (ADC_SQR4_SQ16_Pos)
 
-
-
 /* Internal mask for ADC group injected sequencer:                            */
 /* To select into literal LL_ADC_INJ_RANK_x the relevant bits for:            */
 /* - data register offset                                                     */
@@ -106,8 +104,6 @@ extern "C" {
 #define ADC_INJ_RANK_2_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ2_Pos)
 #define ADC_INJ_RANK_3_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ3_Pos)
 #define ADC_INJ_RANK_4_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ4_Pos)
-
-
 
 /* Internal mask for ADC group regular trigger:                               */
 /* To select into literal LL_ADC_REG_TRIG_x the relevant bits for:            */
@@ -137,8 +133,6 @@ extern "C" {
 #define ADC_REG_TRIG_EXTSEL_BITOFFSET_POS  (ADC_CFGR_EXTSEL_Pos)
 #define ADC_REG_TRIG_EXTEN_BITOFFSET_POS   (ADC_CFGR_EXTEN_Pos)
 
-
-
 /* Internal mask for ADC group injected trigger:                              */
 /* To select into literal LL_ADC_INJ_TRIG_x the relevant bits for:            */
 /* - injected trigger source                                                  */
@@ -166,11 +160,6 @@ extern "C" {
 /* Definition of ADC group injected trigger bits information.                 */
 #define ADC_INJ_TRIG_EXTSEL_BITOFFSET_POS  (ADC_JSQR_JEXTSEL_Pos)
 #define ADC_INJ_TRIG_EXTEN_BITOFFSET_POS   (ADC_JSQR_JEXTEN_Pos)
-
-
-
-
-
 
 /* Internal mask for ADC channel:                                             */
 /* To select into literal LL_ADC_CHANNEL_x the relevant bits for:             */
@@ -397,7 +386,6 @@ extern "C" {
   * @}
   */
 
-
 /* Private macros ------------------------------------------------------------*/
 /** @defgroup ADC_LL_Private_Macros ADC Private Macros
   * @{
@@ -417,7 +405,6 @@ extern "C" {
 /**
   * @}
   */
-
 
 /* Exported types ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -2785,6 +2772,32 @@ typedef struct
 ((__ADC_DATA__) * (__VREFANALOG_VOLTAGE__)                                   \
  / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                                \
 )
+
+/**
+  * @brief  Helper macro to calculate the voltage (unit: mVolt)
+  *         corresponding to a ADC conversion data (unit: digital value) in
+  *         differential ended mode.
+  * @note   ADC data from ADC data register is unsigned and centered around
+  *         middle code in. Converted voltage can be positive or negative
+  *         depending on differential input voltages.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @param  __VREFANALOG_VOLTAGE__ Analog reference voltage (unit: mV)
+  * @param  __ADC_DATA__ ADC conversion data (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  *         @arg @ref LL_ADC_RESOLUTION_6B
+  * @retval ADC conversion data equivalent voltage value (unit: mVolt)
+  */
+#define __LL_ADC_CALC_DIFF_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
+                                           __ADC_DATA__,\
+                                           __ADC_RESOLUTION__)\
+((int32_t)((__ADC_DATA__) << 1U) * (int32_t)(__VREFANALOG_VOLTAGE__)\
+ / (int32_t)(__LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__))\
+ - (int32_t)(__VREFANALOG_VOLTAGE__))
 
 /**
   * @brief  Helper macro to calculate analog reference voltage (Vref+)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_bus.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_bus.h
@@ -92,6 +92,8 @@ extern "C" {
   */
 #if defined(CORDIC)
 #define LL_AHB1_GRP1_PERIPH_ALL           0xF13AD103U
+#elif defined(DCACHE)
+#define LL_AHB1_GRP1_PERIPH_ALL           0xF1021103U
 #else
 #define LL_AHB1_GRP1_PERIPH_ALL           0x91021103U
 #endif /* CORDIC */
@@ -109,6 +111,9 @@ extern "C" {
 #define LL_AHB1_GRP1_PERIPH_ETHTX         RCC_AHB1ENR_ETHTXEN
 #define LL_AHB1_GRP1_PERIPH_ETHRX         RCC_AHB1ENR_ETHRXEN
 #endif /* ETH */
+#if defined(RCC_AHB1ENR_ETHCKEN)
+#define LL_AHB1_GRP1_PERIPH_ETHINTERN     RCC_AHB1ENR_ETHCKEN
+#endif /* RCC_AHB1ENR_ETHCKEN */
 #define LL_AHB1_GRP1_PERIPH_CRC           RCC_AHB1ENR_CRCEN
 #define LL_AHB1_GRP1_PERIPH_RAMCFG        RCC_AHB1ENR_RAMCFGEN
 #define LL_AHB1_GRP1_PERIPH_GTZC1         RCC_AHB1ENR_TZSC1EN
@@ -125,8 +130,10 @@ extern "C" {
 /** @defgroup BUS_LL_EC_AHB2_GRP1_PERIPH  AHB2 GRP1 PERIPH
   * @{
   */
-#if defined(GPIOE)
+#if defined(GPIOI)
 #define LL_AHB2_GRP1_PERIPH_ALL            0xC01F1DFFU
+#elif defined(GPIOE)
+#define LL_AHB2_GRP1_PERIPH_ALL            0xC01F1CFFU
 #else
 #define LL_AHB2_GRP1_PERIPH_ALL            0x40060C8FU
 #endif /* GPIOE */
@@ -169,7 +176,6 @@ extern "C" {
 #if defined(SRAM3_BASE)
 #define LL_AHB2_GRP1_PERIPH_SRAM3          RCC_AHB2ENR_SRAM3EN
 #endif /* SRAM3_BASE */
-
 /**
   * @}
   */
@@ -193,8 +199,10 @@ extern "C" {
 /** @defgroup BUS_LL_EC_APB1_GRP1_PERIPH  APB1 GRP1 PERIPH
   * @{
   */
-#if defined(TIM4)
+#if defined(USART11)
 #define LL_APB1_GRP1_PERIPH_ALL           0xDFFEC9FFU
+#elif defined(USART6)
+#define LL_APB1_GRP1_PERIPH_ALL           0x13FEC87FU
 #else
 #define LL_APB1_GRP1_PERIPH_ALL           0x01E7E833U
 #endif /* TIM4 */
@@ -288,8 +296,10 @@ extern "C" {
 /** @defgroup BUS_LL_EC_APB2_GRP1_PERIPH  APB2 GRP1 PERIPH
   * @{
   */
-#if defined(TIM8)
+#if defined(TIM16)
 #define LL_APB2_GRP1_PERIPH_ALL            0x017F7800U
+#elif defined(TIM8)
+#define LL_APB2_GRP1_PERIPH_ALL            0x01097800U
 #else
 #define LL_APB2_GRP1_PERIPH_ALL            0x01005800U
 #endif /* TIM8 */
@@ -320,7 +330,9 @@ extern "C" {
 #if defined(SAI2)
 #define LL_APB2_GRP1_PERIPH_SAI2           RCC_APB2ENR_SAI2EN
 #endif /* SAI2 */
+#if defined(USB_DRD_FS)
 #define LL_APB2_GRP1_PERIPH_USB            RCC_APB2ENR_USBEN
+#endif /* USB_DRD_FS */
 /**
   * @}
   */
@@ -330,6 +342,8 @@ extern "C" {
   */
 #if defined(SPI5)
 #define LL_APB3_GRP1_PERIPH_ALL           0x0030F9E2U
+#elif defined(I2C4)
+#define LL_APB3_GRP1_PERIPH_ALL           0x00300AC2U
 #else
 #define LL_APB3_GRP1_PERIPH_ALL           0x00200A42U
 #endif /* SPI5 */
@@ -607,7 +621,7 @@ __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClock(uint32_t Periphs)
   *         AHB1ENR    ETHRXEN     LL_AHB1_GRP1_DisableClock\n
   *         AHB1ENR    TZSC1EN     LL_AHB1_GRP1_DisableClock\n
   *         AHB1ENR    BKPRAMEN    LL_AHB1_GRP1_DisableClock\n
-  *         AHB1ENR    DCACHE1EN    LL_AHB1_GRP1_DisableClock\n
+  *         AHB1ENR    DCACHE1EN   LL_AHB1_GRP1_DisableClock\n
   *         AHB1ENR    SRAM1EN     LL_AHB1_GRP1_DisableClock
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_AHB1_GRP1_PERIPH_ALL
@@ -706,7 +720,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_ReleaseReset(uint32_t Periphs)
   *         AHB1LPENR    ETHRXLPEN     LL_AHB1_GRP1_EnableClockSleep\n
   *         AHB1LPENR    TZSC1LPEN     LL_AHB1_GRP1_EnableClockSleep\n
   *         AHB1LPENR    BKPRAMLPEN    LL_AHB1_GRP1_EnableClockSleep\n
-  *         AHB1LPENR    DCACHE1LPEN    LL_AHB1_GRP1_EnableClockSleep\n
+  *         AHB1LPENR    DCACHE1LPEN   LL_AHB1_GRP1_EnableClockSleep\n
   *         AHB1LPENR    SRAM1LPEN     LL_AHB1_GRP1_EnableClockSleep
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_AHB1_GRP1_PERIPH_ALL
@@ -1324,7 +1338,6 @@ __STATIC_INLINE void LL_AHB4_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_AHB4_GRP1_PERIPH_SDMMC1
   *         @arg @ref LL_AHB4_GRP1_PERIPH_SDMMC2
   *         @arg @ref LL_AHB4_GRP1_PERIPH_FMC
-  *         @arg @ref LL_AHB4_GRP1_PERIPH_OSPI1
   * @retval None
   */
 __STATIC_INLINE void LL_AHB4_GRP1_ForceReset(uint32_t Periphs)
@@ -2223,6 +2236,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
   *         APB2ENR      SAI1EN        LL_APB2_GRP1_IsEnabledClock\n
   *         APB2ENR      SAI2EN        LL_APB2_GRP1_IsEnabledClock\n
   *         APB2ENR      USBEN         LL_APB2_GRP1_IsEnabledClock
+
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB2_GRP1_PERIPH_ALL
   *         @arg @ref LL_APB2_GRP1_PERIPH_TIM1
@@ -2311,6 +2325,7 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_SAI1 (*)
   *         @arg @ref LL_APB2_GRP1_PERIPH_SAI2 (*)
   *         @arg @ref LL_APB2_GRP1_PERIPH_USB
+
   *
   *  (*)  : Not available for all stm32h5xxxx family lines.
   * @retval None
@@ -2502,7 +2517,6 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClockSleep(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2544,7 +2558,6 @@ __STATIC_INLINE void LL_APB3_GRP1_EnableClock(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2582,7 +2595,6 @@ __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClock(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2618,7 +2630,6 @@ __STATIC_INLINE void LL_APB3_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2653,7 +2664,6 @@ __STATIC_INLINE void LL_APB3_GRP1_ForceReset(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2690,7 +2700,6 @@ __STATIC_INLINE void LL_APB3_GRP1_ReleaseReset(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2733,7 +2742,6 @@ __STATIC_INLINE void LL_APB3_GRP1_EnableClockSleep(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)
@@ -2771,7 +2779,6 @@ __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClockSleep(uint32_t Periphs)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPUART1
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_I2C4 (*)
-  *         @arg @ref LL_APB3_GRP1_PERIPH_I3C2 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM1
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM3 (*)
   *         @arg @ref LL_APB3_GRP1_PERIPH_LPTIM4 (*)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_cordic.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_cordic.h
@@ -131,12 +131,12 @@ extern "C" {
 /** @defgroup CORDIC_LL_EC_NBWRITE NBWRITE
   * @{
   */
-#define LL_CORDIC_NBWRITE_1                (0x00000000U)             /*!< One 32-bits write containing either only one
-                                                                          32-bit data input (Q1.31 format), or two
-                                                                          16-bit data input (Q1.15 format) packed
-                                                                          in one 32 bits Data */
-#define LL_CORDIC_NBWRITE_2                CORDIC_CSR_NARGS          /*!< Two 32-bit write containing two 32-bits data input
-                                                                          (Q1.31 format) */
+#define LL_CORDIC_NBWRITE_1                (0x00000000U)         /*!< One 32-bits write containing either only one
+                                                                      32-bits data input (Q1.31 format), or two
+                                                                      16-bits data input (Q1.15 format) packed
+                                                                      in one 32 bits Data */
+#define LL_CORDIC_NBWRITE_2                CORDIC_CSR_NARGS      /*!< Two 32-bit write containing two 32-bits data input
+                                                                      (Q1.31 format) */
 /**
   * @}
   */
@@ -144,12 +144,12 @@ extern "C" {
 /** @defgroup CORDIC_LL_EC_NBREAD NBREAD
   * @{
   */
-#define LL_CORDIC_NBREAD_1                 (0x00000000U)             /*!< One 32-bits read containing either only one
-                                                                          32-bit data output (Q1.31 format), or two
-                                                                          16-bit data output (Q1.15 format) packed
-                                                                          in one 32 bits Data */
-#define LL_CORDIC_NBREAD_2                 CORDIC_CSR_NRES           /*!< Two 32-bit Data containing two 32-bits data output
-                                                                          (Q1.31 format) */
+#define LL_CORDIC_NBREAD_1                 (0x00000000U)          /*!< One 32-bits read containing either only one
+                                                                      32-bits data output (Q1.31 format), or two
+                                                                      16-bits data output (Q1.15 format) packed
+                                                                      in one 32 bits Data */
+#define LL_CORDIC_NBREAD_2                 CORDIC_CSR_NRES       /*!< Two 32-bit Data containing two 32-bits data output
+                                                                      (Q1.31 format) */
 /**
   * @}
   */
@@ -218,9 +218,7 @@ extern "C" {
   * @}
   */
 
-
 /* Exported functions --------------------------------------------------------*/
-
 /** @defgroup CORDIC_LL_Exported_Functions CORDIC Exported Functions
   * @{
   */
@@ -748,8 +746,6 @@ __STATIC_INLINE uint32_t LL_CORDIC_ReadData(const CORDIC_TypeDef *CORDICx)
 /**
   * @}
   */
-
-
 
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup CORDIC_LL_EF_Init Initialization and de-initialization functions

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_cortex.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_cortex.h
@@ -21,7 +21,9 @@
     [..]
     The LL CORTEX driver contains a set of generic APIs that can be
     used by user:
-      (+) SYSTICK configuration used by @ref LL_mDelay and @ref LL_Init1msTick
+      (+) SYSTICK configuration used by @ref LL_mDelay and @ref LL_Init1msTick with
+           HCLK source or @ref LL_Init1msTick_HCLK_Div8, @ref LL_Init1msTick_LSI or
+           @ref LL_Init1msTick_LSE with external source
           functions
       (+) Low power mode configuration (SCB register of Cortex-MCU)
       (+) API to access to MCU info (CPUID register)
@@ -74,10 +76,15 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_CLKSOURCE_HCLK SYSTICK Clock Source
   * @{
   */
-#define LL_SYSTICK_CLKSOURCE_HCLK_DIV8     0x00000000U                 /*!< AHB clock divided by 8 selected as SysTick
+#define LL_SYSTICK_CLKSOURCE_EXTERNAL      0x00000000U                 /*!< External clock source selected as SysTick
                                                                             clock source */
 #define LL_SYSTICK_CLKSOURCE_HCLK          SysTick_CTRL_CLKSOURCE_Msk  /*!< AHB clock selected as SysTick
                                                                             clock source */
+/** Legacy definitions for backward compatibility purpose
+  */
+#define LL_SYSTICK_CLKSOURCE_HCLK_DIV8    LL_SYSTICK_CLKSOURCE_EXTERNAL
+/**
+  */
 /**
   * @}
   */
@@ -154,7 +161,7 @@ extern "C" {
   * @{
   */
 #define LL_MPU_ACCESS_NOT_SHAREABLE        (0U << MPU_RBAR_SH_Pos)  /*!< MPU region not shareable   */
-#define LL_MPU_ACCESS_OUTER_SHAREABLE      (1U << MPU_RBAR_SH_Pos)  /*!< MPU region outer shareable */
+#define LL_MPU_ACCESS_OUTER_SHAREABLE      (2U << MPU_RBAR_SH_Pos)  /*!< MPU region outer shareable */
 #define LL_MPU_ACCESS_INNER_SHAREABLE      (3U << MPU_RBAR_SH_Pos)  /*!< MPU region inner shareable */
 /**
   * @}
@@ -238,7 +245,7 @@ __STATIC_INLINE uint32_t LL_SYSTICK_IsActiveCounterFlag(void)
   * @brief  Configures the SysTick clock source
   * @rmtoll STK_CTRL     CLKSOURCE     LL_SYSTICK_SetClkSource
   * @param  Source This parameter can be one of the following values:
-  *         @arg @ref LL_SYSTICK_CLKSOURCE_HCLK_DIV8
+  *         @arg @ref LL_SYSTICK_CLKSOURCE_EXTERNAL
   *         @arg @ref LL_SYSTICK_CLKSOURCE_HCLK
   * @retval None
   */
@@ -258,7 +265,7 @@ __STATIC_INLINE void LL_SYSTICK_SetClkSource(uint32_t Source)
   * @brief  Get the SysTick clock source
   * @rmtoll STK_CTRL     CLKSOURCE     LL_SYSTICK_GetClkSource
   * @retval Returned value can be one of the following values:
-  *         @arg @ref LL_SYSTICK_CLKSOURCE_HCLK_DIV8
+  *         @arg @ref LL_SYSTICK_CLKSOURCE_EXTERNAL
   *         @arg @ref LL_SYSTICK_CLKSOURCE_HCLK
   */
 __STATIC_INLINE uint32_t LL_SYSTICK_GetClkSource(void)
@@ -813,9 +820,6 @@ __STATIC_INLINE void LL_MPU_ConfigRegion(uint32_t Region, uint32_t Attributes, u
 {
   /* Set region index */
   WRITE_REG(MPU->RNR, Region);
-
-  /* Set base address */
-  MPU->RBAR |=  Attributes;
 
   /* Set region base address and region access attributes */
   WRITE_REG(MPU->RBAR, ((BaseAddress & MPU_RBAR_BASE_Msk) | Attributes));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_crs.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_crs.c
@@ -61,7 +61,6 @@ ErrorStatus LL_CRS_DeInit(void)
 }
 
 
-
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dac.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dac.h
@@ -561,7 +561,7 @@ typedef struct
   *         @arg @ref LL_DAC_RESOLUTION_8B
   * @retval DAC conversion data (unit: digital value)
   */
-#define __LL_DAC_CALC_VOLTAGE_TO_DATA(__VREFANALOG_VOLTAGE__, __DAC_VOLTAGE__, __DAC_RESOLUTION__)   \
+#define __LL_DAC_CALC_VOLTAGE_TO_DATA(__VREFANALOG_VOLTAGE__, __DAC_VOLTAGE__, __DAC_RESOLUTION__)     \
   ((__DAC_VOLTAGE__) * __LL_DAC_DIGITAL_SCALE(__DAC_RESOLUTION__)                                      \
    / (__VREFANALOG_VOLTAGE__)                                                                          \
   )

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dcache.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dcache.h
@@ -405,44 +405,44 @@ __STATIC_INLINE void LL_DCACHE_ResetMonitors(DCACHE_TypeDef *DCACHEx, uint32_t M
 
 /**
   * @brief  Get the Read Hit monitor Value
-  * @rmtoll RHMONR       LL_DCACHE_Monitor_GetReadHitValue
+  * @rmtoll RHMONR     RHITMON       LL_DCACHE_Monitor_GetReadHitValue
   * @param  DCACHEx DCACHE instance
   * @retval Value between Min_Data=0 and Max_Data=0xFFFFFFFF
   */
-__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetReadHitValue(DCACHE_TypeDef *DCACHEx)
+__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetReadHitValue(const DCACHE_TypeDef *DCACHEx)
 {
   return DCACHEx->RHMONR;
 }
 
 /**
   * @brief  Get the Read Miss monitor Value
-  * @rmtoll RMMONR       LL_DCACHE_Monitor_GetReadMissValue
+  * @rmtoll RMMONR     RMISSMON       LL_DCACHE_Monitor_GetReadMissValue
   * @param  DCACHEx DCACHE instance
   * @retval Value between Min_Data=0 and Max_Data=0xFFFF
   */
-__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetReadMissValue(DCACHE_TypeDef *DCACHEx)
+__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetReadMissValue(const DCACHE_TypeDef *DCACHEx)
 {
   return DCACHEx->RMMONR;
 }
 
 /**
   * @brief  Get the Write Hit monitor Value
-  * @rmtoll WHMONR       LL_DCACHE_Monitor_GetWriteHitValue
+  * @rmtoll WHMONR     WHITMON       LL_DCACHE_Monitor_GetWriteHitValue
   * @param  DCACHEx DCACHE instance
   * @retval Value between Min_Data=0 and Max_Data=0xFFFFFFFF
   */
-__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetWriteHitValue(DCACHE_TypeDef *DCACHEx)
+__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetWriteHitValue(const DCACHE_TypeDef *DCACHEx)
 {
   return DCACHEx->WHMONR;
 }
 
 /**
   * @brief  Get the Write Miss monitor Value
-  * @rmtoll WMMONR       LL_DCACHE_Monitor_GetWriteMissValue
+  * @rmtoll WMMONR     WMISSMON       LL_DCACHE_Monitor_GetWriteMissValue
   * @param  DCACHEx DCACHE instance
   * @retval Value between Min_Data=0 and Max_Data=0xFFFF
   */
-__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetWriteMissValue(DCACHE_TypeDef *DCACHEx)
+__STATIC_INLINE uint32_t LL_DCACHE_Monitor_GetWriteMissValue(const DCACHE_TypeDef *DCACHEx)
 {
   return DCACHEx->WMMONR;
 }

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dma.c
@@ -115,6 +115,13 @@
 #define IS_LL_DMA_MODE(__VALUE__)                         (((__VALUE__) == LL_DMA_NORMAL) || \
                                                            ((__VALUE__) == LL_DMA_PFCTRL))
 
+#define IS_LL_DMA_PFREQ_INSTANCE(INSTANCE, Channel)       ((((INSTANCE) == GPDMA1)                && \
+                                                            (((Channel)  == LL_DMA_CHANNEL_0)     || \
+                                                             ((Channel)  == LL_DMA_CHANNEL_7)))   || \
+                                                           (((INSTANCE) == GPDMA2)                && \
+                                                            (((Channel)  == LL_DMA_CHANNEL_0)     || \
+                                                             ((Channel)  == LL_DMA_CHANNEL_7))))
+
 #define IS_LL_DMA_DIRECTION(__VALUE__)                    (((__VALUE__) == LL_DMA_DIRECTION_MEMORY_TO_MEMORY) || \
                                                            ((__VALUE__) == LL_DMA_DIRECTION_PERIPH_TO_MEMORY) || \
                                                            ((__VALUE__) == LL_DMA_DIRECTION_MEMORY_TO_PERIPH))
@@ -229,7 +236,8 @@
 
 #define IS_LL_DMA_CHANNEL_DEST_SEC(__VALUE__)             (((__VALUE__) == LL_DMA_CHANNEL_DEST_NSEC) || \
                                                            ((__VALUE__) == LL_DMA_CHANNEL_DEST_SEC))
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 /**
   * @}
   */
@@ -346,7 +354,7 @@ uint32_t LL_DMA_DeInit(DMA_TypeDef *DMAx, uint32_t Channel)
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
     LL_DMA_DisableChannelSecure(DMAx, Channel);
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
   }
 
   return (uint32_t)status;
@@ -405,6 +413,10 @@ uint32_t LL_DMA_Init(DMA_TypeDef *DMAx, uint32_t Channel, LL_DMA_InitTypeDef *DM
   assert_param(IS_LL_DMA_LINK_BASEADDR(DMA_InitStruct->LinkedListBaseAddr));
   assert_param(IS_LL_DMA_LINK_ADDR_OFFSET(DMA_InitStruct->LinkedListAddrOffset));
   assert_param(IS_LL_DMA_MODE(DMA_InitStruct->Mode));
+  if (DMA_InitStruct->Mode == LL_DMA_PFCTRL)
+  {
+    assert_param(IS_LL_DMA_PFREQ_INSTANCE(DMAx, Channel));
+  }
 
   /* Check DMA instance */
   if (IS_LL_GPDMA_CHANNEL_INSTANCE(DMAx, Channel) != 0U)
@@ -742,7 +754,7 @@ void LL_DMA_NodeStructInit(LL_DMA_InitNodeTypeDef *DMA_InitNodeStruct)
   /* Set DMA_InitNodeStruct fields to default values */
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   DMA_InitNodeStruct->DestSecure               = LL_DMA_CHANNEL_DEST_NSEC;
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
   DMA_InitNodeStruct->DestAllocatedPort        = LL_DMA_DEST_ALLOCATED_PORT0;
   DMA_InitNodeStruct->DestHWordExchange        = LL_DMA_DEST_HALFWORD_PRESERVE;
   DMA_InitNodeStruct->DestByteExchange         = LL_DMA_DEST_BYTE_PRESERVE;
@@ -751,7 +763,7 @@ void LL_DMA_NodeStructInit(LL_DMA_InitNodeTypeDef *DMA_InitNodeStruct)
   DMA_InitNodeStruct->DestDataWidth            = LL_DMA_DEST_DATAWIDTH_BYTE;
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   DMA_InitNodeStruct->SrcSecure                = LL_DMA_CHANNEL_SRC_NSEC;
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
   DMA_InitNodeStruct->SrcAllocatedPort         = LL_DMA_SRC_ALLOCATED_PORT0;
   DMA_InitNodeStruct->SrcByteExchange          = LL_DMA_SRC_BYTE_PRESERVE;
   DMA_InitNodeStruct->DataAlignment            = LL_DMA_DATA_ALIGN_ZEROPADD;
@@ -765,6 +777,7 @@ void LL_DMA_NodeStructInit(LL_DMA_InitNodeTypeDef *DMA_InitNodeStruct)
   DMA_InitNodeStruct->BlkHWRequest             = LL_DMA_HWREQUEST_SINGLEBURST;
   DMA_InitNodeStruct->Direction                = LL_DMA_DIRECTION_MEMORY_TO_MEMORY;
   DMA_InitNodeStruct->Request                  = 0x00000000U;
+  DMA_InitNodeStruct->Mode                     = LL_DMA_NORMAL;
   DMA_InitNodeStruct->BlkRptDestAddrUpdateMode = LL_DMA_BLKRPT_DEST_ADDR_INCREMENT;
   DMA_InitNodeStruct->BlkRptSrcAddrUpdateMode  = LL_DMA_BLKRPT_SRC_ADDR_INCREMENT;
   DMA_InitNodeStruct->DestAddrUpdateMode       = LL_DMA_BURST_DEST_ADDR_INCREMENT;
@@ -825,7 +838,7 @@ uint32_t LL_DMA_CreateLinkNode(LL_DMA_InitNodeTypeDef *DMA_InitNodeStruct, LL_DM
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   assert_param(IS_LL_DMA_CHANNEL_SRC_SEC(DMA_InitNodeStruct->SrcSecure));
   assert_param(IS_LL_DMA_CHANNEL_DEST_SEC(DMA_InitNodeStruct->DestSecure));
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   /* Check trigger polarity */
   if (DMA_InitNodeStruct->TriggerPolarity != LL_DMA_TRIG_POLARITY_MASKED)
@@ -888,7 +901,7 @@ uint32_t LL_DMA_CreateLinkNode(LL_DMA_InitNodeTypeDef *DMA_InitNodeStruct, LL_DM
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
     pNode->LinkRegisters[reg_counter] |= (DMA_InitNodeStruct->DestSecure | \
                                           DMA_InitNodeStruct->SrcSecure);
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
     /* Update CTR1 register fields */
     pNode->LinkRegisters[reg_counter] |= (DMA_InitNodeStruct->DestAllocatedPort                              | \
@@ -1120,11 +1133,11 @@ void LL_DMA_DisconnectNextLinkNode(LL_DMA_LinkNodeTypeDef *pLinkNode, uint32_t L
   * @}
   */
 
-#endif /* defined (GPDMA1) */
+#endif /* GPDMA1 */
 
 /**
   * @}
   */
 
-#endif /* defined (USE_FULL_LL_DRIVER) */
+#endif /* USE_FULL_LL_DRIVER */
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_dma.h
@@ -367,7 +367,7 @@ typedef struct
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   uint32_t DestSecure;           /*!< This field specify the destination secure.
                                       This parameter can be a value of @ref DMA_LL_EC_DESTINATION_SECURITY_ATTRIBUTE. */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   uint32_t DestAllocatedPort;    /*!< This field specify the destination allocated port.
                                       This parameter can be a value of @ref DMA_LL_EC_DESTINATION_ALLOCATED_PORT.     */
@@ -390,7 +390,7 @@ typedef struct
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
   uint32_t SrcSecure;            /*!< This field specify the source secure.
                                       This parameter can be a value of @ref DMA_LL_EC_SOURCE_SECURITY_ATTRIBUTE.      */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
   uint32_t SrcAllocatedPort;     /*!< This field specify the source allocated port.
                                       This parameter can be a value of @ref DMA_LL_EC_SOURCE_ALLOCATED_PORT.          */
@@ -441,7 +441,7 @@ typedef struct
                                       This parameter can be a value of @ref DMA_LL_EC_REQUEST_SELECTION.              */
 
   uint32_t Mode;                  /*!< This field DMA Transfer Mode.
-                                      This parameter can be a value of @ref DMA_Transfer_Mode.                        */
+                                      This parameter can be a value of @ref DMA_LL_TRANSFER_MODE.                     */
 
   /* CBR1 register fields ******************************************************
      If any CBR1 fields need to be updated comparing to previous node, it is
@@ -573,14 +573,14 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t LinkRegisters[8];
+  __IO uint32_t LinkRegisters[8U];
 
 } LL_DMA_LinkNodeTypeDef;
 /**
   * @}
   */
 
-#endif /* defined (USE_FULL_LL_DRIVER) */
+#endif /* USE_FULL_LL_DRIVER */
 
 /* Exported constants --------------------------------------------------------*/
 
@@ -609,7 +609,7 @@ typedef struct
 #define LL_DMA_CHANNEL_15  (0x0FU)
 #if defined (USE_FULL_LL_DRIVER)
 #define LL_DMA_CHANNEL_ALL (0x10U)
-#endif /* defined (USE_FULL_LL_DRIVER) */
+#endif /* USE_FULL_LL_DRIVER */
 /**
   * @}
   */
@@ -629,7 +629,7 @@ typedef struct
 /**
   * @}
   */
-#endif /* defined (USE_FULL_LL_DRIVER) */
+#endif /* USE_FULL_LL_DRIVER */
 
 /** @defgroup DMA_LL_EC_PRIORITY_LEVEL Priority Level
   * @{
@@ -912,7 +912,7 @@ typedef struct
 /**
   * @}
   */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /** @defgroup DMA_LL_EC_LINKEDLIST_NODE_TYPE Linked list node type
   * @{
@@ -1431,9 +1431,9 @@ typedef struct
 #if defined (COMP1)
 #define LL_GPDMA1_TRIGGER_COMP1_OUT           44U      /*!< GPDMA1 HW Trigger signal is COMP1_OUT          */
 #endif /* COMP1 */
-#if defined (STM32H503xx)
-#define LL_GPDMA1_TRIGGER_EVENTOUT            45U      /*!< GPDMA1 HW Trigger signal is COMP1_OUT          */
-#endif /* STM32H503xx */
+#if defined (STM32H503xx) || defined(STM32H523xx) || defined(STM32H533xx)
+#define LL_GPDMA1_TRIGGER_EVENTOUT            45U      /*!< GPDMA1 HW Trigger signal is EVENTOUT           */
+#endif /* STM32H503xx || STM32H523xx || STM32H533xx */
 
 /* GPDMA2 Hardware Triggers */
 #define LL_GPDMA2_TRIGGER_EXTI_LINE0          0U       /*!< GPDMA2 HW Trigger signal is EXTI_LINE0         */
@@ -1495,9 +1495,9 @@ typedef struct
 #if defined (COMP1)
 #define LL_GPDMA2_TRIGGER_COMP1_OUT           44U      /*!< GPDMA2 HW Trigger signal is COMP1_OUT          */
 #endif /* COMP1 */
-#if defined (STM32H503xx)
-#define LL_GPDMA2_TRIGGER_EVENTOUT            45U      /*!< GPDMA2 HW Trigger signal is COMP1_OUT          */
-#endif /* STM32H503xx */
+#if defined (STM32H503xx) || defined(STM32H523xx) || defined(STM32H533xx)
+#define LL_GPDMA2_TRIGGER_EVENTOUT            45U      /*!< GPDMA2 HW Trigger signal is EVENTOUT           */
+#endif /* STM32H503xx || STM32H523xx || STM32H533xx */
 /**
   * @}
   */
@@ -2109,7 +2109,7 @@ __STATIC_INLINE void LL_DMA_ConfigChannelSecure(DMA_TypeDef *DMAx, uint32_t Chan
   uint32_t dma_base_addr = (uint32_t)DMAx;
   MODIFY_REG(DMAx->SECCFGR, (DMA_SECCFGR_SEC0 << Channel), ((Configuration & LL_DMA_CHANNEL_SEC) << Channel));
   MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + LL_DMA_CH_OFFSET_TAB[Channel]))->CTR1,
-             (DMA_CTR1_DSEC | DMA_CTR1_DSEC), (Configuration & (~LL_DMA_CHANNEL_SEC)));
+             (DMA_CTR1_SSEC | DMA_CTR1_DSEC), (Configuration & (~LL_DMA_CHANNEL_SEC)));
 }
 
 /**
@@ -2155,7 +2155,9 @@ __STATIC_INLINE void LL_DMA_DisableChannelDestSecure(const DMA_TypeDef *DMAx, ui
   uint32_t dma_base_addr = (uint32_t)DMAx;
   CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + LL_DMA_CH_OFFSET_TAB[Channel]))->CTR1, DMA_CTR1_DSEC);
 }
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
+#if defined (DMA_SECCFGR_SEC0)
 /**
   * @brief Check security attribute of the DMA transfer to the destination.
   * @note  This API is used for all available DMA channels.
@@ -2178,7 +2180,9 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannelDestSecure(const DMA_TypeDef *DM
   return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + LL_DMA_CH_OFFSET_TAB[Channel]))->CTR1, DMA_CTR1_DSEC)
            == (DMA_CTR1_DSEC)) ? 1UL : 0UL);
 }
+#endif /* DMA_SECCFGR_SEC0 */
 
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
   * @brief Enable security attribute of the DMA transfer from the source.
   * @note  This API is used for all available DMA channels.
@@ -2222,7 +2226,9 @@ __STATIC_INLINE void LL_DMA_DisableChannelSrcSecure(const DMA_TypeDef *DMAx, uin
   uint32_t dma_base_addr = (uint32_t)DMAx;
   CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + LL_DMA_CH_OFFSET_TAB[Channel]))->CTR1, DMA_CTR1_SSEC);
 }
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
+#if defined (DMA_SECCFGR_SEC0)
 /**
   * @brief Check security attribute of the DMA transfer from the source.
   * @note  This API is used for all available DMA channels.
@@ -2245,7 +2251,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannelSrcSecure(const DMA_TypeDef *DMA
   return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + LL_DMA_CH_OFFSET_TAB[Channel]))->CTR1, DMA_CTR1_SSEC)
            == (DMA_CTR1_SSEC)) ? 1UL : 0UL);
 }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* DMA_SECCFGR_SEC0 */
 
 /**
   * @brief Set destination allocated port.
@@ -2839,7 +2845,8 @@ __STATIC_INLINE uint32_t LL_DMA_GetSrcDataWidth(const DMA_TypeDef *DMAx, uint32_
   *         CTR2        TRIGM              LL_DMA_ConfigChannelTransfer\n
   *         CTR2        BREQ               LL_DMA_ConfigChannelTransfer\n
   *         CTR2        DREQ               LL_DMA_ConfigChannelTransfer\n
-  *         CTR2        SWREQ              LL_DMA_ConfigChannelTransfer
+  *         CTR2        SWREQ              LL_DMA_ConfigChannelTransfer\n
+  *         CTR2        PFREQ              LL_DMA_ConfigChannelTransfer
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
   *         @arg @ref LL_DMA_CHANNEL_0
@@ -2853,13 +2860,14 @@ __STATIC_INLINE uint32_t LL_DMA_GetSrcDataWidth(const DMA_TypeDef *DMAx, uint32_
   * @param  Configuration This parameter must be a combination of all the following values:
   *         @arg @ref LL_DMA_TCEM_BLK_TRANSFER          or @ref LL_DMA_TCEM_RPT_BLK_TRANSFER      or
   *              @ref LL_DMA_TCEM_EACH_LLITEM_TRANSFER  or @ref LL_DMA_TCEM_LAST_LLITEM_TRANSFER
-  *         @arg @ref LL_DMA_TRIG_POLARITY_MASKED       or @ref LL_DMA_HWREQUEST_BLK
-  *         @arg @ref LL_DMA_HWREQUEST_SINGLEBURST      or @ref LL_DMA_TRIG_POLARITY_RISING       or
+  *         @arg @ref LL_DMA_HWREQUEST_SINGLEBURST      or @ref LL_DMA_HWREQUEST_BLK
+  *         @arg @ref LL_DMA_TRIG_POLARITY_MASKED       or @ref LL_DMA_TRIG_POLARITY_RISING       or
   *              @ref LL_DMA_TRIG_POLARITY_FALLING
   *         @arg @ref LL_DMA_TRIGM_BLK_TRANSFER         or @ref LL_DMA_TRIGM_RPT_BLK_TRANSFER     or
   *              @ref LL_DMA_TRIGM_LLI_LINK_TRANSFER    or @ref LL_DMA_TRIGM_SINGLBURST_TRANSFER
   *         @arg @ref LL_DMA_DIRECTION_PERIPH_TO_MEMORY or @ref LL_DMA_DIRECTION_MEMORY_TO_PERIPH or
   *              @ref LL_DMA_DIRECTION_MEMORY_TO_MEMORY
+  *         @arg @ref LL_DMA_NORMAL                     or @ref LL_DMA_PFCTRL
   *@retval None.
   */
 __STATIC_INLINE void LL_DMA_ConfigChannelTransfer(const DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Configuration)
@@ -4079,7 +4087,7 @@ __STATIC_INLINE void LL_DMA_ConfigBlkRptAddrUpdate(const DMA_TypeDef *DMAx, uint
   * @param  BlkDataLength Block transfer length
                           Value between 0 to 0x0000FFFF
   * @param  BlkRptCount Block repeat counter
-  *                     Value between 0 to 0x00000EFF
+  *                     Value between 0 to 0x000007FF
   *@retval None.
   */
 __STATIC_INLINE void LL_DMA_ConfigBlkCounters(const DMA_TypeDef *DMAx, uint32_t Channel, uint32_t BlkDataLength,
@@ -4253,7 +4261,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetSrcAddrUpdate(const DMA_TypeDef *DMAx, uint32
   *         @arg @ref LL_DMA_CHANNEL_6
   *         @arg @ref LL_DMA_CHANNEL_7
   * @param  BlkRptCount Block repeat counter
-  *                     Value between 0 to 0x00000EFF
+  *                     Value between 0 to 0x000007FF
   * @retval None.
   */
 __STATIC_INLINE void LL_DMA_SetBlkRptCount(const DMA_TypeDef *DMAx, uint32_t Channel, uint32_t BlkRptCount)
@@ -4271,7 +4279,7 @@ __STATIC_INLINE void LL_DMA_SetBlkRptCount(const DMA_TypeDef *DMAx, uint32_t Cha
   * @param  Channel This parameter can be one of the following values:
   *         @arg @ref LL_DMA_CHANNEL_6
   *         @arg @ref LL_DMA_CHANNEL_7
-  * @retval Between 0 to 0x00000EFF
+  * @retval Between 0 to 0x000007FF
   */
 __STATIC_INLINE uint32_t LL_DMA_GetBlkRptCount(const DMA_TypeDef *DMAx, uint32_t Channel)
 {
@@ -4659,7 +4667,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetBlkRptSrcAddrUpdateValue(const DMA_TypeDef *D
   *         @arg @ref LL_DMA_UPDATE_CTR3  (This value is allowed only for 2D addressing channels)
   *         @arg @ref LL_DMA_UPDATE_CBR2  (This value is allowed only for 2D addressing channels)
   *         @arg @ref LL_DMA_UPDATE_CLLR
-  * @param  LinkedListAddrOffset Between 0 to 0x0000FFFC
+  * @param  LinkedListAddrOffset Between 0 to 0x0000FFFC by increment of 4 Bytes.
   * @retval None.
   */
 __STATIC_INLINE void LL_DMA_ConfigLinkUpdate(const DMA_TypeDef *DMAx, uint32_t Channel, uint32_t RegistersUpdate,
@@ -5185,7 +5193,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledCLLRUpdate(const DMA_TypeDef *DMAx, uin
   *         @arg @ref LL_DMA_CHANNEL_5
   *         @arg @ref LL_DMA_CHANNEL_6
   *         @arg @ref LL_DMA_CHANNEL_7
-  * @param  LinkedListAddrOffset Between 0 to 0x0000FFFC
+  * @param  LinkedListAddrOffset Between 0 to 0x0000FFFC by increment of 4 Bytes.
   * @retval None.
   */
 __STATIC_INLINE void LL_DMA_SetLinkedListAddrOffset(const DMA_TypeDef *DMAx, uint32_t Channel,
@@ -5283,7 +5291,9 @@ __STATIC_INLINE void LL_DMA_DisableChannelSecure(DMA_TypeDef *DMAx, uint32_t Cha
 {
   CLEAR_BIT(DMAx->SECCFGR, (DMA_SECCFGR_SEC0 << (Channel & 0x0000000FU)));
 }
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
+#if defined (DMA_SECCFGR_SEC0)
 /**
   * @brief Check if DMA channel secure is enabled.
   * @note  This API is used for all available DMA channels.
@@ -5305,7 +5315,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannelSecure(const DMA_TypeDef *DMAx, 
   return ((READ_BIT(DMAx->SECCFGR, (DMA_SECCFGR_SEC0 << (Channel & 0x0000000FU)))
            == (DMA_SECCFGR_SEC0 << (Channel & 0x0000000FU))) ? 1UL : 0UL);
 }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* DMA_SECCFGR_SEC0 */
 
 /**
   * @brief Enable the DMA channel privilege attribute.
@@ -5392,7 +5402,7 @@ __STATIC_INLINE void LL_DMA_EnableChannelLockAttribute(DMA_TypeDef *DMAx, uint32
 {
   SET_BIT(DMAx->RCFGLOCKR, (DMA_RCFGLOCKR_LOCK0 << (Channel & 0x0000000FU)));
 }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 #if defined (DMA_RCFGLOCKR_LOCK0)
 /**
@@ -5417,7 +5427,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannelLockAttribute(const DMA_TypeDef 
            == (DMA_RCFGLOCKR_LOCK0 << (Channel & 0x0000000FU))) ? 1UL : 0UL);
 }
 
-#endif /* defined (DMA_RCFGLOCKR_LOCK0) */
+#endif /* DMA_RCFGLOCKR_LOCK0 */
 /**
   * @}
   */
@@ -5808,7 +5818,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_SMIS(const DMA_TypeDef *DMAx, uint3
   return ((READ_BIT(DMAx->SMISR, (DMA_SMISR_MIS0 << (Channel & 0x0000000FU)))
            == (DMA_SMISR_MIS0 << (Channel & 0x0000000FU))) ? 1UL : 0UL);
 }
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 /**
   * @}
   */
@@ -6311,7 +6321,7 @@ void     LL_DMA_DisconnectNextLinkNode(LL_DMA_LinkNodeTypeDef *pLinkNode, uint32
 /**
   * @}
   */
-#endif /* defined (USE_FULL_LL_DRIVER) */
+#endif /* USE_FULL_LL_DRIVER */
 
 /**
   * @}
@@ -6321,7 +6331,7 @@ void     LL_DMA_DisconnectNextLinkNode(LL_DMA_LinkNodeTypeDef *pLinkNode, uint32
   * @}
   */
 
-#endif /* defined (GPDMA1) */
+#endif /* GPDMA1 */
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_exti.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_exti.c
@@ -81,15 +81,20 @@ ErrorStatus LL_EXTI_DeInit(void)
 {
   /* Interrupt mask register set to default reset values */
   LL_EXTI_WriteReg(IMR1,   0xFFFE0000U);
-#if (defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx))
-  LL_EXTI_WriteReg(IMR2,   0x03DBBFFFU);
-#else
+#if defined(STM32H533xx) || defined(STM32H523xx)
+  LL_EXTI_WriteReg(IMR2,   0x07DBFFFFU);
+#elif defined(STM32H503xx)
   LL_EXTI_WriteReg(IMR2,   0x001BFFFFU);
-#endif /* defined(STM32H573xx) || defined(STM32H563xx) || defined(STM32H562xx) */
+#else
+  LL_EXTI_WriteReg(IMR2,   0x03DBBFFFU);
+#endif /* defined(STM32H533xx) || defined(STM32H523xx) */
 
   /* Event mask register set to default reset values */
   LL_EXTI_WriteReg(EMR1,   0x00000000U);
   LL_EXTI_WriteReg(EMR2,   0x00000000U);
+#if defined(EXTI_EMR3_EM)
+  LL_EXTI_WriteReg(EMR3,   0x00000000U);
+#endif /* EXTI_EMR3_EM */
 
   /* Rising Trigger selection register set to default reset values */
   LL_EXTI_WriteReg(RTSR1,  0x00000000U);
@@ -257,6 +262,7 @@ ErrorStatus LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
     /* De-configure EXTI Lines in range from 32 to 63 */
     LL_EXTI_DisableIT_32_63(EXTI_InitStruct->Line_32_63);
     LL_EXTI_DisableEvent_32_63(EXTI_InitStruct->Line_32_63);
+
   }
   return status;
 }

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_exti.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_exti.h
@@ -106,51 +106,109 @@ typedef struct
 #define LL_EXTI_LINE_15                EXTI_IMR1_IM15          /*!< Extended line 15 */
 #define LL_EXTI_LINE_16                EXTI_IMR1_IM16          /*!< Extended line 16 */
 #define LL_EXTI_LINE_17                EXTI_IMR1_IM17          /*!< Extended line 17 */
+#if defined(EXTI_IMR1_IM18)
 #define LL_EXTI_LINE_18                EXTI_IMR1_IM18          /*!< Extended line 18 */
+#endif /* EXTI_IMR1_IM18 */
 #define LL_EXTI_LINE_19                EXTI_IMR1_IM19          /*!< Extended line 19 */
+#if defined(EXTI_IMR1_IM20)
 #define LL_EXTI_LINE_20                EXTI_IMR1_IM20          /*!< Extended line 20 */
+#endif /* EXTI_IMR1_IM20 */
 #define LL_EXTI_LINE_21                EXTI_IMR1_IM21          /*!< Extended line 21 */
 #define LL_EXTI_LINE_22                EXTI_IMR1_IM22          /*!< Extended line 22 */
+#if defined(EXTI_IMR1_IM23)
 #define LL_EXTI_LINE_23                EXTI_IMR1_IM23          /*!< Extended line 23 */
+#endif /* EXTI_IMR1_IM23 */
 #define LL_EXTI_LINE_24                EXTI_IMR1_IM24          /*!< Extended line 24 */
 #define LL_EXTI_LINE_25                EXTI_IMR1_IM25          /*!< Extended line 25 */
 #define LL_EXTI_LINE_26                EXTI_IMR1_IM26          /*!< Extended line 26 */
 #define LL_EXTI_LINE_27                EXTI_IMR1_IM27          /*!< Extended line 27 */
 #define LL_EXTI_LINE_28                EXTI_IMR1_IM28          /*!< Extended line 28 */
 #define LL_EXTI_LINE_29                EXTI_IMR1_IM29          /*!< Extended line 29 */
+#if defined(EXTI_IMR1_IM30)
 #define LL_EXTI_LINE_30                EXTI_IMR1_IM30          /*!< Extended line 30 */
+#endif /* EXTI_IMR1_IM30 */
+#if defined(EXTI_IMR1_IM31)
 #define LL_EXTI_LINE_31                EXTI_IMR1_IM31          /*!< Extended line 31 */
+#endif /* EXTI_IMR1_IM31 */
 #define LL_EXTI_LINE_ALL_0_31          EXTI_IMR1_IM            /*!< All Extended line not reserved */
 
+#if defined(EXTI_IMR2_IM32)
 #define LL_EXTI_LINE_32                EXTI_IMR2_IM32          /*!< Extended line 32 */
+#endif /* EXTI_IMR2_IM32 */
+#if defined(EXTI_IMR2_IM33)
 #define LL_EXTI_LINE_33                EXTI_IMR2_IM33          /*!< Extended line 33 */
+#endif /* EXTI_IMR2_IM33 */
+#if defined(EXTI_IMR2_IM34)
 #define LL_EXTI_LINE_34                EXTI_IMR2_IM34          /*!< Extended line 34 */
+#endif /* EXTI_IMR2_IM34 */
+#if defined(EXTI_IMR2_IM35)
 #define LL_EXTI_LINE_35                EXTI_IMR2_IM35          /*!< Extended line 35 */
+#endif /* EXTI_IMR2_IM35 */
+#if defined(EXTI_IMR2_IM36)
 #define LL_EXTI_LINE_36                EXTI_IMR2_IM36          /*!< Extended line 36 */
+#endif /* EXTI_IMR2_IM36 */
 #define LL_EXTI_LINE_37                EXTI_IMR2_IM37          /*!< Extended line 37 */
 #define LL_EXTI_LINE_38                EXTI_IMR2_IM38          /*!< Extended line 38 */
 #define LL_EXTI_LINE_39                EXTI_IMR2_IM39          /*!< Extended line 39 */
 #define LL_EXTI_LINE_40                EXTI_IMR2_IM40          /*!< Extended line 40 */
 #define LL_EXTI_LINE_41                EXTI_IMR2_IM41          /*!< Extended line 41 */
 #define LL_EXTI_LINE_42                EXTI_IMR2_IM42          /*!< Extended line 42 */
+#if defined(EXTI_IMR2_IM43)
 #define LL_EXTI_LINE_43                EXTI_IMR2_IM43          /*!< Extended line 43 */
+#endif /* EXTI_IMR2_IM43 */
+#if defined(EXTI_IMR2_IM44)
 #define LL_EXTI_LINE_44                EXTI_IMR2_IM44          /*!< Extended line 44 */
+#endif /* EXTI_IMR2_IM44 */
+#if defined(EXTI_IMR2_IM45)
 #define LL_EXTI_LINE_45                EXTI_IMR2_IM45          /*!< Extended line 45 */
+#endif /* EXTI_IMR2_IM45 */
 #if defined(ETH)
 #define LL_EXTI_LINE_46                EXTI_IMR2_IM46          /*!< Extended line 46 */
 #endif /* ETH */
 #define LL_EXTI_LINE_47                EXTI_IMR2_IM47          /*!< Extended line 47 */
+#if defined(EXTI_IMR2_IM48)
 #define LL_EXTI_LINE_48                EXTI_IMR2_IM48          /*!< Extended line 48 */
+#endif /* EXTI_IMR2_IM48 */
 #define LL_EXTI_LINE_49                EXTI_IMR2_IM49          /*!< Extended line 49 */
 #define LL_EXTI_LINE_50                EXTI_IMR2_IM50          /*!< Extended line 50 */
+#if defined(EXTI_IMR2_IM51)
 #define LL_EXTI_LINE_51                EXTI_IMR2_IM51          /*!< Extended line 51 */
+#endif /* EXTI_IMR2_IM51 */
+#if defined(EXTI_IMR2_IM52)
 #define LL_EXTI_LINE_52                EXTI_IMR2_IM52          /*!< Extended line 52 */
+#endif /* EXTI_IMR2_IM52 */
 #define LL_EXTI_LINE_53                EXTI_IMR2_IM53          /*!< Extended line 53 */
+#if defined(EXTI_IMR2_IM54)
 #define LL_EXTI_LINE_54                EXTI_IMR2_IM54          /*!< Extended line 54 */
+#endif /* EXTI_IMR2_IM54 */
+#if defined(EXTI_IMR2_IM55)
 #define LL_EXTI_LINE_55                EXTI_IMR2_IM55          /*!< Extended line 55 */
+#endif /* EXTI_IMR2_IM55 */
+#if defined(EXTI_IMR2_IM56)
 #define LL_EXTI_LINE_56                EXTI_IMR2_IM56          /*!< Extended line 56 */
+#endif /* EXTI_IMR2_IM56 */
+#if defined(EXTI_IMR2_IM57)
 #define LL_EXTI_LINE_57                EXTI_IMR2_IM57          /*!< Extended line 57 */
-#define LL_EXTI_LINE_ALL_32_63         EXTI_IMR2_IM            /*!< ALL Extended line */
+#endif /* EXTI_IMR2_IM57 */
+#if defined(EXTI_IMR2_IM58)
+#define LL_EXTI_LINE_58                EXTI_IMR2_IM58          /*!< Extended line 58 */
+#endif /* EXTI_IMR2_IM58 */
+#if defined(EXTI_IMR2_IM59)
+#define LL_EXTI_LINE_59                EXTI_IMR2_IM59          /*!< Extended line 59 */
+#endif /* EXTI_IMR2_IM59 */
+#if defined(EXTI_IMR2_IM60)
+#define LL_EXTI_LINE_60                EXTI_IMR2_IM60          /*!< Extended line 60 */
+#endif /* EXTI_IMR2_IM60 */
+#if defined(EXTI_IMR2_IM61)
+#define LL_EXTI_LINE_61                EXTI_IMR2_IM61          /*!< Extended line 61 */
+#endif /* EXTI_IMR2_IM61 */
+#if defined(EXTI_IMR2_IM62)
+#define LL_EXTI_LINE_62                EXTI_IMR2_IM62          /*!< Extended line 62 */
+#endif /* EXTI_IMR2_IM62 */
+#if defined(EXTI_IMR2_IM63)
+#define LL_EXTI_LINE_63                EXTI_IMR2_IM63          /*!< Extended line 63 */
+#endif /* EXTI_IMR2_IM63 */
+#define LL_EXTI_LINE_ALL_32_63         EXTI_IMR2_IM            /*!< ALL Extended lines */
 
 #define LL_EXTI_LINE_ALL               (0xFFFFFFFFU)           /*!< All Extended line */
 
@@ -165,11 +223,19 @@ typedef struct
 #define LL_EXTI_EXTI_PORTB               EXTI_EXTICR1_EXTI0_0                        /*!< EXTI PORT B */
 #define LL_EXTI_EXTI_PORTC               EXTI_EXTICR1_EXTI0_1                        /*!< EXTI PORT C */
 #define LL_EXTI_EXTI_PORTD               (EXTI_EXTICR1_EXTI0_1|EXTI_EXTICR1_EXTI0_0) /*!< EXTI PORT D */
+#if defined(GPIOE)
 #define LL_EXTI_EXTI_PORTE               EXTI_EXTICR1_EXTI0_2                        /*!< EXTI PORT E */
+#endif /* GPIO E */
+#if defined(GPIOF)
 #define LL_EXTI_EXTI_PORTF               (EXTI_EXTICR1_EXTI0_2|EXTI_EXTICR1_EXTI0_0) /*!< EXTI PORT F */
+#endif /* GPIO F */
+#if defined(GPIOG)
 #define LL_EXTI_EXTI_PORTG               (EXTI_EXTICR1_EXTI0_2|EXTI_EXTICR1_EXTI0_1) /*!< EXTI PORT G */
+#endif /* GPIO G */
 #define LL_EXTI_EXTI_PORTH               (EXTI_EXTICR1_EXTI0_2|EXTI_EXTICR1_EXTI0_1|EXTI_EXTICR1_EXTI0_0) /*!< EXTI PORT H */
+#if defined(GPIOI)
 #define LL_EXTI_EXTI_PORTI               EXTI_EXTICR1_EXTI0_3 /*!< EXTI PORT I */
+#endif /* GPIO I */
 
 /**
   * @}
@@ -265,7 +331,6 @@ typedef struct
   */
 
 
-
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup EXTI_LL_Exported_Functions EXTI Exported Functions
   * @{
@@ -339,6 +404,7 @@ __STATIC_INLINE void LL_EXTI_EnableIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_42
   *         @arg @ref LL_EXTI_LINE_43
   *         @arg @ref LL_EXTI_LINE_44
+  *         @arg @ref LL_EXTI_LINE_45
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_47
   *         @arg @ref LL_EXTI_LINE_48
@@ -350,10 +416,11 @@ __STATIC_INLINE void LL_EXTI_EnableIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableIT_32_63(uint32_t ExtiLine)
@@ -427,6 +494,7 @@ __STATIC_INLINE void LL_EXTI_DisableIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_42
   *         @arg @ref LL_EXTI_LINE_43
   *         @arg @ref LL_EXTI_LINE_44
+  *         @arg @ref LL_EXTI_LINE_45
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_47
   *         @arg @ref LL_EXTI_LINE_48
@@ -438,17 +506,17 @@ __STATIC_INLINE void LL_EXTI_DisableIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableIT_32_63(uint32_t ExtiLine)
 {
   CLEAR_BIT(EXTI->IMR2, ExtiLine);
 }
-
 
 /**
   * @brief  Indicate if ExtiLine Interrupt request is enabled for Lines in range 0 to 31
@@ -516,6 +584,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_42
   *         @arg @ref LL_EXTI_LINE_43
   *         @arg @ref LL_EXTI_LINE_44
+  *         @arg @ref LL_EXTI_LINE_45
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_47
   *         @arg @ref LL_EXTI_LINE_48
@@ -527,10 +596,11 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_32_63(uint32_t ExtiLine)
@@ -609,6 +679,7 @@ __STATIC_INLINE void LL_EXTI_EnableEvent_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_43
   *         @arg @ref LL_EXTI_LINE_44
   *         @arg @ref LL_EXTI_LINE_46
+  *         @arg @ref LL_EXTI_LINE_45
   *         @arg @ref LL_EXTI_LINE_47
   *         @arg @ref LL_EXTI_LINE_48
   *         @arg @ref LL_EXTI_LINE_49
@@ -619,10 +690,11 @@ __STATIC_INLINE void LL_EXTI_EnableEvent_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableEvent_32_63(uint32_t ExtiLine)
@@ -691,8 +763,8 @@ __STATIC_INLINE void LL_EXTI_DisableEvent_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_41
   *         @arg @ref LL_EXTI_LINE_42
   *         @arg @ref LL_EXTI_LINE_43
-  *         @arg @ref LL_EXTI_LINE_44 (*)
-  *         @arg @ref LL_EXTI_LINE_46 (*)
+  *         @arg @ref LL_EXTI_LINE_44
+  *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_47
   *         @arg @ref LL_EXTI_LINE_48
   *         @arg @ref LL_EXTI_LINE_49
@@ -703,10 +775,11 @@ __STATIC_INLINE void LL_EXTI_DisableEvent_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableEvent_32_63(uint32_t ExtiLine)
@@ -787,10 +860,11 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   *
-  *         (*) value not defined in all devices.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_32_63(uint32_t ExtiLine)
@@ -834,6 +908,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_32_63(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_14
   *         @arg @ref LL_EXTI_LINE_15
   *         @arg @ref LL_EXTI_LINE_16
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableRisingTrig_0_31(uint32_t ExtiLine)
@@ -853,8 +928,10 @@ __STATIC_INLINE void LL_EXTI_EnableRisingTrig_0_31(uint32_t ExtiLine)
   * @rmtoll RTSR2        RTx           LL_EXTI_EnableRisingTrig_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
+  *         @arg @ref LL_EXTI_LINE_49
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableRisingTrig_32_63(uint32_t ExtiLine)
@@ -890,6 +967,7 @@ __STATIC_INLINE void LL_EXTI_EnableRisingTrig_32_63(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_14
   *         @arg @ref LL_EXTI_LINE_15
   *         @arg @ref LL_EXTI_LINE_16
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableRisingTrig_0_31(uint32_t ExtiLine)
@@ -910,8 +988,12 @@ __STATIC_INLINE void LL_EXTI_DisableRisingTrig_0_31(uint32_t ExtiLine)
   * @rmtoll RTSR2        RTx           LL_EXTI_DisableRisingTrig_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
+  *         @arg @ref LL_EXTI_LINE_49
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * (*)  : Not available for all stm32h5xxxx family lines.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableRisingTrig_32_63(uint32_t ExtiLine)
@@ -940,6 +1022,7 @@ __STATIC_INLINE void LL_EXTI_DisableRisingTrig_32_63(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_14
   *         @arg @ref LL_EXTI_LINE_15
   *         @arg @ref LL_EXTI_LINE_16
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_0_31(uint32_t ExtiLine)
@@ -953,15 +1036,18 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_0_31(uint32_t ExtiLine)
   * @rmtoll RTSR2        RTx           LL_EXTI_IsEnabledRisingTrig_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
+  *         @arg @ref LL_EXTI_LINE_49
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * (*)  : Not available for all stm32h5xxxx family lines.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_32_63(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->RTSR2, ExtiLine) == (ExtiLine)) ? 1U : 0U);
 }
-
 
 /**
   * @}
@@ -1020,14 +1106,15 @@ __STATIC_INLINE void LL_EXTI_EnableFallingTrig_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableFallingTrig_32_63(uint32_t ExtiLine)
 {
   SET_BIT(EXTI->FTSR2, ExtiLine);
 }
-
 
 /**
   * @brief  Disable ExtiLine Falling Edge Trigger for Lines in range 0 to 31
@@ -1076,14 +1163,16 @@ __STATIC_INLINE void LL_EXTI_DisableFallingTrig_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * (*)  : Not available for all stm32h5xxxx family lines.
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableFallingTrig_32_63(uint32_t ExtiLine)
 {
   CLEAR_BIT(EXTI->FTSR2, ExtiLine);
 }
-
 
 /**
   * @brief  Check if falling edge trigger is enabled for Lines in range 0 to 31
@@ -1120,14 +1209,15 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_32_63(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->FTSR2, ExtiLine) == (ExtiLine)) ? 1U : 0U);
 }
-
 
 /**
   * @}
@@ -1182,14 +1272,15 @@ __STATIC_INLINE void LL_EXTI_GenerateSWI_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
-  *         @arg @ref LL_EXTI_LINE_51
+  *         @arg @ref LL_EXTI_LINE_53
+  *
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_GenerateSWI_32_63(uint32_t ExtiLine)
 {
   SET_BIT(EXTI->SWIER2, ExtiLine);
 }
-
 
 /**
   * @}
@@ -1239,6 +1330,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -1287,6 +1379,7 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval @note This bit is set when the selected edge event arrives on the interrupt
   */
@@ -1335,6 +1428,7 @@ __STATIC_INLINE void LL_EXTI_ClearFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -1342,7 +1436,6 @@ __STATIC_INLINE void LL_EXTI_ClearFallingFlag_32_63(uint32_t ExtiLine)
 {
   WRITE_REG(EXTI->FPR2, ExtiLine);
 }
-
 
 /**
   * @brief  Check if the ExtLine Rising Flag is set or not for Lines in range 0 to 31
@@ -1384,6 +1477,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveRisingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -1432,6 +1526,7 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadRisingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval @note This bit is set when the selected edge event arrives on the interrupt
   */
@@ -1480,6 +1575,7 @@ __STATIC_INLINE void LL_EXTI_ClearRisingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_46
   *         @arg @ref LL_EXTI_LINE_50
   *         @arg @ref LL_EXTI_LINE_53
+  *
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -1518,11 +1614,13 @@ __STATIC_INLINE void LL_EXTI_ClearRisingFlag_32_63(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_EXTI_PORTB
   *         @arg @ref LL_EXTI_EXTI_PORTC
   *         @arg @ref LL_EXTI_EXTI_PORTD
-  *         @arg @ref LL_EXTI_EXTI_PORTE
-  *         @arg @ref LL_EXTI_EXTI_PORTF
-  *         @arg @ref LL_EXTI_EXTI_PORTG
+  *         @arg @ref LL_EXTI_EXTI_PORTE (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTF (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTG (*)
   *         @arg @ref LL_EXTI_EXTI_PORTH
-  *         @arg @ref LL_EXTI_EXTI_PORTI
+  *         @arg @ref LL_EXTI_EXTI_PORTI (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTJ (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTK (*)
   *
   *         (*) value not defined in all devices
   * @param  Line This parameter can be one of the following values:
@@ -1590,11 +1688,15 @@ __STATIC_INLINE void LL_EXTI_SetEXTISource(uint32_t Port, uint32_t Line)
   *         @arg @ref LL_EXTI_EXTI_PORTB
   *         @arg @ref LL_EXTI_EXTI_PORTC
   *         @arg @ref LL_EXTI_EXTI_PORTD
-  *         @arg @ref LL_EXTI_EXTI_PORTE
-  *         @arg @ref LL_EXTI_EXTI_PORTF
-  *         @arg @ref LL_EXTI_EXTI_PORTG
+  *         @arg @ref LL_EXTI_EXTI_PORTE (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTF (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTG (*)
   *         @arg @ref LL_EXTI_EXTI_PORTH
-  *         @arg @ref LL_EXTI_EXTI_PORTI
+  *         @arg @ref LL_EXTI_EXTI_PORTI (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTJ (*)
+  *         @arg @ref LL_EXTI_EXTI_PORTK (*)
+  *
+  *         (*) value not defined in all devices
   */
 __STATIC_INLINE uint32_t LL_EXTI_GetEXTISource(uint32_t Line)
 {
@@ -1685,7 +1787,8 @@ __STATIC_INLINE void LL_EXTI_EnableSecure_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
@@ -1768,7 +1871,8 @@ __STATIC_INLINE void LL_EXTI_DisableSecure_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
@@ -1780,6 +1884,7 @@ __STATIC_INLINE void LL_EXTI_DisableSecure_32_63(uint32_t ExtiLine)
 
 #endif /* __ARM_FEATURE_CMSE */
 
+#if defined(EXTI_SECENR1_SEC0)
 /**
   * @brief  Indicate if ExtiLine Secure attribute is enabled for Lines in range 0 to 31
   * @rmtoll SECCFGR1     SECx          LL_EXTI_IsEnabledSecure_0_31
@@ -1853,7 +1958,8 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledSecure_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
@@ -1862,6 +1968,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledSecure_32_63(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->SECCFGR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
+#endif /* EXTI_SECENR1_SEC0 */
 
 /**
   * @}
@@ -1944,7 +2051,8 @@ __STATIC_INLINE void LL_EXTI_EnablePrivilege_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
@@ -2001,7 +2109,7 @@ __STATIC_INLINE void LL_EXTI_DisablePrivilege_0_31(uint32_t ExtiLine)
 
 /**
   * @brief  Disable ExtiLine Privilege attribute for Lines in range 32 to 63
-  * @rmtoll PRIVCFGR2    PRIVx         LL_EXTI_EnablePrivilege_32_63
+  * @rmtoll PRIVCFGR2    PRIVx         LL_EXTI_DisablePrivilege_32_63
   * @param  ExtiLine This parameter can be one of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
@@ -2027,7 +2135,8 @@ __STATIC_INLINE void LL_EXTI_DisablePrivilege_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
@@ -2110,7 +2219,8 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledPrivilege_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_54
   *         @arg @ref LL_EXTI_LINE_55
   *         @arg @ref LL_EXTI_LINE_56
-  *         @arg @ref LL_EXTI_LINE_57 (*)
+  *         @arg @ref LL_EXTI_LINE_57
+  *         @arg @ref LL_EXTI_LINE_58
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmac.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmac.c
@@ -113,8 +113,6 @@ ErrorStatus LL_FMAC_DeInit(const FMAC_TypeDef *FMACx)
   return (status);
 }
 
-
-
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmac.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmac.h
@@ -38,7 +38,6 @@ extern "C" {
   */
 
 /* Exported types ------------------------------------------------------------*/
-
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup FMAC_LL_Exported_Constants FMAC Exported Constants
   * @{
@@ -147,9 +146,7 @@ extern "C" {
   * @}
   */
 
-
 /* Exported functions --------------------------------------------------------*/
-
 /** @defgroup FMAC_LL_Exported_Functions FMAC Exported Functions
   * @{
   */
@@ -1033,15 +1030,12 @@ __STATIC_INLINE void LL_FMAC_ConfigFunc(FMAC_TypeDef *FMACx, uint8_t Start, uint
   * @}
   */
 
-
-
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup FMAC_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
 ErrorStatus LL_FMAC_Init(FMAC_TypeDef *FMACx);
 ErrorStatus LL_FMAC_DeInit(const FMAC_TypeDef *FMACx);
-
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmc.c
@@ -13,7 +13,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -61,7 +61,7 @@
   * @{
   */
 #if defined(HAL_NOR_MODULE_ENABLED) || defined(HAL_NAND_MODULE_ENABLED) || defined(HAL_SDRAM_MODULE_ENABLED)\
- || defined(HAL_SRAM_MODULE_ENABLED)
+    || defined(HAL_SRAM_MODULE_ENABLED)
 
 /** @defgroup FMC_LL  FMC Low Layer
   * @brief FMC driver modules
@@ -195,7 +195,7 @@
   * @retval HAL status
   */
 HAL_StatusTypeDef  FMC_NORSRAM_Init(FMC_NORSRAM_TypeDef *Device,
-                                    FMC_NORSRAM_InitTypeDef *Init)
+                                    const FMC_NORSRAM_InitTypeDef *Init)
 {
   uint32_t flashaccess;
   uint32_t btcr_reg;
@@ -383,7 +383,7 @@ HAL_StatusTypeDef FMC_NORSRAM_DeInit(FMC_NORSRAM_TypeDef *Device,
   * @retval HAL status
   */
 HAL_StatusTypeDef FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device,
-                                          FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank)
+                                          const FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank)
 {
   uint32_t tmpr;
 
@@ -400,14 +400,15 @@ HAL_StatusTypeDef FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device,
   assert_param(IS_FMC_NORSRAM_BANK(Bank));
 
   /* Set FMC_NORSRAM device timing parameters */
-  MODIFY_REG(Device->BTCR[Bank + 1U], BTR_CLEAR_MASK, (Timing->AddressSetupTime                                  |
-                                                       ((Timing->AddressHoldTime)        << FMC_BTRx_ADDHLD_Pos)  |
-                                                       ((Timing->DataSetupTime)          << FMC_BTRx_DATAST_Pos)  |
-                                                       ((Timing->DataHoldTime)           << FMC_BTRx_DATAHLD_Pos) |
-                                                       ((Timing->BusTurnAroundDuration)  << FMC_BTRx_BUSTURN_Pos) |
-                                                       (((Timing->CLKDivision) - 1U)     << FMC_BTRx_CLKDIV_Pos)  |
-                                                       (((Timing->DataLatency) - 2U)     << FMC_BTRx_DATLAT_Pos)  |
-                                                       (Timing->AccessMode)));
+  Device->BTCR[Bank + 1U] =
+    (Timing->AddressSetupTime << FMC_BTRx_ADDSET_Pos) |
+    (Timing->AddressHoldTime << FMC_BTRx_ADDHLD_Pos) |
+    (Timing->DataSetupTime << FMC_BTRx_DATAST_Pos) |
+    (Timing->DataHoldTime << FMC_BTRx_DATAHLD_Pos) |
+    (Timing->BusTurnAroundDuration << FMC_BTRx_BUSTURN_Pos) |
+    ((Timing->CLKDivision - 1U) << FMC_BTRx_CLKDIV_Pos) |
+    ((Timing->DataLatency - 2U) << FMC_BTRx_DATLAT_Pos) |
+    Timing->AccessMode;
 
   /* Configure Clock division value (in NORSRAM bank 1) when continuous clock is enabled */
   if (HAL_IS_BIT_SET(Device->BTCR[FMC_NORSRAM_BANK1], FMC_BCR1_CCLKEN))
@@ -433,7 +434,7 @@ HAL_StatusTypeDef FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device,
   * @retval HAL status
   */
 HAL_StatusTypeDef FMC_NORSRAM_Extended_Timing_Init(FMC_NORSRAM_EXTENDED_TypeDef *Device,
-                                                   FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank,
+                                                   const FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank,
                                                    uint32_t ExtendedMode)
 {
   /* Check the parameters */
@@ -582,7 +583,7 @@ HAL_StatusTypeDef FMC_NORSRAM_WriteOperation_Disable(FMC_NORSRAM_TypeDef *Device
   * @param  Init Pointer to NAND Initialization structure
   * @retval HAL status
   */
-HAL_StatusTypeDef FMC_NAND_Init(FMC_NAND_TypeDef *Device, FMC_NAND_InitTypeDef *Init)
+HAL_StatusTypeDef FMC_NAND_Init(FMC_NAND_TypeDef *Device, const FMC_NAND_InitTypeDef *Init)
 {
   /* Check the parameters */
   assert_param(IS_FMC_NAND_DEVICE(Device));
@@ -615,7 +616,7 @@ HAL_StatusTypeDef FMC_NAND_Init(FMC_NAND_TypeDef *Device, FMC_NAND_InitTypeDef *
   * @retval HAL status
   */
 HAL_StatusTypeDef FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device,
-                                                   FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
+                                                   const FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
 {
   /* Check the parameters */
   assert_param(IS_FMC_NAND_DEVICE(Device));
@@ -629,10 +630,10 @@ HAL_StatusTypeDef FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device,
   UNUSED(Bank);
 
   /* NAND bank 3 registers configuration */
-  MODIFY_REG(Device->PMEM, PMEM_CLEAR_MASK, (Timing->SetupTime                                 |
-                                             ((Timing->WaitSetupTime) << FMC_PMEM_MEMWAIT_Pos) |
-                                             ((Timing->HoldSetupTime) << FMC_PMEM_MEMHOLD_Pos) |
-                                             ((Timing->HiZSetupTime)  << FMC_PMEM_MEMHIZ_Pos)));
+  Device->PMEM = (Timing->SetupTime |
+                  ((Timing->WaitSetupTime) << FMC_PMEM_MEMWAIT_Pos) |
+                  ((Timing->HoldSetupTime) << FMC_PMEM_MEMHOLD_Pos) |
+                  ((Timing->HiZSetupTime) << FMC_PMEM_MEMHIZ_Pos));
 
   return HAL_OK;
 }
@@ -646,7 +647,7 @@ HAL_StatusTypeDef FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device,
   * @retval HAL status
   */
 HAL_StatusTypeDef FMC_NAND_AttributeSpace_Timing_Init(FMC_NAND_TypeDef *Device,
-                                                      FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
+                                                      const FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
 {
   /* Check the parameters */
   assert_param(IS_FMC_NAND_DEVICE(Device));
@@ -660,10 +661,10 @@ HAL_StatusTypeDef FMC_NAND_AttributeSpace_Timing_Init(FMC_NAND_TypeDef *Device,
   UNUSED(Bank);
 
   /* NAND bank 3 registers configuration */
-  MODIFY_REG(Device->PATT, PATT_CLEAR_MASK, (Timing->SetupTime                                 |
-                                             ((Timing->WaitSetupTime) << FMC_PATT_ATTWAIT_Pos) |
-                                             ((Timing->HoldSetupTime) << FMC_PATT_ATTHOLD_Pos) |
-                                             ((Timing->HiZSetupTime)  << FMC_PATT_ATTHIZ_Pos)));
+  Device->PATT = (Timing->SetupTime |
+                  ((Timing->WaitSetupTime) << FMC_PATT_ATTWAIT_Pos) |
+                  ((Timing->HoldSetupTime) << FMC_PATT_ATTHOLD_Pos) |
+                  ((Timing->HiZSetupTime)  << FMC_PATT_ATTHIZ_Pos));
 
   return HAL_OK;
 }
@@ -767,7 +768,7 @@ HAL_StatusTypeDef FMC_NAND_ECC_Disable(FMC_NAND_TypeDef *Device, uint32_t Bank)
   * @param  Timeout Timeout wait value
   * @retval HAL status
   */
-HAL_StatusTypeDef FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank,
+HAL_StatusTypeDef FMC_NAND_GetECC(const FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank,
                                   uint32_t Timeout)
 {
   uint32_t tickstart;
@@ -855,7 +856,7 @@ HAL_StatusTypeDef FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, ui
   * @param  Init Pointer to SDRAM Initialization structure
   * @retval HAL status
   */
-HAL_StatusTypeDef FMC_SDRAM_Init(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_InitTypeDef *Init)
+HAL_StatusTypeDef FMC_SDRAM_Init(FMC_SDRAM_TypeDef *Device, const FMC_SDRAM_InitTypeDef *Init)
 {
   /* Check the parameters */
   assert_param(IS_FMC_SDRAM_DEVICE(Device));
@@ -918,7 +919,7 @@ HAL_StatusTypeDef FMC_SDRAM_Init(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_InitTypeDe
   * @retval HAL status
   */
 HAL_StatusTypeDef FMC_SDRAM_Timing_Init(FMC_SDRAM_TypeDef *Device,
-                                        FMC_SDRAM_TimingTypeDef *Timing, uint32_t Bank)
+                                        const FMC_SDRAM_TimingTypeDef *Timing, uint32_t Bank)
 {
   /* Check the parameters */
   assert_param(IS_FMC_SDRAM_DEVICE(Device));
@@ -1048,7 +1049,7 @@ HAL_StatusTypeDef FMC_SDRAM_WriteProtection_Disable(FMC_SDRAM_TypeDef *Device, u
   * @retval HAL state
   */
 HAL_StatusTypeDef FMC_SDRAM_SendCommand(FMC_SDRAM_TypeDef *Device,
-                                        FMC_SDRAM_CommandTypeDef *Command, uint32_t Timeout)
+                                        const FMC_SDRAM_CommandTypeDef *Command, uint32_t Timeout)
 {
   /* Check the parameters */
   assert_param(IS_FMC_SDRAM_DEVICE(Device));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_fmc.h
@@ -6,7 +6,7 @@
   ******************************************************************************
   * @attention
   *
-  * Copyright (c) 2022 STMicroelectronics.
+  * Copyright (c) 2023 STMicroelectronics.
   * All rights reserved.
   *
   * This software is licensed under terms that can be found in the LICENSE file
@@ -213,74 +213,75 @@ extern "C" {
 typedef struct
 {
   uint32_t NSBank;                       /*!< Specifies the NORSRAM memory device that will be used.
-                                              This parameter can be a value of @ref FMC_NORSRAM_Bank                  */
+                                              This parameter can be a value of @ref FMC_NORSRAM_Bank                 */
 
   uint32_t DataAddressMux;               /*!< Specifies whether the address and data values are
                                               multiplexed on the data bus or not.
-                                              This parameter can be a value of @ref FMC_Data_Address_Bus_Multiplexing */
+                                              This parameter can be a value of @ref FMC_Data_Address_Bus_Multiplexing*/
 
   uint32_t MemoryType;                   /*!< Specifies the type of external memory attached to
                                               the corresponding memory device.
-                                              This parameter can be a value of @ref FMC_Memory_Type                   */
+                                              This parameter can be a value of @ref FMC_Memory_Type                  */
 
   uint32_t MemoryDataWidth;              /*!< Specifies the external memory device width.
-                                              This parameter can be a value of @ref FMC_NORSRAM_Data_Width            */
+                                              This parameter can be a value of @ref FMC_NORSRAM_Data_Width           */
 
   uint32_t BurstAccessMode;              /*!< Enables or disables the burst access mode for Flash memory,
                                               valid only with synchronous burst Flash memories.
-                                              This parameter can be a value of @ref FMC_Burst_Access_Mode             */
+                                              This parameter can be a value of @ref FMC_Burst_Access_Mode            */
 
   uint32_t WaitSignalPolarity;           /*!< Specifies the wait signal polarity, valid only when accessing
                                               the Flash memory in burst mode.
-                                              This parameter can be a value of @ref FMC_Wait_Signal_Polarity          */
+                                              This parameter can be a value of @ref FMC_Wait_Signal_Polarity         */
 
   uint32_t WaitSignalActive;             /*!< Specifies if the wait signal is asserted by the memory one
                                               clock cycle before the wait state or during the wait state,
                                               valid only when accessing memories in burst mode.
-                                              This parameter can be a value of @ref FMC_Wait_Timing                   */
+                                              This parameter can be a value of @ref FMC_Wait_Timing                  */
 
-  uint32_t WriteOperation;               /*!< Enables or disables the write operation in the selected device by the FMC.
-                                              This parameter can be a value of @ref FMC_Write_Operation               */
+  uint32_t WriteOperation;               /*!< Enables or disables the write operation in the selected device
+                                              by the FMC.
+                                              This parameter can be a value of @ref FMC_Write_Operation              */
 
   uint32_t WaitSignal;                   /*!< Enables or disables the wait state insertion via wait
                                               signal, valid for Flash memory access in burst mode.
-                                              This parameter can be a value of @ref FMC_Wait_Signal                   */
+                                              This parameter can be a value of @ref FMC_Wait_Signal                  */
 
   uint32_t ExtendedMode;                 /*!< Enables or disables the extended mode.
-                                              This parameter can be a value of @ref FMC_Extended_Mode                 */
+                                              This parameter can be a value of @ref FMC_Extended_Mode                */
 
   uint32_t AsynchronousWait;             /*!< Enables or disables wait signal during asynchronous transfers,
                                               valid only with asynchronous Flash memories.
-                                              This parameter can be a value of @ref FMC_AsynchronousWait              */
+                                              This parameter can be a value of @ref FMC_AsynchronousWait             */
 
   uint32_t WriteBurst;                   /*!< Enables or disables the write burst operation.
-                                              This parameter can be a value of @ref FMC_Write_Burst                   */
+                                              This parameter can be a value of @ref FMC_Write_Burst                  */
 
   uint32_t ContinuousClock;              /*!< Enables or disables the FMC clock output to external memory devices.
                                               This parameter is only enabled through the FMC_BCR1 register,
                                               and don't care through FMC_BCR2..4 registers.
-                                              This parameter can be a value of @ref FMC_Continous_Clock               */
+                                              This parameter can be a value of @ref FMC_Continous_Clock              */
 
   uint32_t WriteFifo;                    /*!< Enables or disables the write FIFO used by the FMC controller.
                                               This parameter is only enabled through the FMC_BCR1 register,
                                               and don't care through FMC_BCR2..4 registers.
-                                              This parameter can be a value of @ref FMC_Write_FIFO                    */
+                                              This parameter can be a value of @ref FMC_Write_FIFO                   */
 
   uint32_t PageSize;                     /*!< Specifies the memory page size.
-                                              This parameter can be a value of @ref FMC_Page_Size                     */
+                                              This parameter can be a value of @ref FMC_Page_Size                    */
 
   uint32_t NBLSetupTime;                 /*!< Specifies the NBL setup timing clock cycle number
-                                              This parameter can be a value of @ref FMC_Byte_Lane                     */
+                                              This parameter can be a value of @ref FMC_Byte_Lane                    */
 
   FunctionalState MaxChipSelectPulse;    /*!< Enables or disables the maximum chip select pulse management in this
                                               NSBank for PSRAM refresh.
-                                              This parameter can be set to ENABLE or DISABLE                          */
+                                              This parameter can be set to ENABLE or DISABLE                         */
 
   uint32_t MaxChipSelectPulseTime;       /*!< Specifies the maximum chip select pulse time in FMC_CLK cycles for
                                               synchronous accesses and in HCLK cycles for asynchronous accesses,
                                               valid only if MaxChipSelectPulse is ENABLE.
                                               This parameter can be a value between Min_Data = 1 and Max_Data = 65535.
-                                              @note: This parameter is common to all NSBank.                          */
+                                              @note: This parameter is common to all NSBank.                         */
 } FMC_NORSRAM_InitTypeDef;
 
 /**
@@ -329,7 +330,7 @@ typedef struct
                                                 in NOR Flash memories with synchronous burst mode enable              */
 
   uint32_t AccessMode;                   /*!< Specifies the asynchronous access mode.
-                                              This parameter can be a value of @ref FMC_Access_Mode                   */
+                                              This parameter can be a value of @ref FMC_Access_Mode                  */
 } FMC_NORSRAM_TimingTypeDef;
 #endif /* FMC_BANK1 */
 
@@ -1137,11 +1138,11 @@ typedef struct
   *  @{
   */
 HAL_StatusTypeDef  FMC_NORSRAM_Init(FMC_NORSRAM_TypeDef *Device,
-                                    FMC_NORSRAM_InitTypeDef *Init);
+                                    const FMC_NORSRAM_InitTypeDef *Init);
 HAL_StatusTypeDef  FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device,
-                                           FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank);
+                                           const FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank);
 HAL_StatusTypeDef  FMC_NORSRAM_Extended_Timing_Init(FMC_NORSRAM_EXTENDED_TypeDef *Device,
-                                                    FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank,
+                                                    const FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank,
                                                     uint32_t ExtendedMode);
 HAL_StatusTypeDef  FMC_NORSRAM_DeInit(FMC_NORSRAM_TypeDef *Device,
                                       FMC_NORSRAM_EXTENDED_TypeDef *ExDevice, uint32_t Bank);
@@ -1169,11 +1170,11 @@ HAL_StatusTypeDef  FMC_NORSRAM_WriteOperation_Disable(FMC_NORSRAM_TypeDef *Devic
 /** @defgroup FMC_LL_NAND_Private_Functions_Group1 NAND Initialization/de-initialization functions
   *  @{
   */
-HAL_StatusTypeDef  FMC_NAND_Init(FMC_NAND_TypeDef *Device, FMC_NAND_InitTypeDef *Init);
+HAL_StatusTypeDef  FMC_NAND_Init(FMC_NAND_TypeDef *Device, const FMC_NAND_InitTypeDef *Init);
 HAL_StatusTypeDef  FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device,
-                                                    FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
+                                                    const FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
 HAL_StatusTypeDef  FMC_NAND_AttributeSpace_Timing_Init(FMC_NAND_TypeDef *Device,
-                                                       FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
+                                                       const FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
 HAL_StatusTypeDef  FMC_NAND_DeInit(FMC_NAND_TypeDef *Device, uint32_t Bank);
 /**
   * @}
@@ -1184,7 +1185,7 @@ HAL_StatusTypeDef  FMC_NAND_DeInit(FMC_NAND_TypeDef *Device, uint32_t Bank);
   */
 HAL_StatusTypeDef  FMC_NAND_ECC_Enable(FMC_NAND_TypeDef *Device, uint32_t Bank);
 HAL_StatusTypeDef  FMC_NAND_ECC_Disable(FMC_NAND_TypeDef *Device, uint32_t Bank);
-HAL_StatusTypeDef  FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank,
+HAL_StatusTypeDef  FMC_NAND_GetECC(const FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank,
                                    uint32_t Timeout);
 /**
   * @}
@@ -1202,9 +1203,9 @@ HAL_StatusTypeDef  FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, u
 /** @defgroup FMC_LL_SDRAM_Private_Functions_Group1 SDRAM Initialization/de-initialization functions
   *  @{
   */
-HAL_StatusTypeDef  FMC_SDRAM_Init(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_InitTypeDef *Init);
+HAL_StatusTypeDef  FMC_SDRAM_Init(FMC_SDRAM_TypeDef *Device, const FMC_SDRAM_InitTypeDef *Init);
 HAL_StatusTypeDef  FMC_SDRAM_Timing_Init(FMC_SDRAM_TypeDef *Device,
-                                         FMC_SDRAM_TimingTypeDef *Timing, uint32_t Bank);
+                                         const FMC_SDRAM_TimingTypeDef *Timing, uint32_t Bank);
 HAL_StatusTypeDef  FMC_SDRAM_DeInit(FMC_SDRAM_TypeDef *Device, uint32_t Bank);
 /**
   * @}
@@ -1216,7 +1217,7 @@ HAL_StatusTypeDef  FMC_SDRAM_DeInit(FMC_SDRAM_TypeDef *Device, uint32_t Bank);
 HAL_StatusTypeDef  FMC_SDRAM_WriteProtection_Enable(FMC_SDRAM_TypeDef *Device, uint32_t Bank);
 HAL_StatusTypeDef  FMC_SDRAM_WriteProtection_Disable(FMC_SDRAM_TypeDef *Device, uint32_t Bank);
 HAL_StatusTypeDef  FMC_SDRAM_SendCommand(FMC_SDRAM_TypeDef *Device,
-                                         FMC_SDRAM_CommandTypeDef *Command, uint32_t Timeout);
+                                         const FMC_SDRAM_CommandTypeDef *Command, uint32_t Timeout);
 HAL_StatusTypeDef  FMC_SDRAM_ProgramRefreshRate(FMC_SDRAM_TypeDef *Device, uint32_t RefreshRate);
 HAL_StatusTypeDef  FMC_SDRAM_SetAutoRefreshNumber(FMC_SDRAM_TypeDef *Device,
                                                   uint32_t AutoRefreshNumber);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_gpio.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_gpio.c
@@ -31,7 +31,7 @@
   */
 
 #if defined (GPIOA) || defined (GPIOB) || defined (GPIOC) || defined (GPIOD) || defined (GPIOE) || defined (GPIOF) || \
-    defined (GPIOG) || defined (GPIOH) || defined (GPIOI)
+    defined (GPIOG) || defined (GPIOH) || defined (GPIOI) || defined (GPIOJ) || defined (GPIOK)
 
 /** @addtogroup GPIO_LL
   * @{
@@ -166,6 +166,20 @@ ErrorStatus LL_GPIO_DeInit(const GPIO_TypeDef *GPIOx)
     LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOI);
   }
 #endif /* GPIOI */
+#if defined(GPIOJ)
+  else if (GPIOx == GPIOJ)
+  {
+    LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOJ);
+    LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOJ);
+  }
+#endif /* GPIOJ */
+#if defined(GPIOK)
+  else if (GPIOx == GPIOK)
+  {
+    LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOK);
+    LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOK);
+  }
+#endif /* GPIOK */
   else
   {
     status = ERROR;
@@ -279,7 +293,8 @@ void LL_GPIO_StructInit(LL_GPIO_InitTypeDef *GPIO_InitStruct)
   */
 
 #endif /* defined (GPIOA) || defined (GPIOB) || defined (GPIOC) || defined (GPIOD) || defined (GPIOE) || \
-          defined (GPIOF) || defined (GPIOG) || defined (GPIOH) || defined (GPIOI) */
+          defined (GPIOF) || defined (GPIOG) || defined (GPIOH) || defined (GPIOI) || defined (GPIOJ) || \
+          defined (GPIOK) ||*/
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_gpio.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_gpio.h
@@ -32,7 +32,7 @@ extern "C" {
   */
 
 #if defined (GPIOA) || defined (GPIOB) || defined (GPIOC) || defined (GPIOD) || defined (GPIOE) || defined (GPIOF) || \
-    defined (GPIOG) || defined (GPIOH) || defined (GPIOI)
+    defined (GPIOG) || defined (GPIOH) || defined (GPIOI) || defined (GPIOJ) || defined (GPIOK)
 
 /** @defgroup GPIO_LL GPIO
   * @{
@@ -282,7 +282,8 @@ typedef struct
   */
 __STATIC_INLINE void LL_GPIO_SetPinMode(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Mode)
 {
-  MODIFY_REG(GPIOx->MODER, (GPIO_MODER_MODE0 << (POSITION_VAL(Pin) * 2U)), (Mode << (POSITION_VAL(Pin) * 2U)));
+  MODIFY_REG(GPIOx->MODER, (GPIO_MODER_MODE0 << (POSITION_VAL(Pin) * GPIO_MODER_MODE1_Pos)),
+             (Mode << (POSITION_VAL(Pin) * GPIO_MODER_MODE1_Pos)));
 }
 
 /**
@@ -316,8 +317,8 @@ __STATIC_INLINE void LL_GPIO_SetPinMode(GPIO_TypeDef *GPIOx, uint32_t Pin, uint3
   */
 __STATIC_INLINE uint32_t LL_GPIO_GetPinMode(const GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
-  return (uint32_t)(READ_BIT(GPIOx->MODER,
-                             (GPIO_MODER_MODE0 << (POSITION_VAL(Pin) * 2U))) >> (POSITION_VAL(Pin) * 2U));
+  return (uint32_t)(READ_BIT(GPIOx->MODER, (GPIO_MODER_MODE0 << (POSITION_VAL(Pin) * GPIO_MODER_MODE1_Pos))) >> \
+                    (POSITION_VAL(Pin) * GPIO_MODER_MODE1_Pos));
 }
 
 /**
@@ -422,8 +423,8 @@ __STATIC_INLINE uint32_t LL_GPIO_GetPinOutputType(const GPIO_TypeDef *GPIOx, uin
   */
 __STATIC_INLINE void LL_GPIO_SetPinSpeed(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t  Speed)
 {
-  MODIFY_REG(GPIOx->OSPEEDR, (GPIO_OSPEEDR_OSPEED0 << (POSITION_VAL(Pin) * 2U)),
-             (Speed << (POSITION_VAL(Pin) * 2U)));
+  MODIFY_REG(GPIOx->OSPEEDR, (GPIO_OSPEEDR_OSPEED0 << (POSITION_VAL(Pin) * GPIO_OSPEEDR_OSPEED1_Pos)),
+             (Speed << (POSITION_VAL(Pin) * GPIO_OSPEEDR_OSPEED1_Pos)));
 }
 
 /**
@@ -459,8 +460,9 @@ __STATIC_INLINE void LL_GPIO_SetPinSpeed(GPIO_TypeDef *GPIOx, uint32_t Pin, uint
   */
 __STATIC_INLINE uint32_t LL_GPIO_GetPinSpeed(const GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
-  return (uint32_t)(READ_BIT(GPIOx->OSPEEDR,
-                             (GPIO_OSPEEDR_OSPEED0 << (POSITION_VAL(Pin) * 2U))) >> (POSITION_VAL(Pin) * 2U));
+  return (uint32_t)(READ_BIT(GPIOx->OSPEEDR, (GPIO_OSPEEDR_OSPEED0 << \
+                                              (POSITION_VAL(Pin) * GPIO_OSPEEDR_OSPEED1_Pos))) >> \
+                    (POSITION_VAL(Pin) * GPIO_OSPEEDR_OSPEED1_Pos));
 }
 
 /**
@@ -493,7 +495,8 @@ __STATIC_INLINE uint32_t LL_GPIO_GetPinSpeed(const GPIO_TypeDef *GPIOx, uint32_t
   */
 __STATIC_INLINE void LL_GPIO_SetPinPull(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Pull)
 {
-  MODIFY_REG(GPIOx->PUPDR, (GPIO_PUPDR_PUPD0 << (POSITION_VAL(Pin) * 2U)), (Pull << (POSITION_VAL(Pin) * 2U)));
+  MODIFY_REG(GPIOx->PUPDR, (GPIO_PUPDR_PUPD0 << (POSITION_VAL(Pin) * GPIO_PUPDR_PUPD1_Pos)),
+             (Pull << (POSITION_VAL(Pin) * GPIO_PUPDR_PUPD1_Pos)));
 }
 
 /**
@@ -525,8 +528,8 @@ __STATIC_INLINE void LL_GPIO_SetPinPull(GPIO_TypeDef *GPIOx, uint32_t Pin, uint3
   */
 __STATIC_INLINE uint32_t LL_GPIO_GetPinPull(const GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
-  return (uint32_t)(READ_BIT(GPIOx->PUPDR,
-                             (GPIO_PUPDR_PUPD0 << (POSITION_VAL(Pin) * 2U))) >> (POSITION_VAL(Pin) * 2U));
+  return (uint32_t)(READ_BIT(GPIOx->PUPDR, (GPIO_PUPDR_PUPD0 << (POSITION_VAL(Pin) * GPIO_PUPDR_PUPD1_Pos))) >> \
+                    (POSITION_VAL(Pin) * GPIO_PUPDR_PUPD1_Pos));
 }
 
 /**
@@ -565,8 +568,8 @@ __STATIC_INLINE uint32_t LL_GPIO_GetPinPull(const GPIO_TypeDef *GPIOx, uint32_t 
   */
 __STATIC_INLINE void LL_GPIO_SetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Alternate)
 {
-  MODIFY_REG(GPIOx->AFR[0], (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * 4U)),
-             (Alternate << (POSITION_VAL(Pin) * 4U)));
+  MODIFY_REG(GPIOx->AFR[0], (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * GPIO_AFRL_AFSEL1_Pos)),
+             (Alternate << (POSITION_VAL(Pin) * GPIO_AFRL_AFSEL1_Pos)));
 }
 
 /**
@@ -602,8 +605,8 @@ __STATIC_INLINE void LL_GPIO_SetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin, uin
   */
 __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_0_7(const GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
-  return (uint32_t)(READ_BIT(GPIOx->AFR[0],
-                             (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * 4U))) >> (POSITION_VAL(Pin) * 4U));
+  return (uint32_t)(READ_BIT(GPIOx->AFR[0], (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * GPIO_AFRL_AFSEL1_Pos))) >> \
+                    (POSITION_VAL(Pin) * GPIO_AFRL_AFSEL1_Pos));
 }
 
 /**
@@ -642,8 +645,8 @@ __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_0_7(const GPIO_TypeDef *GPIOx, uint32_
   */
 __STATIC_INLINE void LL_GPIO_SetAFPin_8_15(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Alternate)
 {
-  MODIFY_REG(GPIOx->AFR[1], (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * 4U)),
-             (Alternate << (POSITION_VAL(Pin >> 8U) * 4U)));
+  MODIFY_REG(GPIOx->AFR[1], (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * GPIO_AFRH_AFSEL9_Pos)),
+             (Alternate << (POSITION_VAL(Pin >> 8U) * GPIO_AFRH_AFSEL9_Pos)));
 }
 
 /**
@@ -680,8 +683,8 @@ __STATIC_INLINE void LL_GPIO_SetAFPin_8_15(GPIO_TypeDef *GPIOx, uint32_t Pin, ui
   */
 __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_8_15(const GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
-  return (uint32_t)(READ_BIT(GPIOx->AFR[1],
-                             (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * 4U))) >> (POSITION_VAL(Pin >> 8U) * 4U));
+  return (uint32_t)(READ_BIT(GPIOx->AFR[1], (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * GPIO_AFRH_AFSEL9_Pos))) >> \
+                    (POSITION_VAL(Pin >> 8U) * GPIO_AFRH_AFSEL9_Pos));
 }
 
 /**
@@ -1166,7 +1169,8 @@ void        LL_GPIO_StructInit(LL_GPIO_InitTypeDef *GPIO_InitStruct);
   */
 
 #endif /* defined (GPIOA) || defined (GPIOB) || defined (GPIOC) || defined (GPIOD) || defined (GPIOE) || \
-          defined (GPIOF) || defined (GPIOG) || defined (GPIOH) || defined (GPIOI) */
+          defined (GPIOF) || defined (GPIOG) || defined (GPIOH) || defined (GPIOI) || defined (GPIOJ) || \
+          defined (GPIOK) */
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_i2c.h
@@ -2234,11 +2234,18 @@ __STATIC_INLINE uint32_t LL_I2C_GetSlaveAddr(const I2C_TypeDef *I2Cx)
 __STATIC_INLINE void LL_I2C_HandleTransfer(I2C_TypeDef *I2Cx, uint32_t SlaveAddr, uint32_t SlaveAddrSize,
                                            uint32_t TransferSize, uint32_t EndMode, uint32_t Request)
 {
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  uint32_t tmp = ((uint32_t)(((uint32_t)SlaveAddr & I2C_CR2_SADD) | \
+                             ((uint32_t)SlaveAddrSize & I2C_CR2_ADD10) | \
+                             (((uint32_t)TransferSize << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | \
+                             (uint32_t)EndMode | (uint32_t)Request) & (~0x80000000U));
+
+  /* update CR2 register */
   MODIFY_REG(I2Cx->CR2, I2C_CR2_SADD | I2C_CR2_ADD10 |
              (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31U - I2C_CR2_RD_WRN_Pos))) |
              I2C_CR2_START | I2C_CR2_STOP | I2C_CR2_RELOAD |
              I2C_CR2_NBYTES | I2C_CR2_AUTOEND | I2C_CR2_HEAD10R,
-             SlaveAddr | SlaveAddrSize | (TransferSize << I2C_CR2_NBYTES_Pos) | EndMode | Request);
+             tmp);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_icache.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_icache.h
@@ -560,6 +560,7 @@ __STATIC_INLINE uint32_t LL_ICACHE_IsEnabledRegion(uint32_t Region)
 
 /**
   * @brief  Select the memory remapped region base address.
+  * @note   The useful bits depends on RSIZE as described in the Reference Manual.
   * @rmtoll CRRx         BASEADDR      LL_ICACHE_SetRegionBaseAddress
   * @param  Region This parameter can be one of the following values:
   *         @arg @ref LL_ICACHE_REGION_0
@@ -572,12 +573,13 @@ __STATIC_INLINE uint32_t LL_ICACHE_IsEnabledRegion(uint32_t Region)
 __STATIC_INLINE void LL_ICACHE_SetRegionBaseAddress(uint32_t Region, uint32_t Address)
 {
   MODIFY_REG(*((__IO uint32_t *)(&(ICACHE->CRR0) + (1U * Region))), \
-             ICACHE_CRRx_BASEADDR, (((Address & 0x1FFFFFFFU) >> 21U) & ICACHE_CRRx_BASEADDR));
+             ICACHE_CRRx_BASEADDR, ((Address & 0x1FFFFFFFU) >> 21U));
 }
 
 /**
   * @brief  Get the memory remapped region base address.
   * @note   The base address is the alias in the Code region.
+  * @note   The useful bits depends on RSIZE as described in the Reference Manual.
   * @rmtoll CRRx         BASEADDR      LL_ICACHE_GetRegionBaseAddress
   * @param  Region This parameter can be one of the following values:
   *         @arg @ref LL_ICACHE_REGION_0
@@ -589,18 +591,19 @@ __STATIC_INLINE void LL_ICACHE_SetRegionBaseAddress(uint32_t Region, uint32_t Ad
 __STATIC_INLINE uint32_t LL_ICACHE_GetRegionBaseAddress(uint32_t Region)
 {
   return (READ_BIT(*((__IO uint32_t *)(&(ICACHE->CRR0) + (1U * Region))), \
-                   ICACHE_CRRx_BASEADDR));
+                   ICACHE_CRRx_BASEADDR) << 21U);
 }
 
 /**
-  * @brief  Select the memory remapped region remap address.
+  * @brief  Select the memory remapped region address.
+  * @note   The useful bits depends on RSIZE as described in the Reference Manual.
   * @rmtoll CRRx         REMAPADDR     LL_ICACHE_SetRegionRemapAddress
   * @param  Region This parameter can be one of the following values:
   *         @arg @ref LL_ICACHE_REGION_0
   *         @arg @ref LL_ICACHE_REGION_1
   *         @arg @ref LL_ICACHE_REGION_2
   *         @arg @ref LL_ICACHE_REGION_3
-  * @param  Address  External memory address
+  * @param  Address  Memory address to remap
   * @retval None
   */
 __STATIC_INLINE void LL_ICACHE_SetRegionRemapAddress(uint32_t Region, uint32_t Address)
@@ -610,14 +613,15 @@ __STATIC_INLINE void LL_ICACHE_SetRegionRemapAddress(uint32_t Region, uint32_t A
 }
 
 /**
-  * @brief  Get the memory remapped region base address.
+  * @brief  Get the memory remapped region address.
+  * @note   The useful bits depends on RSIZE as described in the Reference Manual.
   * @rmtoll CRRx         REMAPADDR     LL_ICACHE_GetRegionRemapAddress
   * @param  Region This parameter can be one of the following values:
   *         @arg @ref LL_ICACHE_REGION_0
   *         @arg @ref LL_ICACHE_REGION_1
   *         @arg @ref LL_ICACHE_REGION_2
   *         @arg @ref LL_ICACHE_REGION_3
-  * @retval Address  External memory address
+  * @retval Address  Remapped memory address
   */
 __STATIC_INLINE uint32_t LL_ICACHE_GetRegionRemapAddress(uint32_t Region)
 {

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_lpuart.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_lpuart.h
@@ -2606,6 +2606,21 @@ __STATIC_INLINE void LL_LPUART_RequestRxDataFlush(USART_TypeDef *LPUARTx)
 }
 
 /**
+  * @brief  Request a Transmit data FIFO flush
+  * @note   TXFRQ bit is set to flush the whole FIFO when FIFO mode is enabled. This
+  *         also sets the flag TXFE (TXFIFO empty bit in the LPUART_ISR register).
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  *         FIFO mode feature is supported by the USARTx instance.
+  * @rmtoll RQR          TXFRQ         LL_LPUART_RequestTxDataFlush
+  * @param  LPUARTx LPUART Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_LPUART_RequestTxDataFlush(USART_TypeDef *LPUARTx)
+{
+  SET_BIT(LPUARTx->RQR, (uint16_t)USART_RQR_TXFRQ);
+}
+
+/**
   * @}
   */
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_opamp.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_opamp.c
@@ -65,8 +65,6 @@
    || ((__INPUT_NONINVERTING__) == LL_OPAMP_INPUT_NONINVERT_DAC)            \
   )
 
-
-
 #define IS_LL_OPAMP_INPUT_INVERTING(__INPUT_INVERTING__)                    \
   (((__INPUT_INVERTING__) == LL_OPAMP_INPUT_INVERT_IO0)                     \
    || ((__INPUT_INVERTING__) == LL_OPAMP_INPUT_INVERT_IO1)                  \

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_opamp.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_opamp.h
@@ -70,7 +70,6 @@ extern "C" {
   * @}
   */
 
-
 /* Private macros ----------------------------------------------------------------------------------------------------*/
 /** @defgroup OPAMP_LL_Private_Macros OPAMP Private Macros
   * @{
@@ -87,12 +86,9 @@ extern "C" {
 #define __OPAMP_PTR_REG_OFFSET(__REG__, __REG_OFFSET__)                        \
   ((__IO uint32_t *)((uint32_t) ((uint32_t)(&(__REG__)) + ((__REG_OFFSET__) << 2U))))
 
-
-
 /**
   * @}
   */
-
 
 /* Exported types ----------------------------------------------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -242,8 +238,6 @@ typedef struct
 /**
   * @}
   */
-
-
 
 /** @defgroup OPAMP_LL_EC_POWER_MODE OPAMP PowerMode
   * @{

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_pwr.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_pwr.h
@@ -529,7 +529,73 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledAHBRAM2_16K_ShutOff(void)
 {
   return ((READ_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16SO) == (PWR_PMCR_SRAM2_16SO)) ? 1UL : 0UL);
 }
-#else
+#endif /* PWR_PMCR_SRAM2_16SO */
+
+#if defined(PWR_PMCR_SRAM2_16HSO)
+/**
+  * @brief  Enable the AHB RAM2 high 16K Bytes shut-off in Stop mode
+  * @rmtoll PMCR    SRAM2_16HSO     LL_PWR_EnableAHBRAM2_High_16K_ShutOff
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_EnableAHBRAM2_High_16K_ShutOff(void)
+{
+  SET_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16HSO);
+}
+
+/**
+  * @brief  Disable the AHB RAM2 high 16K Bytes shut-off in Stop mode
+  * @rmtoll PMCR    SRAM2_16HSO     LL_PWR_DisableAHBRAM2_High_16K_ShutOff
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_DisableAHBRAM2_High_16K_ShutOff(void)
+{
+  CLEAR_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16HSO);
+}
+
+/**
+  * @brief  Check if the high AHB RAM2 shut-off in Stop mode is enabled
+  * @rmtoll PMCR    SRAM2_16HSO     LL_PWR_IsEnabledAHBRAM2_16K_ShutOff
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledAHBRAM2_High_16K_ShutOff(void)
+{
+  return ((READ_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16HSO) == (PWR_PMCR_SRAM2_16HSO)) ? 1UL : 0UL);
+}
+#endif /* PWR_PMCR_SRAM2_16HSO */
+
+#if defined(PWR_PMCR_SRAM2_16LSO)
+/**
+  * @brief  Enable the AHB RAM2 low 16K Bytes shut-off in Stop mode
+  * @rmtoll PMCR    SRAM2_16LSO     LL_PWR_EnableAHBRAM2_Low_16K_ShutOff
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_EnableAHBRAM2_Low_16K_ShutOff(void)
+{
+  SET_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16LSO);
+}
+
+/**
+  * @brief  Disable the AHB RAM2 low 16K Bytes shut-off in Stop mode
+  * @rmtoll PMCR    SRAM2_16LSO     LL_PWR_DisableAHBRAM2_Low_16K_ShutOff
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_DisableAHBRAM2_Low_16K_ShutOff(void)
+{
+  CLEAR_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16LSO);
+}
+
+/**
+  * @brief  Check if the low 16K AHB RAM2 shut-off in Stop mode is enabled
+  * @rmtoll PMCR    SRAM2_16LSO     LL_PWR_IsEnabledAHBRAM2_Low_16K_ShutOff
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledAHBRAM2_Low_16K_ShutOff(void)
+{
+  return ((READ_BIT(PWR->PMCR, PWR_PMCR_SRAM2_16LSO) == (PWR_PMCR_SRAM2_16LSO)) ? 1UL : 0UL);
+}
+#endif /* PWR_PMCR_SRAM2_16LSO */
+
+#if defined (PWR_PMCR_SRAM2SO)
 /**
   * @brief  Enable the AHB RAM2 shut-off in Stop mode
   * @rmtoll PMCR    SRAM2SO     LL_PWR_EnableAHBRAM2ShutOff
@@ -559,7 +625,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledAHBRAM2ShutOff(void)
 {
   return ((READ_BIT(PWR->PMCR, PWR_PMCR_SRAM2SO) == (PWR_PMCR_SRAM2SO)) ? 1UL : 0UL);
 }
-#endif /* PWR_PMCR_SRAM2_16SO */
+#endif /* PWR_PMCR_SRAM2SO */
 
 #if defined (PWR_PMCR_SRAM3SO)
 /**
@@ -1092,33 +1158,36 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledUSBVoltageDetector(void)
 
 /**
   * @brief  Enable the independent USB supply.
-  * @rmtoll USBSCR    USB33SV       LL_PWR_EnableVDDUSB
+  * @rmtoll USBSCR    USB33SV       LL_PWR_EnableVddUSB
   * @retval None
   */
-__STATIC_INLINE void LL_PWR_EnableVDDUSB(void)
+__STATIC_INLINE void LL_PWR_EnableVddUSB(void)
 {
   SET_BIT(PWR->USBSCR, PWR_USBSCR_USB33SV);
 }
+#define LL_PWR_EnableVDDUSB  LL_PWR_EnableVddUSB /* for API backward compatibility */
 
 /**
   * @brief  Disable the independent USB supply.
-  * @rmtoll USBSCR    USB33SV       LL_PWR_DisableVDDUSB
+  * @rmtoll USBSCR    USB33SV       LL_PWR_DisableVddUSB
   * @retval None
   */
-__STATIC_INLINE void LL_PWR_DisableVDDUSB(void)
+__STATIC_INLINE void LL_PWR_DisableVddUSB(void)
 {
   CLEAR_BIT(PWR->USBSCR, PWR_USBSCR_USB33SV);
 }
+#define LL_PWR_DisableVDDUSB  LL_PWR_DisableVddUSB /* for API backward compatibility */
 
 /**
   * @brief  Check if the independent USB supply is enabled.
-  * @rmtoll USBSCR    USB33SV       LL_PWR_IsEnabledVDDUSB
+  * @rmtoll USBSCR    USB33SV       LL_PWR_IsEnabledVddUSB
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_PWR_IsEnabledVDDUSB(void)
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledVddUSB(void)
 {
   return ((READ_BIT(PWR->USBSCR, PWR_USBSCR_USB33SV) == (PWR_USBSCR_USB33SV)) ? 1UL : 0UL);
 }
+#define LL_PWR_IsEnabledVDDUSB  LL_PWR_IsEnabledVddUSB /* for API backward compatibility */
 #endif /* PWR_USBSCR_USB33DEN */
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rcc.c
@@ -41,35 +41,47 @@
 /** @addtogroup RCC_LL_Private_Macros
   * @{
   */
-#if defined(USART6)
+#if defined(USART10)
 #define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_USART1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART2_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART3_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART6_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART10_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART11_CLKSOURCE))
+#elif defined(USART6)
+#define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_USART1_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_USART2_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_USART3_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_USART6_CLKSOURCE))
 #else
 #define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_USART1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART2_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_USART3_CLKSOURCE))
 #endif /* USART6 */
 
-#if defined(UART4)
+#if defined(UART7)
 #define IS_LL_RCC_UART_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_UART4_CLKSOURCE) \
                                                 || ((__VALUE__) == LL_RCC_UART5_CLKSOURCE) \
                                                 || ((__VALUE__) == LL_RCC_UART7_CLKSOURCE) \
                                                 || ((__VALUE__) == LL_RCC_UART8_CLKSOURCE) \
                                                 || ((__VALUE__) == LL_RCC_UART9_CLKSOURCE) \
                                                 || ((__VALUE__) == LL_RCC_UART12_CLKSOURCE))
-#endif /* UART4 */
+#elif defined(UART5)
+#define IS_LL_RCC_UART_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_UART4_CLKSOURCE) \
+                                                || ((__VALUE__) == LL_RCC_UART5_CLKSOURCE))
+#endif /* UART7 */
 
 #define IS_LL_RCC_LPUART_CLKSOURCE(__VALUE__) (((__VALUE__) == LL_RCC_LPUART1_CLKSOURCE))
 
-#if defined(I2C3)
+#if defined(I2C4)
 #define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_I2C1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_I2C2_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_I2C3_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_I2C4_CLKSOURCE))
+#elif defined(I2C3)
+#define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_I2C1_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_I2C2_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_I2C3_CLKSOURCE))
 #else
 #define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_I2C1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_I2C2_CLKSOURCE))
@@ -82,18 +94,23 @@
 #define IS_LL_RCC_I3C_CLKSOURCE(__VALUE__) (((__VALUE__) == LL_RCC_I3C1_CLKSOURCE))
 #endif /* I3C2 */
 
-#if defined(SPI4)
+#if defined(SPI5)
 #define IS_LL_RCC_SPI_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_SPI1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI2_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI3_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI4_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI5_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI6_CLKSOURCE))
+#elif defined(SPI4)
+#define IS_LL_RCC_SPI_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_SPI1_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_SPI2_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_SPI3_CLKSOURCE) \
+                                               || ((__VALUE__) == LL_RCC_SPI4_CLKSOURCE))
 #else
 #define IS_LL_RCC_SPI_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_SPI1_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI2_CLKSOURCE) \
                                                || ((__VALUE__) == LL_RCC_SPI3_CLKSOURCE))
-#endif /* SPI4 */
+#endif /* SPI5 */
 
 #if defined(LPTIM3)
 #define IS_LL_RCC_LPTIM_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_LPTIM1_CLKSOURCE) \
@@ -121,7 +138,9 @@
 
 #define IS_LL_RCC_RNG_CLKSOURCE(__VALUE__)      (((__VALUE__) == LL_RCC_RNG_CLKSOURCE))
 
+#if defined(USB_DRD_FS)
 #define IS_LL_RCC_USB_CLKSOURCE(__VALUE__)      (((__VALUE__) == LL_RCC_USB_CLKSOURCE))
+#endif /* USB_DRD_FS */
 
 #define IS_LL_RCC_ADCDAC_CLKSOURCE(__VALUE__)   (((__VALUE__) == LL_RCC_ADCDAC_CLKSOURCE))
 
@@ -364,63 +383,69 @@ void LL_RCC_GetPLL1ClockFreq(LL_PLL_ClocksTypeDef *pPLL_Clocks)
   /* PLL_VCO = (HSE_VALUE, CSI_VALUE or HSI_VALUE/HSIDIV) / PLLM * (PLLN + FRACN)
      SYSCLK = PLL_VCO / PLLP
   */
-  pllsource = LL_RCC_PLL1_GetSource();
 
-  switch (pllsource)
+  pPLL_Clocks->PLL_P_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_Q_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_R_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+
+  if (LL_RCC_PLL1_IsReady() != 0U)
   {
-    case LL_RCC_PLL1SOURCE_HSI:
-      if (LL_RCC_HSI_IsReady() != 0U)
-      {
-        pllinputfreq = HSI_VALUE >> (LL_RCC_HSI_GetDivider() >> RCC_CR_HSIDIV_Pos);
-      }
-      break;
 
-    case LL_RCC_PLL1SOURCE_CSI:
-      if (LL_RCC_CSI_IsReady() != 0U)
-      {
-        pllinputfreq = CSI_VALUE;
-      }
-      break;
+    pllsource = LL_RCC_PLL1_GetSource();
 
-    case LL_RCC_PLL1SOURCE_HSE:
-      if (LL_RCC_HSE_IsReady() != 0U)
-      {
-        pllinputfreq = HSE_VALUE;
-      }
-      break;
-
-    case LL_RCC_PLL1SOURCE_NONE:
-    default:
-      /* PLL clock disabled */
-      break;
-  }
-
-  pPLL_Clocks->PLL_P_Frequency = 0U;
-  pPLL_Clocks->PLL_Q_Frequency = 0U;
-  pPLL_Clocks->PLL_R_Frequency = 0U;
-
-  pllm = LL_RCC_PLL1_GetM();
-  plln = LL_RCC_PLL1_GetN();
-  if (LL_RCC_PLL1FRACN_IsEnabled() != 0U)
-  {
-    fracn = LL_RCC_PLL1_GetFRACN();
-  }
-
-  if (pllm != 0U)
-  {
-    if (LL_RCC_PLL1P_IsEnabled() != 0U)
+    switch (pllsource)
     {
-      pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetP());
+      case LL_RCC_PLL1SOURCE_HSI:
+        if (LL_RCC_HSI_IsReady() != 0U)
+        {
+          pllinputfreq = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
+        }
+        break;
+
+      case LL_RCC_PLL1SOURCE_CSI:
+        if (LL_RCC_CSI_IsReady() != 0U)
+        {
+          pllinputfreq = CSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL1SOURCE_HSE:
+        if (LL_RCC_HSE_IsReady() != 0U)
+        {
+          pllinputfreq = HSE_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL1SOURCE_NONE:
+      default:
+        /* PLL clock disabled */
+        break;
     }
 
-    if (LL_RCC_PLL1Q_IsEnabled() != 0U)
+    pllm = LL_RCC_PLL1_GetM();
+    plln = LL_RCC_PLL1_GetN();
+
+    if (LL_RCC_PLL1FRACN_IsEnabled() != 0U)
     {
-      pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetQ());
+      fracn = LL_RCC_PLL1_GetFRACN();
     }
 
-    if (LL_RCC_PLL1R_IsEnabled() != 0U)
+    if ((pllinputfreq != LL_RCC_PERIPH_FREQUENCY_NO) && (pllm != 0U))
     {
-      pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetR());
+      if (LL_RCC_PLL1P_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetP());
+      }
+
+      if (LL_RCC_PLL1Q_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetQ());
+      }
+
+      if (LL_RCC_PLL1R_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL1_GetR());
+      }
     }
   }
 }
@@ -441,63 +466,69 @@ void LL_RCC_GetPLL2ClockFreq(LL_PLL_ClocksTypeDef *pPLL_Clocks)
   /* PLL_VCO = (HSE_VALUE, CSI_VALUE or HSI_VALUE/HSIDIV) / PLLM * (PLLN + FRACN)
      SYSCLK = PLL_VCO / PLLP
   */
-  pllsource = LL_RCC_PLL2_GetSource();
 
-  switch (pllsource)
+  pPLL_Clocks->PLL_P_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_Q_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_R_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+
+  if (LL_RCC_PLL2_IsReady() != 0U)
   {
-    case LL_RCC_PLL2SOURCE_HSI:
-      if (LL_RCC_HSI_IsReady() != 0U)
-      {
-        pllinputfreq = HSI_VALUE >> (LL_RCC_HSI_GetDivider() >> RCC_CR_HSIDIV_Pos);
-      }
-      break;
 
-    case LL_RCC_PLL2SOURCE_CSI:
-      if (LL_RCC_CSI_IsReady() != 0U)
-      {
-        pllinputfreq = CSI_VALUE;
-      }
-      break;
+    pllsource = LL_RCC_PLL2_GetSource();
 
-    case LL_RCC_PLL2SOURCE_HSE:
-      if (LL_RCC_HSE_IsReady() != 0U)
-      {
-        pllinputfreq = HSE_VALUE;
-      }
-      break;
-
-    case LL_RCC_PLL2SOURCE_NONE:
-    default:
-      /* PLL clock disabled */
-      break;
-  }
-
-  pPLL_Clocks->PLL_P_Frequency = 0U;
-  pPLL_Clocks->PLL_Q_Frequency = 0U;
-  pPLL_Clocks->PLL_R_Frequency = 0U;
-
-  pllm = LL_RCC_PLL2_GetM();
-  plln = LL_RCC_PLL2_GetN();
-  if (LL_RCC_PLL2FRACN_IsEnabled() != 0U)
-  {
-    fracn = LL_RCC_PLL2_GetFRACN();
-  }
-
-  if (pllm != 0U)
-  {
-    if (LL_RCC_PLL2P_IsEnabled() != 0U)
+    switch (pllsource)
     {
-      pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetP());
+      case LL_RCC_PLL2SOURCE_HSI:
+        if (LL_RCC_HSI_IsReady() != 0U)
+        {
+          pllinputfreq = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
+        }
+        break;
+
+      case LL_RCC_PLL2SOURCE_CSI:
+        if (LL_RCC_CSI_IsReady() != 0U)
+        {
+          pllinputfreq = CSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL2SOURCE_HSE:
+        if (LL_RCC_HSE_IsReady() != 0U)
+        {
+          pllinputfreq = HSE_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL2SOURCE_NONE:
+      default:
+        /* PLL clock disabled */
+        break;
     }
 
-    if (LL_RCC_PLL2Q_IsEnabled() != 0U)
+    pllm = LL_RCC_PLL2_GetM();
+    plln = LL_RCC_PLL2_GetN();
+
+    if (LL_RCC_PLL2FRACN_IsEnabled() != 0U)
     {
-      pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetQ());
+      fracn = LL_RCC_PLL2_GetFRACN();
     }
 
-    if (LL_RCC_PLL2R_IsEnabled() != 0U)
+    if ((pllinputfreq != LL_RCC_PERIPH_FREQUENCY_NO) && (pllm != 0U))
     {
-      pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetR());
+      if (LL_RCC_PLL2P_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetP());
+      }
+
+      if (LL_RCC_PLL2Q_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetQ());
+      }
+
+      if (LL_RCC_PLL2R_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL2_GetR());
+      }
     }
   }
 }
@@ -519,63 +550,68 @@ void LL_RCC_GetPLL3ClockFreq(LL_PLL_ClocksTypeDef *pPLL_Clocks)
   /* PLL_VCO = (HSE_VALUE, CSI_VALUE or HSI_VALUE/HSIDIV) / PLLM * (PLLN + FRACN)
      SYSCLK = PLL_VCO / PLLP
   */
-  pllsource = LL_RCC_PLL3_GetSource();
 
-  switch (pllsource)
+  pPLL_Clocks->PLL_P_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_Q_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+  pPLL_Clocks->PLL_R_Frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+
+  if (LL_RCC_PLL3_IsReady() != 0U)
   {
-    case LL_RCC_PLL3SOURCE_HSI:
-      if (LL_RCC_HSI_IsReady() != 0U)
-      {
-        pllinputfreq = HSI_VALUE >> (LL_RCC_HSI_GetDivider() >> RCC_CR_HSIDIV_Pos);
-      }
-      break;
 
-    case LL_RCC_PLL3SOURCE_CSI:
-      if (LL_RCC_CSI_IsReady() != 0U)
-      {
-        pllinputfreq = CSI_VALUE;
-      }
-      break;
+    pllsource = LL_RCC_PLL3_GetSource();
 
-    case LL_RCC_PLL3SOURCE_HSE:
-      if (LL_RCC_HSE_IsReady() != 0U)
-      {
-        pllinputfreq = HSE_VALUE;
-      }
-      break;
-
-    case LL_RCC_PLL3SOURCE_NONE:
-    default:
-      /* PLL clock disabled */
-      break;
-  }
-
-  pPLL_Clocks->PLL_P_Frequency = 0U;
-  pPLL_Clocks->PLL_Q_Frequency = 0U;
-  pPLL_Clocks->PLL_R_Frequency = 0U;
-
-  pllm = LL_RCC_PLL3_GetM();
-  plln = LL_RCC_PLL3_GetN();
-  if (LL_RCC_PLL3FRACN_IsEnabled() != 0U)
-  {
-    fracn = LL_RCC_PLL3_GetFRACN();
-  }
-
-  if ((pllm != 0U) && (pllinputfreq != 0U))
-  {
-    if (LL_RCC_PLL3P_IsEnabled() != 0U)
+    switch (pllsource)
     {
-      pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetP());
+      case LL_RCC_PLL3SOURCE_HSI:
+        if (LL_RCC_HSI_IsReady() != 0U)
+        {
+          pllinputfreq = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
+        }
+        break;
+
+      case LL_RCC_PLL3SOURCE_CSI:
+        if (LL_RCC_CSI_IsReady() != 0U)
+        {
+          pllinputfreq = CSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL3SOURCE_HSE:
+        if (LL_RCC_HSE_IsReady() != 0U)
+        {
+          pllinputfreq = HSE_VALUE;
+        }
+        break;
+
+      case LL_RCC_PLL3SOURCE_NONE:
+      default:
+        /* PLL clock disabled */
+        break;
     }
 
-    if (LL_RCC_PLL3Q_IsEnabled() != 0U)
+    pllm = LL_RCC_PLL3_GetM();
+    plln = LL_RCC_PLL3_GetN();
+    if (LL_RCC_PLL3FRACN_IsEnabled() != 0U)
     {
-      pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetQ());
+      fracn = LL_RCC_PLL3_GetFRACN();
     }
 
-    if (LL_RCC_PLL3R_IsEnabled() != 0U)
+    if ((pllinputfreq != LL_RCC_PERIPH_FREQUENCY_NO) && (pllm != 0U))
     {
-      pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetR());
+      if (LL_RCC_PLL3P_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_P_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetP());
+      }
+
+      if (LL_RCC_PLL3Q_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_Q_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetQ());
+      }
+
+      if (LL_RCC_PLL3R_IsEnabled() != 0U)
+      {
+        pPLL_Clocks->PLL_R_Frequency = LL_RCC_CalcPLLClockFreq(pllinputfreq, pllm, plln, fracn, LL_RCC_PLL3_GetR());
+      }
     }
   }
 }
@@ -663,7 +699,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART1_CLKSOURCE_HSI:    /* USART1 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -722,7 +758,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART2_CLKSOURCE_HSI:    /* USART2 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -781,7 +817,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART3_CLKSOURCE_HSI:    /* USART3 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -840,7 +876,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART6_CLKSOURCE_HSI:    /* USART6 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -900,7 +936,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART10_CLKSOURCE_HSI:    /* USART10 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -960,7 +996,7 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
       case LL_RCC_USART11_CLKSOURCE_HSI:    /* USART11 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          usart_frequency = HSI_VALUE;
+          usart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1047,7 +1083,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART4_CLKSOURCE_HSI:     /* UART4 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1104,7 +1140,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART5_CLKSOURCE_HSI:     /* UART5 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1127,6 +1163,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
         break;
     }
   }
+#if defined(UART7)
   else if (UARTxSource == LL_RCC_UART7_CLKSOURCE)
   {
     /* UART7CLK clock frequency */
@@ -1161,7 +1198,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART7_CLKSOURCE_HSI:     /* UART7 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1184,6 +1221,8 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
         break;
     }
   }
+#endif /* UART7 */
+#if defined(UART8)
   else if (UARTxSource == LL_RCC_UART8_CLKSOURCE)
   {
     /* UART8CLK clock frequency */
@@ -1218,7 +1257,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART8_CLKSOURCE_HSI:     /* UART8 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1241,6 +1280,8 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
         break;
     }
   }
+#endif /* UART8 */
+#if defined(UART9)
   else if (UARTxSource == LL_RCC_UART9_CLKSOURCE)
   {
     /* UART9CLK clock frequency */
@@ -1275,7 +1316,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART9_CLKSOURCE_HSI:     /* UART9 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1298,6 +1339,8 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
         break;
     }
   }
+#endif /* UART9 */
+#if defined(UART12)
   else if (UARTxSource == LL_RCC_UART12_CLKSOURCE)
   {
     /* UART12CLK clock frequency */
@@ -1332,7 +1375,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
       case LL_RCC_UART12_CLKSOURCE_HSI:     /* UART12 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          uart_frequency = HSI_VALUE;
+          uart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1355,6 +1398,7 @@ uint32_t LL_RCC_GetUARTClockFreq(uint32_t UARTxSource)
         break;
     }
   }
+#endif /* UART12 */
   else
   {
     /* nothing to do */
@@ -1579,7 +1623,7 @@ uint32_t LL_RCC_GetSPIClockFreq(uint32_t SPIxSource)
       case LL_RCC_SPI4_CLKSOURCE_HSI:    /* SPI4 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          spi_frequency = HSI_VALUE;
+          spi_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1638,7 +1682,7 @@ uint32_t LL_RCC_GetSPIClockFreq(uint32_t SPIxSource)
       case LL_RCC_SPI5_CLKSOURCE_HSI:    /* SPI5 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          spi_frequency = HSI_VALUE;
+          spi_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1697,7 +1741,7 @@ uint32_t LL_RCC_GetSPIClockFreq(uint32_t SPIxSource)
       case LL_RCC_SPI6_CLKSOURCE_HSI:    /* SPI6 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          spi_frequency = HSI_VALUE;
+          spi_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1786,7 +1830,7 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
       case LL_RCC_I2C1_CLKSOURCE_HSI:    /* I2C1 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          i2c_frequency = HSI_VALUE;
+          i2c_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1838,7 +1882,7 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
       case LL_RCC_I2C2_CLKSOURCE_HSI:    /* I2C2 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          i2c_frequency = HSI_VALUE;
+          i2c_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1879,7 +1923,7 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
       case LL_RCC_I2C3_CLKSOURCE_HSI:    /* I2C3 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          i2c_frequency = HSI_VALUE;
+          i2c_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -1920,7 +1964,7 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
       case LL_RCC_I2C4_CLKSOURCE_HSI:    /* I2C4 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          i2c_frequency = HSI_VALUE;
+          i2c_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -2000,7 +2044,7 @@ uint32_t LL_RCC_GetI3CClockFreq(uint32_t I3CxSource)
       case LL_RCC_I3C1_CLKSOURCE_HSI:    /* I3C1 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          I3C_frequency = HSI_VALUE;
+          I3C_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -2024,6 +2068,17 @@ uint32_t LL_RCC_GetI3CClockFreq(uint32_t I3CxSource)
         I3C_frequency = RCC_GetPCLK3ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
         break;
 
+#if defined(RCC_CR_PLL3ON)
+      case LL_RCC_I3C2_CLKSOURCE_PLL3R:   /* I3C2 Clock is PLL3 R */
+        if (LL_RCC_PLL3_IsReady() != 0U)
+        {
+          if (LL_RCC_PLL3R_IsEnabled() != 0U)
+          {
+            LL_RCC_GetPLL3ClockFreq(&PLL_Clocks);
+            I3C_frequency = PLL_Clocks.PLL_R_Frequency;
+          }
+        }
+#else
       case LL_RCC_I3C2_CLKSOURCE_PLL2R:   /* I3C2 Clock is PLL2 R */
         if (LL_RCC_PLL2_IsReady() != 0U)
         {
@@ -2033,12 +2088,13 @@ uint32_t LL_RCC_GetI3CClockFreq(uint32_t I3CxSource)
             I3C_frequency = PLL_Clocks.PLL_R_Frequency;
           }
         }
+#endif /* PLL3 */
         break;
 
       case LL_RCC_I3C2_CLKSOURCE_HSI:    /* I3C2 Clock is HSI Osc. */
         if (LL_RCC_HSI_IsReady() == 1U)
         {
-          I3C_frequency = HSI_VALUE;
+          I3C_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
         }
         break;
 
@@ -2108,7 +2164,7 @@ uint32_t LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource)
     case LL_RCC_LPUART1_CLKSOURCE_HSI:    /* LPUART1 Clock is HSI Osc. */
       if (LL_RCC_HSI_IsReady() == 1U)
       {
-        lpuart_frequency = HSI_VALUE;
+        lpuart_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       }
       break;
 
@@ -2783,6 +2839,7 @@ uint32_t LL_RCC_GetRNGClockFreq(uint32_t RNGxSource)
   return rng_frequency;
 }
 
+#if defined(USB_DRD_FS)
 /**
   * @brief  Return USBx clock frequency
   * @param  USBxSource This parameter can be one of the following values:
@@ -2843,6 +2900,7 @@ uint32_t LL_RCC_GetUSBClockFreq(uint32_t USBxSource)
 
   return usb_frequency;
 }
+#endif /* USB_DRD_FS */
 
 /**
   * @brief  Return ADCxDAC clock frequency
@@ -2891,7 +2949,7 @@ uint32_t LL_RCC_GetADCDACClockFreq(uint32_t ADCDACxSource)
     case LL_RCC_ADCDAC_CLKSOURCE_HSI:          /* ADCDAC Clock is HSI Osc. */
       if (LL_RCC_HSI_IsReady() == 1U)
       {
-        adcdac_frequency = HSI_VALUE;
+        adcdac_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       }
       break;
 
@@ -3129,7 +3187,7 @@ uint32_t LL_RCC_GetCLKPClockFreq(uint32_t CLKPxSource)
     case LL_RCC_CLKP_CLKSOURCE_HSI:          /* HSI used as CLKP clock source */
       if (LL_RCC_HSI_IsReady() != 0U)
       {
-        clkp_frequency = HSI_VALUE >> (LL_RCC_HSI_GetDivider() >> RCC_CR_HSIDIV_Pos);
+        clkp_frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       }
       break;
 
@@ -3182,7 +3240,7 @@ uint32_t RCC_GetSystemClockFreq(void)
   switch (LL_RCC_GetSysClkSource())
   {
     case LL_RCC_SYS_CLKSOURCE_STATUS_HSI:   /* HSI used as system clock  source */
-      frequency = HSI_VALUE;
+      frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       break;
 
     case LL_RCC_SYS_CLKSOURCE_STATUS_CSI:   /* CSI used as system clock  source */
@@ -3198,7 +3256,7 @@ uint32_t RCC_GetSystemClockFreq(void)
       break;
 
     default:
-      frequency = HSI_VALUE;
+      frequency = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       break;
   }
 
@@ -3267,7 +3325,7 @@ uint32_t RCC_PLL1_GetFreqSystem(void)
   switch (pllsource)
   {
     case LL_RCC_PLL1SOURCE_HSI:  /* HSI used as PLL1 clock source */
-      pllinputfreq = HSI_VALUE;
+      pllinputfreq = __LL_RCC_CALC_HSI_FREQ(LL_RCC_HSI_GetDivider());
       break;
 
     case LL_RCC_PLL1SOURCE_CSI:  /* CSI used as PLL1 clock source */
@@ -3287,16 +3345,9 @@ uint32_t RCC_PLL1_GetFreqSystem(void)
 }
 
 
-
-
-
-
-
-
 /**
   * @}
   */
-
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rcc.h
@@ -726,7 +726,11 @@ typedef struct
 
 #if defined(I3C2)
 #define LL_RCC_I3C2_CLKSOURCE_PCLK3         LL_CLKSOURCE(CCIPR4_OFFSET, RCC_CCIPR4_I3C2SEL, RCC_CCIPR4_I3C2SEL_Pos, 0x00000000U)              /*!< PCLK3 clock used as I3C2 clock source */
+#if defined(RCC_CR_PLL3ON)
+#define LL_RCC_I3C2_CLKSOURCE_PLL3R         LL_CLKSOURCE(CCIPR4_OFFSET, RCC_CCIPR4_I3C2SEL, RCC_CCIPR4_I3C2SEL_Pos, RCC_CCIPR4_I3C2SEL_0)     /*!< PLL3 R clock used as I3C2 clock source */
+#else
 #define LL_RCC_I3C2_CLKSOURCE_PLL2R         LL_CLKSOURCE(CCIPR4_OFFSET, RCC_CCIPR4_I3C2SEL, RCC_CCIPR4_I3C2SEL_Pos, RCC_CCIPR4_I3C2SEL_0)     /*!< PLL2 R clock used as I3C2 clock source */
+#endif /* PLL3 */
 #define LL_RCC_I3C2_CLKSOURCE_HSI           LL_CLKSOURCE(CCIPR4_OFFSET, RCC_CCIPR4_I3C2SEL, RCC_CCIPR4_I3C2SEL_Pos, RCC_CCIPR4_I3C2SEL_1)     /*!< HSI clock used as I3C2 clock source */
 #define LL_RCC_I3C2_CLKSOURCE_NONE          LL_CLKSOURCE(CCIPR4_OFFSET, RCC_CCIPR4_I3C2SEL, RCC_CCIPR4_I3C2SEL_Pos, RCC_CCIPR4_I3C2SEL)       /*!< NONE clock used as I3C2 clock source */
 #endif /* I3C2 */
@@ -908,6 +912,7 @@ typedef struct
   * @}
   */
 
+#if defined(USB_DRD_FS)
 /** @defgroup RCC_LL_EC_USB_CLKSOURCE  Peripheral USB clock source selection
   * @{
   */
@@ -920,6 +925,7 @@ typedef struct
 /**
   * @}
   */
+#endif /* USB_DRD_FS */
 
 /** @defgroup RCC_LL_EC_ADCDAC_CLKSOURCE  Peripheral ADCDAC clock source selection
   * @{
@@ -1120,6 +1126,7 @@ typedef struct
   * @}
   */
 
+#if defined(USB_DRD_FS)
 /** @defgroup RCC_LL_EC_USB  Peripheral USB get clock source
   * @{
   */
@@ -1127,6 +1134,7 @@ typedef struct
 /**
   * @}
   */
+#endif /* USB_DRD_FS */
 
 /** @defgroup RCC_LL_EC_ADCDAC  Peripheral ADCDAC get clock source
   * @{
@@ -2803,7 +2811,6 @@ __STATIC_INLINE void LL_RCC_SetI2CClockSource(uint32_t I2CxSource)
   * @rmtoll CCIPR4       I3C1SEL    LL_RCC_SetI3CClockSource\n
   *         CCIPR4       I3C2SEL    LL_RCC_SetI3CClockSource
   * @param  I3CxSource This parameter can be one of the following values:
-  *         @arg @ref LL_RCC_I3C1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_I3C1_CLKSOURCE_PLL3R (*)
   *         @arg @ref LL_RCC_I3C1_CLKSOURCE_PLL2R (**)
   *         @arg @ref LL_RCC_I3C1_CLKSOURCE_HSI
@@ -2999,6 +3006,7 @@ __STATIC_INLINE void LL_RCC_SetRNGClockSource(uint32_t RNGxSource)
   MODIFY_REG(RCC->CCIPR5, RCC_CCIPR5_RNGSEL, RNGxSource);
 }
 
+#if defined(USB_DRD_FS)
 /**
   * @brief  Configure USB clock source
   * @rmtoll CCIPR4       USBSEL      LL_RCC_SetUSBClockSource
@@ -3015,6 +3023,7 @@ __STATIC_INLINE void LL_RCC_SetUSBClockSource(uint32_t USBxSource)
 {
   MODIFY_REG(RCC->CCIPR4, RCC_CCIPR4_USBSEL, USBxSource);
 }
+#endif /* USB_DRD_FS */
 
 /**
   * @brief  Configure ADCx kernel clock source
@@ -3724,7 +3733,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetSAIClockSource(uint32_t SAIx)
 /**
   * @brief  Get SDMMCx kernel clock source
   * @rmtoll CCIPR4         SDMMC1SEL        LL_RCC_GetSDMMCClockSource
-  *         CCIPR4         SDMMC2SEL        LL_RCC_GetSDMMCClockSource
+  * rmtoll  CCIPR4         SDMMC2SEL        LL_RCC_GetSDMMCClockSource
   * @param  SDMMCx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_SDMMC1_CLKSOURCE
   *         @arg @ref LL_RCC_SDMMC2_CLKSOURCE (*)
@@ -3758,6 +3767,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetRNGClockSource(uint32_t RNGx)
   return (uint32_t)(READ_BIT(RCC->CCIPR5, RNGx));
 }
 
+#if defined(USB_DRD_FS)
 /**
   * @brief  Get USB clock source
   * @rmtoll CCIPR4       USBSEL      LL_RCC_GetUSBClockSource
@@ -3775,6 +3785,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetUSBClockSource(uint32_t USBx)
 {
   return (uint32_t)(READ_BIT(RCC->CCIPR4, USBx));
 }
+#endif /* USB_DRD_FS */
 
 /**
   * @brief  Get ADCDACx kernel clock source
@@ -6033,7 +6044,9 @@ uint32_t    LL_RCC_GetSAIClockFreq(uint32_t SAIxSource);
 uint32_t    LL_RCC_GetSDMMCClockFreq(uint32_t SDMMCxSource);
 #endif /* SDMMC1 */
 uint32_t    LL_RCC_GetRNGClockFreq(uint32_t RNGxSource);
+#if defined(USB_DRD_FS)
 uint32_t    LL_RCC_GetUSBClockFreq(uint32_t USBxSource);
+#endif /* USB_DRD_FS */
 uint32_t    LL_RCC_GetADCDACClockFreq(uint32_t ADCDACxSource);
 uint32_t    LL_RCC_GetDACLPClockFreq(uint32_t DACLPxSource);
 #if defined(OCTOSPI1)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rng.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rng.c
@@ -110,7 +110,7 @@ ErrorStatus LL_RNG_DeInit(const RNG_TypeDef *RNGx)
   *          - SUCCESS: RNG registers are initialized according to RNG_InitStruct content
   *          - ERROR: not applicable
   */
-ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, LL_RNG_InitTypeDef *RNG_InitStruct)
+ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, const LL_RNG_InitTypeDef *RNG_InitStruct)
 {
   /* Check the parameters */
   assert_param(IS_RNG_ALL_INSTANCE(RNGx));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rng.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rng.h
@@ -230,7 +230,8 @@ __STATIC_INLINE uint32_t LL_RNG_IsEnabled(const RNG_TypeDef *RNGx)
   */
 __STATIC_INLINE void LL_RNG_EnableClkErrorDetect(RNG_TypeDef *RNGx)
 {
-  CLEAR_BIT(RNGx->CR, RNG_CR_CED);
+  MODIFY_REG(RNGx->CR, RNG_CR_CED | RNG_CR_CONDRST, LL_RNG_CED_ENABLE | RNG_CR_CONDRST);
+  CLEAR_BIT(RNGx->CR, RNG_CR_CONDRST);
 }
 
 /**
@@ -241,7 +242,8 @@ __STATIC_INLINE void LL_RNG_EnableClkErrorDetect(RNG_TypeDef *RNGx)
   */
 __STATIC_INLINE void LL_RNG_DisableClkErrorDetect(RNG_TypeDef *RNGx)
 {
-  SET_BIT(RNGx->CR, RNG_CR_CED);
+  MODIFY_REG(RNGx->CR, RNG_CR_CED | RNG_CR_CONDRST, LL_RNG_CED_DISABLE | RNG_CR_CONDRST);
+  CLEAR_BIT(RNGx->CR, RNG_CR_CONDRST);
 }
 
 /**
@@ -331,7 +333,7 @@ __STATIC_INLINE void LL_RNG_EnableNistCompliance(RNG_TypeDef *RNGx)
 __STATIC_INLINE void LL_RNG_DisableNistCompliance(RNG_TypeDef *RNGx)
 {
   MODIFY_REG(RNGx->CR, RNG_CR_NISTC | RNG_CR_CONDRST, LL_RNG_CUSTOM_NIST | RNG_CR_CONDRST);
-  CLEAR_BIT(RNGx->CR, RNG_CR_CONDRST);;
+  CLEAR_BIT(RNGx->CR, RNG_CR_CONDRST);
 }
 
 /**
@@ -442,7 +444,7 @@ __STATIC_INLINE uint32_t LL_RNG_GetConfig3(const RNG_TypeDef *RNGx)
   */
 __STATIC_INLINE void LL_RNG_SetClockDivider(RNG_TypeDef *RNGx, uint32_t Divider)
 {
-  MODIFY_REG(RNGx->CR, RNG_CR_CLKDIV | RNG_CR_CONDRST, (Divider << RNG_CR_CLKDIV_Pos) | RNG_CR_CONDRST);
+  MODIFY_REG(RNGx->CR, RNG_CR_CLKDIV | RNG_CR_CONDRST, Divider | RNG_CR_CONDRST);
   CLEAR_BIT(RNGx->CR, RNG_CR_CONDRST);
 }
 
@@ -672,6 +674,9 @@ __STATIC_INLINE uint32_t LL_RNG_IsEnabledArdis(const RNG_TypeDef *RNGx)
   */
 __STATIC_INLINE void LL_RNG_SetHealthConfig(RNG_TypeDef *RNGx, uint32_t HTCFG)
 {
+#if defined(RNG_HTCR_NIST_VALUE)
+  /* For NIST compliance we can fin the recommended value in the application note AN4230 */
+#endif /* defined(RNG_HTCR_NIST_VALUE) */
   WRITE_REG(RNGx->HTCR, HTCFG);
 }
 
@@ -689,11 +694,47 @@ __STATIC_INLINE uint32_t LL_RNG_GetHealthConfig(const RNG_TypeDef *RNGx)
 /**
   * @}
   */
+#if defined(RNG_NSCR_NIST_VALUE)
+
+/** @defgroup RNG_LL_EF_Noise_Test_Control Noise Test Control
+  * @{
+  */
+
+/**
+  * @brief  Set RNG Noise Test Control
+  * @rmtoll NSCR NOISECFG LL_RNG_SetNoiseConfig
+  * @param  RNGx RNG Instance
+  * @param  NOISECFG can be values of 32 bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_RNG_SetNoiseConfig(RNG_TypeDef *RNGx, uint32_t NOISECFG)
+{
+  /* For NIST compliance we can fin the recommended value in the application note AN4230 */
+  WRITE_REG(RNGx->NSCR, NOISECFG);
+}
+
+/**
+  * @brief  Get RNG Noise Test Control
+  * @rmtoll NSCR NOISECFG LL_RNG_GetNoiseConfig
+  * @param  RNGx RNG Instance
+  * @retval Return 32-bit RNG Noise Test configuration
+  */
+__STATIC_INLINE uint32_t LL_RNG_GetNoiseConfig(const RNG_TypeDef *RNGx)
+{
+
+  return (uint32_t)READ_REG(RNGx->NSCR);
+}
+
+/**
+  * @}
+  */
+
+#endif /* defined(RNG_NSCR_NIST_VALUE) */
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup RNG_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
-ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, LL_RNG_InitTypeDef *RNG_InitStruct);
+ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, const LL_RNG_InitTypeDef *RNG_InitStruct);
 void LL_RNG_StructInit(LL_RNG_InitTypeDef *RNG_InitStruct);
 ErrorStatus LL_RNG_DeInit(const RNG_TypeDef *RNGx);
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rtc.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_rtc.h
@@ -640,14 +640,16 @@ typedef struct
 /** @defgroup RTC_LL_EC_ACTIVE_ASYNC_PRESCALER   ACTIVE TAMPER ASYNCHRONOUS PRESCALER CLOCK
   * @{
   */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK      0U                                                                   /*!< RTCCLK     */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_2    TAMP_ATCR1_ATCKSEL_0                                                 /*!< RTCCLK/2   */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_4    TAMP_ATCR1_ATCKSEL_1                                                 /*!< RTCCLK/4   */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_8    (TAMP_ATCR1_ATCKSEL_1 | TAMP_ATCR1_ATCKSEL_0)                        /*!< RTCCLK/8   */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_16   TAMP_ATCR1_ATCKSEL_2                                                 /*!< RTCCLK/16  */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_32   (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_0)                        /*!< RTCCLK/32  */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_64   (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_1)                        /*!< RTCCLK/64  */
-#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_128  (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_1 | TAMP_ATCR1_ATCKSEL_0) /*!< RTCCLK/128 */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK      0U                                                                   /*!< RTCCLK      */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_2    TAMP_ATCR1_ATCKSEL_0                                                 /*!< RTCCLK/2    */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_4    TAMP_ATCR1_ATCKSEL_1                                                 /*!< RTCCLK/4    */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_8    (TAMP_ATCR1_ATCKSEL_1 | TAMP_ATCR1_ATCKSEL_0)                        /*!< RTCCLK/8    */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_16   TAMP_ATCR1_ATCKSEL_2                                                 /*!< RTCCLK/16   */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_32   (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_0)                        /*!< RTCCLK/32   */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_64   (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_1)                        /*!< RTCCLK/64   */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_128  (TAMP_ATCR1_ATCKSEL_2 | TAMP_ATCR1_ATCKSEL_1 | TAMP_ATCR1_ATCKSEL_0) /*!< RTCCLK/128  */
+#define LL_RTC_TAMPER_ATAMP_ASYNCPRES_RTCCLK_2048 (TAMP_ATCR1_ATCKSEL_3 | TAMP_ATCR1_ATCKSEL_1 | TAMP_ATCR1_ATCKSEL_0) /*!< RTCCLK/2048 */
+
 /**
   * @}
   */
@@ -1588,7 +1590,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetFormat(RTC_TypeDef *RTCx, uint32_t TimeForma
 
 /**
   * @brief  Get time format (AM or PM notation)
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1622,7 +1624,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
 
 /**
   * @brief  Get Hours in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1657,7 +1659,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
 
 /**
   * @brief  Get Minutes in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1692,7 +1694,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
 
 /**
   * @brief  Get Seconds in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1746,7 +1748,7 @@ __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx,
 
 /**
   * @brief  Get time (hour, minute and second) in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1895,7 +1897,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetYear(RTC_TypeDef *RTCx, uint32_t Year)
 
 /**
   * @brief  Get Year in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Year from BCD to Binary format
   * @rmtoll RTC_DR           YT            LL_RTC_DATE_GetYear\n
@@ -1929,7 +1931,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
 
 /**
   * @brief  Get Week day
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @rmtoll RTC_DR           WDU           LL_RTC_DATE_GetWeekDay
   * @param  RTCx RTC Instance
@@ -1976,7 +1978,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetMonth(RTC_TypeDef *RTCx, uint32_t Month)
 
 /**
   * @brief  Get Month in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Month from BCD to Binary format
   * @rmtoll RTC_DR           MT            LL_RTC_DATE_GetMonth\n
@@ -2018,7 +2020,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
 
 /**
   * @brief  Get Day in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
   * @rmtoll RTC_DR           DT            LL_RTC_DATE_GetDay\n
@@ -2084,7 +2086,7 @@ __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx,
 
 /**
   * @brief  Get date (WeekDay, Day, Month and Year) in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macros __LL_RTC_GET_WEEKDAY, __LL_RTC_GET_YEAR, __LL_RTC_GET_MONTH,
   * and __LL_RTC_GET_DAY are available to get independently each parameter.
@@ -3505,7 +3507,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_ITAMP_Disable(const RTC_TypeDef *RTCx, uint32
 /**
   * @brief  Enable backup register erase after internal tamper event detection
   * @rmtoll TAMP_CR3       ITAMP1NOER     LL_RTC_TAMPER_ITAMP_EnableEraseBKP
-  *         TAMP_CR3       ITAMP2NOER...  LL_RTC_TAMPER_ITAMP_EnableEraseBKP
+  * @rmtoll TAMP_CR3       ITAMP2NOER     LL_RTC_TAMPER_ITAMP_EnableEraseBKP
   * @param  RTCx RTC Instance
   * @param  InternalTamper This parameter can be a combination of the following values:
   *         @arg @ref RTC_LL_EC_ITAMPER_NOERASE
@@ -3521,7 +3523,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_ITAMP_EnableEraseBKP(const RTC_TypeDef *RTCx,
 /**
   * @brief  Disable backup register erase after internal tamper event detection
   * @rmtoll TAMP_CR3       ITAMP1NOER     LL_RTC_TAMPER_ITAMP_DisableEraseBKP
-  *         TAMP_CR3       ITAMP2NOER...  LL_RTC_TAMPER_ITAMP_DisableEraseBKP
+  * @rmtoll TAMP_CR3       ITAMP2NOER     LL_RTC_TAMPER_ITAMP_DisableEraseBKP
   * @param  RTCx RTC Instance
   * @param  InternalTamper This parameter can be a combination of the following values:
   *         @arg @ref RTC_LL_EC_ITAMPER_NOERASE

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_spi.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_spi.c
@@ -573,9 +573,12 @@ ErrorStatus LL_I2S_Init(SPI_TypeDef *SPIx, LL_I2S_InitTypeDef *I2S_InitStruct)
   uint32_t packetlength = 1UL;
   uint32_t ispcm = 0UL;
   uint32_t tmp;
-  uint32_t sourceclock;
+  uint32_t sourceclock = 0UL;
 
   ErrorStatus status = ERROR;
+
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(sourceclock);
 
   /* Check the I2S parameters */
   assert_param(IS_I2S_ALL_INSTANCE(SPIx));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_spi.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_spi.h
@@ -836,7 +836,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledIOLock(const SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_SetTxCRCInitPattern(SPI_TypeDef *SPIx, uint32_t TXCRCInitAll)
 {
-  MODIFY_REG(SPIx->CR1, SPI_CR1_RCRCINI, TXCRCInitAll);
+  MODIFY_REG(SPIx->CR1, SPI_CR1_TCRCINI, TXCRCInitAll);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_system.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_system.h
@@ -149,8 +149,8 @@ extern "C" {
 /** @defgroup SYSTEM_LL_SBS_EPOCH_Selection  EPOCH Selection
   * @{
   */
-#define LL_SBS_EPOCH_SEL_SECURE         0x0UL                         /*!< EPOCH secure selected */
-#define LL_SBS_EPOCH_SEL_NONSECURE      SBS_EPOCHSELCR_EPOCH_SEL_0    /*!< EPOCH non secure selected */
+#define LL_SBS_EPOCH_SEL_NONSECURE      0x0UL                         /*!< EPOCH non secure selected */
+#define LL_SBS_EPOCH_SEL_SECURE         SBS_EPOCHSELCR_EPOCH_SEL_0    /*!< EPOCH secure selected */
 #define LL_SBS_EPOCH_SEL_PUFCHECK       SBS_EPOCHSELCR_EPOCH_SEL_1    /*!< EPOCH all zeros for PUF integrity check */
 
 /**
@@ -213,8 +213,6 @@ extern "C" {
 #define LL_SBS_CLASSB_NSEC              0U                      /*!< Class B configuration secure/non-secure access */
 #define LL_SBS_FPU_SEC                  SBS_SECCFGR_FPUSEC      /*!< FPU configuration secure-only access */
 #define LL_SBS_FPU_NSEC                 0U                      /*!< FPU configuration secure/non-secure access */
-#define LL_SBS_SMPS_SEC                 SBS_SECCFGR_SDCE_SEC_EN /*!< SMPS configuration secure-only access */
-#define LL_SBS_SMPS_NSEC                0U                      /*!< SMPS configuration secure/non-secure access */
 /**
   * @}
   */
@@ -822,7 +820,6 @@ __STATIC_INLINE uint32_t LL_SBS_GetAuthDbgSec(void)
 {
   return ((SBS->DBGCR & SBS_DBGCR_DBG_AUTH_SEC) >> SBS_DBGCR_DBG_AUTH_SEC_Pos);
 }
-
 #endif /* SBS_DBGCR_DBG_AUTH_SEC */
 
 /**
@@ -976,20 +973,17 @@ __STATIC_INLINE uint32_t LL_SBS_GetSecureLock(void)
   */
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-
 /**
   * @brief  Configure Secure mode
   * @note Only available from secure state when system implements security (TZEN=1)
   * @rmtoll SECCFGR     SBSSEC        LL_SBS_ConfigSecure\n
   *         SECCFGR     CLASSBSEC     LL_SBS_ConfigSecure\n
-  *         SECCFGR     FPUSEC        LL_SBS_ConfigSecure\n
-  *         SECCFGR     SDCE_SEC_EN   LL_SBS_ConfigSecure
+  *         SECCFGR     FPUSEC        LL_SBS_ConfigSecure
   * @param  Configuration This parameter shall be the full combination
   *         of the following values:
   *         @arg @ref LL_SBS_CLOCK_SEC or LL_SBS_CLOCK_NSEC
   *         @arg @ref LL_SBS_CLASSB_SEC or LL_SBS_CLASSB_NSEC
   *         @arg @ref LL_SBS_FPU_SEC or LL_SBS_FPU_NSEC
-  *         @arg @ref LL_SBS_SMPS_SEC or LL_SBS_SMPS_NSEC
   * @retval None
   */
 __STATIC_INLINE void LL_SBS_ConfigSecure(uint32_t Configuration)
@@ -1002,19 +996,16 @@ __STATIC_INLINE void LL_SBS_ConfigSecure(uint32_t Configuration)
   * @note Only available when system implements security (TZEN=1)
   * @rmtoll SECCFGR     SBSSEC        LL_SBS_ConfigSecure\n
   *         SECCFGR     CLASSBSEC     LL_SBS_ConfigSecure\n
-  *         SECCFGR     FPUSEC        LL_SBS_ConfigSecure\n
-  *         SECCFGR     SDCE_SEC_EN   LL_SBS_ConfigSecure
+  *         SECCFGR     FPUSEC        LL_SBS_ConfigSecure
   * @retval Returned value is the combination of the following values:
   *         @arg @ref LL_SBS_CLOCK_SEC or LL_SBS_CLOCK_NSEC
   *         @arg @ref LL_SBS_CLASSB_SEC or LL_SBS_CLASSB_NSEC
   *         @arg @ref LL_SBS_FPU_SEC or LL_SBS_FPU_NSEC
-  *         @arg @ref LL_SBS_SMPS_SEC or LL_SBS_SMPS_NSEC
   */
 __STATIC_INLINE uint32_t LL_SBS_GetConfigSecure(void)
 {
-  return (uint32_t)(READ_BIT(SBS->SECCFGR, LL_SBS_CLOCK_SEC | LL_SBS_CLASSB_SEC | LL_SBS_FPU_SEC | LL_SBS_SMPS_SEC));
+  return (uint32_t)(READ_BIT(SBS->SECCFGR, LL_SBS_CLOCK_SEC | LL_SBS_CLASSB_SEC | LL_SBS_FPU_SEC));
 }
-
 #endif /* __ARM_FEATURE_CMSE && __ARM_FEATURE_CMSE == 3U */
 
 /**
@@ -1031,7 +1022,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetConfigSecure(void)
 
 /**
   * @brief  Get the compensation cell value of the GPIO PMOS transistor supplied by VDD
-  * @rmtoll CCVALR    PCV1   LL_SBS_GetPMOSVddCompensationValue
+  * @rmtoll CCVALR    APSRC1   LL_SBS_GetPMOSVddCompensationValue
   * @retval Returned value is the PMOS compensation cell
   */
 __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddCompensationValue(void)
@@ -1041,7 +1032,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddCompensationValue(void)
 
 /**
   * @brief  Get the compensation cell value of the GPIO NMOS transistor supplied by VDD
-  * @rmtoll CCVALR    NCV1   LL_SBS_GetNMOSVddCompensationValue
+  * @rmtoll CCVALR    ANSRC1   LL_SBS_GetNMOSVddCompensationValue
   * @retval Returned value is the NMOS compensation cell
   */
 __STATIC_INLINE uint32_t LL_SBS_GetNMOSVddCompensationValue(void)
@@ -1051,7 +1042,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetNMOSVddCompensationValue(void)
 
 /**
   * @brief  Get the compensation cell value of the GPIO PMOS transistor supplied by VDDIO2
-  * @rmtoll CCVALR    PCV2   LL_SBS_GetPMOSVddIO2CompensationValue
+  * @rmtoll CCVALR    APSRC2   LL_SBS_GetPMOSVddIO2CompensationValue
   * @retval Returned value is the PMOS compensation cell
   */
 __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddIO2CompensationValue(void)
@@ -1061,7 +1052,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddIO2CompensationValue(void)
 
 /**
   * @brief  Get the compensation cell value of the GPIO NMOS transistor supplied by VDDIO2
-  * @rmtoll CCVALR    NCV2   LL_SBS_GetNMOSVddIO2CompensationValue
+  * @rmtoll CCVALR    ANSRC2   LL_SBS_GetNMOSVddIO2CompensationValue
   * @retval Returned value is the NMOS compensation cell
   */
 __STATIC_INLINE uint32_t LL_SBS_GetNMOSVddIO2CompensationValue(void)
@@ -1071,7 +1062,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetNMOSVddIO2CompensationValue(void)
 
 /**
   * @brief  Set the compensation cell code of the GPIO PMOS transistor supplied by VDD
-  * @rmtoll CCSWCR    PCC1  LL_SBS_SetPMOSVddCompensationCode
+  * @rmtoll CCSWCR    SW_APSRC1  LL_SBS_SetPMOSVddCompensationCode
   * @param  PMOSCode PMOS compensation code
   *         This code is applied to the PMOS compensation cell when the CS1 bit of the
   *         SBS_CCCSR is set
@@ -1084,7 +1075,7 @@ __STATIC_INLINE void LL_SBS_SetPMOSVddCompensationCode(uint32_t PMOSCode)
 
 /**
   * @brief  Get the compensation cell code of the GPIO PMOS transistor supplied by VDD
-  * @rmtoll CCSWCR    PCC1   LL_SBS_GetPMOSVddCompensationCode
+  * @rmtoll CCSWCR    SW_APSRC1   LL_SBS_GetPMOSVddCompensationCode
   * @retval Returned value is the PMOS compensation cell
   */
 __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddCompensationCode(void)
@@ -1094,7 +1085,7 @@ __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddCompensationCode(void)
 
 /**
   * @brief  Set the compensation cell code of the GPIO PMOS transistor supplied by VDDIO
-  * @rmtoll CCSWCR    PCC2  LL_SBS_SetPMOSVddIOCompensationCode
+  * @rmtoll CCSWCR    SW_APSRC2  LL_SBS_SetPMOSVddIOCompensationCode
   * @param  PMOSCode PMOS compensation code
   *         This code is applied to the PMOS compensation cell when the CS2 bit of the
   *         SBS_CCCSR is set
@@ -1105,10 +1096,9 @@ __STATIC_INLINE void LL_SBS_SetPMOSVddIOCompensationCode(uint32_t PMOSCode)
   MODIFY_REG(SBS->CCSWCR, SBS_CCSWCR_SW_APSRC2, PMOSCode << SBS_CCSWCR_SW_APSRC2_Pos);
 }
 
-
 /**
   * @brief  Get the compensation cell code of the GPIO PMOS transistor supplied by VDDIO
-  * @rmtoll CCSWCR    PCC2   LL_SBS_GetPMOSVddIOCompensationCode
+  * @rmtoll CCSWCR    SW_APSRC2   LL_SBS_GetPMOSVddIOCompensationCode
   * @retval Returned value is the PMOS compensation
   */
 __STATIC_INLINE uint32_t LL_SBS_GetPMOSVddIOCompensationCode(void)
@@ -1243,7 +1233,7 @@ __STATIC_INLINE uint32_t LL_SBS_IsActiveFlag_VddCMPCR(void)
 
 /**
   * @brief  Get Compensation Cell ready Flag of GPIO supplied by VDDIO
-  * @rmtoll CCCSR   RDY1   LL_SBS_IsActiveFlag_VddIOCMPCR
+  * @rmtoll CCCSR   RDY2   LL_SBS_IsActiveFlag_VddIOCMPCR
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_SBS_IsActiveFlag_VddIOCMPCR(void)
@@ -1820,5 +1810,5 @@ __STATIC_INLINE uint32_t LL_SBS_GetEraseAfterResetStatus(void)
 }
 #endif
 
-#endif /* STM32h5xx_LL_SYSTEM_H */
+#endif /* STM32H5xx_LL_SYSTEM_H */
 

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_tim.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_tim.c
@@ -79,8 +79,8 @@
                                      || ((__VALUE__) == LL_TIM_OCMODE_RETRIG_OPM2) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_COMBINED_PWM1) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_COMBINED_PWM2) \
-                                     || ((__VALUE__) == LL_TIM_OCMODE_ASSYMETRIC_PWM1) \
-                                     || ((__VALUE__) == LL_TIM_OCMODE_ASSYMETRIC_PWM2) \
+                                     || ((__VALUE__) == LL_TIM_OCMODE_ASYMMETRIC_PWM1) \
+                                     || ((__VALUE__) == LL_TIM_OCMODE_ASYMMETRIC_PWM2) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_PULSE_ON_COMPARE) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_DIRECTION_OUTPUT))
 
@@ -783,6 +783,8 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, const LL_TIM_BDTR_InitTypeDef *T
   assert_param(IS_LL_TIM_BREAK_STATE(TIM_BDTRInitStruct->BreakState));
   assert_param(IS_LL_TIM_BREAK_POLARITY(TIM_BDTRInitStruct->BreakPolarity));
   assert_param(IS_LL_TIM_AUTOMATIC_OUTPUT_STATE(TIM_BDTRInitStruct->AutomaticOutput));
+  assert_param(IS_LL_TIM_BREAK_FILTER(TIM_BDTRInitStruct->BreakFilter));
+  assert_param(IS_LL_TIM_BREAK_AFMODE(TIM_BDTRInitStruct->BreakAFMode));
 
   /* Set the Lock level, the Break enable Bit and the Polarity, the OSSR State,
   the OSSI State, the dead time value and the Automatic Output Enable Bit */
@@ -795,8 +797,6 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, const LL_TIM_BDTR_InitTypeDef *T
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKE, TIM_BDTRInitStruct->BreakState);
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKP, TIM_BDTRInitStruct->BreakPolarity);
   MODIFY_REG(tmpbdtr, TIM_BDTR_AOE, TIM_BDTRInitStruct->AutomaticOutput);
-  assert_param(IS_LL_TIM_BREAK_FILTER(TIM_BDTRInitStruct->BreakFilter));
-  assert_param(IS_LL_TIM_BREAK_AFMODE(TIM_BDTRInitStruct->BreakAFMode));
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKF, TIM_BDTRInitStruct->BreakFilter);
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, TIM_BDTRInitStruct->BreakAFMode);
 
@@ -850,8 +850,6 @@ static ErrorStatus OC1Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 1: Reset the CC1E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC1E);
@@ -879,8 +877,10 @@ static ErrorStatus OC1Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC1NP, TIM_OCInitStruct->OCNPolarity << 2U);
@@ -929,8 +929,6 @@ static ErrorStatus OC2Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 2: Reset the CC2E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC2E);
@@ -958,8 +956,10 @@ static ErrorStatus OC2Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC2NP, TIM_OCInitStruct->OCNPolarity << 6U);
@@ -1008,8 +1008,6 @@ static ErrorStatus OC3Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 3: Reset the CC3E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC3E);
@@ -1037,8 +1035,10 @@ static ErrorStatus OC3Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC3NP, TIM_OCInitStruct->OCNPolarity << 10U);
@@ -1087,8 +1087,6 @@ static ErrorStatus OC4Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
 
   /* Disable the Channel 4: Reset the CC4E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC4E);
@@ -1116,8 +1114,10 @@ static ErrorStatus OC4Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC4NP, TIM_OCInitStruct->OCNPolarity << 14U);
@@ -1392,7 +1392,7 @@ static ErrorStatus IC4Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM
              (TIM_CCMR2_CC4S | TIM_CCMR2_IC4F | TIM_CCMR2_IC4PSC),
              (TIM_ICInitStruct->ICActiveInput | TIM_ICInitStruct->ICFilter | TIM_ICInitStruct->ICPrescaler) >> 8U);
 
-  /* Select the Polarity and set the CC2E Bit */
+  /* Select the Polarity and set the CC4E Bit */
   MODIFY_REG(TIMx->CCER,
              (TIM_CCER_CC4P | TIM_CCER_CC4NP),
              ((TIM_ICInitStruct->ICPolarity << 12U) | TIM_CCER_CC4E));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_tim.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_tim.h
@@ -161,6 +161,8 @@ static const uint8_t SHIFT_TAB_OISx[] =
 @endcond
   */
 
+#define OCREF_CLEAR_SELECT_POS (28U)
+#define OCREF_CLEAR_SELECT_MSK (0x1U << OCREF_CLEAR_SELECT_POS)                /*!< 0x10000000 */
 /**
   * @}
   */
@@ -682,10 +684,10 @@ typedef struct
 /** @defgroup TIM_LL_EC_COUNTERMODE Counter Mode
   * @{
   */
-#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!<Counter used as upcounter */
+#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!< Counter used as upcounter */
 #define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR          /*!< Counter used as downcounter */
 #define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
-#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
+#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
 #define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS          /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
 /**
   * @}
@@ -767,6 +769,15 @@ typedef struct
   */
 #endif /* USE_FULL_LL_DRIVER */
 
+/** Legacy definitions for compatibility purpose
+@cond 0
+  */
+#define LL_TIM_OCMODE_ASSYMETRIC_PWM1 LL_TIM_OCMODE_ASYMMETRIC_PWM1
+#define LL_TIM_OCMODE_ASSYMETRIC_PWM2 LL_TIM_OCMODE_ASYMMETRIC_PWM2
+/**
+@endcond
+  */
+
 /** @defgroup TIM_LL_EC_OCMODE Output Configuration Mode
   * @{
   */
@@ -782,8 +793,8 @@ typedef struct
 #define LL_TIM_OCMODE_RETRIG_OPM2              (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)                    /*!<Retrigerrable OPM mode 2*/
 #define LL_TIM_OCMODE_COMBINED_PWM1            (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)                    /*!<Combined PWM mode 1*/
 #define LL_TIM_OCMODE_COMBINED_PWM2            (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2) /*!<Combined PWM mode 2*/
-#define LL_TIM_OCMODE_ASSYMETRIC_PWM1          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2) /*!<Asymmetric PWM mode 1*/
-#define LL_TIM_OCMODE_ASSYMETRIC_PWM2          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)                      /*!<Asymmetric PWM mode 2*/
+#define LL_TIM_OCMODE_ASYMMETRIC_PWM1          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2) /*!<Asymmetric PWM mode 1*/
+#define LL_TIM_OCMODE_ASYMMETRIC_PWM2          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)                      /*!<Asymmetric PWM mode 2*/
 #define LL_TIM_OCMODE_PULSE_ON_COMPARE         (TIM_CCMR2_OC3M_3 | TIM_CCMR2_OC3M_1)                    /*!<Pulse on Compare mode */
 #define LL_TIM_OCMODE_DIRECTION_OUTPUT         (TIM_CCMR2_OC3M_3 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_0) /*!<Direction output mode */
 /**
@@ -1034,7 +1045,10 @@ typedef struct
 #define LL_TIM_TIM1_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
 #if defined(COMP1)
 #define LL_TIM_TIM1_ETRSOURCE_COMP1       TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to COMP1_OUT */
-#endif /* COMP1*/
+#endif /* COMP1 */
+#if defined(COMP2)
+#define LL_TIM_TIM1_ETRSOURCE_COMP2       TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP2 */
 #define LL_TIM_TIM1_ETRSOURCE_ADC1_AWD1   (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< ADC1 analog watchdog 1 */
 #define LL_TIM_TIM1_ETRSOURCE_ADC1_AWD2   TIM1_AF1_ETRSEL_2                                           /*!< ADC1 analog watchdog 2 */
 #define LL_TIM_TIM1_ETRSOURCE_ADC1_AWD3   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ADC1 analog watchdog 3 */
@@ -1048,22 +1062,34 @@ typedef struct
 #define LL_TIM_TIM2_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
 #if defined(COMP1)
 #define LL_TIM_TIM2_ETRSOURCE_COMP1       TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to COMP1_OUT */
-#endif /* COMP1*/
-#define LL_TIM_TIM2_ETRSOURCE_LSE         (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_1)                     /*!< ETR input is connected to LSE */
+#endif /* COMP1 */
+#if defined(COMP2)
+#define LL_TIM_TIM2_ETRSOURCE_COMP2       TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP2 */
+#define LL_TIM_TIM2_ETRSOURCE_LSE         (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to LSE */
 #if defined(SAI1)
 #define LL_TIM_TIM2_ETRSOURCE_SAI1_FSA    TIM1_AF1_ETRSEL_2                                           /*!< ETR input is connected to SAI1_FSA */
-#define LL_TIM_TIM2_ETRSOURCE_SAI1_FSB    (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_2)                     /*!< ETR input is connected to SAI1_FSB */
+#define LL_TIM_TIM2_ETRSOURCE_SAI1_FSB    (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to SAI1_FSB */
 #endif /* SAI1 */
-#define LL_TIM_TIM2_ETRSOURCE_TIM3_ETR    (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_3)                     /*!< ETR input is connected to TIM3 ETR */
+#define LL_TIM_TIM2_ETRSOURCE_TIM3_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to TIM3 ETR */
 #if defined(TIM4)
-#define LL_TIM_TIM2_ETRSOURCE_TIM4_ETR    (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_3)                     /*!< ETR input is connected to TIM4 ETR */
+#define LL_TIM_TIM2_ETRSOURCE_TIM4_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< ETR input is connected to TIM4 ETR */
 #endif /* TIM4 */
 #if defined(TIM5)
-#define LL_TIM_TIM2_ETRSOURCE_TIM5_ETR    (TIM1_AF1_ETRSEL_0 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_3 ) /*!< ETR input is connected to TIM5 ETR */
+#define LL_TIM_TIM2_ETRSOURCE_TIM5_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to TIM5 ETR */
 #endif /* TIM5 */
+#if defined(USB_DRD_FS)
+#define LL_TIM_TIM2_ETRSOURCE_USB_SOF     (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to USB SOF */
+#elif defined(USB_OTG_HS)
+#define LL_TIM_TIM2_ETRSOURCE_USBHS_SOF   (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2)                     /*!< ETR is connected to USBHS OTG SOF */
+#define LL_TIM_TIM2_ETRSOURCE_USBFS_SOF   (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR is connected to USBFS OTG SOF */
+#endif /* USB_DRD_FS */
 #if defined(ETH_NS)
-#define LL_TIM_TIM2_ETRSOURCE_ETH_PPS     (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_3 ) /*!< ETR input is connected to ETH PPS */
+#define LL_TIM_TIM2_ETRSOURCE_ETH_PPS     (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1) /*!< ETR input is connected to ETH PPS */
 #endif /* ETH_NS */
+#if defined(PLAY1)
+#define LL_TIM_TIM2_ETRSOURCE_PLAY1_OUT0  TIM1_AF1_ETRSEL_Msk                                         /*!< ETR input is connected to PLAY1 output 0 */
+#endif /* PLAY1 */
 /**
   * @}
   */
@@ -1074,7 +1100,15 @@ typedef struct
 #define LL_TIM_TIM3_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
 #if defined(COMP1)
 #define LL_TIM_TIM3_ETRSOURCE_COMP1       TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to COMP1_OUT */
-#endif /* COMP1*/
+#endif /* COMP1 */
+#if defined(COMP2)
+#define LL_TIM_TIM3_ETRSOURCE_COMP2       TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP2 */
+#if defined(ADC2)
+#define LL_TIM_TIM3_ETRSOURCE_ADC2_AWD1   (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< ADC2 analog watchdog 1 */
+#define LL_TIM_TIM3_ETRSOURCE_ADC2_AWD2   TIM1_AF1_ETRSEL_2                                           /*!< ADC2 analog watchdog 2 */
+#define LL_TIM_TIM3_ETRSOURCE_ADC2_AWD3   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ADC2 analog watchdog 3 */
+#endif /* ADC2 */
 #define LL_TIM_TIM3_ETRSOURCE_TIM2_ETR    TIM1_AF1_ETRSEL_3                                           /*!< ETR input is connected to TIM2 ETR */
 #if defined(TIM4)
 #define LL_TIM_TIM3_ETRSOURCE_TIM4_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< ETR input is connected to TIM4 ETR */
@@ -1085,6 +1119,9 @@ typedef struct
 #if defined(ETH_NS)
 #define LL_TIM_TIM3_ETRSOURCE_ETH_PPS     (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_3 ) /*!< ETR input is connected to ETH PPS */
 #endif /* ETH_NS */
+#if defined(PLAY1)
+#define LL_TIM_TIM3_ETRSOURCE_PLAY1_OUT0  TIM1_AF1_ETRSEL_Msk                                         /*!< ETR input is connected to PLAY1 output 0 */
+#endif /* PLAY1 */
 /**
   * @}
   */
@@ -1093,10 +1130,14 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM4_ETRSOURCE External Trigger Source TIM4
   * @{
   */
-#define LL_TIM_TIM4_ETRSOURCE_GPIO         0x00000000U                                                 /*!< ETR input is connected to GPIO */
-#define LL_TIM_TIM4_ETRSOURCE_TIM2_ETR     TIM1_AF1_ETRSEL_3                                           /*!< ETR input is connected to TIM3 ETR */
-#define LL_TIM_TIM4_ETRSOURCE_TIM3_ETR     (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to TIM4 ETR */
-#define LL_TIM_TIM4_ETRSOURCE_TIM5_ETR     (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1| TIM1_AF1_ETRSEL_0)  /*!< ETR input is connected to TIM5 ETR */
+#define LL_TIM_TIM4_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM4_ETRSOURCE_COMP1       TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to COMP1_OUT */
+#define LL_TIM_TIM4_ETRSOURCE_COMP2       TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP1 && COMP2 */
+#define LL_TIM_TIM4_ETRSOURCE_TIM2_ETR    TIM1_AF1_ETRSEL_3                                           /*!< ETR input is connected to TIM3 ETR */
+#define LL_TIM_TIM4_ETRSOURCE_TIM3_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to TIM4 ETR */
+#define LL_TIM_TIM4_ETRSOURCE_TIM5_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to TIM5 ETR */
 /**
   * @}
   */
@@ -1109,9 +1150,19 @@ typedef struct
 #define LL_TIM_TIM5_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
 #define LL_TIM_TIM5_ETRSOURCE_SAI2_FSA    TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to SAI2_FSA */
 #define LL_TIM_TIM5_ETRSOURCE_SAI2_FSB    TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to SAI2_FSB */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM5_ETRSOURCE_COMP1       (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to COMP1_OUT */
+#define LL_TIM_TIM5_ETRSOURCE_COMP2       (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP1 && COMP2 */
 #define LL_TIM_TIM5_ETRSOURCE_TIM2_ETR    TIM1_AF1_ETRSEL_3                                           /*!< ETR input is connected to TIM2 ETR */
 #define LL_TIM_TIM5_ETRSOURCE_TIM3_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_0)                     /*!< ETR input is connected to TIM3 ETR */
 #define LL_TIM_TIM5_ETRSOURCE_TIM4_ETR    (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_1)                     /*!< ETR input is connected to TIM4 ETR */
+#if defined(USB_DRD_FS)
+#define LL_TIM_TIM5_ETRSOURCE_USB_SOF     (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to USB SOF */
+#elif defined(USB_OTG_HS)
+#define LL_TIM_TIM5_ETRSOURCE_USBHS_SOF   (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2)                     /*!< ETR is connected to USBHS OTG SOF */
+#define LL_TIM_TIM5_ETRSOURCE_USBFS_SOF   (TIM1_AF1_ETRSEL_3 | TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR is connected to USBFS OTG SOF */
+#endif /* USB_DRD_FS */
 /**
   * @}
   */
@@ -1122,9 +1173,18 @@ typedef struct
   * @{
   */
 #define LL_TIM_TIM8_ETRSOURCE_GPIO        0x00000000U                                                 /*!< ETR input is connected to GPIO */
-#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD1   (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< ADC4 analog watchdog 1 */
-#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD2   TIM1_AF1_ETRSEL_2                                           /*!< ADC4 analog watchdog 2 */
-#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD3   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ADC4 analog watchdog 3 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM8_ETRSOURCE_COMP1       TIM1_AF1_ETRSEL_0                                           /*!< ETR input is connected to COMP1_OUT */
+#define LL_TIM_TIM8_ETRSOURCE_COMP2       TIM1_AF1_ETRSEL_1                                           /*!< ETR input is connected to COMP2_OUT */
+#endif /* COMP1 && COMP2 */
+#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD1   (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)                     /*!< ADC2 analog watchdog 1 */
+#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD2   TIM1_AF1_ETRSEL_2                                           /*!< ADC2 analog watchdog 2 */
+#define LL_TIM_TIM8_ETRSOURCE_ADC2_AWD3   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)                     /*!< ADC2 analog watchdog 3 */
+#if defined(ADC3)
+#define LL_TIM_TIM8_ETRSOURCE_ADC3_AWD1   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1)                     /*!< ADC3 analog watchdog 1 */
+#define LL_TIM_TIM8_ETRSOURCE_ADC3_AWD2   (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ADC3 analog watchdog 2 */
+#define LL_TIM_TIM8_ETRSOURCE_ADC3_AWD3   TIM1_AF1_ETRSEL_3                                           /*!< ADC3 analog watchdog 3 */
+#endif /* ADC3 */
 /**
   * @}
   */
@@ -1228,6 +1288,15 @@ typedef struct
 #if defined(COMP1)
 #define LL_TIM_BKIN_SOURCE_BKCOMP1             TIM1_AF1_BKCMP1E    /*!< internal signal: COMP1 output */
 #endif /* COMP1 */
+#if defined(COMP2)
+#define LL_TIM_BKIN_SOURCE_BKCOMP2             TIM1_AF1_BKCMP2E    /*!< internal signal: COMP2 output */
+#endif /* COMP2 */
+#if defined(PLAY1)
+#define LL_TIM_BKIN_SOURCE_PLAY1               TIM1_AF1_BKCMP3E    /*!< internal signal: PLAY1 output */
+#endif /* PLAY1 */
+#if defined(MDF1)
+#define LL_TIM_BKIN_SOURCE_MDF1                TIM1_AF1_BKDF1BK0E  /*!< internal signal: Digital filter break output */
+#endif /* MDF1 */
 /**
   * @}
   */
@@ -1259,6 +1328,15 @@ typedef struct
   * @}
   */
 
+/** Legacy definitions for compatibility purpose
+@cond 0
+  */
+#define LL_TIM_ReArmBRK(_PARAM_)
+#define LL_TIM_ReArmBRK2(_PARAM_)
+/**
+@endcond
+  */
+
 /** @defgroup TIM_LL_EC_DMABURST_BASEADDR DMA Burst Base Address
   * @{
   */
@@ -1288,6 +1366,7 @@ typedef struct
 #define LL_TIM_DMABURST_BASEADDR_TISEL         (TIM_DCR_DBA_4 | TIM_DCR_DBA_2 | TIM_DCR_DBA_1 | TIM_DCR_DBA_0)  /*!< TIMx_TISEL register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_AF1           (TIM_DCR_DBA_4 | TIM_DCR_DBA_3)                                  /*!< TIMx_AF1 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_AF2           (TIM_DCR_DBA_4 | TIM_DCR_DBA_3 | TIM_DCR_DBA_0)                  /*!< TIMx_AF2 register is the DMA base address for DMA burst */
+#define LL_TIM_DMABURST_BASEADDR_OR1           (TIM_DCR_DBA_4 | TIM_DCR_DBA_3 | TIM_DCR_DBA_1)                  /*!< TIMx_OR1 register is the DMA base address for DMA burst */
 /**
   * @}
   */
@@ -1341,10 +1420,13 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM1_TI1_RMP  TIM1 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM1_TI1_RMP_GPIO   0x00000000UL
-#if defined(COMP1)
-#define LL_TIM_TIM1_TI1_RMP_COMP1    TIM_TISEL_TI1SEL_0
-#endif /* COMP1 */
+#define LL_TIM_TIM1_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM1_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM1_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM1_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM1_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM1_TI1 is connected to COMP2 output */
+#elif defined(COMP1)
+#define LL_TIM_TIM1_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_0                                  /*!< TIM1_TI1 is connected to COMP1 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1352,16 +1434,21 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM2_TI1_RMP  TIM2 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM2_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM2_TI1 is connected to GPIO     */
+#define LL_TIM_TIM2_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM2_TI1 is connected to GPIO */
 #if defined(STM32H503xx)
-#define LL_TIM_TIM2_TI1_RMP_LSI                TIM_TISEL_TI1SEL_0                                  /*!< TIM2_TI1 is connected to LSI      */
-#define LL_TIM_TIM2_TI1_RMP_LSE                TIM_TISEL_TI1SEL_1                                  /*!< TIM2_TI1 is connected to LSE      */
-#define LL_TIM_TIM2_TI1_RMP_RTC                (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM2_TI1 is connected to RTC      */
+#define LL_TIM_TIM2_TI1_RMP_LSI                TIM_TISEL_TI1SEL_0                                  /*!< TIM2_TI1 is connected to LSI */
+#define LL_TIM_TIM2_TI1_RMP_LSE                TIM_TISEL_TI1SEL_1                                  /*!< TIM2_TI1 is connected to LSE */
+#define LL_TIM_TIM2_TI1_RMP_RTC                (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM2_TI1 is connected to RTC */
 #define LL_TIM_TIM2_TI1_RMP_TIM3_TI1           TIM_TISEL_TI1SEL_2                                  /*!< TIM2_TI1 is connected to TIM3 TI1 */
 #endif /* STM32H503xx */
 #if defined(ETH_NS)
-#define LL_TIM_TIM2_TI1_RMP_ETH_PPS          TIM_TISEL_TI1SEL_0                                    /*!< TIM2_TI1 is connected to ETH_ PPS */
+#define LL_TIM_TIM2_TI1_RMP_ETH_PPS            TIM_TISEL_TI1SEL_0                                  /*!< TIM2_TI1 is connected to ETH PPS */
 #endif /* ETH_NS */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM2_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM2_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM2_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM2_TI1 is connected to COMP2 output */
+#define LL_TIM_TIM2_TI1_RMP_PLAY1_OUT3         TIM_TISEL_TI1SEL_2                                  /*!< TIM2_TI1 is connected to PLAY1 output 3 */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1369,13 +1456,17 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM2_TI2_RMP  TIM2 External Input Ch2 Remap
   * @{
   */
-#define LL_TIM_TIM2_TI2_RMP_GPIO               0x00000000UL                                        /*!< TIM2_TI1 is connected to GPIO     */
+#define LL_TIM_TIM2_TI2_RMP_GPIO               0x00000000UL                                        /*!< TIM2_TI2 is connected to GPIO */
 #if defined(STM32H503xx)
 #define LL_TIM_TIM2_TI2_RMP_HSI_1024           TIM_TISEL_TI2SEL_0                                  /*!< TIM2_TI2 is connected to HSI_1024 */
-#define LL_TIM_TIM2_TI2_RMP_CSI_128            TIM_TISEL_TI2SEL_1                                  /*!< TIM2_TI2 is connected to CSI_128  */
-#define LL_TIM_TIM2_TI2_RMP_MCO2               (TIM_TISEL_TI2SEL_1 |TIM_TISEL_TI2SEL_0)            /*!< TIM2_TI2 is connected to MCO2     */
-#define LL_TIM_TIM2_TI2_RMP_MCO1               TIM_TISEL_TI2SEL_2                                  /*!< TIM2_TI2 is connected to MCO1     */
+#define LL_TIM_TIM2_TI2_RMP_CSI_128            TIM_TISEL_TI2SEL_1                                  /*!< TIM2_TI2 is connected to CSI_128 */
+#define LL_TIM_TIM2_TI2_RMP_MCO2               (TIM_TISEL_TI2SEL_1 |TIM_TISEL_TI2SEL_0)            /*!< TIM2_TI2 is connected to MCO2 */
+#define LL_TIM_TIM2_TI2_RMP_MCO1               TIM_TISEL_TI2SEL_2                                  /*!< TIM2_TI2 is connected to MCO1 */
 #endif /* STM32H503xx */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM2_TI2_RMP_COMP1              TIM_TISEL_TI2SEL_0                                  /*!< TIM2_TI2 is connected to COMP1 output */
+#define LL_TIM_TIM2_TI2_RMP_COMP2              TIM_TISEL_TI2SEL_1                                  /*!< TIM2_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1384,9 +1475,9 @@ typedef struct
   * @{
   */
 #define LL_TIM_TIM2_TI4_RMP_GPIO               0x00000000UL                                        /*!< TIM2_TI4 is connected to GPIO */
-#if defined(COMP1)
-#define LL_TIM_TIM2_TI4_RMP_COMP1              TIM_TISEL_TI4SEL_0                                  /*!< TIM2_TI2 is connected to COMP1 */
-#endif /* COMP1 */
+#if defined(STM32H503xx)
+#define LL_TIM_TIM2_TI4_RMP_COMP1              TIM_TISEL_TI4SEL_0                                  /*!< TIM2_TI4 is connected to COMP1 output */
+#endif /* STM32H503xx */
 /**
   * @}
   */
@@ -1394,16 +1485,21 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM3_TI1_RMP  TIM3 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM3_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM3_TI1 is connected to GPIO     */
+#define LL_TIM_TIM3_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM3_TI1 is connected to GPIO */
 #if defined(STM32H503xx)
-#define LL_TIM_TIM3_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_0                                  /*!< TIM2_TI1 is connected to COMP1    */
-#define LL_TIM_TIM3_TI1_RMP_MCO1               TIM_TISEL_TI1SEL_1                                  /*!< TIM2_TI1 is connected to MCO1     */
-#define LL_TIM_TIM3_TI1_RMP_TIM2_TI1           (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM2_TI1 is connected to TIM2 TI1 */
-#define LL_TIM_TIM3_TI1_RMP_HSE_1MHZ           TIM_TISEL_TI1SEL_2                                  /*!< TIM2_TI1 is connected to HSE 1MHZ */
+#define LL_TIM_TIM3_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_0                                  /*!< TIM3_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM3_TI1_RMP_MCO1               TIM_TISEL_TI1SEL_1                                  /*!< TIM3_TI1 is connected to MCO1 */
+#define LL_TIM_TIM3_TI1_RMP_TIM2_TI1           (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM3_TI1 is connected to TIM2 TI1 */
+#define LL_TIM_TIM3_TI1_RMP_HSE_1MHZ           TIM_TISEL_TI1SEL_2                                  /*!< TIM3_TI1 is connected to HSE 1MHZ */
 #endif /* STM32H503xx */
 #if defined(ETH_NS)
-#define LL_TIM_TIM3_TI1_RMP_ETH_PPS            TIM_TISEL_TI1SEL_0                                /*!< TIM2_TI1 is connected to ETH PPS */
+#define LL_TIM_TIM3_TI1_RMP_ETH_PPS            TIM_TISEL_TI1SEL_0                                  /*!< TIM3_TI1 is connected to ETH PPS */
 #endif /* ETH_NS */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM3_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM3_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM3_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM3_TI1 is connected to COMP2 output */
+#define LL_TIM_TIM3_TI1_RMP_PLAY1_OUT3         TIM_TISEL_TI1SEL_2                                  /*!< TIM3_TI1 is connected to PLAY1 output 3 */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1411,39 +1507,138 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM3_TI2_RMP  TIM3 External Input Ch2 Remap
   * @{
   */
-#define LL_TIM_TIM3_TI2_RMP_GPIO               0x00000000UL                                        /*!< TIM3_TI2 is connected to GPIO     */
+#define LL_TIM_TIM3_TI2_RMP_GPIO               0x00000000UL                                        /*!< TIM3_TI2 is connected to GPIO */
 #if defined(STM32H503xx)
-#define LL_TIM_TIM3_TI2_RMP_CSI_128            TIM_TISEL_TI2SEL_0                                  /*!< TIM3_TI2 is connected to CSI 128  */
-#define LL_TIM_TIM3_TI2_RMP_MCO2               TIM_TISEL_TI2SEL_1                                  /*!< TIM3_TI2 is connected to MCO2     */
+#define LL_TIM_TIM3_TI2_RMP_CSI_128            TIM_TISEL_TI2SEL_0                                  /*!< TIM3_TI2 is connected to CSI 128 */
+#define LL_TIM_TIM3_TI2_RMP_MCO2               TIM_TISEL_TI2SEL_1                                  /*!< TIM3_TI2 is connected to MCO2 */
 #define LL_TIM_TIM3_TI2_RMP_HSI_1024           (TIM_TISEL_TI2SEL_1 |TIM_TISEL_TI2SEL_0)            /*!< TIM3_TI2 is connected to HSI 1024 */
 #endif /* STM32H503xx */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM3_TI2_RMP_COMP1              TIM_TISEL_TI2SEL_0                                  /*!< TIM3_TI2 is connected to COMP1 output */
+#define LL_TIM_TIM3_TI2_RMP_COMP2              TIM_TISEL_TI2SEL_1                                  /*!< TIM3_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
+
+#if defined(TIM4)
+/** @defgroup TIM_LL_EC_TIM4_TI1_RMP  TIM4 External Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM4_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM4_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM4_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM4_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM4_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM4_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+/**
+  * @}
+  */
+#endif /* TIM4 */
+
+#if defined(TIM5)
+/** @defgroup TIM_LL_EC_TIM5_TI1_RMP  TIM5 External Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM5_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM5_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM5_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM5_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM5_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM5_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+/**
+  * @}
+  */
+#endif /* TIM5 */
+
+#if defined(TIM8)
+/** @defgroup TIM_LL_EC_TIM8_TI1_RMP  TIM8 External Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM8_TI1_RMP_GPIO               0x00000000UL                                        /*!< TIM8_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM8_TI1_RMP_COMP1              TIM_TISEL_TI1SEL_1                                  /*!< TIM8_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM8_TI1_RMP_COMP2              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM8_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+/**
+  * @}
+  */
+#endif /* TIM8 */
 
 #if defined(TIM12)
 /** @defgroup TIM_LL_EC_TIM12_TI1_RMP  TIM12 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM12_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM12_TI1 is connected to GPIO     */
+#define LL_TIM_TIM12_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM12_TI1 is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM12_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_1                                  /*!< TIM12_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM12_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM12_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 #define LL_TIM_TIM12_TI1_RMP_HSI_1024          TIM_TISEL_TI1SEL_2                                  /*!< TIM12_TI1 is connected to HSI 1024 */
-#define LL_TIM_TIM12_TI1_RMP_CSI_128           (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_0)            /*!< TIM12_TI1 is connected to CSI 128  */
+#define LL_TIM_TIM12_TI1_RMP_CSI_128           (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_0)            /*!< TIM12_TI1 is connected to CSI 128 */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_LL_EC_TIM12_TI2_RMP  TIM12 External Input Ch2 Remap
+  * @{
+  */
+#define LL_TIM_TIM12_TI2_RMP_GPIO              0x00000000UL                                        /*!< TIM12_TI2 is connected to GPIO */
+#if defined(COMP2)
+#define LL_TIM_TIM12_TI2_RMP_COMP2             TIM_TISEL_TI2SEL_0                                  /*!< TIM12_TI2 is connected to COMP2 output */
+#endif /* COMP2 */
 /**
   * @}
   */
 #endif /* TIM12 */
 
+#if defined(TIM13)
+/** @defgroup TIM_LL_EC_TIM13_TI1_RMP  TIM13 External Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM13_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM13_TI1 is connected to GPIO */
+#if defined(I3C1)
+#define LL_TIM_TIM13_TI1_RMP_I3C1_IBIACK       TIM_TISEL_TI1SEL_0                                  /*!< TIM13_TI1 is connected to I3C1 IBI ACK */
+#endif /* I3C1 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM13_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_1                                  /*!< TIM13_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM13_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM13_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+/**
+  * @}
+  */
+#endif /* TIM13 */
+
+#if defined(TIM14)
+/** @defgroup TIM_LL_EC_TIM14_TI1_RMP  TIM14 External Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM14_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM14_TI1 is connected to GPIO */
+#if defined(I3C2)
+#define LL_TIM_TIM14_TI1_RMP_I3C2_IBIACK       TIM_TISEL_TI1SEL_0                                  /*!< TIM14_TI1 is connected to I3C2 IBI ACK */
+#endif /* I3C1 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM14_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_1                                  /*!< TIM14_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM14_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM14_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+/**
+  * @}
+  */
+#endif /* TIM14 */
+
 #if defined(TIM15)
 /** @defgroup TIM_LL_EC_TIM15_TI1_RMP  TIM15 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM15_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM15_TI1 is connected to GPIO   */
-#define LL_TIM_TIM15_TI1_RMP_TIM2              TIM_TISEL_TI1SEL_0                                  /*!< TIM15_TI1 is connected to TIM2   */
-#define LL_TIM_TIM15_TI1_RMP_TIM3              TIM_TISEL_TI1SEL_1                                  /*!< TIM15_TI1 is connected to TIM3   */
-#define LL_TIM_TIM15_TI1_RMP_TIM4              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM15_TI1 is connected to TIM4   */
-#define LL_TIM_TIM15_TI1_RMP_LSE               TIM_TISEL_TI1SEL_2                                  /*!< TIM15_TI1 is connected to LSE    */
+#define LL_TIM_TIM15_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM15_TI1 is connected to GPIO */
+#define LL_TIM_TIM15_TI1_RMP_TIM2              TIM_TISEL_TI1SEL_0                                  /*!< TIM15_TI1 is connected to TIM2 */
+#define LL_TIM_TIM15_TI1_RMP_TIM3              TIM_TISEL_TI1SEL_1                                  /*!< TIM15_TI1 is connected to TIM3 */
+#define LL_TIM_TIM15_TI1_RMP_TIM4              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM15_TI1 is connected to TIM4 */
+#define LL_TIM_TIM15_TI1_RMP_LSE               TIM_TISEL_TI1SEL_2                                  /*!< TIM15_TI1 is connected to LSE */
 #define LL_TIM_TIM15_TI1_RMP_CSI_128           (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_0)            /*!< TIM15_TI1 is connected to CSI 128*/
-#define LL_TIM_TIM15_TI1_RMP_MCO2              (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_1)            /*!< TIM15_TI1 is connected to MCO2   */
+#define LL_TIM_TIM15_TI1_RMP_MCO2              (TIM_TISEL_TI1SEL_2 |TIM_TISEL_TI1SEL_1)            /*!< TIM15_TI1 is connected to MCO2 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM15_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_3                                  /*!< TIM15_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM15_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_3 | TIM_TISEL_TI1SEL_0)           /*!< TIM15_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1451,10 +1646,14 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM15_TI2_RMP  TIM15 External Input Ch2 Remap
   * @{
   */
-#define LL_TIM_TIM15_TI2_RMP_GPIO              0x00000000UL                                        /*!< TIM15_TI1 is connected to GPIO   */
-#define LL_TIM_TIM15_TI2_RMP_TIM2              TIM_TISEL_TI2SEL_0                                  /*!< TIM15_TI2 is connected to TIM2   */
-#define LL_TIM_TIM15_TI2_RMP_TIM3              TIM_TISEL_TI2SEL_1                                  /*!< TIM15_TI2 is connected to TIM3   */
-#define LL_TIM_TIM15_TI2_RMP_TIM4              (TIM_TISEL_TI2SEL_1 | TIM_TISEL_TI2SEL_0)           /*!< TIM15_TI2 is connected to TIM4   */
+#define LL_TIM_TIM15_TI2_RMP_GPIO              0x00000000UL                                        /*!< TIM15_TI1 is connected to GPIO */
+#define LL_TIM_TIM15_TI2_RMP_TIM2              TIM_TISEL_TI2SEL_0                                  /*!< TIM15_TI2 is connected to TIM2 */
+#define LL_TIM_TIM15_TI2_RMP_TIM3              TIM_TISEL_TI2SEL_1                                  /*!< TIM15_TI2 is connected to TIM3 */
+#define LL_TIM_TIM15_TI2_RMP_TIM4              (TIM_TISEL_TI2SEL_1 | TIM_TISEL_TI2SEL_0)           /*!< TIM15_TI2 is connected to TIM4 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM15_TI2_RMP_COMP1             TIM_TISEL_TI2SEL_2                                  /*!< TIM15_TI2 is connected to COMP1 output */
+#define LL_TIM_TIM15_TI2_RMP_COMP2             (TIM_TISEL_TI2SEL_2 | TIM_TISEL_TI2SEL_0)           /*!< TIM15_TI2 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1465,9 +1664,13 @@ typedef struct
   * @{
   */
 #define LL_TIM_TIM16_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM16_TI1 is connected to GPIO */
-#define LL_TIM_TIM16_TI1_RMP_LSI               TIM_TISEL_TI1SEL_0                                  /*!< TIM16_TI1 is connected to LSI  */
-#define LL_TIM_TIM16_TI1_RMP_LSE               TIM_TISEL_TI1SEL_1                                  /*!< TIM16_TI1 is connected to LSE  */
-#define LL_TIM_TIM16_TI1_RMP_RTC_WKUP          (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM16_TI1 is connected to RTC  */
+#define LL_TIM_TIM16_TI1_RMP_LSI               TIM_TISEL_TI1SEL_0                                  /*!< TIM16_TI1 is connected to LSI */
+#define LL_TIM_TIM16_TI1_RMP_LSE               TIM_TISEL_TI1SEL_1                                  /*!< TIM16_TI1 is connected to LSE */
+#define LL_TIM_TIM16_TI1_RMP_RTC_WKUP          (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM16_TI1 is connected to RTC */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM16_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_3                                  /*!< TIM16_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM16_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_3 | TIM_TISEL_TI1SEL_0)           /*!< TIM16_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1477,9 +1680,13 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM17_TI1_RMP  TIM17 External Input Ch1 Remap
   * @{
   */
-#define LL_TIM_TIM17_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM17_TI1 is connected to GPIO     */
+#define LL_TIM_TIM17_TI1_RMP_GPIO              0x00000000UL                                        /*!< TIM17_TI1 is connected to GPIO */
 #define LL_TIM_TIM17_TI1_RMP_HSE_1MHZ          TIM_TISEL_TI1SEL_1                                  /*!< TIM17_TI1 is connected to HSE 1MHZ */
-#define LL_TIM_TIM17_TI1_RMP_MCO1              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM17_TI1 is connected to MCO1     */
+#define LL_TIM_TIM17_TI1_RMP_MCO1              (TIM_TISEL_TI1SEL_1 | TIM_TISEL_TI1SEL_0)           /*!< TIM17_TI1 is connected to MCO1 */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_TIM17_TI1_RMP_COMP1             TIM_TISEL_TI1SEL_2                                  /*!< TIM17_TI1 is connected to COMP1 output */
+#define LL_TIM_TIM17_TI1_RMP_COMP2             (TIM_TISEL_TI1SEL_2 | TIM_TISEL_TI1SEL_0)           /*!< TIM17_TI1 is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -1488,8 +1695,11 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCREF_CLR_INT OCREF clear input selection
   * @{
   */
-#define LL_TIM_OCREF_CLR_INT_OCREF_CLR     0x00000000U         /*!< OCREF_CLR_INT is connected to the OCREF_CLR input */
-#define LL_TIM_OCREF_CLR_INT_ETR           TIM_SMCR_OCCS       /*!< OCREF_CLR_INT is connected to ETRF */
+#define LL_TIM_OCREF_CLR_INT_ETR         OCREF_CLEAR_SELECT_MSK                   /*!< OCREF_CLR_INT is connected to ETRF */
+#if defined(COMP1) && defined(COMP2)
+#define LL_TIM_OCREF_CLR_INT_COMP1       0x00000000U                              /*!< OCREF clear input is connected to COMP1_OUT */
+#define LL_TIM_OCREF_CLR_INT_COMP2       TIM1_AF2_OCRSEL_0                        /*!< OCREF clear input is connected to COMP2_OUT */
+#endif /* COMP1 && COMP2 */
 /**
   * @}
   */
@@ -2229,6 +2439,17 @@ __STATIC_INLINE void LL_TIM_CC_DisablePreload(TIM_TypeDef *TIMx)
 }
 
 /**
+  * @brief  Indicates whether the capture/compare control bits (CCxE, CCxNE and OCxM) preload is enabled.
+  * @rmtoll CR2          CCPC          LL_TIM_CC_IsEnabledPreload
+  * @param  TIMx Timer instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_TIM_CC_IsEnabledPreload(const TIM_TypeDef *TIMx)
+{
+  return ((READ_BIT(TIMx->CR2, TIM_CR2_CCPC) == (TIM_CR2_CCPC)) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Set the updated source of the capture/compare control bits (CCxE, CCxNE and OCxM).
   * @note Macro IS_TIM_COMMUTATION_EVENT_INSTANCE(TIMx) can be used to check
   *       whether or not a timer instance is able to generate a commutation event.
@@ -2464,8 +2685,8 @@ __STATIC_INLINE void LL_TIM_OC_ConfigOutput(TIM_TypeDef *TIMx, uint32_t Channel,
   *         @arg @ref LL_TIM_OCMODE_RETRIG_OPM2
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM1
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM2
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM1
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM2
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM1
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM2
   *         @arg @ref LL_TIM_OCMODE_PULSE_ON_COMPARE   (for channel 3 or channel 4 only)
   *         @arg @ref LL_TIM_OCMODE_DIRECTION_OUTPUT   (for channel 3 or channel 4 only)
   * @retval None
@@ -2506,8 +2727,8 @@ __STATIC_INLINE void LL_TIM_OC_SetMode(TIM_TypeDef *TIMx, uint32_t Channel, uint
   *         @arg @ref LL_TIM_OCMODE_RETRIG_OPM2
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM1
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM2
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM1
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM2
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM1
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM2
   *         @arg @ref LL_TIM_OCMODE_PULSE_ON_COMPARE   (for channel 3 or channel 4 only)
   *         @arg @ref LL_TIM_OCMODE_DIRECTION_OUTPUT   (for channel 3 or channel 4 only)
   */
@@ -3897,6 +4118,7 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   *
   *            @arg @ref LL_TIM_TIM1_ETRSOURCE_GPIO
   *            @arg @ref LL_TIM_TIM1_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM1_ETRSOURCE_COMP2      (*)
   *            @arg @ref LL_TIM_TIM1_ETRSOURCE_ADC1_AWD1
   *            @arg @ref LL_TIM_TIM1_ETRSOURCE_ADC1_AWD2
   *            @arg @ref LL_TIM_TIM1_ETRSOURCE_ADC1_AWD3
@@ -3905,27 +4127,38 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   *
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_GPIO
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM2_ETRSOURCE_COMP2      (*)
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_LSE
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_SAI1_FSA   (*)
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_SAI1_FSB   (*)
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_TIM3_ETR
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_TIM4_ETR   (*)
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_TIM5_ETR   (*)
+  *            @arg @ref LL_TIM_TIM2_ETRSOURCE_USB_SOF    (*)
+  *            @arg @ref LL_TIM_TIM2_ETRSOURCE_USBHS_SOF  (*)
+  *            @arg @ref LL_TIM_TIM2_ETRSOURCE_USBFS_SOF  (*)
   *            @arg @ref LL_TIM_TIM2_ETRSOURCE_ETH_PPS    (*)
-
+  *            @arg @ref LL_TIM_TIM2_ETRSOURCE_PLAY1_OUT0 (*)
   *
   *         TIM3: any combination of ETR_RMP where
   *
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_GPIO
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM3_ETRSOURCE_COMP2      (*)
+  *            @arg @ref LL_TIM_TIM3_ETRSOURCE_ADC2_AWD1  (*)
+  *            @arg @ref LL_TIM_TIM3_ETRSOURCE_ADC2_AWD2  (*)
+  *            @arg @ref LL_TIM_TIM3_ETRSOURCE_ADC2_AWD3  (*)
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_TIM2_ETR
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_TIM4_ETR   (*)
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_TIM5_ETR   (*)
   *            @arg @ref LL_TIM_TIM3_ETRSOURCE_ETH_PPS    (*)
+  *            @arg @ref LL_TIM_TIM3_ETRSOURCE_PLAY1_OUT0 (*)
   *
   *         TIM4: any combination of ETR_RMP where     (**)
   *
   *            @arg @ref LL_TIM_TIM4_ETRSOURCE_GPIO
+  *            @arg @ref LL_TIM_TIM4_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM4_ETRSOURCE_COMP2      (*)
   *            @arg @ref LL_TIM_TIM4_ETRSOURCE_TIM2_ETR
   *            @arg @ref LL_TIM_TIM4_ETRSOURCE_TIM3_ETR
   *            @arg @ref LL_TIM_TIM4_ETRSOURCE_TIM5_ETR
@@ -3935,17 +4168,27 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_GPIO
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_SAI2_FSA
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_SAI2_FSB
+  *            @arg @ref LL_TIM_TIM5_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM5_ETRSOURCE_COMP2      (*)
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_TIM2_ETR
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_TIM3_ETR
   *            @arg @ref LL_TIM_TIM5_ETRSOURCE_TIM4_ETR
+  *            @arg @ref LL_TIM_TIM5_ETRSOURCE_USB_SOF    (*)
+  *            @arg @ref LL_TIM_TIM5_ETRSOURCE_USBHS_SOF  (*)
+  *            @arg @ref LL_TIM_TIM5_ETRSOURCE_USBFS_SOF  (*)
   *
   *         TIM8: any combination of ETR_RMP where  (**)
   *
   *            . . ETR_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM8_ETRSOURCE_GPIO
+  *            @arg @ref LL_TIM_TIM8_ETRSOURCE_COMP1      (*)
+  *            @arg @ref LL_TIM_TIM8_ETRSOURCE_COMP2      (*)
   *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC2_AWD1
   *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC2_AWD2
   *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC2_AWD3
+  *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC3_AWD1  (*)
+  *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC3_AWD2  (*)
+  *            @arg @ref LL_TIM_TIM8_ETRSOURCE_ADC3_AWD3  (*)
   *
   *         (*)  Value not defined in all devices. \n
   *         (**) Timer instance not available on all devices. \n
@@ -4123,18 +4366,6 @@ __STATIC_INLINE void LL_TIM_DisarmBRK(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Re-arm the break input (when it operates in bidirectional mode).
-  * @note  The Break input is automatically armed as soon as MOE bit is set.
-  * @rmtoll BDTR         BKDSRM        LL_TIM_ReArmBRK
-  * @param  TIMx Timer instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_TIM_ReArmBRK(TIM_TypeDef *TIMx)
-{
-  CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKDSRM);
-}
-
-/**
   * @brief  Enable the break 2 function.
   * @note Macro IS_TIM_BKIN2_INSTANCE(TIMx) can be used to check whether or not
   *       a timer instance provides a second break input.
@@ -4221,18 +4452,6 @@ __STATIC_INLINE void LL_TIM_ConfigBRK2(TIM_TypeDef *TIMx, uint32_t Break2Polarit
 __STATIC_INLINE void LL_TIM_DisarmBRK2(TIM_TypeDef *TIMx)
 {
   SET_BIT(TIMx->BDTR, TIM_BDTR_BK2DSRM);
-}
-
-/**
-  * @brief  Re-arm the break 2 input (when it operates in bidirectional mode).
-  * @note  The Break 2 input is automatically armed as soon as MOE bit is set.
-  * @rmtoll BDTR         BK2DSRM       LL_TIM_ReArmBRK2
-  * @param  TIMx Timer instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_TIM_ReArmBRK2(TIM_TypeDef *TIMx)
-{
-  CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BK2DSRM);
 }
 
 /**
@@ -4343,15 +4562,24 @@ __STATIC_INLINE uint32_t LL_TIM_IsEnabledAllOutputs(const TIM_TypeDef *TIMx)
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINE         LL_TIM_EnableBreakInputSource\n
   *         AF1          BKCMP1E       LL_TIM_EnableBreakInputSource\n
+  *         AF1          BKCMP2E       LL_TIM_EnableBreakInputSource\n
+  *         AF1          BKCMP3E       LL_TIM_EnableBreakInputSource\n
+  *         AF1          BKDF1BK0E     LL_TIM_EnableBreakInputSource\n
   *         AF2          BK2INE        LL_TIM_EnableBreakInputSource\n
   *         AF2          BK2CMP1E      LL_TIM_EnableBreakInputSource\n
+  *         AF2          BK2CMP2E      LL_TIM_EnableBreakInputSource\n
+  *         AF2          BK2CMP3E      LL_TIM_EnableBreakInputSource\n
+  *         AF2          BK2DF1BK1E    LL_TIM_EnableBreakInputSource
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1 (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_PLAY1      (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_MDF1       (*)
   *
   *         (*)  Value not defined in all devices.
   * @retval None
@@ -4368,15 +4596,24 @@ __STATIC_INLINE void LL_TIM_EnableBreakInputSource(TIM_TypeDef *TIMx, uint32_t B
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINE         LL_TIM_DisableBreakInputSource\n
   *         AF1          BKCMP1E       LL_TIM_DisableBreakInputSource\n
+  *         AF1          BKCMP2E       LL_TIM_DisableBreakInputSource\n
+  *         AF1          BKCMP3E       LL_TIM_DisableBreakInputSource\n
+  *         AF1          BKDF1BK0E     LL_TIM_DisableBreakInputSource\n
   *         AF2          BK2INE        LL_TIM_DisableBreakInputSource\n
   *         AF2          BK2CMP1E      LL_TIM_DisableBreakInputSource\n
+  *         AF2          BK2CMP2E      LL_TIM_DisableBreakInputSource\n
+  *         AF2          BK2CMP3E      LL_TIM_DisableBreakInputSource\n
+  *         AF2          BK2DF1BK1E    LL_TIM_DisableBreakInputSource
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1 (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_PLAY1      (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_MDF1       (*)
   *
   *         (*)  Value not defined in all devices.
   * @retval None
@@ -4393,15 +4630,21 @@ __STATIC_INLINE void LL_TIM_DisableBreakInputSource(TIM_TypeDef *TIMx, uint32_t 
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINP         LL_TIM_SetBreakInputSourcePolarity\n
   *         AF1          BKCMP1P       LL_TIM_SetBreakInputSourcePolarity\n
+  *         AF1          BKCMP2P       LL_TIM_SetBreakInputSourcePolarity\n
+  *         AF1          BKCMP3P       LL_TIM_SetBreakInputSourcePolarity\n
   *         AF2          BK2INP        LL_TIM_SetBreakInputSourcePolarity\n
   *         AF2          BK2CMP1P      LL_TIM_SetBreakInputSourcePolarity\n
+  *         AF2          BK2CMP2P      LL_TIM_SetBreakInputSourcePolarity\n
+  *         AF2          BK2CMP3P      LL_TIM_SetBreakInputSourcePolarity
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1 (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2    (*)
+  *         @arg @ref LL_TIM_BKIN_SOURCE_PLAY1      (*)
   * @param  Polarity This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_POLARITY_LOW
   *         @arg @ref LL_TIM_BKIN_POLARITY_HIGH
@@ -4568,6 +4811,7 @@ __STATIC_INLINE uint32_t LL_TIM_IsEnabledDeadTimePreload(const TIM_TypeDef *TIMx
   *         @arg @ref LL_TIM_DMABURST_BASEADDR_TISEL
   *         @arg @ref LL_TIM_DMABURST_BASEADDR_AF1
   *         @arg @ref LL_TIM_DMABURST_BASEADDR_AF2
+  *         @arg @ref LL_TIM_DMABURST_BASEADDR_OR1
   * @param  DMABurstLength This parameter can be one of the following values:
   *         @arg @ref LL_TIM_DMABURST_LENGTH_1TRANSFER
   *         @arg @ref LL_TIM_DMABURST_LENGTH_2TRANSFERS
@@ -4843,17 +5087,16 @@ __STATIC_INLINE void LL_TIM_ConfigIDX(TIM_TypeDef *TIMx, uint32_t Configuration)
   *         TIM3_TISEL    TI1SEL      LL_TIM_SetRemap\n
   *         TIM3_TISEL    TI2SEL      LL_TIM_SetRemap\n
   *         TIM4_TISEL    TI1SEL      LL_TIM_SetRemap\n
-  *         TIM4_TISEL    TI2SEL      LL_TIM_SetRemap\n
   *         TIM5_TISEL    TI1SEL      LL_TIM_SetRemap\n
-  *         TIM5_TISEL    TI2SEL      LL_TIM_SetRemap\n
   *         TIM8_TISEL    TI1SEL      LL_TIM_SetRemap\n
   *         TIM12_TISEL   TI1SEL      LL_TIM_SetRemap\n
+  *         TIM12_TISEL   TI2SEL      LL_TIM_SetRemap\n
   *         TIM13_TISEL   TI1SEL      LL_TIM_SetRemap\n
   *         TIM14_TISEL   TI1SEL      LL_TIM_SetRemap\n
   *         TIM15_TISEL   TI1SEL      LL_TIM_SetRemap\n
   *         TIM15_TISEL   TI2SEL      LL_TIM_SetRemap\n
   *         TIM16_TISEL   TI1SEL      LL_TIM_SetRemap\n
-  *         TIM17_TISEL   TI1SEL      LL_TIM_SetRemap\n
+  *         TIM17_TISEL   TI1SEL      LL_TIM_SetRemap
   *
   * @param  TIMx Timer instance
   * @param  Remap Remap param depends on the TIMx. Description available only
@@ -4864,69 +5107,78 @@ __STATIC_INLINE void LL_TIM_ConfigIDX(TIM_TypeDef *TIMx, uint32_t Configuration)
   *
   *         TIM1: one of the following values:
   *            @arg LL_TIM_TIM1_TI1_RMP_GPIO:                TIM1 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM1_TI1_RMP_COMP1:               TIM1 TI1 is connected to COMP1 output  (*)
-  *            @arg LL_TIM_TIM1_TI2_RMP_GPIO:                TIM1 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM1_TI3_RMP_GPIO:                TIM1 TI3 is connected to GPIO
-  *            @arg LL_TIM_TIM1_TI4_RMP_GPIO:                TIM1 TI4 is connected to GPIO
+  *            @arg LL_TIM_TIM1_TI1_RMP_COMP1:               TIM1 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM1_TI1_RMP_COMP2:               TIM1 TI1 is connected to COMP2 output    (*)
   *
   *         TIM2: one of the following values:
   *            @arg LL_TIM_TIM2_TI1_RMP_GPIO:                TIM2 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM2_TI1_RMP_LSI:                 TIM2 TI1 is connected to LSI           (*)
-  *            @arg LL_TIM_TIM2_TI1_RMP_LSE:                 TIM2 TI1 is connected to LSE           (*)
-  *            @arg LL_TIM_TIM2_TI1_RMP_RTC:                 TIM2 TI1 is connected to RTC           (*)
-  *            @arg LL_TIM_TIM2_TI1_RMP_TIM3_TI1:            TIM2 TI1 is connected to TIM3 TI1      (*)
-  *            @arg LL_TIM_TIM2_TI1_RMP_ETH_PPS:             TIM2 TI1 is connected to ETH PPS       (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_LSI:                 TIM2 TI1 is connected to LSI             (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_LSE:                 TIM2 TI1 is connected to LSE             (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_RTC:                 TIM2 TI1 is connected to RTC             (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_TIM3_TI1:            TIM2 TI1 is connected to TIM3 TI1        (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_ETH_PPS:             TIM2 TI1 is connected to ETH PPS         (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_COMP1:               TIM2 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_COMP2:               TIM2 TI1 is connected to COMP2 output    (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_PLAY1_OUT3:          TIM2 TI1 is connected to PLAY1 output 3  (*)
   *            @arg LL_TIM_TIM2_TI2_RMP_GPIO:                TIM2 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM2_TI2_RMP_HSI_1024:            TIM2 TI2 is connected to HSI 1024      (*)
-  *            @arg LL_TIM_TIM2_TI2_RMP_CSI_128:             TIM2 TI2 is connected to CSI 128       (*)
-  *            @arg LL_TIM_TIM2_TI2_RMP_MCO2:                TIM2 TI2 is connected to MCO2          (*)
-  *            @arg LL_TIM_TIM2_TI2_RMP_MCO1:                TIM2 TI2 is connected to MCO1          (*)
-  *            @arg LL_TIM_TIM2_TI3_RMP_GPIO:                TIM2 TI3 is connected to GPIO
+  *            @arg LL_TIM_TIM2_TI2_RMP_HSI_1024:            TIM2 TI2 is connected to HSI 1024        (*)
+  *            @arg LL_TIM_TIM2_TI2_RMP_CSI_128:             TIM2 TI2 is connected to CSI 128         (*)
+  *            @arg LL_TIM_TIM2_TI2_RMP_MCO2:                TIM2 TI2 is connected to MCO2            (*)
+  *            @arg LL_TIM_TIM2_TI2_RMP_MCO1:                TIM2 TI2 is connected to MCO1            (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_COMP1:               TIM2 TI2 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM2_TI1_RMP_COMP2:               TIM2 TI2 is connected to COMP2 output    (*)
   *            @arg LL_TIM_TIM2_TI4_RMP_GPIO:                TIM2 TI4 is connected to GPIO
-  *            @arg LL_TIM_TIM2_TI4_RMP_COMP1:               TIM2 TI4 is connected to COMP1         (*)
+  *            @arg LL_TIM_TIM2_TI4_RMP_COMP1:               TIM2 TI4 is connected to COMP1           (*)
   *
   *         TIM3: one of the following values:
   *            @arg LL_TIM_TIM3_TI1_RMP_GPIO:                TIM3 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM3_TI1_RMP_COMP1:               TIM3 TI1 is connected to COMP1 output  (*)
-  *            @arg LL_TIM_TIM3_TI1_RMP_MCO1:                TIM3 TI1 is connected to MCO1          (*)
-  *            @arg LL_TIM_TIM3_TI1_RMP_TIM2_TI1:            TIM3 TI1 is connected to TIM2 TI1      (*)
-  *            @arg LL_TIM_TIM3_TI1_RMP_HSE_1MHZ:            TIM3 TI1 is connected to HSE_1MHZ      (*)
-  *            @arg LL_TIM_TIM3_TI1_RMP_ETH_PPS:             TIM3 TI1 is connected to ETH PPS       (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_COMP1:               TIM3 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_COMP2:               TIM3 TI1 is connected to COMP2 output    (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_MCO1:                TIM3 TI1 is connected to MCO1            (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_TIM2_TI1:            TIM3 TI1 is connected to TIM2 TI1        (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_HSE_1MHZ:            TIM3 TI1 is connected to HSE_1MHZ        (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_ETH_PPS:             TIM3 TI1 is connected to ETH PPS         (*)
+  *            @arg LL_TIM_TIM3_TI1_RMP_PLAY1_OUT3:          TIM3 TI1 is connected to PLAY1 output 3  (*)
   *            @arg LL_TIM_TIM3_TI2_RMP_GPIO:                TIM3 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM3_TI2_RMP_CSI_128:             TIM3 TI2 is connected to CSI_128       (*)
-  *            @arg LL_TIM_TIM3_TI2_RMP_MCO2:                TIM3 TI2 is connected to MCO2          (*)
-  *            @arg LL_TIM_TIM3_TI2_RMP_HSI_1024:            TIM3 TI2 is connected to HSI_1024      (*)
-  *            @arg LL_TIM_TIM3_TI3_RMP_GPIO:                TIM3 TI3 is connected to GPIO
-  *            @arg LL_TIM_TIM3_TI4_RMP_GPIO:                TIM3 TI4 is connected to GPIO
+  *            @arg LL_TIM_TIM3_TI2_RMP_CSI_128:             TIM3 TI2 is connected to CSI_128         (*)
+  *            @arg LL_TIM_TIM3_TI2_RMP_MCO2:                TIM3 TI2 is connected to MCO2            (*)
+  *            @arg LL_TIM_TIM3_TI2_RMP_HSI_1024:            TIM3 TI2 is connected to HSI_1024        (*)
+  *            @arg LL_TIM_TIM3_TI2_RMP_COMP1:               TIM3 TI2 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM3_TI2_RMP_COMP2:               TIM3 TI2 is connected to COMP2 output    (*)
   *
   *         TIM4: one of the following values: (**)
   *            @arg LL_TIM_TIM4_TI1_RMP_GPIO:                TIM4 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM4_TI2_RMP_GPIO:                TIM4 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM4_TI3_RMP_GPIO:                TIM4 TI3 is connected to GPIO
-  *            @arg LL_TIM_TIM4_TI4_RMP_GPIO:                TIM4 TI4 is connected to GPIO
+  *            @arg LL_TIM_TIM4_TI1_RMP_COMP1:               TIM4 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM4_TI1_RMP_COMP2:               TIM4 TI1 is connected to COMP2 output    (*)
   *
   *         TIM5: one of the following values: (**)
   *            @arg LL_TIM_TIM5_TI1_RMP_GPIO:                TIM5 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM5_TI2_RMP_GPIO:                TIM5 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM5_TI3_RMP_GPIO:                TIM5 TI3 is connected to GPIO
-  *            @arg LL_TIM_TIM5_TI4_RMP_GPIO:                TIM5 TI4 is connected to GPIO
+  *            @arg LL_TIM_TIM5_TI1_RMP_COMP1:               TIM5 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM5_TI1_RMP_COMP2:               TIM5 TI1 is connected to COMP2 output    (*)
   *
   *         TIM8: one of the following values: (**)
   *            @arg LL_TIM_TIM8_TI1_RMP_GPIO:                TIM8 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM8_TI2_RMP_GPIO:                TIM8 TI2 is connected to GPIO
-  *            @arg LL_TIM_TIM8_TI3_RMP_GPIO:                TIM8 TI3 is connected to GPIO
-  *            @arg LL_TIM_TIM8_TI4_RMP_GPIO:                TIM8 TI4 is connected to GPIO
+  *            @arg LL_TIM_TIM8_TI1_RMP_COMP1:               TIM8 TI1 is connected to COMP1 output    (*)
+  *            @arg LL_TIM_TIM8_TI1_RMP_COMP2:               TIM8 TI1 is connected to COMP2 output    (*)
   *
   *         TIM12: one of the following values: (**)
   *            @arg LL_TIM_TIM12_TI1_RMP_GPIO:               TIM12 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM12_TI1_RMP_HSI_1024:           TIM12 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM12_TI1_RMP_CSI_128:            TIM12 TI1 is connected to GPIO
+  *            @arg LL_TIM_TIM12_TI1_RMP_COMP1:              TIM12 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM12_TI1_RMP_COMP2:              TIM12 TI1 is connected to COMP2 output   (*)
+  *            @arg LL_TIM_TIM12_TI1_RMP_HSI_1024:           TIM12 TI1 is connected to HSI 1024
+  *            @arg LL_TIM_TIM12_TI1_RMP_CSI_128:            TIM12 TI1 is connected to CSI 128
   *
   *         TIM13: one of the following values: (**)
   *            @arg LL_TIM_TIM13_TI1_RMP_GPIO:               TIM13 TI1 is connected to GPIO
+  *            @arg LL_TIM_TIM13_TI1_RMP_I3C1_IBIACK:        TIM13 TI1 is connected to I3C1 IBI ACK   (*)
+  *            @arg LL_TIM_TIM13_TI1_RMP_COMP1:              TIM13 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM13_TI1_RMP_COMP2:              TIM13 TI1 is connected to COMP2 output   (*)
   *
   *         TIM14: one of the following values: (**)
   *            @arg LL_TIM_TIM14_TI1_RMP_GPIO:               TIM14 TI1 is connected to GPIO
+  *            @arg LL_TIM_TIM14_TI1_RMP_I3C2_IBIACK:        TIM14 TI1 is connected to I3C2 IBI ACK   (*)
+  *            @arg LL_TIM_TIM14_TI1_RMP_COMP1:              TIM14 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM14_TI1_RMP_COMP2:              TIM14 TI1 is connected to COMP2 output   (*)
   *
   *         TIM15: one of the following values: (**)
   *            @arg LL_TIM_TIM15_TI1_RMP_GPIO:               TIM15 TI1 is connected to GPIO
@@ -4936,21 +5188,29 @@ __STATIC_INLINE void LL_TIM_ConfigIDX(TIM_TypeDef *TIMx, uint32_t Configuration)
   *            @arg LL_TIM_TIM15_TI1_RMP_LSE:                TIM15 TI1 is connected to LSE
   *            @arg LL_TIM_TIM15_TI1_RMP_CSI_128:            TIM15 TI1 is connected to CSI/128
   *            @arg LL_TIM_TIM15_TI1_RMP_MCO2:               TIM15 TI1 is connected to MCO2
+  *            @arg LL_TIM_TIM15_TI1_RMP_COMP1:              TIM15 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM15_TI1_RMP_COMP2:              TIM15 TI1 is connected to COMP2 output   (*)
   *            @arg LL_TIM_TIM15_TI2_RMP_GPIO:               TIM15 TI1 is connected to GPIO
   *            @arg LL_TIM_TIM15_TI2_RMP_TIM2:               TIM15 TI1 is connected to TIM2
   *            @arg LL_TIM_TIM15_TI2_RMP_TIM3:               TIM15 TI1 is connected to TIM3
   *            @arg LL_TIM_TIM15_TI2_RMP_TIM4:               TIM15 TI1 is connected to TIM4
+  *            @arg LL_TIM_TIM15_TI2_RMP_COMP1:              TIM15 TI2 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM15_TI2_RMP_COMP2:              TIM15 TI2 is connected to COMP2 output   (*)
   *
   *         TIM16: one of the following values: (**)
-  *            @arg LL_TIM_TIM16_TI1_RMP_GPIO:              TIM16 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM16_TI1_RMP_LSI:               TIM16 TI1 is connected to LSI
-  *            @arg LL_TIM_TIM16_TI1_RMP_LSE:               TIM16 TI1 is connected to LSE
-  *            @arg LL_TIM_TIM16_TI1_RMP_RTC_WKUP:          TIM16 TI1 is connected to RTC_WKUP
+  *            @arg LL_TIM_TIM16_TI1_RMP_GPIO:               TIM16 TI1 is connected to GPIO
+  *            @arg LL_TIM_TIM16_TI1_RMP_LSI:                TIM16 TI1 is connected to LSI
+  *            @arg LL_TIM_TIM16_TI1_RMP_LSE:                TIM16 TI1 is connected to LSE
+  *            @arg LL_TIM_TIM16_TI1_RMP_RTC_WKUP:           TIM16 TI1 is connected to RTC_WKUP
+  *            @arg LL_TIM_TIM16_TI1_RMP_COMP1:              TIM16 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM16_TI1_RMP_COMP2:              TIM16 TI1 is connected to COMP2 output   (*)
   *
   *         TIM17: one of the following values: (**)
-  *            @arg LL_TIM_TIM17_TI1_RMP_GPIO:              TIM17 TI1 is connected to GPIO
-  *            @arg LL_TIM_TIM17_TI1_RMP_HSE_1MHZ:          TIM17 TI1 is connected to HSE_1MHZ
-  *            @arg LL_TIM_TIM17_TI1_RMP_MCO1:              TIM17 TI1 is connected to MCO1
+  *            @arg LL_TIM_TIM17_TI1_RMP_GPIO:               TIM17 TI1 is connected to GPIO
+  *            @arg LL_TIM_TIM17_TI1_RMP_HSE_1MHZ:           TIM17 TI1 is connected to HSE_1MHZ
+  *            @arg LL_TIM_TIM17_TI1_RMP_MCO1:               TIM17 TI1 is connected to MCO1
+  *            @arg LL_TIM_TIM17_TI1_RMP_COMP1:              TIM17 TI1 is connected to COMP1 output   (*)
+  *            @arg LL_TIM_TIM17_TI1_RMP_COMP2:              TIM17 TI1 is connected to COMP2 output   (*)
   *
   *         (*)  Value not defined in all devices. \n
   *         (**) Timer instance not available on all devices. \n
@@ -4960,6 +5220,42 @@ __STATIC_INLINE void LL_TIM_ConfigIDX(TIM_TypeDef *TIMx, uint32_t Configuration)
 __STATIC_INLINE void LL_TIM_SetRemap(TIM_TypeDef *TIMx, uint32_t Remap)
 {
   MODIFY_REG(TIMx->TISEL, (TIM_TISEL_TI1SEL | TIM_TISEL_TI2SEL | TIM_TISEL_TI3SEL | TIM_TISEL_TI4SEL), Remap);
+}
+
+/**
+  * @brief  Enable request for HSE 1MHz clock used for TISEL remap.
+  * @note Only TIM17 support HSE 1MHz remap
+  * @rmtoll OR1         RTCPREEN           LL_TIM_EnableRTCPRE
+  * @param  TIMx Timer instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_TIM_EnableRTCPRE(TIM_TypeDef *TIMx)
+{
+  SET_BIT(TIMx->OR1, TIM_OR1_RTCPREEN);
+}
+
+/**
+  * @brief  Disable request for HSE 1MHz clock used for TISEL remap.
+  * @note Only TIM17 support HSE 1MHz remap
+  * @rmtoll OR1         RTCPREEN           LL_TIM_DisableRTCPRE
+  * @param  TIMx Timer instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_TIM_DisableRTCPRE(TIM_TypeDef *TIMx)
+{
+  CLEAR_BIT(TIMx->OR1, TIM_OR1_RTCPREEN);
+}
+
+/**
+  * @brief  Indicate whether request for HSE 1MHz clock is enabled.
+  * @note Only TIM17 support HSE 1MHz remap
+  * @rmtoll OR1         RTCPREEN           LL_TIM_IsEnabledRTCPRE
+  * @param  TIMx Timer instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledRTCPRE(const TIM_TypeDef *TIMx)
+{
+  return ((READ_BIT(TIMx->OR1, TIM_OR1_RTCPREEN) == (TIM_OR1_RTCPREEN)) ? 1UL : 0UL);
 }
 
 /**
@@ -4974,15 +5270,21 @@ __STATIC_INLINE void LL_TIM_SetRemap(TIM_TypeDef *TIMx, uint32_t Remap)
   * @note The OCxREF signal of a given channel can be cleared when a high level is applied on the OCREF_CLR_INPUT
   * @note This function can only be used in Output compare and PWM modes.
   * @rmtoll SMCR          OCCS                LL_TIM_SetOCRefClearInputSource
+  * @rmtoll AF2           OCRSEL              LL_TIM_SetOCRefClearInputSource
   * @param  TIMx Timer instance
   * @param  OCRefClearInputSource This parameter can be one of the following values:
-  *         @arg @ref LL_TIM_OCREF_CLR_INT_OCREF_CLR
   *         @arg @ref LL_TIM_OCREF_CLR_INT_ETR
+  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP1 (*)
+  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP2 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetOCRefClearInputSource(TIM_TypeDef *TIMx, uint32_t OCRefClearInputSource)
 {
-  MODIFY_REG(TIMx->SMCR, TIM_SMCR_OCCS, OCRefClearInputSource);
+  MODIFY_REG(TIMx->SMCR, TIM_SMCR_OCCS,
+             ((OCRefClearInputSource & OCREF_CLEAR_SELECT_MSK) >> OCREF_CLEAR_SELECT_POS) << TIM_SMCR_OCCS_Pos);
+  MODIFY_REG(TIMx->AF2, TIM1_AF2_OCRSEL, OCRefClearInputSource);
 }
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_ucpd.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_ucpd.c
@@ -112,7 +112,7 @@ ErrorStatus LL_UCPD_DeInit(UCPD_TypeDef *UCPDx)
   *         the configuration information for the UCPD peripheral.
   * @retval An ErrorStatus enumeration value. (Return always SUCCESS)
   */
-ErrorStatus LL_UCPD_Init(UCPD_TypeDef *UCPDx, LL_UCPD_InitTypeDef *UCPD_InitStruct)
+ErrorStatus LL_UCPD_Init(UCPD_TypeDef *UCPDx, const LL_UCPD_InitTypeDef *UCPD_InitStruct)
 {
   /* Check the ucpd Instance UCPDx*/
   assert_param(IS_UCPD_ALL_INSTANCE(UCPDx));

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_ucpd.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_ucpd.h
@@ -869,7 +869,7 @@ __STATIC_INLINE void LL_UCPD_EnableIT_RxOvr(UCPD_TypeDef *UCPDx)
 }
 
 /**
-  * @brief  Enable Rx hard resrt interrupt
+  * @brief  Enable Rx hard reset interrupt
   * @rmtoll IMR          RXHRSTDETIE         LL_UCPD_EnableIT_RxHRST
   * @param  UCPDx UCPD Instance
   * @retval None
@@ -1034,7 +1034,7 @@ __STATIC_INLINE void LL_UCPD_DisableIT_RxOvr(UCPD_TypeDef *UCPDx)
 }
 
 /**
-  * @brief  Disable Rx hard resrt interrupt
+  * @brief  Disable Rx hard reset interrupt
   * @rmtoll IMR          RXHRSTDETIE         LL_UCPD_DisableIT_RxHRST
   * @param  UCPDx UCPD Instance
   * @retval None
@@ -1199,7 +1199,7 @@ __STATIC_INLINE uint32_t LL_UCPD_IsEnableIT_RxOvr(UCPD_TypeDef const *const UCPD
 }
 
 /**
-  * @brief  Check if Rx hard resrt interrupt enabled
+  * @brief  Check if Rx hard reset interrupt enabled
   * @rmtoll IMR          RXHRSTDETIE         LL_UCPD_IsEnableIT_RxHRST
   * @param  UCPDx UCPD Instance
   * @retval State of bit (1 or 0).
@@ -1372,7 +1372,7 @@ __STATIC_INLINE void LL_UCPD_ClearFlag_RxOvr(UCPD_TypeDef *UCPDx)
 }
 
 /**
-  * @brief  Clear Rx hard resrt interrupt
+  * @brief  Clear Rx hard reset interrupt
   * @rmtoll ICR          RXHRSTDETIE         LL_UCPD_ClearFlag_RxHRST
   * @param  UCPDx UCPD Instance
   * @retval None
@@ -1523,7 +1523,7 @@ __STATIC_INLINE uint32_t LL_UCPD_IsActiveFlag_RxOvr(UCPD_TypeDef const *const UC
 }
 
 /**
-  * @brief  Check if Rx hard resrt interrupt
+  * @brief  Check if Rx hard reset interrupt
   * @rmtoll SR          RXHRSTDET         LL_UCPD_IsActiveFlag_RxHRST
   * @param  UCPDx UCPD Instance
   * @retval None
@@ -1855,7 +1855,7 @@ __STATIC_INLINE void LL_UCPD_SetRxOrdExt2(UCPD_TypeDef *UCPDx, uint32_t SOPExt)
   */
 
 ErrorStatus LL_UCPD_DeInit(UCPD_TypeDef *UCPDx);
-ErrorStatus LL_UCPD_Init(UCPD_TypeDef *UCPDx, LL_UCPD_InitTypeDef *UCPD_InitStruct);
+ErrorStatus LL_UCPD_Init(UCPD_TypeDef *UCPDx, const LL_UCPD_InitTypeDef *UCPD_InitStruct);
 void        LL_UCPD_StructInit(LL_UCPD_InitTypeDef *UCPD_InitStruct);
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usart.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usart.c
@@ -375,7 +375,7 @@ ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, const LL_USART_InitTypeDef *USA
 #if defined(UART9)
     else if (USARTx == UART9)
     {
-      periphclk = LL_RCC_GetUSARTClockFreq(LL_RCC_UART9_CLKSOURCE);
+      periphclk = LL_RCC_GetUARTClockFreq(LL_RCC_UART9_CLKSOURCE);
     }
 #endif /* UART9 */
 #if defined(USART10)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usb.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usb.c
@@ -211,6 +211,47 @@ HAL_StatusTypeDef USB_DevInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg)
   return ret;
 }
 
+/**
+  * @brief  USB_FlushTxFifo : Flush a Tx FIFO
+  * @param  USBx : Selected device
+  * @param  num : FIFO number
+  *         This parameter can be a value from 1 to 15
+            15 means Flush all Tx FIFOs
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushTxFifo(USB_DRD_TypeDef const *USBx, uint32_t num)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(USBx);
+  UNUSED(num);
+
+  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
+              only by USB OTG FS peripheral.
+            - This function is added to ensure compatibility across platforms.
+   */
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_FlushRxFifo : Flush Rx FIFO
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushRxFifo(USB_DRD_TypeDef const *USBx)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(USBx);
+
+  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
+              only by USB OTG FS peripheral.
+            - This function is added to ensure compatibility across platforms.
+   */
+
+  return HAL_OK;
+}
+
+
 #if defined (HAL_PCD_MODULE_ENABLED)
 /**
   * @brief  Activate and configure an endpoint
@@ -962,13 +1003,13 @@ HAL_StatusTypeDef USB_HostInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg)
   /* Clear All Pending Interrupt */
   USBx->ISTR = 0U;
 
+  /* Set the PullDown on the PHY */
+  USBx->BCDR |= USB_BCDR_DPPD;
+
   /* Enable Global interrupt */
   USBx->CNTR |= (USB_CNTR_CTRM | USB_CNTR_PMAOVRM | USB_CNTR_ERRM |
                  USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_DCON |
                  USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_L1REQM);
-
-  /* Remove Reset */
-  USBx->CNTR &= ~USB_CNTR_USBRST;
 
   return HAL_OK;
 }
@@ -1085,7 +1126,7 @@ HAL_StatusTypeDef USB_HC_Init(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num,
 
   wChRegVal = USB_DRD_GET_CHEP(USBx, phy_ch_num) & USB_CH_T_MASK;
 
-  /* initialize host Channel */
+  /* Initialize host Channel */
   switch (ep_type)
   {
     case EP_TYPE_CTRL:
@@ -1109,7 +1150,17 @@ HAL_StatusTypeDef USB_HC_Init(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num,
       break;
   }
 
-  wChRegVal &= ~USB_CHEP_DEVADDR;
+  /* Clear device address, Endpoint number and Low Speed Endpoint fields */
+  wChRegVal &= ~(USB_CHEP_DEVADDR |
+                 USB_CHEP_ADDR |
+                 USB_CHEP_LSEP |
+                 USB_CHEP_NAK |
+                 USB_CHEP_KIND |
+                 USB_CHEP_ERRTX |
+                 USB_CHEP_ERRRX |
+                 (0xFU << 27));
+
+  /* Set device address and Endpoint number associated to the channel */
   wChRegVal |= (((uint32_t)dev_address << USB_CHEP_DEVADDR_Pos) |
                 ((uint32_t)epnum & 0x0FU));
 
@@ -1122,7 +1173,7 @@ HAL_StatusTypeDef USB_HC_Init(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num,
     wChRegVal |= USB_CHEP_LSEP;
   }
 
-  /* Set the dev_address & ep type */
+  /* Update the channel register value */
   USB_DRD_SET_CHEP(USBx, phy_ch_num, (wChRegVal | USB_CH_VTRX | USB_CH_VTTX));
 
   return ret;
@@ -1156,6 +1207,18 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc)
 
     if (hc->doublebuffer == 0U)
     {
+      if ((hc->ep_type == EP_TYPE_BULK) ||
+          (hc->ep_type == EP_TYPE_INTR))
+      {
+        USB_DRD_CLEAR_RX_DTOG(USBx, phy_ch_num);
+
+        /* Set Data PID */
+        if (hc->data_pid == HC_PID_DATA1)
+        {
+          USB_DRD_RX_DTOG(USBx, phy_ch_num);
+        }
+      }
+
       /* Set RX buffer count */
       USB_DRD_SET_CHEP_RX_CNT(USBx, phy_ch_num, len);
     }
@@ -1167,11 +1230,11 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc)
       {
         (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_BULK_DBUFF_ENBALE);
 
-        /*Set the Double buffer counter*/
+        /* Set the Double buffer counter */
         USB_DRD_SET_CHEP_DBUF0_CNT(USBx, phy_ch_num, 0U, len);
         USB_DRD_SET_CHEP_DBUF1_CNT(USBx, phy_ch_num, 0U, len);
       }
-      else  /* switch to single buffer mode */
+      else  /* Switch to single buffer mode */
       {
         (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_BULK_DBUFF_DISABLE);
 
@@ -1179,7 +1242,7 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc)
         USB_DRD_SET_CHEP_RX_CNT(USBx, phy_ch_num, len);
       }
     }
-    else  /* isochronous */
+    else  /* Isochronous */
     {
       /* Set the Double buffer counter */
       USB_DRD_SET_CHEP_DBUF0_CNT(USBx, phy_ch_num, 0U, len);
@@ -1187,12 +1250,12 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc)
     }
 #endif /* USE_USB_DOUBLE_BUFFER */
 
-    /*Enable host channel */
-    USB_DRD_SET_CHEP_RX_STATUS(USBx, phy_ch_num, USB_CHEP_RX_STRX);
+    /* Enable host channel */
+    USB_DRD_SET_CHEP_RX_STATUS(USBx, phy_ch_num, USB_CH_RX_VALID);
   }
   else   /* Out Channel */
   {
-    /* Multi packet transfer*/
+    /* Multi packet transfer */
     if (hc->xfer_len > hc->max_packet)
     {
       len = hc->max_packet;
@@ -1202,16 +1265,28 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc)
       len = hc->xfer_len;
     }
 
-    /* configure and validate Tx endpoint */
+    /* Configure and validate Tx endpoint */
     if (hc->doublebuffer == 0U)
     {
       USB_WritePMA(USBx, hc->xfer_buff, hc->pmaadress, (uint16_t)len);
       USB_DRD_SET_CHEP_TX_CNT(USBx, phy_ch_num, (uint16_t)len);
 
-      /*SET PID SETUP  */
+      /* SET PID SETUP  */
       if ((hc->data_pid) == HC_PID_SETUP)
       {
         USB_DRD_CHEP_TX_SETUP(USBx,  phy_ch_num);
+      }
+
+      if ((hc->ep_type == EP_TYPE_BULK) ||
+          (hc->ep_type == EP_TYPE_INTR))
+      {
+        USB_DRD_CLEAR_TX_DTOG(USBx, phy_ch_num);
+
+        /* Set Data PID */
+        if (hc->data_pid == HC_PID_DATA1)
+        {
+          USB_DRD_TX_DTOG(USBx, phy_ch_num);
+        }
       }
     }
 #if (USE_USB_DOUBLE_BUFFER == 1U)

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usb.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_usb.h
@@ -37,6 +37,9 @@ extern "C" {
   */
 
 /* Exported types ------------------------------------------------------------*/
+#ifndef HAL_USB_TIMEOUT
+#define HAL_USB_TIMEOUT                                       0xF000000U
+#endif /* define HAL_USB_TIMEOUT */
 
 /**
   * @brief  USB Mode definition
@@ -84,39 +87,39 @@ typedef enum
   */
 typedef struct
 {
-  uint32_t dev_endpoints;           /*!< Device Endpoints number.
+  uint8_t dev_endpoints;            /*!< Device Endpoints number.
                                          This parameter depends on the used USB core.
                                          This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
 
-  uint32_t Host_channels;           /*!< Host Channels number.
+  uint8_t Host_channels;            /*!< Host Channels number.
                                          This parameter Depends on the used USB core.
                                          This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
 
-  uint32_t dma_enable;              /*!< USB DMA state.
+  uint8_t dma_enable;              /*!< USB DMA state.
                                          If DMA is not supported this parameter shall be set by default to zero */
 
-  uint32_t speed;                   /*!< USB Core speed.
-                                         This parameter can be any value of @ref PCD_Speed/HCD_Speed
-                                                                                 (HCD_SPEED_xxx, HCD_SPEED_xxx) */
+  uint8_t speed;                   /*!< USB Core speed.
+                                        This parameter can be any value of @ref PCD_Speed/HCD_Speed
+                                                                                (HCD_SPEED_xxx, HCD_SPEED_xxx) */
 
-  uint32_t ep0_mps;                 /*!< Set the Endpoint 0 Max Packet size.                                    */
+  uint8_t ep0_mps;                 /*!< Set the Endpoint 0 Max Packet size.                                    */
 
-  uint32_t phy_itface;              /*!< Select the used PHY interface.
-                                         This parameter can be any value of @ref PCD_PHY_Module/HCD_PHY_Module  */
+  uint8_t phy_itface;              /*!< Select the used PHY interface.
+                                        This parameter can be any value of @ref PCD_PHY_Module/HCD_PHY_Module  */
 
-  uint32_t Sof_enable;              /*!< Enable or disable the output of the SOF signal.                        */
+  uint8_t Sof_enable;              /*!< Enable or disable the output of the SOF signal.                        */
 
-  uint32_t low_power_enable;        /*!< Enable or disable the low Power Mode.                                  */
+  uint8_t low_power_enable;        /*!< Enable or disable the low Power Mode.                                  */
 
-  uint32_t lpm_enable;              /*!< Enable or disable Link Power Management.                               */
+  uint8_t lpm_enable;              /*!< Enable or disable Link Power Management.                               */
 
-  uint32_t battery_charging_enable; /*!< Enable or disable Battery charging.                                    */
+  uint8_t battery_charging_enable; /*!< Enable or disable Battery charging.                                    */
 
-  uint32_t vbus_sensing_enable;     /*!< Enable or disable the VBUS Sensing feature.                            */
+  uint8_t vbus_sensing_enable;     /*!< Enable or disable the VBUS Sensing feature.                            */
 
-  uint32_t bulk_doublebuffer_enable;  /*!< Enable or disable the double buffer mode on bulk EP                  */
+  uint8_t bulk_doublebuffer_enable;  /*!< Enable or disable the double buffer mode on bulk EP                  */
 
-  uint32_t iso_singlebuffer_enable;   /*!< Enable or disable the Single buffer mode on Isochronous  EP          */
+  uint8_t iso_singlebuffer_enable;   /*!< Enable or disable the Single buffer mode on Isochronous  EP          */
 } USB_CfgTypeDef;
 
 typedef struct
@@ -683,20 +686,17 @@ typedef USB_HCTypeDef       USB_DRD_HCTypeDef;
     \
     (pdwReg) &= ~(USB_CNTRX_BLSIZE | USB_CNTRX_NBLK_MSK); \
     \
-    if ((wCount) > 62U) \
+    if ((wCount) == 0U) \
     { \
-      USB_DRD_CALC_BLK32((pdwReg), (wCount), wNBlocks); \
+      (pdwReg) |= USB_CNTRX_BLSIZE; \
+    } \
+    else if ((wCount) <= 62U) \
+    { \
+       USB_DRD_CALC_BLK2((pdwReg), (wCount), wNBlocks); \
     } \
     else \
     { \
-      if ((wCount) == 0U) \
-      { \
-        (pdwReg) |= USB_CNTRX_BLSIZE; \
-      } \
-      else \
-      { \
-        USB_DRD_CALC_BLK2((pdwReg), (wCount), wNBlocks); \
-      } \
+      USB_DRD_CALC_BLK32((pdwReg), (wCount), wNBlocks); \
     } \
   } while(0) /* USB_DRD_SET_CHEP_CNT_RX_REG */
 
@@ -845,6 +845,9 @@ HAL_StatusTypeDef USB_DevInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_DRD_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_DRD_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_DRD_TypeDef *USBx, USB_DRD_ModeTypeDef mode);
+
+HAL_StatusTypeDef USB_FlushRxFifo(USB_DRD_TypeDef const *USBx);
+HAL_StatusTypeDef USB_FlushTxFifo(USB_DRD_TypeDef const *USBx, uint32_t num);
 
 #if defined (HAL_PCD_MODULE_ENABLED)
 HAL_StatusTypeDef USB_ActivateEndpoint(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_utils.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_utils.c
@@ -41,9 +41,9 @@
   * @{
   */
 #define UTILS_MAX_FREQUENCY_SCALE0  250000000U         /*!< Maximum frequency for system clock at power scale0, in Hz */
-#define UTILS_MAX_FREQUENCY_SCALE1  180000000U         /*!< Maximum frequency for system clock at power scale1, in Hz */
-#define UTILS_MAX_FREQUENCY_SCALE2  130000000U         /*!< Maximum frequency for system clock at power scale2, in Hz */
-#define UTILS_MAX_FREQUENCY_SCALE3   80000000U         /*!< Maximum frequency for system clock at power scale3, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE1  200000000U         /*!< Maximum frequency for system clock at power scale1, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE2  150000000U         /*!< Maximum frequency for system clock at power scale2, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE3  100000000U         /*!< Maximum frequency for system clock at power scale3, in Hz */
 
 /* Defines used for PLL range */
 #define UTILS_PLLVCO_INPUT_MIN1       1000000U      /*!< Frequency min for the low range PLLVCO input, in Hz    */
@@ -64,31 +64,31 @@
 #define UTILS_HSE_FREQUENCY_MAX            50000000U      /*!< Frequency max for HSE frequency, in Hz   */
 
 /* Defines used for FLASH latency according to HCLK Frequency */
-#define UTILS_SCALE0_LATENCY0_FREQ     38000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 0 */
-#define UTILS_SCALE0_LATENCY1_FREQ     76000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 0 */
-#define UTILS_SCALE0_LATENCY2_FREQ    114000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 0 */
-#define UTILS_SCALE0_LATENCY3_FREQ    152000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 0 */
-#define UTILS_SCALE0_LATENCY4_FREQ    190000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 0 */
+#define UTILS_SCALE0_LATENCY0_FREQ     42000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 0 */
+#define UTILS_SCALE0_LATENCY1_FREQ     84000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 0 */
+#define UTILS_SCALE0_LATENCY2_FREQ    126000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 0 */
+#define UTILS_SCALE0_LATENCY3_FREQ    168000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 0 */
+#define UTILS_SCALE0_LATENCY4_FREQ    210000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 0 */
 #define UTILS_SCALE0_LATENCY5_FREQ    250000000U       /*!< HCLK frequency to set FLASH latency 5 in power scale 0 */
 
-#define UTILS_SCALE1_LATENCY0_FREQ     32000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 1 */
-#define UTILS_SCALE1_LATENCY1_FREQ     64000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 1 */
-#define UTILS_SCALE1_LATENCY2_FREQ     96000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 1 */
-#define UTILS_SCALE1_LATENCY3_FREQ    128000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 1 */
-#define UTILS_SCALE1_LATENCY4_FREQ    160000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 1 */
-#define UTILS_SCALE1_LATENCY5_FREQ    180000000U       /*!< HCLK frequency to set FLASH latency 5 in power scale 1 */
+#define UTILS_SCALE1_LATENCY0_FREQ     34000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 1 */
+#define UTILS_SCALE1_LATENCY1_FREQ     68000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 1 */
+#define UTILS_SCALE1_LATENCY2_FREQ    102000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 1 */
+#define UTILS_SCALE1_LATENCY3_FREQ    136000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 1 */
+#define UTILS_SCALE1_LATENCY4_FREQ    170000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 1 */
+#define UTILS_SCALE1_LATENCY5_FREQ    200000000U       /*!< HCLK frequency to set FLASH latency 5 in power scale 1 */
 
-#define UTILS_SCALE2_LATENCY0_FREQ     26000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 2 */
-#define UTILS_SCALE2_LATENCY1_FREQ     50000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
-#define UTILS_SCALE2_LATENCY2_FREQ     80000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 2 */
-#define UTILS_SCALE2_LATENCY3_FREQ    106000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 2 */
-#define UTILS_SCALE2_LATENCY4_FREQ    130000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 2 */
+#define UTILS_SCALE2_LATENCY0_FREQ     30000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 2 */
+#define UTILS_SCALE2_LATENCY1_FREQ     60000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
+#define UTILS_SCALE2_LATENCY2_FREQ     90000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 2 */
+#define UTILS_SCALE2_LATENCY3_FREQ    120000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 2 */
+#define UTILS_SCALE2_LATENCY4_FREQ    150000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 2 */
 
-#define UTILS_SCALE3_LATENCY0_FREQ     16000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
-#define UTILS_SCALE3_LATENCY1_FREQ     32000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
-#define UTILS_SCALE3_LATENCY2_FREQ     50000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
-#define UTILS_SCALE3_LATENCY3_FREQ     65000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 3 */
-#define UTILS_SCALE3_LATENCY4_FREQ     80000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 3 */
+#define UTILS_SCALE3_LATENCY0_FREQ     20000000U       /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
+#define UTILS_SCALE3_LATENCY1_FREQ     40000000U       /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
+#define UTILS_SCALE3_LATENCY2_FREQ     60000000U       /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
+#define UTILS_SCALE3_LATENCY3_FREQ     80000000U       /*!< HCLK frequency to set FLASH latency 3 in power scale 3 */
+#define UTILS_SCALE3_LATENCY4_FREQ    100000000U       /*!< HCLK frequency to set FLASH latency 4 in power scale 3 */
 /**
   * @}
   */
@@ -201,7 +201,8 @@ static ErrorStatus UTILS_PLL_IsBusy(void);
   */
 
 /**
-  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base.
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base with HCLK
+  *         as SysTick clock source.
   * @note   When a RTOS is used, it is recommended to avoid changing the Systick
   *         configuration by calling this function, for a delay use rather osDelay RTOS service.
   * @param  HCLKFrequency HCLK frequency in Hz
@@ -215,16 +216,59 @@ void LL_Init1msTick(uint32_t HCLKFrequency)
 }
 
 /**
-  * @brief  This function provides accurate delay (in milliseconds) based
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base with HCLK/8
+  *         as SysTick clock source.
+  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
+  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
+  * @param  HCLKFrequency HCLK frequency in Hz
+  * @retval None
+  */
+void LL_Init1msTick_HCLK_Div8(uint32_t HCLKFrequency)
+{
+  /* Configure the SysTick to have 1ms time base with HCLK/8 as SysTick clock source */
+  SysTick->LOAD = (uint32_t)((HCLKFrequency / 8000U) - 1UL);
+  SysTick->VAL = 0UL;
+  SysTick->CTRL = SysTick_CTRL_ENABLE_Msk;
+}
+
+/**
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base with LSE as SysTick clock source.
+  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
+  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
+  * @retval None
+  */
+void LL_Init1msTick_LSE(void)
+{
+  /* Configure the SysTick to have 1ms time base with LSE as SysTick clock source */
+  SysTick->LOAD = (uint32_t)((LSE_VALUE / 1000U) - 1UL);
+  SysTick->VAL = 0UL;
+  SysTick->CTRL = SysTick_CTRL_ENABLE_Msk;
+}
+
+/**
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base with LSI as SysTick clock source.
+  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
+  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
+  * @retval None
+  */
+void LL_Init1msTick_LSI(void)
+{
+  /* Configure the SysTick to have 1ms time base with LSI as SysTick clock source */
+  SysTick->LOAD = (uint32_t)((LSI_VALUE / 1000U) - 1UL);
+  SysTick->VAL = 0UL;
+  SysTick->CTRL = SysTick_CTRL_ENABLE_Msk;
+}
+
+/**
+  * @brief  This function provides minimum delay (in milliseconds) based
   *         on SysTick counter flag
   * @note   When a RTOS is used, it is recommended to avoid using blocking delay
   *         and use rather osDelay service.
   * @note   To respect 1ms timebase, user should call @ref LL_Init1msTick function which
   *         will configure Systick to 1ms
-  * @param  Delay specifies the delay time length, in milliseconds.
+  * @param  Delay specifies the minimum delay time length, in milliseconds.
   * @retval None
   */
-
 void LL_mDelay(uint32_t Delay)
 {
   __IO uint32_t  tmp = SysTick->CTRL;  /* Clear the COUNTFLAG first */
@@ -274,19 +318,19 @@ void LL_mDelay(uint32_t Delay)
              (++) | Latency         |                          HCLK clock frequency (MHz)                         |
              (++) |                 |-----------------------------------------------------------------------------|
              (++) |                 |  voltage range 0  |  voltage range 1 | voltage range 2  | voltage range 3   |
-             (++) |                 |    1.26 - 1.35V   |   1.15 - 1.26V   |   1.05 - 1.15V   |   0,95 - 1,05V    |
+             (++) |                 |    1.30 - 1.40V   |   1.15 - 1.26V   |   1.05 - 1.15V   |   0,95 - 1,05V    |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |0WS(1 CPU cycles)|   0 < HCLK <= 38  |  0 < HCLK <= 32  |  0 < HCLK <= 26  | 0 < HCLK <= 16    |
+             (++) |0WS(1 CPU cycles)|   0 < HCLK <= 42  |  0 < HCLK <= 34  |  0 < HCLK <= 30  | 0 < HCLK <= 20    |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |1WS(2 CPU cycles)|  38 < HCLK <= 76  | 32 < HCLK <= 64  | 26 < HCLK <= 50  | 16 < HCLK <= 32   |
+             (++) |1WS(2 CPU cycles)|  42 < HCLK <= 84  | 34 < HCLK <= 68  | 30 < HCLK <= 60  | 20 < HCLK <= 40   |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |2WS(3 CPU cycles)|  76 < HCLK <= 114 | 64 < HCLK <= 96  | 50 < HCLK <= 80  | 32 < HCLK <= 50   |
+             (++) |2WS(3 CPU cycles)|  84 < HCLK <= 126 | 68 < HCLK <= 102 | 60 < HCLK <= 90  | 40 < HCLK <= 60   |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |3WS(4 CPU cycles)| 114 < HCLK <= 152 | 96 < HCLK <= 128 | 80 < HCLK <= 106 | 50 < HCLK <= 65   |
+             (++) |3WS(4 CPU cycles)| 126 < HCLK <= 168 | 102 < HCLK <= 136| 90 < HCLK <= 120 | 60 < HCLK <= 80   |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |4WS(5 CPU cycles)|  152 < HCLK <= 190| 128 < HCLK <= 160| 106 < HCLK <= 130| 65 < HCLK <= 80   |
+             (++) |4WS(5 CPU cycles)|  168 < HCLK <= 210| 136 < HCLK <= 170| 120 < HCLK <= 150| 80 < HCLK <= 100  |
              (++) |-----------------|-------------------|------------------|------------------|-------------------|
-             (++) |5WS(6 CPU cycles)|  190 < HCLK <= 250| 160 < HCLK <= 180|        NA        |         NA        |
+             (++) |5WS(6 CPU cycles)|  210 < HCLK <= 250| 170 < HCLK <= 200|        NA        |         NA        |
              (++) +-----------------+-------------------+------------------+------------------+-------------------+
 
   @endinternal
@@ -630,31 +674,31 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
     {
       if (HCLK_Frequency <= UTILS_SCALE0_LATENCY0_FREQ)
       {
-        /* 0 < HCLK <= 38 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
+        /* 0 < HCLK <= 42 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
       }
       else if ((HCLK_Frequency <= UTILS_SCALE0_LATENCY1_FREQ))
       {
-        /* 38 < HCLK <=76  => 1WS (2 CPU cycles) */
+        /* 42 < HCLK <=84  => 1WS (2 CPU cycles) */
         latency = LL_FLASH_LATENCY_1;
       }
       else if (HCLK_Frequency <= UTILS_SCALE0_LATENCY2_FREQ)
       {
-        /* 76 < HCLK <= 114 => 2WS (3 CPU cycles) */
+        /* 84 < HCLK <= 126 => 2WS (3 CPU cycles) */
         latency = LL_FLASH_LATENCY_2;
       }
       else if (HCLK_Frequency <= UTILS_SCALE0_LATENCY3_FREQ)
       {
-        /* 114 < HCLK <= 152 => 3WS (4 CPU cycles) */
+        /* 126 < HCLK <= 168 => 3WS (4 CPU cycles) */
         latency = LL_FLASH_LATENCY_3;
       }
       else if (HCLK_Frequency <= UTILS_SCALE0_LATENCY4_FREQ)
       {
-        /* 152 < HCLK <= 190 => 4WS (5 CPU cycles) */
+        /* 168 < HCLK <= 210 => 4WS (5 CPU cycles) */
         latency = LL_FLASH_LATENCY_4;
       }
       else if (HCLK_Frequency <= UTILS_SCALE0_LATENCY5_FREQ)
       {
-        /* 190 < HCLK <= 250 => 5WS (6 CPU cycles) */
+        /* 210 < HCLK <= 250 => 5WS (6 CPU cycles) */
         latency = LL_FLASH_LATENCY_5;
       }
       else
@@ -666,31 +710,31 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
     {
       if (HCLK_Frequency <= UTILS_SCALE1_LATENCY0_FREQ)
       {
-        /* 0 < HCLK <= 32 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
+        /* 0 < HCLK <= 34 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
       }
       else if (HCLK_Frequency <= UTILS_SCALE1_LATENCY1_FREQ)
       {
-        /* 32 < HCLK <=64  => 1WS (2 CPU cycles) */
+        /* 34 < HCLK <=68  => 1WS (2 CPU cycles) */
         latency = LL_FLASH_LATENCY_1;
       }
       else if (HCLK_Frequency <= UTILS_SCALE1_LATENCY2_FREQ)
       {
-        /* 64 < HCLK <= 96 => 2WS (3 CPU cycles) */
+        /* 68 < HCLK <= 102 => 2WS (3 CPU cycles) */
         latency = LL_FLASH_LATENCY_2;
       }
       else if (HCLK_Frequency <= UTILS_SCALE1_LATENCY3_FREQ)
       {
-        /* 96 < HCLK <= 128 => 3WS (4 CPU cycles) */
+        /* 102 < HCLK <= 136 => 3WS (4 CPU cycles) */
         latency = LL_FLASH_LATENCY_3;
       }
       else if (HCLK_Frequency <= UTILS_SCALE1_LATENCY4_FREQ)
       {
-        /* 128 < HCLK <= 160 => 4WS (5 CPU cycles) */
+        /* 136 < HCLK <= 170 => 4WS (5 CPU cycles) */
         latency = LL_FLASH_LATENCY_4;
       }
       else if (HCLK_Frequency <= UTILS_SCALE1_LATENCY5_FREQ)
       {
-        /* 160 < HCLK <= 150 => 5WS (6 CPU cycles) */
+        /* 170 < HCLK <= 200 => 5WS (6 CPU cycles) */
         latency = LL_FLASH_LATENCY_5;
       }
       else
@@ -702,26 +746,26 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
     {
       if (HCLK_Frequency <= UTILS_SCALE2_LATENCY0_FREQ)
       {
-        /* 0 < HCLK <= 26 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
+        /* 0 < HCLK <= 30 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
       }
       else if (HCLK_Frequency <= UTILS_SCALE2_LATENCY1_FREQ)
       {
-        /* 26 < HCLK <= 50 => 1WS (2 CPU cycles) */
+        /* 30 < HCLK <= 60 => 1WS (2 CPU cycles) */
         latency = LL_FLASH_LATENCY_1;
       }
       else if (HCLK_Frequency <= UTILS_SCALE2_LATENCY2_FREQ)
       {
-        /* 50 < HCLK <= 80 => 2WS (3 CPU cycles) */
+        /* 60 < HCLK <= 90 => 2WS (3 CPU cycles) */
         latency = LL_FLASH_LATENCY_2;
       }
       else if (HCLK_Frequency <= UTILS_SCALE2_LATENCY3_FREQ)
       {
-        /* 80 < HCLK <= 106 => 3WS (4 CPU cycles) */
+        /* 90 < HCLK <= 120 => 3WS (4 CPU cycles) */
         latency = LL_FLASH_LATENCY_3;
       }
       else if (HCLK_Frequency <= UTILS_SCALE2_LATENCY4_FREQ)
       {
-        /* 106 < HCLK <= 130 => 4WS (5 CPU cycles) */
+        /* 120 < HCLK <= 150 => 4WS (5 CPU cycles) */
         latency = LL_FLASH_LATENCY_4;
       }
       else
@@ -733,26 +777,26 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
     {
       if (HCLK_Frequency  <= UTILS_SCALE3_LATENCY0_FREQ)
       {
-        /* 0 < HCLK <= 16 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
+        /* 0 < HCLK <= 20 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
       }
       else if (HCLK_Frequency <= UTILS_SCALE3_LATENCY1_FREQ)
       {
-        /* 16 < HCLK <= 32 => 1WS (2 CPU cycles) */
+        /* 20 < HCLK <= 40 => 1WS (2 CPU cycles) */
         latency = LL_FLASH_LATENCY_1;
       }
       else if (HCLK_Frequency <= UTILS_SCALE3_LATENCY2_FREQ)
       {
-        /* 32 < HCLK <= 50 => 2WS (3 CPU cycles) */
+        /* 40 < HCLK <= 60 => 2WS (3 CPU cycles) */
         latency = LL_FLASH_LATENCY_2;
       }
       else if (HCLK_Frequency <= UTILS_SCALE3_LATENCY3_FREQ)
       {
-        /* 50 < HCLK <= 65 => 3WS (4 CPU cycles) */
+        /* 60 < HCLK <= 80 => 3WS (4 CPU cycles) */
         latency = LL_FLASH_LATENCY_3;
       }
       else if (HCLK_Frequency <= UTILS_SCALE3_LATENCY4_FREQ)
       {
-        /* 65 < HCLK <= 80 => 4WS (5 CPU cycles) */
+        /* 80 < HCLK <= 100 => 4WS (5 CPU cycles) */
         latency = LL_FLASH_LATENCY_4;
       }
       else

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_utils.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_ll_utils.h
@@ -202,6 +202,9 @@ typedef struct
 #define LL_UTILS_PACKAGETYPE_UFBGA169_SMPS    0x0000000EU /*!< UFBGA169 with internal SMPS package type            */
 #define LL_UTILS_PACKAGETYPE_WLCSP25          0x0000000FU /*!< WLCSP25 package type                                */
 #define LL_UTILS_PACKAGETYPE_UFQFPN48         0x00000010U /*!< UFQFPN48 package type                               */
+#define LL_UTILS_PACKAGETYPE_WLCSP39          0x00000011U /*!< WLCSP39 package type                                */
+#define LL_UTILS_PACKAGETYPE_UFBGA100         0x00000014U /*!< UFBGA100 package type                               */
+#define LL_UTILS_PACKAGETYPE_UFBGA144         0x00000015U /*!< UFBGA144 package type                               */
 /**
   * @}
   */
@@ -278,6 +281,10 @@ __STATIC_INLINE uint32_t LL_GetFlashSize(void)
   *         @arg @ref LL_UTILS_PACKAGETYPE_UFBGA169_SMPS
   *         @arg @ref LL_UTILS_PACKAGETYPE_WLCSP25
   *         @arg @ref LL_UTILS_PACKAGETYPE_UFQFPN48
+  *         @arg @ref LL_UTILS_PACKAGETYPE_WLCSP39
+  *         @arg @ref LL_UTILS_PACKAGETYPE_UFBGA100
+  *         @arg @ref LL_UTILS_PACKAGETYPE_UFBGA144
+  * @note   Refer to product datasheet for availability of package on a specific device
   */
 __STATIC_INLINE uint32_t LL_GetPackageType(void)
 {
@@ -310,6 +317,9 @@ __STATIC_INLINE void LL_InitTick(uint32_t HCLKFrequency, uint32_t Ticks)
 }
 
 void        LL_Init1msTick(uint32_t HCLKFrequency);
+void        LL_Init1msTick_HCLK_Div8(uint32_t HCLKFrequency);
+void        LL_Init1msTick_LSE(void);
+void        LL_Init1msTick_LSI(void);
 void        LL_mDelay(uint32_t Delay);
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.c
@@ -19,13 +19,11 @@
 /* Includes ----------------------------------------------------------------------------------------------------------*/
 #include "stm32h5xx_util_i3c.h"
 
-#if defined(DEVICE_I3C)
-
 /** @addtogroup STM32H5xx_UTIL_Driver
   * @{
   */
 
-/** @addtogroup I3C
+/** @addtogroup UTILITY_I3C
   * @{
   */
 
@@ -35,15 +33,16 @@
   * @{
   */
 #define SEC210PSEC              (uint64_t)100000000000 /*!< 10ps, to take two decimal float of ns calculation */
-#define TI3CH_MIN               3200U    /*!< Open drain & push pull SCL high min, 32ns */
-#define TI3CH_OD_MAX            4100U    /*!< Open drain SCL high max, 41 ns */
-#define TI3CL_OD_MIN            20000U   /*!< Open drain SCL low min, 200 ns */
-#define TFMPL_OD_MIN            50000U   /*!< Fast Mode Plus Open drain SCL low min, 500 ns */
-#define TFML_OD_MIN             130000U  /*!< Fast Mode Open drain SCL low min, 1300 ns */
-#define TFM_MIN                 250000U  /*!< Fast Mode, period min for ti3cclk, 2.5us */
-#define TSM_MIN                 1000000U /*!< Standard Mode, period min for ti3cclk, 10us */
-#define TI3C_CAS_MIN            3840U    /*!< Time SCL after START min, 38.4 ns */
-#define TCAPA                   35000U   /*!< Capacitor effect Value measure on Nucleo around 350ns */
+#define TI3CH_MIN               3200U       /*!< Open drain & push pull SCL high min, 32ns */
+#define TI3CH_OD_MAX            4100U       /*!< Open drain SCL high max, 41 ns */
+#define TI3CL_OD_MIN            20000U      /*!< Open drain SCL low min, 200 ns */
+#define TFMPL_OD_MIN            50000U      /*!< Fast Mode Plus Open drain SCL low min, 500 ns */
+#define TFML_OD_MIN             130000U     /*!< Fast Mode Open drain SCL low min, 1300 ns */
+#define TFM_MIN                 250000U     /*!< Fast Mode, period min for ti3cclk, 2.5us */
+#define TSM_MIN                 1000000U    /*!< Standard Mode, period min for ti3cclk, 10us */
+#define TI3C_CAS_MIN            3840U       /*!< Time SCL after START min, 38.4 ns */
+#define TCAPA                   35000U      /*!< Capacitor effect Value measure on Nucleo around 350ns */
+#define I3C_FREQUENCY_MAX       257000000U  /*!< Maximum I3C frequency */
 /**
   * @}
   */
@@ -130,6 +129,17 @@ ErrorStatus I3C_CtrlTimingComputation(const I3C_CtrlTimingTypeDef *pInputTiming,
   uint32_t sdahold;
 
   /* Verify Parameters */
+  if (pInputTiming->clockSrcFreq > I3C_FREQUENCY_MAX)
+  {
+    /* Above this frequency, some timing register parameters are over than field value */
+    status = ERROR;
+  }
+
+  if ((pInputTiming->busType != I3C_PURE_I3C_BUS) && (pInputTiming->busType != I3C_MIXED_BUS))
+  {
+    status = ERROR;
+  }
+
   if (((pInputTiming->clockSrcFreq == 0U) || (pInputTiming->i3cPPFreq == 0U)) &&
       (pInputTiming->busType == I3C_PURE_I3C_BUS))
   {
@@ -409,5 +419,3 @@ ErrorStatus I3C_TgtTimingComputation(const I3C_TgtTimingTypeDef *pInputTiming,
 /**
   * @}
   */
-
- #endif /* DEVICE_I3C */

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/STM32H5xx_HAL_Driver/stm32h5xx_util_i3c.h
@@ -24,24 +24,24 @@
 extern "C" {
 #endif
 
-#if defined(DEVICE_I3C)
-
 /* Includes ----------------------------------------------------------------------------------------------------------*/
 #if defined (USE_HAL_DRIVER)
 #include "stm32h5xx_hal.h"
-#else
-#include "stm32h5xx_ll_i3c.h"
 #endif /* USE_HAL_DRIVER */
+
+#if defined (USE_FULL_LL_DRIVER)
+#include "stm32h5xx_ll_i3c.h"
+#endif /* USE_FULL_LL_DRIVER */
 
 /** @addtogroup STM32H5xx_UTIL_Driver
   * @{
   */
 
-/** @addtogroup I3C
+/** @defgroup UTILITY_I3C I3C Utility
   * @{
   */
 /* Exported types ----------------------------------------------------------------------------------------------------*/
-/** @defgroup I3C_Exported_Types I3C Exported Types
+/** @defgroup I3C_UTIL_Exported_Types I3C Utility Exported Types
   * @{
   */
 
@@ -127,7 +127,6 @@ ErrorStatus I3C_TgtTimingComputation(const I3C_TgtTimingTypeDef *pInputTiming,
 /**
   * @}
   */
-#endif /* #if DEVICE_I3C */
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/stm32h5xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/stm32h5xx_hal_conf.h
@@ -142,7 +142,7 @@ The real value may vary depending on the variations
 in voltage and temperature.*/
 
 #if !defined  (LSI_STARTUP_TIME)
-#define LSI_STARTUP_TIME          130UL      /*!< Time out for LSI start up, in ms */
+#define LSI_STARTUP_TIME          130UL      /*!< Time out for LSI start up, in us */
 #endif /* LSI_STARTUP_TIME */
 
 /**
@@ -422,9 +422,12 @@ in voltage and temperature.*/
 #include "stm32h5xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
-#ifdef HAL_I3C_MODULE_ENABLED
-#include "stm32h5xx_hal_i3c.h"
-#endif /* HAL_I3C_MODULE_ENABLED */
+// Mbed patch to prevent circular include: ll_i3c.h includes this header, but hal_i3c.h needs ll_i3c.h to compile.
+// Boom.
+// So, don't include hal_i3c.h from this header.
+// #ifdef HAL_I3C_MODULE_ENABLED
+// #include "stm32h5xx_hal_i3c.h"
+// #endif /* HAL_I3C_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
 #include "stm32h5xx_hal_iwdg.h"

--- a/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/stm32h5xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32H5/STM32Cube_FW/stm32h5xx_hal_conf.h
@@ -422,12 +422,9 @@ in voltage and temperature.*/
 #include "stm32h5xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
-// Mbed patch to prevent circular include: ll_i3c.h includes this header, but hal_i3c.h needs ll_i3c.h to compile.
-// Boom.
-// So, don't include hal_i3c.h from this header.
-// #ifdef HAL_I3C_MODULE_ENABLED
-// #include "stm32h5xx_hal_i3c.h"
-// #endif /* HAL_I3C_MODULE_ENABLED */
+#ifdef HAL_I3C_MODULE_ENABLED
+#include "stm32h5xx_hal_i3c.h"
+#endif /* HAL_I3C_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
 #include "stm32h5xx_hal_iwdg.h"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This MR fixes some test failures that we have been seeing with STM32H5 processors on the spi-basic DMA abort test.  Unfortunately, it seems like this isn't a scenario that STMicro tests when releasing their HAL, because I found two different issues with it.

Issue number 1 was that, in one of the DMA callbacks, it was concluding that the channel didn't abort successfully because a certain register flag (`DMA_CCR_EN`) was still set after aborting the channel.  
![Debugger screenshot](https://github.com/user-attachments/assets/70ed33ee-bc02-4733-a197-d61d39df3c89)

I'm not entirely 100% sure *why* that flag was still set, but it seems like checking it was in error, because in the latest release of the HAL, they removed the code that does the check!
![Check removed diff](https://github.com/user-attachments/assets/1a319de9-773a-4acd-932e-37fa95ffd954)

Unfortunately, updating the HAL introduced a different issue, where aborting the transfer would fail to correctly abort the Rx DMA channel.  After some time going back and forth, I was finally able to work out what was going on.  I filed a bug with STMicro [here](https://github.com/STMicroelectronics/stm32h5xx_hal_driver/issues/8).

This MR updates Mbed to use the latest release (commit 7e8c7d8e) of the STM32H5 HAL driver, plus the patch mentioned in the issue above.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- Aborting DMA SPI transfers should work now on STM32H5

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
New test results for STM32H5 pushed here: https://mbed-ce.github.io/mbed-ce-test-tools/tests/index.html

----------------------------------------------------------------------------------------------------------------
