### PR TITLE
Update cmsis_mcu_descr.py for custom targets

### DIFF
--- a/tools/python/mbed_tools/cli/cmsis_mcu_descr.py
+++ b/tools/python/mbed_tools/cli/cmsis_mcu_descr.py
@@ -25,6 +25,8 @@ import datetime
 import logging
 import json
 import sys
+import re
+import argparse
 from typing import Set, Dict, Any
 
 LOGGER = logging.getLogger(__name__)
@@ -35,8 +37,8 @@ MBED_OS_DIR = THIS_SCRIPT_DIR.parent.parent.parent.parent
 TARGETS_JSON5_PATH = MBED_OS_DIR / "targets" / "targets.json5"
 CMSIS_MCU_DESCRIPTIONS_JSON_PATH = MBED_OS_DIR / "targets" / "cmsis_mcu_descriptions.json5"
 
-CUSTOM_DIR = THIS_SCRIPT_DIR.parent.parent.parent.parent.parent
-CUSTOM_TARGETS_JSON5_PATH = CUSTOM_DIR / "custom_targets" / "custom_targets.json5"
+PROJECT_ROOT = THIS_SCRIPT_DIR.parent.parent.parent.parent.parent
+CUSTOM_TARGETS_JSON_PATH = None
 
 # Top-level command
 @click.group(
@@ -68,19 +70,58 @@ def open_cmsis_cache(*, must_exist: bool = True) -> cmsis_pack_manager.Cache:
 
     return cmsis_cache
 
+def find_json_files(root_dir, exclude_dirs=[], file_pattern=r".*\.(json|json5)"):
+    """
+    Recursively searches for files matching the specified pattern in a given directory, excluding specified directories.
+
+    Args:
+        root_dir (str): The root directory to search.
+        exclude_dirs (list): A list of directory names to exclude.
+        file_pattern (str): A regular expression pattern to match file names.
+
+    Returns:
+        A list of paths to found files.
+    """
+    json_files = []
+
+    for root, dirs, files in os.walk(root_dir):
+        # Exclude specified directories
+        for exclude_dir in exclude_dirs:
+            if exclude_dir in dirs:
+                dirs.remove(exclude_dir)
+
+        for file in files:
+            if re.match(file_pattern, file):
+                json_files.append(pathlib.Path(os.path.join(root, file)))
+
+    return json_files
+
 
 def get_mcu_names_used_by_targets_json5() -> Set[str]:
     """
-    Accumulate set of all `device_name` properties used by all targets defined in targets.json5 and custom_targets.json5
+    Accumulate set of all `device_name` properties used by all targets defined in targets.json5 and custom_targets.json/json5.
     """
+
+    # Search for files starting with "custom_targets" of type .json or .json5. Also exclude some folders like build and mbed-os
+    exclude_dirs = ["build", "mbed-os", ".git"]
+    file_pattern = r"custom_targets\.(json|json5)"  
+    custom_targets_file = find_json_files(PROJECT_ROOT, exclude_dirs, file_pattern)
+
+    for file in custom_targets_file:
+        if os.path.exists(file):
+            global CUSTOM_TARGETS_JSON_PATH 
+            CUSTOM_TARGETS_JSON_PATH = file
+            print(f"File exist {CUSTOM_TARGETS_JSON_PATH}")
+
+
     used_mcu_names = set()
     LOGGER.info("Scanning targets.json5 for used MCU names...")
-    json5_contents = decode_json_file(TARGETS_JSON5_PATH)
-    if os.path.exists(CUSTOM_TARGETS_JSON5_PATH):
-        LOGGER.info("Scanning custom_targets.json5 for used MCU names...")
-        json5_contents.update(decode_json_file(CUSTOM_TARGETS_JSON5_PATH))
+    json_contents = decode_json_file(TARGETS_JSON5_PATH)
+    if custom_targets_file:
+        LOGGER.info("Scanning custom_targets.json/json5. for used MCU names...")
+        json_contents.update(decode_json_file(CUSTOM_TARGETS_JSON_PATH))
 
-    for target_details in json5_contents.values():
+    for target_details in json_contents.values():
         if "device_name" in target_details:
             used_mcu_names.add(target_details["device_name"])
     return used_mcu_names
@@ -159,26 +200,27 @@ def check_missing():
 
 @cmsis_mcu_descr.command(
     name="fetch-missing",
-    short_help="Fetch any missing MCU descriptions used by targets.json5 or custom_targets.json5."
+    short_help="Fetch any missing MCU descriptions used by targets.json5 or custom_targets.json/json5.."
 )
 def fetch_missing():
     """
-    Scans through cmsis_mcu_descriptions.json for any missing MCU descriptions that are referenced by 
-    targets.json5 or custom_targets.json5. If any are found, they are imported from the CMSIS cache.
+    Scans through cmsis_mcu_descriptions.json5 for any missing MCU descriptions that are referenced by 
+    targets.json5 or custom_targets.json/json5. If any are found, they are imported from the CMSIS cache.
 
     Note that downloaded descriptions should be checked for accuracy before they are committed.
     """
+
     used_mcu_names = get_mcu_names_used_by_targets_json5()
 
     # Accumulate set of all keys in cmsis_mcu_descriptions.json
-    LOGGER.info("Scanning cmsis_mcu_descriptions.json for missing MCUs...")
+    LOGGER.info("Scanning cmsis_mcu_descriptions.json5 file for missing MCUs...")
     cmsis_mcu_descriptions_json_contents: Dict[str, Any] = decode_json_file(CMSIS_MCU_DESCRIPTIONS_JSON_PATH)
     available_mcu_names = cmsis_mcu_descriptions_json_contents.keys()
 
     # Are there any missing?
     missing_mcu_names = used_mcu_names - available_mcu_names
     if len(missing_mcu_names) == 0:
-        print("No missing MCUs, no work to do.")
+        LOGGER.info("No missing MCUs, no work to do.")
         return
 
     # Load CMSIS cache to access new MCUs
@@ -193,10 +235,10 @@ def fetch_missing():
                                f"to be added manually?")
         missing_mcus_dict[mcu] = cmsis_cache.index[mcu]
         
