### PR TITLE
Upload: Fix GDB restart command for pyOCD

### DIFF
--- a/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
@@ -59,5 +59,5 @@ set(UPLOAD_LAUNCH_COMMANDS
 "tbreak main"
 )
 set(UPLOAD_RESTART_COMMANDS
-"monitor reset"
+"monitor reset halt"
 )


### PR DESCRIPTION
### Summary of changes <!-- Required -->

PyOCD debug restart can be failed without this somehow. It appears the device under debug must be halted after `MBED_UPLOAD_RESTART_COMMANDS`, but this is broken. Change to `monitor reset halt` to fix it.

NOTE: The above issue is reproduced on Nuvoton's NUMAKER_IOT_M467 target.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

