### PR TITLE
Support override of memory_bank_config in mbed_app.json

### DIFF
--- a/tools/python/mbed_tools/build/_internal/config/config.py
+++ b/tools/python/mbed_tools/build/_internal/config/config.py
@@ -41,6 +41,11 @@ class Config(UserDict):
                 _apply_override(self.data, override)
                 continue
 
+            # Support override of memory_bank_config in mbed_app.json
+            if override.namespace == "target" and override.name == "memory_bank_config":
+                _apply_override(self.data, override)
+                continue
+
             setting = next(
                 filter(
                     lambda x: x.name == override.name and x.namespace == override.namespace,


### PR DESCRIPTION
### Summary of changes <!-- Required -->

`memory_bank_config` can be defined in targets.json or custom_targets.json per-target, but cannot by application. This enables this override by adding `target.memory_bank_config` config in `target_overrides` section of mbed_app.json as usual.

Fix #370.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

