### PR TITLE
Cordio BLE: Fix two integer overflows (CVE-2024-48982)

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
@@ -2471,6 +2471,11 @@ void hciEvtProcessCmdCmpl(uint8_t *p, uint8_t len)
   uint8_t       cbackEvt = 0;
   hciEvtCback_t cback = hciCb.evtCback;
 
+  if (len > 3)
+  {
+    return;
+  }
+
   BSTREAM_TO_UINT8(numPkts, p);
   BSTREAM_TO_UINT16(opcode, p);
 
@@ -2684,7 +2689,7 @@ void hciEvtProcessCmdCmpl(uint8_t *p, uint8_t len)
     if (cbackEvt == HCI_UNHANDLED_CMD_CMPL_CBACK_EVT) {
       const uint8_t structSize = sizeof(hciUnhandledCmdCmplEvt_t) - 1 /* removing the fake 1-byte array */;
       const uint8_t remainingLen = len - 3 /* we already read opcode and numPkts */;
-      const uint8_t msgSize = structSize + remainingLen;
+      const uint16_t msgSize = structSize + remainingLen;
 
       pMsg = WsfBufAlloc(msgSize);
       if (pMsg != NULL) {

--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
@@ -2471,7 +2471,7 @@ void hciEvtProcessCmdCmpl(uint8_t *p, uint8_t len)
   uint8_t       cbackEvt = 0;
   hciEvtCback_t cback = hciCb.evtCback;
 
-  if (len > 3)
+  if (len < 3)
   {
     return;
   }


### PR DESCRIPTION
### Summary of changes <!-- Required -->

`hciEvtProcessMsg` parses incoming hci command packets. In doing so, it dynamically determines the length of the packet body by reading a byte from the packet header.

 - https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L2748

Then, `hciEvtProcessCmdCmpl` is called. A buffer is allocated to hold the packet, the length of which is determined by the sum of this 8-bit integer and the length of a structure to hold some metadata but without 3 bytes that are assumed to exist and have already been read.

 - https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L2685-L2695

This can be exploited in 2 ways, the first of which sets a `len < 3`. This means that

```
len = 0x2
remainingLen = len - 0x3 = 0xff (=> write amount)
msgSize = remainingLen + sizeof(hciUnhandledCmdCmplEvt_t) = 0xff + 0x5 = 0x4 (=> buffer size)
```

The other takes advantage of the fact that `msgSize` is a `uint8_t`.
Picking a `len = 0xff` leaves:

```
len = 0xff
remainingLen = len - 0x3 = 0xfc (=> write amount)
msgSize = remainingLen + sizeof(hciUnhandledCmdCmplEvt_t) = 0xfc + 0x5 = 0x1 (=> buffer size)
```

This leads to a too small allocation for the message buffer and the following call to `memcpy()` results in a buffer overflow.

This fix addresses both of these issues by:
1. Ignoring packets with a length less than 3
2. Changing `msgSize` to be a `uint16_t`

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
