### PR TITLE
Codrio BLE: ignore packet if data allocation fails (CVE-2024-48985)

### DIFF
--- a/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
+++ b/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
@@ -239,7 +239,15 @@ void hciTrSerialRxIncoming(uint8_t *pBuf, uint8_t len)
         }
         else
         {
+          /**
+           * As above, simply employing WSF_ASSERT is not reasonable.
+           * Instead, it is advisable to discard this data packet,
+           * exit the packet processing function,
+           * and adjust the stateRx back to HCI_RX_STATE_IDLE.
+          */
+          stateRx = HCI_RX_STATE_IDLE;
           WSF_ASSERT(0); /* allocate falied */
+          return;
         }
 
       }


### PR DESCRIPTION
### Summary of changes <!-- Required -->
`hciTrSerialRxIncoming` parses incoming hci packets. It takes two bytes from the packet header and tries to allocate a buffer based on the packet size contained in those bytes. There is no logic to account for the case of an allocate failing. If `WSF_ASSERT` is not enabled (it isn't by default), the packet isn't dropped either.

 - https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c#L200

This means that the function will stay in it's `HCI_RX_STATE_HEADER` state for longer than intended. Because every iteration of the loop writes another byte to `hdrRx` and the intended exit condition for this state has been passed, it will continue writing to `hdrRx` past it's bounds, causing a buffer overflow.

This fix handles the failed allocation by resetting the parser and exiting the function, similar to #374.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
