### PR TITLE
M2354: Fix some TF-M minor issues

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/CMakeLists.txt
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(mbed-m2354-tfm INTERFACE)
+if(NOT TARGET mbed-m2354-tfm)
+    add_library(mbed-m2354-tfm INTERFACE)
+endif()
 
 if("NU_M2354" IN_LIST MBED_TARGET_LABELS)
     add_subdirectory(TARGET_NU_M2354)

--- a/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/README.md
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/README.md
@@ -100,6 +100,12 @@ $ cmake -S . \
 -G"Unix Makefiles"
 ```
 
+**NOTE**: To build for NuMaker-IoT-M2354 board, add below lines to above:
+```
+-DNU_TGT_NUMAKER_M2354=OFF \
+-DNU_TGT_NUMAKER_IOT_M2354=ON \
+```
+
 Then:
 
 ```

--- a/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/signing_key/nuvoton_m2354-root-rsa-3072.md
+++ b/targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/signing_key/nuvoton_m2354-root-rsa-3072.md
@@ -1,11 +1,14 @@
 # Nuvoton M2354 RSA keypair
 
-A default RSA key pair is given to the Nuvoton M2354 target.
+Two default RSA key pairs are given to the Nuvoton M2354 target.
 
-Public key was pre-compiled to `targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/bl2.bin` and private key is in `nuvoton_m2354-root-rsa-3072.pem` for Secure image and `nuvoton_m2354-root-rsa-3072_1.pem` for Non-Secure image.
+Public keys were pre-compiled to `bl2.bin` and private keys are in
+`nuvoton_m2354-root-rsa-3072.pem` and `nuvoton_m2354-root-rsa-3072_1.pem`
+for Secure image and Non-Secure image separately.
 
 DO NOT use them in production code, they are exclusively for testing!
 
-Private key must be stored in a safe place outside of the repository.
+Private keys must be stored in a safe place outside of the repository.
 
-`tools/psa/tfm/bin_utils/imgtool.py` can be used to generate new key pairs.
+[Image tool](https://github.com/mcu-tools/mcuboot/blob/main/docs/imgtool.md)
+can be used to generate new key pairs.


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes some minor issues of Nuvoton's M2354 target, including:
1. TF-M import document
2. Pre-create of cmake target `mbed-m2354-tfm` for use in `custom_targets`.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

