### PR TITLE
Upload: NUVOTON: Fix GDB restart command for pyOCD

### DIFF
--- a/targets/TARGET_NUVOTON/CMakeLists.txt
+++ b/targets/TARGET_NUVOTON/CMakeLists.txt
@@ -27,3 +27,16 @@ target_sources(mbed-nuvoton
 
 target_link_libraries(mbed-nuvoton INTERFACE mbed-cmsis-cortex-m)
 
+# PyOCD debug restart is failed without this somehow. It appears the device
+# under debug must be halted after MBED_UPLOAD_RESTART_COMMANDS, but this is
+# broken. Change to "monitor reset halt" to fix it.
+function(mbed_upload_nuvoton_adjust_restart_command_for_pyocd target)
+    if(DEFINED MBED_UPLOAD_RESTART_COMMANDS AND
+       "${UPLOAD_METHOD}" STREQUAL "PYOCD")
+        set(MBED_UPLOAD_RESTART_COMMANDS "monitor reset halt" CACHE INTERNAL "" FORCE)
+    endif()
+endfunction()
+
+function(mbed_adjust_upload_debug_commands target)
+    mbed_upload_nuvoton_adjust_restart_command_for_pyocd(${target})
+endfunction()

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -169,6 +169,12 @@ function(mbed_set_post_build target)
         mbed_generate_map_file(${target})
     endif()
 
+    # Give chance to adjust MBED_UPLOAD_LAUNCH_COMMANDS or MBED_UPLOAD_RESTART_COMMANDS
+    # for debug launch
+    if(COMMAND mbed_adjust_upload_debug_commands)
+        mbed_adjust_upload_debug_commands(${target})
+    endif()
+
     mbed_generate_upload_target(${target})
     mbed_generate_ide_debug_configuration(${target})
 endfunction()


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR includes two parts:

1.  Give chance to adjust GDB commands `MBED_UPLOAD_LAUNCH_COMMANDS` or `MBED_UPLOAD_RESTART_COMMANDS` for debug launch by implementing `mbed_adjust_upload_debug_commands` cmake function.
1.  Based on above, for Nuvoton targets, fix GDB restart command for pyOCD.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

