### PR TITLE
Cordio BLE: ignore messages with overlong headers (CVE-2024-48986)

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
@@ -2738,6 +2738,7 @@ void hciEvtProcessMsg(uint8_t *pEvt)
   uint8_t   evt;
   uint8_t   subEvt;
   uint8_t   len;
+  uint8_t   extraMsgLen = 0;
   uint8_t   cbackEvt = 0;
   hciEvt_t  *pMsg;
   uint16_t  handle;
@@ -2997,6 +2998,7 @@ void hciEvtProcessMsg(uint8_t *pEvt)
 #endif
       hciEvtStats.numVendorSpecEvt++;
       cbackEvt = HCI_VENDOR_SPEC_CBACK_EVT;
+      extraMsgLen = len;
 
 #ifdef WSF_DETOKEN_TRACE
       if (WsfDetokenProcessHciEvent(len, pEvt))
@@ -3014,7 +3016,7 @@ void hciEvtProcessMsg(uint8_t *pEvt)
   if (cbackEvt != 0)
   {
     /* allocate temp buffer */
-    if ((pMsg = WsfBufAlloc(hciEvtCbackLen[cbackEvt])) != NULL)
+    if ((pMsg = WsfBufAlloc(hciEvtCbackLen[cbackEvt] + extraMsgLen)) != NULL)
     {
       /* initialize message header */
       pMsg->hdr.param = 0;


### PR DESCRIPTION
### Summary of changes <!-- Required -->
`hciEvtProcessMsg` parses incoming hci command packets. In doing so, it dynamically determines the length of the packet body and the event type by reading 2 bytes from the packet header.

 - https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L2747-L2748

Depending on the event type, it will set a callback flag. If this flag is set later, it allocates a buffer with a semi-constant length determined by an event type to buffer length lookup table.
It then copies bytes into the allocated buffer but uses the packet supplied length value to copy them.

 - https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L3017-L3025

This leads to a buffer overflow.

This fix addresses the issue by only copying as many bytes as fit in the buffer.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
