### PR TITLE
Fix STM32H7Ax build

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H7A3xIQ/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(mbed-stm32h7a3xiq INTERFACE)
 
 target_sources(mbed-stm32h7a3xiq
     INTERFACE
-        system_clock.c
         ${STARTUP_FILE}
 )
 

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3718,11 +3718,11 @@
         "public": false,
         "core": "Cortex-M7FD",
         "extra_labels_add": [
-            "STM32H7A3xIQ"
+            "STM32H7A3xIQ",
+            "STM32H7_280MHZ"
         ],
         "macros_add": [
             "STM32H7A3xxQ",
-            "STM32H7_280MHZ",
             "MBED_SPLIT_HEAP"
         ],
         "device_name": "STM32H7A3ZITxQ"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fix for build errors on STM32H7Ax:
- Typo in targets JSON so clock settings weren't being applied
- CMake looking for nonexistent system_clock.c

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Tested locally, it compiles now!
----------------------------------------------------------------------------------------------------------------
