### PR TITLE
Fix STM32H7 dual core inheritance again

### DIFF
--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3421,10 +3421,10 @@
         ],
         "device_name": "STM32H745ZITx"
     },
+	
+	// These targets contain the extra bits to add to the MCU_STM32H745xI target to set it for the
+	// CM4 or CM7 core.
     "MCU_STM32H745xI_CM4": {
-        "inherits": [
-            "MCU_STM32H745xI"
-        ],
         "public": false,
         "extra_labels_add": [
             "STM32H745xI_CM4"
@@ -3442,9 +3442,6 @@
         ]
     },
     "MCU_STM32H745xI_CM7": {
-        "inherits": [
-            "MCU_STM32H745xI"
-        ],
         "public": false,
         "extra_labels_add": [
             "STM32H745xI_CM7"
@@ -3463,6 +3460,7 @@
         ]
     },
     "NUCLEO_H745ZI_Q": {
+		"inherits": ["MCU_STM32H745xI"],
         "supported_form_factors": [
             "ARDUINO_UNO"
         ],
@@ -3508,10 +3506,9 @@
             "STM32H747xx"
         ]
     },
+	// These targets contain the extra bits to add to the MCU_STM32H747xI target to set it for the
+	// CM4 or CM7 core.
     "MCU_STM32H747xI_CM7": {
-        "inherits": [
-            "MCU_STM32H747xI"
-        ],
         "public": false,
         "extra_labels_add": [
             "STM32H747xI_CM7"
@@ -3530,9 +3527,6 @@
         ]
     },
     "MCU_STM32H747xI_CM4": {
-        "inherits": [
-            "MCU_STM32H747xI"
-        ],
         "public": false,
         "extra_labels_add": [
             "STM32H747xI_CM4"
@@ -3557,6 +3551,7 @@
     "DISCO_H747I": {
         "image_url": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/images/310/MFG_STM32H747I-DISCO.jpg",
         "public": false,
+		"inherits": ["MCU_STM32H747xI"],
         "overrides": {
             "system_power_supply": "PWR_DIRECT_SMPS_SUPPLY",
             // Cannot enable overdrive mode because the default power supply is SMPS
@@ -3564,9 +3559,11 @@
         }
     },
     "DISCO_H747I_CM7": {
+		// NOTE: inherit from MCU_STM32H747xI_CM7 first so that target's attributes get priority over
+		// DISCO_H747I's attributes.
         "inherits": [
-            "MCU_STM32H747xI_CM7",
-            "DISCO_H747"
+		    "MCU_STM32H747xI_CM7",
+		    "DISCO_H747I"
         ],
         "supported_form_factors": [
             "ARDUINO_UNO",
@@ -3590,8 +3587,8 @@
     },
     "DISCO_H747I_CM4": {
         "inherits": [
-            "MCU_STM32H747xI_CM4",
-            "DISCO_H747"
+			"MCU_STM32H747xI_CM4",
+            "DISCO_H747I"
         ],
         "extra_labels_add": [
             "DISCO_H747I",
@@ -3669,10 +3666,10 @@
         "image_url": "https://store.arduino.cc/cdn/shop/products/ABX00042_00.iso_1200x900.jpg?v=1675840144"
     },
     "ARDUINO_PORTENTA_H7_M7": {
-        "inherits": ["ARDUINO_PORTENTA_H7", "MCU_STM32H747xI_CM7"],
+        "inherits": ["MCU_STM32H747xI_CM7", "ARDUINO_PORTENTA_H7"]
     },
     "ARDUINO_PORTENTA_H7_M4": {
-        "inherits": ["ARDUINO_PORTENTA_H7", "MCU_STM32H747xI_CM4"],
+        "inherits": ["MCU_STM32H747xI_CM4", "ARDUINO_PORTENTA_H7"]
     },
     "MCU_STM32H750xB": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Noticed that the website generator CI job was printing some warnings about overriding some attributes that didn't exist and then dying with a foreign key error.  Oops!

Turns out that I kinda messed up in my attempt to refactor these STM32H7 targets.  Not only were there some typos, which weren't caught by the testing I did but were caught by the website generator, but also the inheritance order is backwards from how I expected it: the first target in the list of parent targets gets the highest "priority" and can override the attributes from the other targets.  Interestingly, this [is actually documented](https://github.com/mbed-ce/mbed-os/blob/master/tools/python/mbed_tools/targets/_internal/targets_json_parsers/overriding_attribute_parser.py#L61) in the code if you know where to look.

To fix this, I swapped the "inherits" order and made the CM4/CM7 targets not inherit from any other targets, which should fix the issue by making sure that they have priority to override stuff from the base MCU targets.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- Fix some errors configuring and building for STM32H7 dual core targets

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
