### PR TITLE
Fix relative paths to custom upload method file, fix incorrect CAN length on STMicro

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -1033,7 +1033,7 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     msg->type = (CANType)(((uint8_t)0x02 & can->sFIFOMailBox[rxfifo_default].RIR) >> 1);
     /* Get the DLC */
-    msg->len = ((can->sFIFOMailBox[rxfifo_default].RDTR & CAN_RDT0R_DLC) < 8) ? ((uint8_t)0x0F & can->sFIFOMailBox[rxfifo_default].RDTR) : ((uint8_t) 8);
+    msg->len = ((can->sFIFOMailBox[rxfifo_default].RDTR & CAN_RDT0R_DLC) < 8) ? (CAN_RDT0R_DLC & can->sFIFOMailBox[rxfifo_default].RDTR) : ((uint8_t) 8);
     /* Get the FMI */
     // msg->FMI = (uint8_t)0xFF & (can->sFIFOMailBox[rxfifo_default].RDTR >> 8);
     /* Get the data field */

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -1014,7 +1014,7 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
 int can_read(can_t *obj, CAN_Message *msg, int handle)
 {
     //FIFO selection cannot be controlled by software for STM32, default FIFO is 0, hence handle is not used
-    int rxfifo_default = DEFAULT_RXFIFO; 
+    const int rxfifo_default = DEFAULT_RXFIFO;
     CAN_TypeDef *can = obj->CanHandle.Instance;
 
     // check FPM0 which holds the pending message count in FIFO 0
@@ -1033,7 +1033,7 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     msg->type = (CANType)(((uint8_t)0x02 & can->sFIFOMailBox[rxfifo_default].RIR) >> 1);
     /* Get the DLC */
-    msg->len = ((uint8_t)0x0F & can->sFIFOMailBox[rxfifo_default].RDTR < 8) ? ((uint8_t)0x0F & can->sFIFOMailBox[rxfifo_default].RDTR) : ((uint8_t) 8);
+    msg->len = ((can->sFIFOMailBox[rxfifo_default].RDTR & CAN_RDT0R_DLC) < 8) ? ((uint8_t)0x0F & can->sFIFOMailBox[rxfifo_default].RDTR) : ((uint8_t) 8);
     /* Get the FMI */
     // msg->FMI = (uint8_t)0xFF & (can->sFIFOMailBox[rxfifo_default].RDTR >> 8);
     /* Get the data field */

--- a/tools/cmake/app.cmake
+++ b/tools/cmake/app.cmake
@@ -64,6 +64,8 @@ set(EXPECTED_MBED_UPLOAD_CFG_FILE_PATH ${MBED_SOURCE_DIR}/targets/upload_method_
 
 # check if a custom upload config path is defined in top lvl cmake
 if((DEFINED CUSTOM_UPLOAD_CFG_PATH))
+	# Make path absolute, as required by EXISTS
+	get_filename_component(CUSTOM_UPLOAD_CFG_PATH "${CUSTOM_UPLOAD_CFG_PATH}" ABSOLUTE BASE_DIR ${CMAKE_SOURCE_DIR})
     if(EXISTS ${CUSTOM_UPLOAD_CFG_PATH})
         include(${CUSTOM_UPLOAD_CFG_PATH})
         message(STATUS "Mbed: Custom upload config included from ${CUSTOM_UPLOAD_CFG_PATH}")


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Noticed while working on the custom targets example that if you pass a relative path to CUSTOM_UPLOAD_CFG_PATH, it errors out, because EXISTS in CMake only works with absolute paths (seriously this is such a common foot-gun and they still have not fixed it).

Also noticed a compiler warning coming from the STM32 CAN code.  It appears that there was some unintentional behavior happening because the `<` operator has higher precedence than `&`, so the comparison was happening before the mask!  It looks like they were trying to get the length from the DLC field, so I updated the code to use a proper register definition and parentheses as needed.
![image](https://github.com/user-attachments/assets/a8fe0a3d-c1a0-48de-8b1c-bc064e7140b8)


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
