### PR TITLE
Update RP2040 target to use flash memory bank

### DIFF
--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/TOOLCHAIN_GCC_ARM/memmap_default_mbed.ld
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/TOOLCHAIN_GCC_ARM/memmap_default_mbed.ld
@@ -37,8 +37,17 @@ MEMORY
      * Scratch banks are commonly used for critical data and functions accessed only by one core (when only
      * one core is accessing the RAM bank, there is no opportunity for stalls).
      */
-    SCRATCH_X(rwx) : ORIGIN = MBED_CONFIGURED_RAM_BANK_SCRATCH_X_START, LENGTH = MBED_CONFIGURED_RAM_BANK_SCRATCH_X_SIZE
-    SCRATCH_Y(rwx) : ORIGIN = MBED_CONFIGURED_RAM_BANK_SCRATCH_Y_START, LENGTH = MBED_CONFIGURED_RAM_BANK_SCRATCH_Y_SIZE
+    SCRATCH_X(rwx) : ORIGIN = MBED_RAM_BANK_SCRATCH_X_START, LENGTH = MBED_RAM_BANK_SCRATCH_X_SIZE
+    SCRATCH_Y(rwx) : ORIGIN = MBED_RAM_BANK_SCRATCH_Y_START, LENGTH = MBED_RAM_BANK_SCRATCH_Y_SIZE
+
+/* If we are at the start of RAM, we are core 0.  Otherwise we are core 1. */
+#if MBED_CONFIGURED_RAM_BANK_IRAM1_START == MBED_RAM_BANK_IRAM1_START
+#define STACK_SCRATCH SCRATCH_X
+#define STACK_SCRATCH_STATIC_END_SYMBOL __scratch_x_end__
+#else
+#define STACK_SCRATCH SCRATCH_Y
+#define STACK_SCRATCH_STATIC_END_SYMBOL __scratch_y_end__
+#endif
 }
 
 ENTRY(_entry_point)
@@ -221,20 +230,17 @@ SECTIONS
     } > RAM
 
     /* Check if data + heap exceeds RAM limit */
-    ASSERT(__HeapLimit >= ORIGIN(RAM) + LENGTH(RAM), "region RAM overflowed")
+    ASSERT(__end__ < ORIGIN(RAM) + LENGTH(RAM), "region RAM overflowed")
 
     .flash_end : {
         PROVIDE(__flash_binary_end = .);
     } > FLASH
 
-    /* stack limit is poorly named, but historically is maximum heap ptr */
-    __StackTop = ORIGIN(SCRATCH) + LENGTH(SCRATCH_Y);
+    __StackTop = ORIGIN(STACK_SCRATCH) + LENGTH(STACK_SCRATCH);
     __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
     __StackBottom = __StackLimit;
+    ASSERT(__StackLimit >= STACK_SCRATCH_STATIC_END_SYMBOL, "stack scratch region overflowed")
     PROVIDE(__stack = __StackTop);
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
 
     ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
     /* todo assert on extra code */

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/TOOLCHAIN_GCC_ARM/memmap_default_mbed.ld
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/TOOLCHAIN_GCC_ARM/memmap_default_mbed.ld
@@ -22,8 +22,6 @@
     __stack (== StackTop)
 */
 
-#include "../cmsis_nvic.h"
-
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
     /* This value is normally defined by the tools
        to 0x1000 for bare metal and 0x400 for RTOS */
@@ -32,15 +30,15 @@
 
 MEMORY
 {
-    FLASH(rx) : ORIGIN = MBED_ROM_START, LENGTH = MBED_ROM_SIZE
-    RAM(rwx) : ORIGIN =  MBED_RAM_START, LENGTH = MBED_RAM_SIZE
+    FLASH(rx) : ORIGIN = MBED_CONFIGURED_ROM_BANK_QSPI_FLASH_START, LENGTH = MBED_CONFIGURED_ROM_BANK_QSPI_FLASH_SIZE
+    RAM(rwx) : ORIGIN =  MBED_CONFIGURED_RAM_BANK_IRAM1_START, LENGTH = MBED_CONFIGURED_RAM_BANK_IRAM1_SIZE
 
     /*
      * Scratch banks are commonly used for critical data and functions accessed only by one core (when only
      * one core is accessing the RAM bank, there is no opportunity for stalls).
      */
-    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
-    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+    SCRATCH_X(rwx) : ORIGIN = MBED_CONFIGURED_RAM_BANK_SCRATCH_X_START, LENGTH = MBED_CONFIGURED_RAM_BANK_SCRATCH_X_SIZE
+    SCRATCH_Y(rwx) : ORIGIN = MBED_CONFIGURED_RAM_BANK_SCRATCH_Y_START, LENGTH = MBED_CONFIGURED_RAM_BANK_SCRATCH_Y_SIZE
 }
 
 ENTRY(_entry_point)
