### PR TITLE
Fix lots of Greentea test warnings

### DIFF
--- a/connectivity/FEATURE_BLE/source/generic/GattClientImpl.cpp
+++ b/connectivity/FEATURE_BLE/source/generic/GattClientImpl.cpp
@@ -488,6 +488,7 @@ struct GattClient::DiscoveryControlBlock final : public ProcedureControlBlock {
     bool done;
 };
 
+#undef TRACE_CLASS
 #define TRACE_CLASS "ReadControlBlock"
 struct GattClient::ReadControlBlock final : public ProcedureControlBlock {
     using ProcedureControlBlock::connection_handle;
@@ -701,6 +702,7 @@ struct GattClient::ReadControlBlock final : public ProcedureControlBlock {
 /*
  * Control block for the write process
  */
+#undef TRACE_CLASS
 #define TRACE_CLASS "WriteControlBlock"
 struct GattClient::WriteControlBlock final : public ProcedureControlBlock {
     using ProcedureControlBlock::connection_handle;
@@ -926,6 +928,7 @@ struct GattClient::WriteControlBlock final : public ProcedureControlBlock {
 /*
  * Control block for the descriptor discovery process
  */
+#undef TRACE_CLASS
 #define TRACE_CLASS "DescriptorDiscoveryControlBlock"
 struct GattClient::DescriptorDiscoveryControlBlock final : public ProcedureControlBlock {
     using ProcedureControlBlock::connection_handle;

--- a/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_cert_in_filesystem.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tls/tlssocket_cert_in_filesystem.cpp
@@ -36,7 +36,8 @@ void TLSSOCKET_CERT_IN_FILESYSTEM()
     TEST_ASSERT_EQUAL(0, fs.mount(&bd));
 
     FILE *fp = fopen("/fs/certs.pem", "wb");
-    int ret = fwrite(tls_global::cert, strlen(tls_global::cert), 1, fp);
+    size_t ret = fwrite(tls_global::cert, strlen(tls_global::cert), 1, fp);
+    TEST_ASSERT_EQUAL(1, ret);
     fclose(fp);
 
     TLSSocket sock;

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/main.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/main.cpp
@@ -73,7 +73,7 @@ static void _ifup()
 #if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
     tr_info("Waiting for GLOBAL_UP\n");
     while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
-        ThisThread::sleep_for(500);
+        ThisThread::sleep_for(500ms);
     }
 #endif
     tr_info("MBED: UDPClient IP address is '%s'\n", address ? address.get_ip_address() : "null");

--- a/drivers/tests/TESTS/mbed_drivers/reset_reason/main.cpp
+++ b/drivers/tests/TESTS/mbed_drivers/reset_reason/main.cpp
@@ -27,7 +27,7 @@
 #if DEVICE_WATCHDOG
 #   include "hal/watchdog_api.h"
 #   define MSG_VALUE_WATCHDOG_STATUS 1
-#   define WDG_TIMEOUT_MS 50UL
+#   define WDG_TIMEOUT_MS 50ms
 #else
 #   define MSG_VALUE_WATCHDOG_STATUS 0
 #endif
@@ -60,7 +60,7 @@
  * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
  * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS 150
+#define SERIAL_FLUSH_TIME_MS 150ms
 
 typedef enum {
     CMD_STATUS_CONTINUE,
@@ -113,7 +113,7 @@ static cmd_status_t handle_command(const char *key, const char *value)
     if (strcmp(key, MSG_KEY_DEVICE_RESET) == 0 && strcmp(value, MSG_VALUE_DEVICE_RESET_WATCHDOG) == 0) {
         greentea_send_kv(MSG_KEY_DEVICE_RESET, MSG_VALUE_DEVICE_RESET_ACK);
         ThisThread::sleep_for(SERIAL_FLUSH_TIME_MS); // Wait for the serial buffers to flush.
-        watchdog_config_t config = { .timeout_ms = WDG_TIMEOUT_MS };
+        watchdog_config_t config = { .timeout_ms = WDG_TIMEOUT_MS.count() };
         if (hal_watchdog_init(&config) != WATCHDOG_STATUS_OK) {
             TEST_ASSERT_MESSAGE(0, "hal_watchdog_init() error.");
             return CMD_STATUS_ERROR;

--- a/drivers/usb/include/usb/internal/USBDevice.h
+++ b/drivers/usb/include/usb/internal/USBDevice.h
@@ -547,6 +547,8 @@ private:
     void _complete_set_configuration();
     void _complete_set_interface();
 
+    void _clear_endpoints();
+
     struct endpoint_info_t {
         mbed::Callback<void()> callback;
         uint16_t max_packet_size;

--- a/drivers/usb/source/USBDevice.cpp
+++ b/drivers/usb/source/USBDevice.cpp
@@ -402,7 +402,7 @@ void USBDevice::_complete_set_configuration()
     if ((_abort_control || !success) && !configured()) {
         // The set configuration request was aborted or failed so
         // reset any endpoints which may have been added.
-        memset(_endpoint_info, 0, sizeof(_endpoint_info));
+        _clear_endpoints();
         _device.configuration = 0;
         _endpoint_add_remove_allowed = false;
     }
@@ -1348,7 +1348,7 @@ USBDevice::USBDevice(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
     this->product_id = product_id;
     this->product_release = product_release;
 
-    memset(_endpoint_info, 0, sizeof(_endpoint_info));
+    _clear_endpoints();
     memset(&_transfer, 0, sizeof(_transfer));
     _transfer.user_callback = None;
 
@@ -1754,7 +1754,7 @@ void USBDevice::_change_state(DeviceState new_state)
     bool leaving_default_state = (old_state >= Default) && (new_state < Default);
 
     if (leaving_configured_state) {
-        memset(_endpoint_info, 0, sizeof(_endpoint_info));
+        _clear_endpoints();
         _device.configuration = 0;
         _endpoint_add_remove_allowed = false;
     }
@@ -1770,4 +1770,11 @@ void USBDevice::_change_state(DeviceState new_state)
 void USBDevice::_run_later(void (USBDevice::*function)())
 {
     _post_process = function;
+}
+
+void USBDevice::_clear_endpoints()
+{
+    for (auto &info : _endpoint_info) {
+        info = endpoint_info_t{};
+    }
 }

--- a/drivers/usb/tests/TESTS/usb_device/msd/main.cpp
+++ b/drivers/usb/tests/TESTS/usb_device/msd/main.cpp
@@ -217,7 +217,7 @@ void msd_process(USBMSD *msd)
     Semaphore proc;
     msd->attach(callback(run_processing, &proc));
     while (!msd_process_done) {
-        proc.try_acquire_for(100);
+        proc.try_acquire_for(100ms);
         msd->process();
         if (msd->media_removed()) {
             media_remove_event.release();
@@ -233,7 +233,7 @@ void msd_process(USBMSD *msd)
     for (int x = 0; x < 15; x++) { \
         prev_read_counter = usb.get_read_counter();\
         prev_program_counter = usb.get_program_counter();\
-        ThisThread::sleep_for(1000);\
+        ThisThread::sleep_for(1000ms);\
         if ((usb.get_read_counter() == prev_read_counter) && \
             (usb.get_program_counter() == prev_program_counter)) {\
             break;\
@@ -241,18 +241,19 @@ void msd_process(USBMSD *msd)
     }
 
 
-#define TEST_ASSERT_EQUAL_STRING_LOOP(expected, actual, loop_index)                             \
-        if (strcmp(expected, actual) != 0) {                                                    \
-            char str[128];                                                                      \
-            sprintf(str, "expected %s was %s (loop index: %lu)", expected, actual, loop_index); \
-            TEST_ASSERT_MESSAGE(false, str);                                                    \
+char testMessageBuffer[300];
+
+
+#define TEST_ASSERT_EQUAL_STRING_LOOP(expected, actual, loop_index)                                           \
+        if (strcmp(expected, actual) != 0) {                                                                  \
+            sprintf(testMessageBuffer, "expected %s was %s (loop index: %lu)", expected, actual, loop_index); \
+            TEST_ASSERT_MESSAGE(false, testMessageBuffer);                                                    \
         }
 
-#define TEST_ASSERT_EQUAL_LOOP(expected, actual, loop_index)                                    \
-        if (expected != actual) {                                                               \
-            char str[128];                                                                      \
-            sprintf(str, "expected %d was %d (loop index: %lu)", expected, actual, loop_index); \
-            TEST_ASSERT_MESSAGE(false, str);                                                    \
+#define TEST_ASSERT_EQUAL_LOOP(expected, actual, loop_index)                                                  \
+        if (expected != actual) {                                                                             \
+            sprintf(testMessageBuffer, "expected %d was %d (loop index: %lu)", expected, actual, loop_index); \
+            TEST_ASSERT_MESSAGE(false, testMessageBuffer);                                                    \
         }
 
 
@@ -341,7 +342,7 @@ void mount_unmount_test(BlockDevice *bd, FileSystem *fs)
             TEST_ASSERT_EQUAL_STRING_LOOP("passed", _key, i);
 
             // wait for unmount event (set 10s timeout)
-            media_remove_event.try_acquire_for(10000);
+            media_remove_event.try_acquire_for(10s);
             if (!usb.media_removed()) {
                 TEST_ASSERT_EQUAL_LOOP(true, usb.media_removed(), i);
             }
@@ -436,7 +437,7 @@ void mount_unmount_and_data_test(BlockDevice *bd, FileSystem *fs)
     TEST_ASSERT_EQUAL_STRING("passed", _key);
 
     do {
-        ThisThread::sleep_for(1);
+        ThisThread::sleep_for(1ms);
     } while (test_files_exist(fs_root));
     TEST_ASSERT_EQUAL(false, test_files_exist(fs_root));
 

--- a/hal/tests/TESTS/mbed_hal/ospi/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/ospi/main.cpp
@@ -115,7 +115,7 @@ static void _ospi_write_read_test(Ospi &ospi, ospi_bus_width_t write_inst_width,
     ospi_status_t ret = OSPI_STATUS_OK;
 
     Timer timer;
-    int erase_time = 0, write_time = 0, read_time = 0;
+    std::chrono::microseconds erase_time{}, write_time{}, read_time{};
     size_t buf_len = data_size;
 
     for (uint32_t tc = 0; tc < test_count; tc++) {
@@ -136,7 +136,7 @@ static void _ospi_write_read_test(Ospi &ospi, ospi_bus_width_t write_inst_width,
         WAIT_FOR(SECTOR_ERASE_MAX_TIME, ospi);
 
         timer.stop();
-        erase_time = timer.read_us();
+        erase_time = timer.elapsed_time();
 
         // switching to extended-SPI/DPI/QPI mode here for write operation
         // for DPI/QPI ospi.cmd is automatically switched to 2_2_2/4_4_4 mode
@@ -167,7 +167,7 @@ static void _ospi_write_read_test(Ospi &ospi, ospi_bus_width_t write_inst_width,
             WAIT_FOR(PAGE_PROG_MAX_TIME, ospi);
 
             timer.stop();
-            write_time = timer.read_us();
+            write_time = timer.elapsed_time();
         }
 
         // switching back to single channel SPI
@@ -193,7 +193,7 @@ static void _ospi_write_read_test(Ospi &ospi, ospi_bus_width_t write_inst_width,
             TEST_ASSERT_EQUAL(read_size, buf_len);
 
             timer.stop();
-            read_time = timer.read_us();
+            read_time = timer.elapsed_time();
         }
         ospi.cmd.set_dummy_cycles(0);
 
@@ -211,13 +211,13 @@ static void _ospi_write_read_test(Ospi &ospi, ospi_bus_width_t write_inst_width,
             if (tx_buf[i] != rx_buf[i]) {
                 log_data("tx data", tx_buf, data_size);
                 log_data("rx data", rx_buf, data_size);
-                utest_printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
+                utest_printf("erase/write/read time: %" PRIi64 "/%" PRIi64 "/%" PRIi64 " [us]\r\n", erase_time.count(), write_time.count(), read_time.count());
                 TEST_ASSERT_EQUAL(tx_buf[i], rx_buf[i]);
             }
         }
 
 #ifdef OSPI_TEST_LOG_FLASH_TIME
-        utest_printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
+        utest_printf("erase/write/read time: %" PRIi64 "/%" PRIi64 "/%" PRIi64 " [us]\r\n", erase_time.count(), write_time.count(), read_time.count());
 #endif
 
 #ifdef OSPI_TEST_LOG_DATA

--- a/hal/tests/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -32,7 +32,7 @@ void sleep_manager_locking_thread_test()
 {
     for (uint32_t i = 0; i < 100; i++) {
         sleep_manager_lock_deep_sleep();
-        ThisThread::sleep_for(25);
+        ThisThread::sleep_for(25ms);
         sleep_manager_unlock_deep_sleep();
     }
 }
@@ -45,7 +45,7 @@ void sleep_manager_multithread_test()
         Thread t2(osPriorityNormal, TEST_STACK_SIZE);
 
         t1.start(callback(cb));
-        ThisThread::sleep_for(25);
+        ThisThread::sleep_for(25ms);
         t2.start(callback(cb));
 
         // Wait for the threads to finish
@@ -70,13 +70,13 @@ void sleep_manager_irq_test()
         Ticker ticker1;
         Timer timer;
 
-        ticker1.attach_us(&sleep_manager_locking_irq_test, 1000);
+        ticker1.attach(&sleep_manager_locking_irq_test, 1ms);
 
         // run this for 10 seconds
         timer.start();
-        int start = timer.read();
-        int end = start + 10;
-        while (timer.read() < end) {
+        const auto start = timer.elapsed_time();
+        const auto end = start + 10s;
+        while (timer.elapsed_time() < end) {
             sleep_manager_locking_irq_test();
         }
         timer.stop();

--- a/hal/tests/TESTS/mbed_hal/ticker/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/ticker/main.cpp
@@ -2251,7 +2251,7 @@ static void test_match_interval_passed_table()
         {0xfffffffe, 0xffffffff, 0xffffffff, true},
         {0x00000000, 0xffffffff, 0xffffffff, true},
     };
-    for (int i = 0; i < MBED_ARRAY_SIZE(test_values); i++) {
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(test_values); i++) {
         const uint32_t prev = test_values[i].prev;
         const uint32_t cur = test_values[i].cur;
         const uint32_t match = test_values[i].match;

--- a/hal/tests/TESTS/pin_names/arduino_uno/main.cpp
+++ b/hal/tests/TESTS/pin_names/arduino_uno/main.cpp
@@ -154,7 +154,7 @@ void UART_test()
     }
 
     // 3. check if Arduino_uno pins are not using the same UART instance as console
-    int console_uart = pinmap_peripheral(CONSOLE_TX, serial_tx_pinmap());
+    uint32_t console_uart = pinmap_peripheral(CONSOLE_TX, serial_tx_pinmap());
     if (console_uart != 0) {
         TEST_ASSERT_NOT_EQUAL(console_uart, pinmap_peripheral(TX_pin, serial_tx_pinmap()));
     }

--- a/platform/tests/TESTS/mbed_functional/callback/main.cpp
+++ b/platform/tests/TESTS/mbed_functional/callback/main.cpp
@@ -755,11 +755,6 @@ static int construct_count;
 static int destruct_count;
 static int copy_count;
 
-static int live_count()
-{
-    return construct_count - destruct_count;
-}
-
 struct FunctionObject {
     FunctionObject(int n) : val(n)
     {
@@ -824,6 +819,11 @@ void test_trivial()
 }
 
 #if MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL
+static int live_count()
+{
+    return construct_count - destruct_count;
+}
+
 void test_nontrivial()
 {
     {

--- a/platform/tests/TESTS/mbed_micro/cpp/main.cpp
+++ b/platform/tests/TESTS/mbed_micro/cpp/main.cpp
@@ -30,7 +30,7 @@ class Test {
 
 private:
     const char *name;
-    const int pattern;
+    const uint32_t pattern;
 
 public:
     Test(const char *_name, bool print_message = true) : name(_name), pattern(PATTERN_CHECK_VALUE)

--- a/platform/tests/TESTS/mbed_platform/FileHandle/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/FileHandle/main.cpp
@@ -101,7 +101,7 @@ void test_fwrite_fread()
     std::clearerr(file);
 
     // ARMCC/IAR returns 0 here instead of number of elements successfully written !!!
-    TEST_ASSERT_TRUE(write_ret >= 0 && write_ret <= (str2_size - 1));
+    TEST_ASSERT_TRUE(write_ret <= (str2_size - 1));
 
     // write 3; expected written 0
     TestFile<FS>::resetFunctionCallHistory();

--- a/platform/tests/TESTS/mbed_platform/error_handling/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/error_handling/main.cpp
@@ -267,7 +267,7 @@ void test_error_hook()
     }
 
     MBED_WARNING1(MBED_ERROR_INVALID_ARGUMENT, "Test for error hook", 1234);
-    bool acquired = callback_sem.try_acquire_for(5000);
+    bool acquired = callback_sem.try_acquire_for(5s);
 
     TEST_ASSERT(acquired);
 }

--- a/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/CMakeLists.txt
+++ b/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/CMakeLists.txt
@@ -12,3 +12,8 @@ mbed_greentea_add_test(
         main.cpp
         mbed_printf.c
 )
+
+# Disable "snprintf into buffer of size x" warnings
+target_compile_options(test-mbed-platform-minimal-printf-compliance
+	PRIVATE
+	-Wno-format-truncation)

--- a/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -126,7 +126,7 @@ static int make_test_string(
 )
 {
     char *exp_str = &expected_string[0];
-    int str_length = 0;
+    size_t str_length = 0;
     memset(exp_str, 0, MAX_STRING_SIZE);
     if (prefix) {
         str_length = strlen(prefix);

--- a/platform/tests/TESTS/mbed_platform/wait_ns/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/wait_ns/main.cpp
@@ -77,7 +77,8 @@ void test_wait_ns_time_measurement()
     timer.stop();
 
     /* Check results - wait_val_us us have elapsed. */
-    TEST_ASSERT_FLOAT_WITHIN(DELTA * wait_val_s, MIDPOINT * wait_val_s, timer.read());
+    TEST_ASSERT_FLOAT_WITHIN(DELTA * wait_val_s, MIDPOINT * wait_val_s,
+                             std::chrono::duration<float>(timer.elapsed_time()).count());
 }
 
 utest::v1::status_t test_setup(const size_t number_of_cases)

--- a/rtos/tests/TESTS/mbed_rtos/heap_and_stack/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/heap_and_stack/main.cpp
@@ -260,7 +260,7 @@ void test_heap_allocation_free(void)
     check_and_free_heap(head, max_allocation_size);
 
     // Force a task switch so a stack check is performed
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(10s);
 
     printf("Total size dynamically allocated: %luB\n", max_allocation_size);
 }

--- a/rtos/tests/TESTS/mbed_rtos/malloc/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/malloc/main.cpp
@@ -89,7 +89,7 @@ void test_multithread_allocation(void)
 
     // Give the test time to run
     while (test_time--) {
-        ThisThread::sleep_for(1000);
+        ThisThread::sleep_for(1s);
     }
 
     // Join and delete all threads

--- a/rtos/tests/TESTS/mbed_rtos/mutex/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/mutex/main.cpp
@@ -58,7 +58,6 @@ volatile bool mutex_defect = false;
 bool manipulate_protected_zone(const Kernel::Clock::duration thread_delay)
 {
     bool result = true;
-    osStatus stat;
 
     stdio_mutex.lock();
 
@@ -128,7 +127,6 @@ void test_multiple_threads(void)
 
 void test_dual_thread_nolock_lock_thread(Mutex *mutex)
 {
-    osStatus stat;
     mutex->lock();
 
     mutex->unlock();
@@ -184,7 +182,6 @@ void test_dual_thread_lock_unlock_thread(Mutex *mutex)
 void test_dual_thread_lock_unlock(void)
 {
     Mutex mutex;
-    osStatus stat;
     Thread thread(osPriorityNormal, TEST_STACK_SIZE);
 
     mutex.lock();
@@ -230,7 +227,6 @@ template <void (*F)(Mutex *)>
 void test_dual_thread_lock(void)
 {
     Mutex mutex;
-    osStatus stat;
     Thread thread(osPriorityNormal, TEST_STACK_SIZE);
 
     mutex.lock();
@@ -251,7 +247,6 @@ void test_dual_thread_lock(void)
 void test_single_thread_lock_recursive(void)
 {
     Mutex mutex;
-    osStatus stat;
 
     mutex.lock();
 
@@ -287,7 +282,6 @@ void test_single_thread_trylock(void)
 void test_single_thread_lock(void)
 {
     Mutex mutex;
-    osStatus stat;
 
     mutex.lock();
 

--- a/rtos/tests/TESTS/mbed_rtos/threads/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/threads/main.cpp
@@ -370,7 +370,7 @@ void test_thread_flags_set()
     Thread::State state = t_wait.get_state();
     TEST_ASSERT_EQUAL(Thread::WaitingThreadFlag, state);
 
-    int32_t res = t_wait.flags_set(S);
+    t_wait.flags_set(S);
 
     t_wait.join();
 }
@@ -741,7 +741,7 @@ void test_msg_put()
 /** Utility function that places some date on the stack */
 void use_some_stack()
 {
-    volatile uint32_t stack_filler[10] = {0xDEADBEEF};
+    [[maybe_unused]] volatile uint32_t stack_filler[10] = {0xDEADBEEF};
 }
 
 /** Testing thread with external stack memory

--- a/tools/cmake/toolchains/GCC_ARM.cmake
+++ b/tools/cmake/toolchains/GCC_ARM.cmake
@@ -34,6 +34,7 @@ list(APPEND common_options
     "-Wextra"
     "-Wno-unused-parameter"
     "-Wno-missing-field-initializers"
+    "-Wno-psabi" # Disable "parameter passing changed in GCC 7.1" warning
     "-fmessage-length=0"
     "-fno-exceptions"
     "-ffunction-sections"

--- a/tools/python/memap/memap.py
+++ b/tools/python/memap/memap.py
@@ -158,7 +158,7 @@ class _Parser(ABC):
 
         # Don't count the heap output section for memory bank size tracking, because the linker scripts (almost always?)
         # configure that section to expand to fill the remaining amount of space
-        if section not in {".heap"}:
+        if section not in {".heap", ".heap_0"}:
             self._add_symbol_to_memory_banks(symbol_name, start_addr, size)
             if vma_lma_offset != 0:
                 self._add_symbol_to_memory_banks(f"<initializer for {symbol_name}>", start_addr + vma_lma_offset, size)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Ever since I've started on Mbed CE, there have been ludicrous amounts of warnings every time the greentea tests are compiled.  The vast majority of these are due to tests using deprecated API, especially legacy RTOS functions that don't use chrono types.  This PR fixes at least 90% of these warnings, so the greentea build is now a much more warning-free experience.  There are still a few here and there but it's a lot better now at least.

Someday I want to fix all of the warnings and then make the CI builds use -Werror but... not today.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
Way less warnings in Greentea test builds

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
