### PR TITLE
Cordio BLE: fix OOB read in event processing (CVE-2024-48984)

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c
@@ -1331,6 +1331,11 @@ static void hciEvtProcessLeExtAdvReport(uint8_t *p, uint8_t len)
   while (i-- > 0)
   {
     ptr += HCI_EXT_ADV_RPT_DATA_LEN_OFFSET;
+    // discard event if it doesn't contain enough data
+    if (ptr >= p + len)
+    {
+        return;
+    }
     BSTREAM_TO_UINT8(dataLen, ptr);
     ptr += dataLen;
 
@@ -1340,6 +1345,12 @@ static void hciEvtProcessLeExtAdvReport(uint8_t *p, uint8_t len)
       /* update max len */
       maxLen = dataLen;
     }
+  }
+
+  // finally check that the last report is fully contained within the event
+  if (ptr > p + len)
+  {
+      return;
   }
 
   /* allocate temp buffer that can hold max length ext adv/scan rsp data */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

`hciEvtProcessLeExtAdvReport` parses lists of hci reports. In doing so, it dynamically determines the length of the list by reading a byte from the input buffer.

https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L1317

The function then steps through the input buffer and reads the length of all the individual reports in order to find the largest one. It then allocates a buffer that is capable of holding the largest report. 

https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/ble-host/sources/hci/dual_chip/hci_evt.c#L1331-L1343

However, no check is done to ensure that those other reports are actually held within the buffer.

This fix checks that all reports are fully contained within the buffer.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
