### PR TITLE
Decrease compile time with nanostack-libservice

### DIFF
--- a/connectivity/libraries/nanostack-libservice/CMakeLists.txt
+++ b/connectivity/libraries/nanostack-libservice/CMakeLists.txt
@@ -22,8 +22,6 @@ target_sources(mbed-nanostack-libservice
         source/nvmHelper/ns_nvm_helper.c
 )
 
-target_link_libraries(mbed-nanostack-libservice PUBLIC mbed-nanostack-hal_mbed_cmsis_rtos)
-
 # The definition, source files and include directories below
 # are needed by mbed-trace which is part of the mbed-core CMake target
 target_compile_definitions(mbed-core-flags


### PR DESCRIPTION
### Summary of changes <!-- Required -->

nanostack-libservice involves two parts: common (e.g. [libip4string](https://github.com/mbed-ce/mbed-os/tree/master/connectivity/libraries/nanostack-libservice/source/libip4string)) and nanostack-specific (e.g. [nvmHelper](https://github.com/mbed-ce/mbed-os/tree/master/connectivity/libraries/nanostack-libservice/source/nvmHelper)). For nanostack-specific, it needs to link [nanostack hal](https://github.com/mbed-ce/mbed-os/tree/master/connectivity/nanostack/nanostack-hal-mbed-cmsis-rtos) and will pull in 200+ nanostack files for compile. This is unnecessary for common only application e.g. lwipstack. To fix this, the following strategy is applied for nanostack-libservice cmake listfile:
1.  For compiling nanostack-specific, it doesn't rely on nanostack hal because its needed header file has placed underneath ([mbed-client-libservice/platform](https://github.com/mbed-ce/mbed-os/tree/master/connectivity/libraries/nanostack-libservice/mbed-client-libservice/platform)).
2.  For application needing the nanostack-specific, the nanostack cmake listfile shall specify the link dependency.

This actually rolls back #378 on [this line](https://github.com/mbed-ce/mbed-os/pull/378/files#r1817970196)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

