### PR TITLE
Cordio BLE: Fix integer overflows (CVE-2024-48983)

### DIFF
--- a/connectivity/FEATURE_BLE/libraries/cordio_stack/wsf/sources/port/baremetal/wsf_msg.c
+++ b/connectivity/FEATURE_BLE/libraries/cordio_stack/wsf/sources/port/baremetal/wsf_msg.c
@@ -53,6 +53,10 @@ typedef struct wsfMsg_tag
 /*************************************************************************************************/
 void *WsfMsgDataAlloc(uint16_t len, uint8_t tailroom)
 {
+  /* check for overflow */
+  if (len > UINT16_MAX - tailroom) {
+    return NULL;
+  }
   return WsfMsgAlloc(len + tailroom);
 }
 
@@ -68,6 +72,11 @@ void *WsfMsgDataAlloc(uint16_t len, uint8_t tailroom)
 void *WsfMsgAlloc(uint16_t len)
 {
   wsfMsg_t  *pMsg;
+
+  /* check for overflow */
+  if (len > UINT16_MAX - sizeof(wsfMsg_t)) {
+    return NULL;
+  }
 
   pMsg = WsfBufAlloc(len + sizeof(wsfMsg_t));
 

--- a/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
+++ b/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c
@@ -204,6 +204,12 @@ void hciTrSerialRxIncoming(uint8_t *pBuf, uint8_t len)
         }
 
         /* allocate data buffer to hold entire packet */
+        /* check that the length doesn't overflow */
+        if (hdrLen > UINT16_MAX - dataLen)
+        {
+          stateRx = HCI_RX_STATE_IDLE;
+          return;
+        }
         if (pktIndRx == HCI_ACL_TYPE)
         {
           pPktRx = (uint8_t*)WsfMsgDataAlloc(hdrLen + dataLen, 0);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

`hciTrSerialRxIncoming` parses incoming hci packets. In doing so, it dynamically determines the length of the packet body. For the case of `HCI_ACL_TYPE` this is done by reading 2 bytes from the packet header.

https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c#L182-L195

A buffer is then allocated to hold the packet, the length of which is determined by the sum of this 16bit integer and the length of the packet header.

https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/source/cordio/stack_adaptation/hci_tr.c#L197-L201

The final buffer size is also increased by `WsfMsgAlloc`, which adds the size of one `wsfMsg_t`.

https://github.com/mbed-ce/mbed-os/blob/54e8693ef4ff7e025018094f290a1d5cf380941f/connectivity/FEATURE_BLE/libraries/cordio_stack/wsf/sources/port/baremetal/wsf_msg.c#L72

For large `dataLen` values, this addition may result in an integer overflow which causes the allocated buffer to be very small. Header and body are then copied separately, resulting in one operation of size `hdrLen` and one of size `dataLen`, the latter of which is always larger than the allocated buffer. This leads to a buffer overflow which, if large amounts of data are written, will likely result in corruption of memory data and may cause the system to crash.

This fix eliminates the issue by check for integer overflows, both in `hciTrSerialRxIncoming` and `WsfMsgAlloc`.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
