### PR TITLE
Upload: Fix mbed_adjust_upload_debug_commands for multiple targets

### DIFF
--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -12,8 +12,14 @@
 # NOTE: Place at the very start so that it can override by the below loaded
 #       upload method if need be.
 function(mbed_adjust_upload_debug_commands target)
-    # MBED_UPLOAD_LAUNCH_COMMANDS defined?
-    if(NOT DEFINED MBED_UPLOAD_LAUNCH_COMMANDS)
+    # MBED_UPLOAD_LAUNCH_COMMANDS_BAK = first version of MBED_UPLOAD_LAUNCH_COMMANDS
+    if(DEFINED MBED_UPLOAD_LAUNCH_COMMANDS_BAK)
+        # Need first version for fresh adjust
+        set(MBED_UPLOAD_LAUNCH_COMMANDS ${MBED_UPLOAD_LAUNCH_COMMANDS_BAK})
+    elseif(DEFINED MBED_UPLOAD_LAUNCH_COMMANDS)
+        # No FORCE for saving first version only
+        set(MBED_UPLOAD_LAUNCH_COMMANDS_BAK ${MBED_UPLOAD_LAUNCH_COMMANDS} CACHE INTERNAL "")
+    else()
         return()
     endif()
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The purpose of `mbed_adjust_upload_debug_commands()` is to adjust first version of `MBED_UPLOAD_LAUNCH_COMMANDS`. For multiple executalbe cmake targets, `MBED_UPLOAD_LAUNCH_COMMANDS` becomes not fresh and may cause error. To overcome this, one new cmake cache variable `MBED_UPLOAD_LAUNCH_COMMANDS_BAK` is introduced to save first version of `MBED_UPLOAD_LAUNCH_COMMANDS`.

Fix #383

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