-    if os.path.exists(CUSTOM_TARGETS_JSON5_PATH):
-        print(f"Remove 'device_name' and add the 'memories' section as 'memory_banks' section\nfrom following entries to {CUSTOM_TARGETS_JSON5_PATH}:")
+    if os.path.exists(CUSTOM_TARGETS_JSON_PATH):
+        LOGGER.info(f"Remove 'device_name' and add the 'memories' section as 'memory_banks' section\nfrom following entries to {CUSTOM_TARGETS_JSON_PATH}:")
     else:
-        print(f"Add the following entries to {CMSIS_MCU_DESCRIPTIONS_JSON_PATH}:")
+       LOGGER.info(f"Add the following entries to {CMSIS_MCU_DESCRIPTIONS_JSON_PATH}:")
 
     print(json.dumps(missing_mcus_dict, indent=4, sort_keys=True))
     sys.exit(1) 

--- a/tools/python/mbed_tools/cli/cmsis_mcu_descr.py
+++ b/tools/python/mbed_tools/cli/cmsis_mcu_descr.py
@@ -234,8 +234,8 @@ def fetch_missing():
                                f"to be added manually?")
         missing_mcus_dict[mcu] = cmsis_cache.index[mcu]
         
-    LOGGER.info(f"In case of Custom target remove 'device_name' from your custom_targets.json5 file and add\n" +
+    LOGGER.info("In case of Custom target remove 'device_name' from your custom_targets.json5 file and add\n" +
                     "just the 'memories' section as 'memory_banks' section from content below.\n" +
-                    "Otherwise add the whole following entries to {CMSIS_MCU_DESCRIPTIONS_JSON_PATH}:")
+                    f"Otherwise add the whole following entries to {CMSIS_MCU_DESCRIPTIONS_JSON_PATH}:")
     print(json.dumps(missing_mcus_dict, indent=4, sort_keys=True))
     sys.exit(1) 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
This PR will update cmsis_mcu_descr.py to be able to operate also for custom targets.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The script was able to scan only targets.json5 file and potential existence of custom_targets.json5 was ignored.
Well, no more.


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
N/A

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
N/A

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

<details><summary>Console output</summary>

