### PR TITLE
Support wifi as default network interface

### DIFF
--- a/connectivity/drivers/wifi/CMakeLists.txt
+++ b/connectivity/drivers/wifi/CMakeLists.txt
@@ -14,6 +14,35 @@ macro(create_mbed_wifi_target)
 	endif()
 endmacro()
 
+# Collect sources which need to extract from static library to override
+# weak symbols. Their paths are required to relative to this directory
+# ,so that they match with entries in static library and their corresponding
+# object files there can be found and extracted.
+set(MBED_WIFI_OVERRIDE_SOURCES "" CACHE INTERNAL "" FORCE)
+
+# Add override sources by subdirectories
+#
+# The input sources are required to relative to their subdirectories
+# and will get converted to relative to this directory herein.
+function(mbed_wifi_add_override_sources)
+    set(override_sources ${MBED_WIFI_OVERRIDE_SOURCES})
+
+    foreach(override_source ${ARGN})
+        # Convert to relative to this directory
+        file(RELATIVE_PATH
+            override_source_fix
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}
+            ${CMAKE_CURRENT_LIST_DIR}/${override_source}
+        )
+
+        set(override_sources
+            ${override_sources}
+            ${override_source_fix}
+        )
+    endforeach()
+
+    set(MBED_WIFI_OVERRIDE_SOURCES ${override_sources} CACHE INTERNAL "" FORCE)
+endfunction()
 
 # The WICED subdirectory is for wifi drivers developed using Infineon WICED framework.
 # https://community.infineon.com/t5/Knowledge-Base-Articles/WICED-Wi-Fi-FAQ/ta-p/247356
@@ -39,3 +68,54 @@ if("COMPONENT_ESPRESSIF_ESP8266=1" IN_LIST MBED_TARGET_DEFINITIONS)
     add_subdirectory(COMPONENT_ESPRESSIF_ESP8266)
 endif()
 
+# Extract override objects from static library and pass them to
+# link options to actively participate in linking and override weak
+# symbols.
+if(TARGET mbed-wifi AND NOT "${MBED_WIFI_OVERRIDE_SOURCES}" STREQUAL "")
+    set(override_sources ${MBED_WIFI_OVERRIDE_SOURCES})
+    list(TRANSFORM override_sources APPEND ${CMAKE_CXX_OUTPUT_EXTENSION} OUTPUT_VARIABLE override_objects)
+    list(TRANSFORM override_objects PREPEND ${CMAKE_CURRENT_BINARY_DIR}/ OUTPUT_VARIABLE override_objects_fullpath)
+
+    if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+        # Override objects passed via target_link_options are finally
+        # de-duplicated, so we can avoid multiple definition issue caused
+        # due to cyclic target link via target_link_libraries.
+        #
+        # https://cmake.org/cmake/help/latest/command/target_link_options.html#option-de-duplication
+        target_link_options(mbed-wifi
+            INTERFACE
+                ${override_objects_fullpath}
+        )
+
+        # Commands for extracting override objects
+        foreach(override_object ${override_objects})
+            get_filename_component(override_object_dirname ${override_object} DIRECTORY)
+
+            # Extract object files from static library
+            #
+            # NOTE: The support has restrictions on input static library:
+            # 1. No full path match modifier ('P') is specified on creating
+            #    the static library.
+            # 2. Object file names must be different for just one-level entry
+            #    names in the static library.
+            # https://sourceware.org/binutils/docs/binutils/ar-cmdline.html
+            set(extract_commands
+                ${extract_commands}
+                COMMAND
+                    ${CMAKE_COMMAND} -E make_directory ${override_object_dirname}
+                COMMAND
+                    ${CMAKE_AR} x --output ${override_object_dirname} $<TARGET_FILE_NAME:mbed-wifi> ${override_object}
+            )
+        endforeach()
+
+        add_custom_command(
+            TARGET
+                mbed-wifi
+            POST_BUILD
+            ${extract_commands}
+            WORKING_DIRECTORY
+                ${CMAKE_CURRENT_BINARY_DIR}
+            VERBATIM
+        )
+    endif()
+endif()

--- a/connectivity/drivers/wifi/CMakeLists.txt
+++ b/connectivity/drivers/wifi/CMakeLists.txt
@@ -23,6 +23,9 @@ if("WICED" IN_LIST MBED_TARGET_LABELS)
 endif()
 
 if("STM" IN_LIST MBED_TARGET_LABELS)
+    if("EMW3080B" IN_LIST MBED_TARGET_LABELS)
+        create_mbed_wifi_target()
+    endif()
     add_subdirectory(TARGET_STM EXCLUDE_FROM_ALL)
 endif()
 

--- a/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/CMakeLists.txt
+++ b/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/CMakeLists.txt
@@ -12,3 +12,10 @@ target_include_directories(mbed-wifi
         .
         ./ESP8266
 )
+
+# Add sources which contain override symbols
+if("MBED_CONF_ESP8266_PROVIDE_DEFAULT=1" IN_LIST MBED_CONFIG_DEFINITIONS)
+    mbed_wifi_add_override_sources(
+        ESP8266Interface.cpp
+    )
+endif()

--- a/connectivity/drivers/wifi/TARGET_STM/CMakeLists.txt
+++ b/connectivity/drivers/wifi/TARGET_STM/CMakeLists.txt
@@ -2,6 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if("EMW3080B" IN_LIST MBED_TARGET_LABELS)
-    create_mbed_wifi_target()
     add_subdirectory(COMPONENT_EMW3080B EXCLUDE_FROM_ALL)
 endif()

--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/CMakeLists.txt
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/CMakeLists.txt
@@ -21,3 +21,10 @@ target_sources(mbed-wifi
         mx_wifi/core/mx_wifi_ipc.c
         mx_wifi/core/mx_wifi_slip.c
 )
+
+# Add sources which contain override symbols
+if("MBED_CONF_EMW3080B_PROVIDE_DEFAULT=1" IN_LIST MBED_CONFIG_DEFINITIONS)
+    mbed_wifi_add_override_sources(
+        EMW3080BInterface.cpp
+    )
+endif()

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -74,6 +74,12 @@ if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=MESH" IN_LIST MBED_CONFIG_DE
     target_link_libraries(mbed-netsocket-api PUBLIC mbed-nanostack-mbed_mesh_api)
 endif()
 
+# Similarly if wifi networking is used bring in that library
+if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=WIFI" IN_LIST MBED_CONFIG_DEFINITIONS)
+    if(TARGET mbed-wifi)
+        target_link_libraries(mbed-netsocket-api PUBLIC mbed-wifi)
+    endif()
+endif()
 
 if("DEVICE_EMAC=1" IN_LIST MBED_TARGET_DEFINITIONS)
     target_link_libraries(mbed-netsocket-api


### PR DESCRIPTION
### Summary of changes


This supports configuring WiFi as default network interface. This support requires overriding weak symbol `WiFiInterface::get_default_instance` when e.g. `"esp8266.provide-default: true"` is specified in `mbed_app.json`. The override will fail because WiFi objects are archived in static library `libmbed-wifi.a` and don't participate in linking as expected, dependent on linker and library link order. To fix this, the override objects are extracted and passed to linker command line so that they always participate in the linking.
 

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->


    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

