### PR TITLE
Fix build of CYTFM_064B0S2_4343W

### DIFF
--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -11,7 +11,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python packages
+        # Note: pip>=20.3 is needed to install dependencies of cysecuretools
         run: |
+          python3 -m pip install --upgrade pip
           python3 -m pip install -r tools/requirements.txt
 
       # Note: For this CI job we use MBED_CREATE_PYTHON_VENV=FALSE so that we can make sure

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/CMakeLists.txt
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYTFM_064B0S2_4343W/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(mbed-cytfm-064b0s2-4343w
         mbed-cytfm-064b0s2-4343w-cm4
         mbed-cytfm-064b0s2-4343w-bsp-design-modus
         mbed-psoc6
+        mbed-psa
 )
 
 target_compile_definitions(mbed-cytfm-064b0s2-4343w
@@ -70,7 +71,6 @@ target_compile_definitions(mbed-cytfm-064b0s2-4343w
 )
 
 mbed_post_build_psoc6_sign_image(
-    "tfm_s.hex"
     "CYTFM_064B0S2_4343W"
     "policy_multi_CM0_CM4_tfm.json"
     "multi_image"

--- a/targets/TARGET_Cypress/scripts/PSOC6.py
+++ b/targets/TARGET_Cypress/scripts/PSOC6.py
@@ -177,14 +177,14 @@ def sign_image(toolchain, resourses, elf, binf, m0hex):
     )
 
 def sign_hex(
-    build_dir, m0hex_filename, target_name, policy, notification, boot_scheme,
+    build_dir, m0hex_signed_intermediate, target_name, policy, notification, boot_scheme,
     cm0_img_id, cm4_img_id, elf, m4hex, m0hex
 ):
     """
     Adds signature to a binary file being built,
     using cysecuretools python package.
     :param build_dir: The build directory
-    :param m0hex_filename: The file name of the Cortex-M0 hex
+    :param m0hex_filename: Path to store intermediate signed CM0 hex file at
     :param target_name: The name of the Mbed target
     :param policy: The path to the policy file
     :param notification: The object to output notification with
@@ -199,9 +199,8 @@ def sign_hex(
     # that need to be signed
 
     if m0hex != '':
-        m0hex_build = os.path.join(build_dir, m0hex_filename)
-        copy2(m0hex, m0hex_build)
-        m0hex = m0hex_build
+        copy2(m0hex, m0hex_signed_intermediate)
+        m0hex = m0hex_signed_intermediate
 
     # Mapping from mbed target to cysecuretools target
     TARGET_MAPPING = {
@@ -327,7 +326,7 @@ def sign_action(args):
     """Entry point for the "sign" CLI command."""
     sign_hex(
         args.build_dir,
-        args.m0hex_filename,
+        args.m0hex_signed_intermediate,
         args.target_name,
         args.policy_file_name,
         logging.getLogger(__name__),
@@ -369,7 +368,7 @@ def parse_args():
         "--build-dir", required=True, help="the build directory."
     )
     sign_subcommand.add_argument(
-        "--m0hex-filename", required=True, help="the name of the HEX file."
+        "--m0hex-signed-intermediate", required=True, help="Path to store intermediate signed CM0 hex file at."
     )
     sign_subcommand.add_argument(
         "--target-name", help="the Mbed target name."

--- a/targets/TARGET_Cypress/scripts/PSOC6.py
+++ b/targets/TARGET_Cypress/scripts/PSOC6.py
@@ -173,7 +173,7 @@ def sign_image(toolchain, resourses, elf, binf, m0hex):
         toolchain.target.cm4_img_id,
         elf,
         binf,
-        m0hexf
+        m0hex
     )
 
 def sign_hex(
@@ -184,7 +184,7 @@ def sign_hex(
     Adds signature to a binary file being built,
     using cysecuretools python package.
     :param build_dir: The build directory
-    :param m0hex_filename: Path to store intermediate signed CM0 hex file at
+    :param m0hex_signed_intermediate: Path to store intermediate signed CM0 hex file at
     :param target_name: The name of the Mbed target
     :param policy: The path to the policy file
     :param notification: The object to output notification with

--- a/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
+++ b/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
@@ -54,7 +54,6 @@ endmacro()
 # Sign a Cortex-M4 HEX with Cortex-M0 HEX.
 #
 macro(mbed_post_build_psoc6_sign_image
-    m0hex_filename
     cypress_psoc6_target
     policy_file_name
     boot_scheme
@@ -70,7 +69,7 @@ macro(mbed_post_build_psoc6_sign_image
                 ${Python3_EXECUTABLE} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/PSOC6.py
                 sign
                 --build-dir ${CMAKE_BINARY_DIR}
-                --m0hex-filename ${m0hex_filename}
+                --m0hex-signed-intermediate $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.cm0-signed-image.hex
                 --target-name ${cypress_psoc6_target}
                 --policy-file-name ${policy_file_name}
                 --boot-scheme ${boot_scheme}

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -33,6 +33,7 @@ lxml; sys_platform == 'darwin'
 # needed for signing secure images
 cryptography
 cbor
+cysecuretools~=6.0
 
 # Needed for downloading CMSIS MCU descriptions
 cmsis-pack-manager~=0.5.0


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
This PR fixes a couple issues preventing the build of the CYTFM_064B0S2_4343W target:
- Missing dependency on `cysecuretools` in requirements.txt prevented the post build script from running
- The post build script was trying to create and sign `tfm_s.hex` in the build dir for every target that compiled, so if multiple targets built in parallel, the build would fail with a corrupt file error.
- Missing dependency on `mbed-psa` for the MCU target, added this the same as for the Nuvoton target

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Verified that this target now compiles with these fixes
    
----------------------------------------------------------------------------------------------------------------