```json5
[main] Configuring project: mbed-ce-custom-targets 
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" -DCMAKE_BUILD_TYPE:STRING=Develop -DMBED_TARGET:STRING=F103VGT6 -DUPLOAD_METHOD:STRING=NONE -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE --no-warn-unused-cli -SC:/MbedCE/mbed-ce-custom-targets -Bc:/MbedCE/mbed-ce-custom-targets/build -G Ninja
[cmake] Not searching for unused variables given on the command line.
[cmake] -- Found Python3: C:/MbedCE/mbed-ce-custom-targets/mbed-os/venv/Scripts/python.exe (found version "3.12.4") found components: Interpreter 
[cmake] -- Mbed: First CMake run detected, generating configs...
[cmake] INFO: Custom_targets file detected - C:\MbedCE\mbed-ce-custom-targets\custom_targets\custom_targets.json5
[cmake] INFO: Scanning targets.json5 for used MCU names...
[cmake] INFO: Scanning custom_targets.json/json5. for used MCU names...
[cmake] INFO: Scanning cmsis_mcu_descriptions.json5 file for missing MCUs...
[cmake] INFO: CMSIS MCU description cache was last updated: 4 months ago
[cmake] INFO: In case of Custom target remove 'device_name' from your custom_targets.json5 file and add
[cmake] just the 'memories' section as 'memory_banks' section from content below.
[cmake] Otherwise add the whole following entries to C:\MbedCE\mbed-ce-custom-targets\mbed-os\targets\cmsis_mcu_descriptions.json5:
[cmake] {
[cmake]     "STM32F103VG": {
[cmake]         "algorithms": [
[cmake]             {
[cmake]                 "default": true,
[cmake]                 "file_name": "Flash/STM32F10x_1024.FLM",
[cmake]                 "ram_size": null,
[cmake]                 "ram_start": null,
[cmake]                 "size": 1048576,
[cmake]                 "start": 134217728,
[cmake]                 "style": "Keil"
[cmake]             },
[cmake]             {
[cmake]                 "default": false,
[cmake]                 "file_name": "Flash/STM32F10x_OPT.FLM",
[cmake]                 "ram_size": null,
[cmake]                 "ram_start": null,
[cmake]                 "size": 16,
[cmake]                 "start": 536868864,
[cmake]                 "style": "Keil"
[cmake]             }
[cmake]         ],
[cmake]         "family": "STM32F1 Series",
[cmake]         "from_pack": {
[cmake]             "pack": "STM32F1xx_DFP",
[cmake]             "url": "https://www.keil.com/pack/",
[cmake]             "vendor": "Keil",
[cmake]             "version": "2.4.1"
[cmake]         },
[cmake]         "memories": {
[cmake]             "IRAM1": {
[cmake]                 "access": {
[cmake]                     "execute": false,
[cmake]                     "non_secure": false,
[cmake]                     "non_secure_callable": false,
[cmake]                     "peripheral": false,
[cmake]                     "read": true,
[cmake]                     "secure": false,
[cmake]                     "write": true
[cmake]                 },
[cmake]                 "default": true,
[cmake]                 "p_name": null,
[cmake]                 "size": 98304,
[cmake]                 "start": 536870912,
[cmake]                 "startup": false
[cmake]             },
[cmake]             "IROM1": {
[cmake]                 "access": {
[cmake]                     "execute": true,
[cmake]                     "non_secure": false,
[cmake]                     "non_secure_callable": false,
[cmake]                     "peripheral": false,
[cmake]                     "read": true,
[cmake]                     "secure": false,
[cmake]                     "write": false
[cmake]                 },
[cmake]                 "default": true,
[cmake]                 "p_name": null,
[cmake]                 "size": 1048576,
[cmake]                 "start": 134217728,
[cmake]                 "startup": true
[cmake]             }
[cmake]         },
[cmake]         "name": "STM32F103VG",
[cmake]         "processors": [
[cmake]             {
[cmake]                 "address": null,
[cmake]                 "ap": 0,
[cmake]                 "apid": null,
[cmake]                 "core": "CortexM3",
[cmake]                 "default_reset_sequence": null,
[cmake]                 "dp": 0,
[cmake]                 "fpu": "None",
[cmake]                 "mpu": "Present",
[cmake]                 "name": null,
[cmake]                 "svd": "SVD/STM32F103xx.svd",
[cmake]                 "unit": 0
[cmake]             }
[cmake]         ],
[cmake]         "sub_family": "STM32F103",
[cmake]         "vendor": "STMicroelectronics:13"
[cmake]     }
[cmake] }
[cmake] ERROR: Target specifies device_name STM32F103VG but this device is not
[cmake] listed in C:\MbedCE\mbed-ce-custom-targets\mbed-os\tools\cmake\..\..\targets\cmsis_mcu_descriptions.json5. Please verified you device name in mbed-os	argets.json or your custom_targets.json5 file.
[cmake] Otherwise, see the instructions above this message.
[cmake] 
[cmake] More information may be available by using the command line option '-vv'.
[cmake] CMake Error at mbed-os/tools/cmake/mbed_generate_configuration.cmake:123 (message):
[cmake]   mbedtools configure failed! Cannot build this project.  Command was cd
[cmake]   C:/MbedCE/mbed-ce-custom-targets/mbed-os/tools/cmake/../python &&
[cmake]   C:/MbedCE/mbed-ce-custom-targets/mbed-os/venv/Scripts/python.exe -m
[cmake]   mbed_tools.cli.main -v configure -t GCC_ARM -m F103VGT6 --mbed-os-path
[cmake]   C:/MbedCE/mbed-ce-custom-targets/mbed-os/tools/cmake/../..  --output-dir
[cmake]   C:/MbedCE/mbed-ce-custom-targets/build --program-path
[cmake]   C:/MbedCE/mbed-ce-custom-targets --app-config
[cmake]   C:/MbedCE/mbed-ce-custom-targets/mbed_app.json5 --custom-targets-json
[cmake]   C:/MbedCE/mbed-ce-custom-targets/custom_targets/custom_targets.json5
[cmake] Call Stack (most recent call first):
[cmake]   mbed-os/tools/cmake/app.cmake:24 (include)
[cmake]   CMakeLists.txt:27 (include)
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" -DCMAKE_BUILD_TYPE:STRING=Develop -DMBED_TARGET:STRING=F103VGT6 -DUPLOAD_METHOD:STRING=NONE -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE --no-warn-unused-cli -SC:/MbedCE/mbed-ce-custom-targets -Bc:/MbedCE/mbed-ce-custom-targets/build -G Ninja exited with code: 1
```
</details>
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
