### PR TITLE
Fix messed up CMake targets for NUCLEO_H745ZI_Q

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(TARGET_STM32H745xI_CM4 EXCLUDE_FROM_ALL)
-add_subdirectory(TARGET_STM32H745xI_CM7 EXCLUDE_FROM_ALL)
-
 add_library(mbed-stm32h745xi INTERFACE)
 
 target_link_libraries(mbed-stm32h745xi INTERFACE mbed-stm32h7)
+
+add_subdirectory(TARGET_STM32H745xI_CM7 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_STM32H745xI_CM4 EXCLUDE_FROM_ALL)
+add_subdirectory(TARGET_NUCLEO_H745ZI_Q EXCLUDE_FROM_ALL)

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_NUCLEO_H745ZI_Q/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H745xI/TARGET_NUCLEO_H745ZI_Q/CMakeLists.txt
@@ -8,39 +8,12 @@ target_sources(mbed-nucleo-h745zi-q
         PeripheralPins.c
 )
 
-target_include_directories(mbed-nucleo-h745i
+target_include_directories(mbed-nucleo-h745zi-q
     INTERFACE
         .
 )
 
 target_link_libraries(mbed-nucleo-h745zi-q INTERFACE mbed-stm32h745xi-cm7)
 
-
-add_library(mbed-nucleo-h745i-cm7 INTERFACE)
-
-target_sources(mbed-nucleo-h745i-cm7
-    INTERFACE
-        PeripheralPins.c
-)
-
-target_include_directories(mbed-nucleo-h745zi-cm7
-    INTERFACE
-        .
-)
-
-target_link_libraries(mbed-nucleo-h745zi-cm7 INTERFACE mbed-stm32h745xi-cm7)
-
-
-add_library(mbed-nucleo-h745zi-cm4 INTERFACE)
-
-target_sources(mbed-nucleo-h745zi-cm4
-    INTERFACE
-        PeripheralPins.c
-)
-
-target_include_directories(mbed-nucleo-h745i-cm4
-    INTERFACE
-        .
-)
-
-target_link_libraries(mbed-nucleo-h745zi-cm4 INTERFACE mbed-stm32h745xi-cm4)
+add_library(mbed-nucleo-h745zi-q-cm7 ALIAS mbed-nucleo-h745zi-q)
+add_library(mbed-nucleo-h745zi-q-cm4 ALIAS mbed-nucleo-h745zi-q)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The CMake build files for NUCLEO_H745ZI_Q were quite messed up -- it never added the subdirectory, and some of the target names had typos so it couldn't actually build properly.  This fixes the buildfile issues and condenses down the CMake targets to remove duplicated code.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Built locally for NUCLEO_H745ZI_Q_CM7 and it builds OK!

----------------------------------------------------------------------------------------------------------------