@@ -218,16 +216,19 @@ SECTIONS
         __end__ = .;
         PROVIDE(end = .);
         *(.heap*)
-        . = ORIGIN(RAM) + LENGTH(RAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
+        . = ORIGIN(RAM) + LENGTH(RAM);
         __HeapLimit = .;
     } > RAM
+
+    /* Check if data + heap exceeds RAM limit */
+    ASSERT(__HeapLimit >= ORIGIN(RAM) + LENGTH(RAM), "region RAM overflowed")
 
     .flash_end : {
         PROVIDE(__flash_binary_end = .);
     } > FLASH
 
     /* stack limit is poorly named, but historically is maximum heap ptr */
-    __StackTop = ORIGIN(SCRATCH_Y) + LENGTH(SCRATCH_Y);
+    __StackTop = ORIGIN(SCRATCH) + LENGTH(SCRATCH_Y);
     __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
     __StackBottom = __StackLimit;
     PROVIDE(__stack = __StackTop);

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/cmsis_nvic.h
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/cmsis_nvic.h
@@ -17,24 +17,5 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
-#if !defined(MBED_ROM_START)
-#define MBED_ROM_START  0x10000000
-#endif
-
-#if !defined(MBED_ROM_SIZE)
-#if defined(PICO_FLASH_SIZE_BYTES)
-#define MBED_ROM_SIZE PICO_FLASH_SIZE_BYTES
-#else
-#define MBED_ROM_SIZE  (2048*1024)
-#endif
-#endif
-
-#if !defined(MBED_RAM_START)
-#define MBED_RAM_START  0x20000000
-#endif
-
-#if !defined(MBED_RAM_SIZE)
-#define MBED_RAM_SIZE  (256*1024)
-#endif
 
 #endif

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/flash_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/flash_api.c
@@ -1,3 +1,20 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2024, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /******************************************************************************
  * INCLUDE
  ******************************************************************************/

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/flash_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/flash_api.c
@@ -88,7 +88,7 @@ uint32_t flash_get_size(const flash_t *obj)
 {
     (void)(obj);
 
-    return PICO_FLASH_SIZE_BYTES;
+    return MBED_ROM_BANK_QSPI_FLASH_SIZE;
 }
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)

--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/rtc_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/rtc_api.c
@@ -1,3 +1,20 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2024, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #if DEVICE_RTC
 
 #include "mbed_critical.h"
@@ -81,6 +98,8 @@ void rtc_write(time_t t)
     // won't produce the expected result.  I wasn't able to find any errata or anything documenting
     // this behavior, but it's very consistent, and the RTC tests fail if the below block is removed.
     // To fix the error, we just decrease the time by 1 second before writing it to the registers.
+    // Update 2024: This is now a known, if not officially acknowledged, errata:
+    // https://forums.raspberrypi.com/viewtopic.php?t=377876
     if (t >= 1) {
         t -= 1;
     }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -9792,6 +9792,21 @@
             // (so the ADC can never read 100%).
             "default-adc-vref": 3.3
         },
+        "memory_banks": {
+            "QSPI_FLASH": {
+                "access": {
+                    "execute": true,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "startup": true,
+                "size": 0x200000, // 2MiB
+                "start": 0x10000000
+            }
+        },
         "image_url": "https://cdn11.bigcommerce.com/s-2fbyfnm8ev/images/stencil/1280x1280/products/1212/4275/Pico3__75642.1611086462.jpg?c=2"
     },
     "RASPBERRY_PI_PICO_SWD": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I noticed that RPi Pico got broken a while back due to the upload method changes, because it does not have a flash bank defined, so the upload methods don't have a location to upload to.  Funnily enough I actually did write such a flash bank definition in the memory banks example on the page, but never actually put it into the code X_X.

This PR updates the RP2040 target to:
- Have a defined QSPI flash bank, whose size can be configured via `memory_banks` and `memory_bank_config`
  - Generally custom target creators should set the physical size of the flash in `memory_banks` and the configured area for the Mbed application in `memory_bank_config`, because the `memory_banks` definition is now used for the flash programming HAL
- Use the configured flash and RAM sizes in the linker script, opening the way for building images for core 1 using the same linker script
- Use either SCRATCH_X or SCRATCH_Y for the stack, depending on which core the RAM is configured for

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
Fix CMake configuration failing for RP2040 if an upload method is enabled

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Test run in progress...
----------------------------------------------------------------------------------------------------------------
