### PR TITLE
Fix off-by-1 error in memap's symbol-contained-in-memory-bank check, clean up some linker script stuff

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -159,7 +159,7 @@ SECTIONS
      * values to stack symbols later */
     .stack_dummy (NOLOAD):
     {
-        *(.stack)
+        . += STACK_SIZE;
     } > RAM
 
     /* Set stack top to end of RAM, and stack limit move down by

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -95,9 +95,10 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
         #  add linker script only for tests
         if(MBED_IS_STANDALONE)
             target_link_options(${TARGET}
-            INTERFACE
-                "-T" "${LINKER_SCRIPT_PATH}"
-            )
+                INTERFACE
+                    "-T" "${LINKER_SCRIPT_PATH}"
+                )
+            set_property(TARGET ${TARGET} APPEND PROPERTY INTERFACE_LINK_DEPENDS ${LINKER_SCRIPT_PATH})
         endif()
     endforeach()
 
@@ -150,5 +151,6 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
         PRIVATE
             "-T" "${CUSTOM_LINKER_SCRIPT_PATH}"
     )
+    set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS ${CUSTOM_LINKER_SCRIPT_PATH})
 
 endfunction(mbed_set_custom_linker_script)

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -128,19 +128,14 @@ function(mbed_set_post_build target)
             get_target_property(POST_BUILD_TARGET_LINK_LIBRARIES ${target} LINK_LIBRARIES)
             if("mbed-os" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
                 get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
-                target_link_options(${target}
-                PRIVATE
-                    "-T" "${LINKER_SCRIPT_PATH}"
-            )
             elseif("mbed-baremetal" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
                 get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
-                target_link_options(${target}
-                PRIVATE
-                    "-T" "${LINKER_SCRIPT_PATH}"
-            )
             else()
                 message(FATAL_ERROR "Target ${target} used with mbed_set_post_build() but does not link to mbed-os or mbed-baremetal!")
             endif()
+
+            target_link_options(${target} PRIVATE "-T" "${LINKER_SCRIPT_PATH}")
+            set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS ${LINKER_SCRIPT_PATH})
         else()
             message(STATUS "${target} uses custom linker script  ${ARGV1}")
             mbed_set_custom_linker_script(${target} ${ARGV1})

--- a/tools/python/memap/memap.py
+++ b/tools/python/memap/memap.py
@@ -63,7 +63,6 @@ from collections import defaultdict
 from prettytable import PrettyTable, HEADER
 from jinja2 import FileSystemLoader, StrictUndefined
 from jinja2.environment import Environment
-from future.utils import with_metaclass
 
 
 # Be sure that the tools directory is in the search path
@@ -127,7 +126,7 @@ class _Parser(ABC):
         for banks in self.memory_banks.values():
             for bank_info in banks:
                 if bank_info.contains_addr(symbol_start_addr):
-                    if bank_info.contains_addr(end_addr):
+                    if bank_info.contains_addr(end_addr - 1): # end_addr is the first address past the end of the symbol so we subtract 1 here
                         # Symbol fully inside this memory bank
                         bank_info.used_size += size
 
@@ -234,7 +233,9 @@ class _GccParser(_Parser):
 
     # Gets the input section name from the line, if it exists.
     # Input section names are always indented 1 space.
-    RE_INPUT_SECTION_NAME = re.compile(r'^ (\.\w+\.?\w*\.?\w*)')  # Note: This allows up to 3 dots... hopefully that's enough...
+    # Note: This allows up to 3 dots... hopefully that's enough...
+    # It can also calture "*fill*" instead of something that looks like a section name.
+    RE_INPUT_SECTION_NAME = re.compile(r'^ ((?:\.\w+\.?\w*\.?\w*)|(?:\*fill\*))')
 
     ALL_SECTIONS = (
         _Parser.SECTIONS
@@ -844,7 +845,7 @@ class MemapParser(object):
 
 def main():
     """Entry Point"""
-    version = '0.4.0'
+    version = '1.0.0'
 
     # Parser handling
     parser = ArgumentParser(

--- a/tools/python/memap/memap.py
+++ b/tools/python/memap/memap.py
@@ -145,7 +145,7 @@ class _Parser(ABC):
         """ Adds information about a symbol (e.g. a function or global variable) to the data structures.
 
         Positional arguments:
-        symbol_name - Descriptive name of the symbol, e.g. ".text.some_function"
+        symbol_name - Descriptive name of the symbol, e.g. ".text.some_function" or "*fill*"
         object_name - name of the object file containing the symbol
         start addr - start address of symbol
         size - the size of the symbol being added

--- a/tools/python/memap/memap.py
+++ b/tools/python/memap/memap.py
@@ -234,7 +234,7 @@ class _GccParser(_Parser):
     # Gets the input section name from the line, if it exists.
     # Input section names are always indented 1 space.
     # Note: This allows up to 3 dots... hopefully that's enough...
-    # It can also calture "*fill*" instead of something that looks like a section name.
+    # It can also capture "*fill*" instead of something that looks like a section name.
     RE_INPUT_SECTION_NAME = re.compile(r'^ ((?:\.\w+\.?\w*\.?\w*)|(?:\*fill\*))')
 
     ALL_SECTIONS = (


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I noticed that for targets that had stack fill up until the end of a memory bank, the new memap version was doing some weird stuff:
- It would print a warning about the symbol going outside of the memory bank,
- And, that warning would have the wrong name, it would call out a previous symbol name rather than saying it was `*fill*` that did it 

Turns out there was an off by 1 error in the check for whether a symbol went outside a memory bank, and an issue with the regex that detected the names of input sections.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Verified that we aren't seeing the memap warning after this issue.
    
----------------------------------------------------------------------------------------------------------------
