### PR TITLE
Fix the vulnerability of mbed-os #15462 issue

### DIFF
--- a/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
+++ b/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
@@ -170,9 +170,18 @@ void hciTrSerialRxIncoming(uint8_t *pBuf, uint8_t len)
           hdrLen = HCI_EVT_HDR_LEN;
           break;
         default:
-          /* invalid packet type */
+          /**
+           * invalid packet type 
+           * 
+           * fix: Simply employing WSF_ASSERT in the event of 
+           * an "invalid packet type" is not reasonable. 
+           * Instead, it is advisable to discard this data packet, 
+           * exit the packet processing function, 
+           * and adjust the stateRx back to HCI_RX_STATE_IDLE.
+          */
+          stateRx = HCI_RX_STATE_IDLE;
           WSF_ASSERT(0);
-          break;
+          return;
       }
 
       /* see if entire header has been read */


### PR DESCRIPTION
Based on
https://github.com/ARMmbed/mbed-os/pull/15474

Summary of changes
Set the stateRx variable to HCI_RX_STATE_IDLE when an invalid HCI packet type is detected, to prevent overflow in the hdrRx buffer.

Impact of changes
Migration actions required
Documentation
Pull request type
[X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)
Test results
[] No Tests required for this change (E.g docs only update)
[X] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR