### PR TITLE
Fix wifi cannot configure as default network interface

### DIFF
--- a/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/CMakeLists.txt
+++ b/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/CMakeLists.txt
@@ -12,3 +12,15 @@ target_include_directories(mbed-wifi
         .
         ./ESP8266
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-wifi
+        INTERFACE
+            LINKER:--undefined=LINK_ESP8266INTERFACE_CPP
+    )
+endif()

--- a/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/ESP8266Interface.cpp
+++ b/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP8266/ESP8266Interface.cpp
@@ -1149,6 +1149,20 @@ WiFiInterface *WiFiInterface::get_default_instance()
     return &esp;
 }
 
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_ESP8266INTERFACE_CPP(void)
+{
+}
+
 #endif
 
 void ESP8266Interface::refresh_conn_state_cb()

--- a/connectivity/drivers/wifi/COMPONENT_WHD/whd_mac/CMakeLists.txt
+++ b/connectivity/drivers/wifi/COMPONENT_WHD/whd_mac/CMakeLists.txt
@@ -21,3 +21,15 @@ target_sources(mbed-wifi
         utils/cydhcp_server_debug.cpp
         utils/cynetwork_utils.c
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-wifi
+        INTERFACE
+            LINKER:--undefined=LINK_WHD_INTERFACE_CPP
+    )
+endif()

--- a/connectivity/drivers/wifi/COMPONENT_WHD/whd_mac/interface/whd_interface.cpp
+++ b/connectivity/drivers/wifi/COMPONENT_WHD/whd_mac/interface/whd_interface.cpp
@@ -32,3 +32,17 @@ WhdSoftAPInterface *WhdSoftAPInterface::get_default_instance()
     static WhdSoftAPInterface softap;
     return &softap;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_WHD_INTERFACE_CPP(void)
+{
+}

--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/CMakeLists.txt
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/CMakeLists.txt
@@ -21,3 +21,15 @@ target_sources(mbed-wifi
         mx_wifi/core/mx_wifi_ipc.c
         mx_wifi/core/mx_wifi_slip.c
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-wifi
+        INTERFACE
+            LINKER:--undefined=LINK_EMW3080BINTERFACE_CPP
+    )
+endif()

--- a/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080BInterface.cpp
+++ b/connectivity/drivers/wifi/TARGET_STM/COMPONENT_EMW3080B/EMW3080BInterface.cpp
@@ -365,3 +365,19 @@ WiFiInterface *WiFiInterface::get_target_default_instance()
     return &wifi;
 }
 #endif /* MBED_CONF_NSAPI_PRESENT */
+
+#if MBED_CONF_EMW3080B_PROVIDE_DEFAULT || defined(MBED_CONF_NSAPI_PRESENT)
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_EMW3080BINTERFACE_CPP(void)
+{
+}
+#endif

--- a/connectivity/drivers/wifi/TARGET_WICED/CMakeLists.txt
+++ b/connectivity/drivers/wifi/TARGET_WICED/CMakeLists.txt
@@ -24,3 +24,15 @@ target_sources(mbed-wiced
 )
 
 target_link_libraries(mbed-wifi PUBLIC mbed-wiced)
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-wifi
+        INTERFACE
+            LINKER:--undefined=LINK_DEFAULT_WIFI_INTERFACE_CPP
+    )
+endif()

--- a/connectivity/drivers/wifi/TARGET_WICED/wiced_interface/default_wifi_interface.cpp
+++ b/connectivity/drivers/wifi/TARGET_WICED/wiced_interface/default_wifi_interface.cpp
@@ -25,4 +25,18 @@ WiFiInterface *WiFiInterface::get_target_default_instance()
     return &wifi;
 }
 
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_DEFAULT_WIFI_INTERFACE_CPP(void)
+{
+}
+
 #endif

--- a/connectivity/netsocket/CMakeLists.txt
+++ b/connectivity/netsocket/CMakeLists.txt
@@ -74,6 +74,12 @@ if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=MESH" IN_LIST MBED_CONFIG_DE
     target_link_libraries(mbed-netsocket-api PUBLIC mbed-nanostack-mbed_mesh_api)
 endif()
 
+# Similarly if wifi networking is used bring in that library
+if("MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=WIFI" IN_LIST MBED_CONFIG_DEFINITIONS)
+    if(TARGET mbed-wifi)
+        target_link_libraries(mbed-netsocket-api PUBLIC mbed-wifi)
+    endif()
+endif()
 
 if("DEVICE_EMAC=1" IN_LIST MBED_TARGET_DEFINITIONS)
     target_link_libraries(mbed-netsocket-api


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes WiFi cannot configure as default network interface, e.g. `"esp8266.provide-default": true`. This configuration requires support for weak symbol override. Object files archived in static library don't always participate in linking, dependent on linker and link order. The steps below introduced in this PR pull in the override object file anyway even though it comes from static library:

1. Add e.g. GCC linker option `--undefined=<LINK_FOO>`
2. Add `<LINK_FOO>` function with `extern "C"` in override source file

See: https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do

**NOTE**: This provides an alternative to #373 and would be more reasonable.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    X[] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
