### PR TITLE
Fix build for devices with MESH as the default network type

### DIFF
--- a/connectivity/drivers/802.15.4_RF/CMakeLists.txt
+++ b/connectivity/drivers/802.15.4_RF/CMakeLists.txt
@@ -9,6 +9,9 @@ macro(create_mbed_802_15_4_target)
 		# Nanostack drivers always require Mbed RTOS
 		target_link_libraries(mbed-802.15.4-rf PUBLIC mbed-core-flags mbed-rtos-flags)
 
+		# For NanostackRfPhy.h
+		target_link_libraries(mbed-802.15.4-rf PUBLIC mbed-nanostack)
+
 		target_link_libraries(mbed-nanostack
 		    INTERFACE
 		        mbed-802.15.4-rf

--- a/connectivity/nanostack/mbed-mesh-api/CMakeLists.txt
+++ b/connectivity/nanostack/mbed-mesh-api/CMakeLists.txt
@@ -34,8 +34,13 @@ target_link_libraries(mbed-nanostack-mbed_mesh_api
     PUBLIC
         mbed-nanostack-hal_mbed_cmsis_rtos
         mbed-nanostack-sal_stack
+		mbed-nanostack
         mbed-netsocket-api
         mbed-core-flags
     PRIVATE
         mbed-rtos-flags
 )
+
+# Since there are a lot of circular references between this library and mbed-netsocket-api,
+# we have to have CMake repeat the libraries on the link line multiple times.
+set_property(TARGET mbed-nanostack-mbed_mesh_api PROPERTY LINK_INTERFACE_MULTIPLICITY 3)

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -69,6 +69,12 @@ if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=CELLULAR" IN_LIST MBED_CONFI
     target_link_libraries(mbed-netsocket-api PUBLIC mbed-cellular)
 endif()
 
+# Similarly if mesh networking is used bring in that library
+if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=MESH" IN_LIST MBED_CONFIG_DEFINITIONS)
+    target_link_libraries(mbed-netsocket-api PUBLIC mbed-nanostack-mbed_mesh_api)
+endif()
+
+
 if("DEVICE_EMAC=1" IN_LIST MBED_TARGET_DEFINITIONS)
     target_link_libraries(mbed-netsocket-api
         INTERFACE


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This is somewhat similar to the fix I had to do for wifi devices a while back.  If the default network device is MESH, we need to ensure that Nanostack and the mesh networking drivers are linked in with `mbed-netsocket`.  This also fixes some CMake build issues for nanostack and the mesh networking drivers.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Tested and KW41Z greentea compiles with this PR!

----------------------------------------------------------------------------------------------------------------
