### PR TITLE
STM32H7: Don't use DTCM memory for heap

### DIFF
--- a/cmsis/device/rtos/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
+++ b/cmsis/device/rtos/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
@@ -29,10 +29,20 @@ static osMutexId_t               env_mutex_id;
 static mbed_rtos_storage_mutex_t env_mutex_obj;
 static osMutexAttr_t             env_mutex_attr;
 
+// Stack symbols from linker script
 extern uint32_t             __StackLimit;
 extern uint32_t             __StackTop;
+
+// Heap symbols from linker script
+#if defined(MBED_SPLIT_HEAP)
+extern uint32_t __mbed_sbrk_start;
+extern uint32_t __mbed_krbs_start;
+extern uint32_t __mbed_sbrk_start_0;
+extern uint32_t __mbed_krbs_start_0;
+#else
 extern uint32_t             __end__;
 extern uint32_t             __HeapLimit;
+#endif
 
 extern void __libc_init_array(void);
 
@@ -45,8 +55,15 @@ void software_init_hook(void)
 {
     mbed_stack_isr_start = (unsigned char *) &__StackLimit;
     mbed_stack_isr_size = (uint32_t) &__StackTop - (uint32_t) &__StackLimit;
+#if defined(MBED_SPLIT_HEAP)
+    mbed_heap_start = (unsigned char *) &__mbed_sbrk_start;
+    mbed_heap_size = (uint32_t) &__mbed_krbs_start - (uint32_t) &__mbed_sbrk_start;
+    mbed_heap_start_0 = (unsigned char *) &__mbed_sbrk_start_0;
+    mbed_heap_size_0 = (uint32_t) &__mbed_krbs_start_0 - (uint32_t) &__mbed_sbrk_start_0;
+#else
     mbed_heap_start = (unsigned char *) &__end__;
     mbed_heap_size = (uint32_t) &__HeapLimit - (uint32_t) &__end__;
+#endif
 
     mbed_init();
     mbed_rtos_start();

--- a/cmsis/device/rtos/include/mbed_boot.h
+++ b/cmsis/device/rtos/include/mbed_boot.h
@@ -58,6 +58,11 @@ extern "C" {
 extern unsigned char *mbed_heap_start;
 extern uint32_t mbed_heap_size;
 
+#if defined(MBED_SPLIT_HEAP)
+extern unsigned char *mbed_heap_start_0;
+extern uint32_t mbed_heap_size_0;
+#endif
+
 /* Stack limits */
 extern unsigned char *mbed_stack_isr_start;
 extern uint32_t mbed_stack_isr_size;

--- a/cmsis/device/rtos/source/mbed_boot.c
+++ b/cmsis/device/rtos/source/mbed_boot.c
@@ -46,7 +46,7 @@
  * - Value INITIAL_SP is ignored
  *
  * GCC Memory layout :
- * - Heap explicitly placed in linker script (*.ld file) and heap start (__end___) and heap end (__HeapLimit) should be defined in linker script
+ * - Heap explicitly placed in linker script (*.ld file) and heap start (__end___) and heap end (__HeapLimit) should be defined in linker script (or __mbed_sbrk_start/__mbed_sbrk_start_0 and __mbed_krbs_start/__mbed_krbs_start_0 for split heap targets)
  * - Interrupt stack placed in linker script **.ld file) and stack start (__StackTop) and stack end (__StackLimit) should be defined in linker script
  *
  * ARM Memory layout :

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -120,6 +120,11 @@ extern const char __stderr_name[] = "/stderr";
 unsigned char *mbed_heap_start = 0;
 uint32_t mbed_heap_size = 0;
 
+#if defined(MBED_SPLIT_HEAP)
+unsigned char *mbed_heap_start_0 = 0;
+uint32_t mbed_heap_size_0 = 0;
+#endif
+
 #if !MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 
 /* newlib has the filehandle field in the FILE struct as a short, so

--- a/rtos/tests/TESTS/mbed_rtos/heap_and_stack/main.cpp
+++ b/rtos/tests/TESTS/mbed_rtos/heap_and_stack/main.cpp
@@ -28,6 +28,7 @@
 #include "greentea-client/test_env.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
+#include "mbed_boot.h"
 
 using utest::v1::Case;
 
@@ -39,17 +40,8 @@ static const int test_timeout = 30;
 // Malloc fill pattern
 #define MALLOC_FILL                 0x55
 
-extern unsigned char *mbed_heap_start;
-extern uint32_t mbed_heap_size;
 extern unsigned char *mbed_stack_isr_start;
 extern uint32_t mbed_stack_isr_size;
-
-#if defined(TOOLCHAIN_GCC_ARM) && defined(MBED_SPLIT_HEAP)
-extern uint32_t __mbed_sbrk_start_0;
-extern uint32_t __mbed_krbs_start_0;
-unsigned char *mbed_heap_start_0 = (unsigned char *) &__mbed_sbrk_start_0;;
-uint32_t mbed_heap_size_0 = (uint32_t) &__mbed_krbs_start_0 - (uint32_t) &__mbed_sbrk_start_0;
-#endif
 
 struct linked_list {
     linked_list *next;

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
@@ -187,15 +187,14 @@ SECTIONS
         _ebss = .;
     } > SRAM
 
-    .heap (COPY):
+    /* Check if data + stack will exceed SRAM limit */
+    ASSERT(_ebss < ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE, "region SRAM does not have enough space for boot stack size")
+
+    .heap_0 (NOLOAD):
     {
-        __end__ = .;
-        PROVIDE(end = .);
-        PROVIDE(__mbed_sbrk_start = .);
-        *(.heap*)
+        PROVIDE(__mbed_sbrk_start_0 = .);
         . = ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
-        PROVIDE(__mbed_krbs_start = .);
-        __HeapLimit = .;
+        PROVIDE(__mbed_krbs_start_0 = .);
     } > SRAM
 
     /* .stack_dummy section doesn't contains any symbols. It is only
@@ -213,9 +212,6 @@ SECTIONS
     __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
     PROVIDE(__stack = __StackTop);
 
-    /* Check if data + heap + stack exceeds SRAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region SRAM overflowed with stack")
-
     /* Ethernet DMA descriptors should be at the start of SRAM_D2 because they need an MPU region 
        and because the CM4 and CM7 have to agree on their location.*/
     .eth_descriptors (NOLOAD) : {
@@ -230,11 +226,11 @@ SECTIONS
         *(.EthBuffers)
     } >SRAM_D2 
 
-    /* Use the rest of DTCM as additional heap */
-    .heap_0 (COPY):
+    /* Use SRAM_D2 as additional heap */
+    .heap (NOLOAD):
     {
-        PROVIDE(__mbed_sbrk_start_0 = .);
-        . += (ORIGIN(SRAM_DTC) + LENGTH(SRAM_DTC) - .);
-        PROVIDE(__mbed_krbs_start_0 = .);
-    } > SRAM_DTC
+        PROVIDE(__mbed_sbrk_start = .);
+        . += (ORIGIN(SRAM_D2) + LENGTH(SRAM_D2) - .);
+        PROVIDE(__mbed_krbs_start = .);
+    } > SRAM_D2
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM4/STM32H745_H747_CM4.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM4/STM32H745_H747_CM4.ld
@@ -182,14 +182,15 @@ SECTIONS
         _ebss = .;
     } > SRAM_D2
 
+    /* Check if data + stack will exceed SRAM limit */
+    ASSERT(_ebss < ORIGIN(SRAM_D2) + LENGTH(SRAM_D2) - MBED_CONF_TARGET_BOOT_STACK_SIZE, "region SRAM does not have enough space for boot stack size")
+
     .heap (COPY):
     {
         __end__ = .;
         PROVIDE(end = .);
-        PROVIDE(__mbed_sbrk_start = .);
         *(.heap*)
         . = ORIGIN(SRAM_D2) + LENGTH(SRAM_D2) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
-        PROVIDE(__mbed_krbs_start = .);
         __HeapLimit = .;
     } > SRAM_D2
     /* .stack_dummy section doesn't contains any symbols. It is only
@@ -206,9 +207,6 @@ SECTIONS
     _estack = __StackTop;
     __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Check if data + heap + stack exceeds SRAM_D2 limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region SRAM_D2 overflowed with stack")
 
     /* Put crash data in the otherwise unused D3 SRAM */
     .crash_data_ram :

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
@@ -174,14 +174,14 @@ SECTIONS
         _ebss = .;
     } > SRAM
 
+    /* Check if data + stack will exceed SRAM limit */
+    ASSERT(_ebss < ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE, "region SRAM does not have enough space for boot stack size")
+
     .heap (COPY):
     {
         __end__ = .;
         PROVIDE(end = .);
-        PROVIDE(__mbed_sbrk_start = .);
-        *(.heap*)
         . = ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
-        PROVIDE(__mbed_krbs_start = .);
         __HeapLimit = .;
     } > SRAM
 
@@ -230,12 +230,4 @@ SECTIONS
         . = ALIGN(8);
         __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
     } > SRAM_D3
-    
-    /* Use the rest of DTCM as additional heap */
-    .heap_0 (COPY):
-    {
-        PROVIDE(__mbed_sbrk_start_0 = .);
-        . += (ORIGIN(SRAM_DTC) + LENGTH(SRAM_DTC) - .);
-        PROVIDE(__mbed_krbs_start_0 = .);
-    } > SRAM_DTC
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
@@ -174,15 +174,14 @@ SECTIONS
         _ebss = .;
     } > SRAM
 
-    .heap (COPY):
+    /* Check if data + stack will exceed SRAM limit */
+    ASSERT(_ebss < ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE, "region SRAM does not have enough space for boot stack size")
+
+    .heap_0 (NOLOAD):
     {
-        __end__ = .;
-        PROVIDE(end = .);
-        PROVIDE(__mbed_sbrk_start = .);
-        *(.heap*)
+        PROVIDE(__mbed_sbrk_start_0 = .);
         . = ORIGIN(SRAM) + LENGTH(SRAM) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
-        PROVIDE(__mbed_krbs_start = .);
-        __HeapLimit = .;
+        PROVIDE(__mbed_krbs_start_0 = .);
     } > SRAM
 
     /* .stack_dummy section doesn't contains any symbols. It is only
@@ -199,9 +198,6 @@ SECTIONS
     _estack = __StackTop;
     __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Check if data + heap + stack exceeds SRAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region SRAM overflowed with stack")
 
     /* Put crash data in the otherwise unused D3 SRAM */
     .crash_data_ram :
@@ -229,11 +225,11 @@ SECTIONS
         *(.EthBuffers)
     } >SRAM_AXI 
 
-    /* Use the rest of DTCM as additional heap */
-    .heap_0 (COPY):
+    /* Use SRAM_AXI as additional heap */
+    .heap (NOLOAD):
     {
-        PROVIDE(__mbed_sbrk_start_0 = .);
-        . += (ORIGIN(SRAM_DTC) + LENGTH(SRAM_DTC) - .);
-        PROVIDE(__mbed_krbs_start_0 = .);
-    } > SRAM_DTC
+        PROVIDE(__mbed_sbrk_start = .);
+        . += (ORIGIN(SRAM_AXI) + LENGTH(SRAM_AXI) - .);
+        PROVIDE(__mbed_krbs_start = .);
+    } > SRAM_AXI
 }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3455,8 +3455,7 @@
             }
         },
         "macros_add": [
-            "CORE_CM7",
-            "MBED_SPLIT_HEAP"
+            "CORE_CM7"
         ]
     },
     "NUCLEO_H745ZI_Q": {
@@ -3522,8 +3521,7 @@
             }
         },
         "macros_add": [
-            "CORE_CM7",
-            "MBED_SPLIT_HEAP"
+            "CORE_CM7"
         ]
     },
     "MCU_STM32H747xI_CM4": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The change that I made a month or two ago to use DTCM as the default heap on STM32H7 has caused some unforseen consequences.  Basically, the DMA controller cannot access anything in DTCM in any shape or form, so using SDIO, Ethernet, or DMA SPI with heap-allocated buffers will cause a crash or unintended behavior.

This PR updates the STM32H7 linker scripts (soooo glad there are only 4 of them now!) to use main SRAM as heap 0 and SRAM_D2/SRAM_AXI as heap.  This way, we still can take advantage of two of the memory banks for heap size, but we don't have to deal with the issues caused by DTCM.  DTCM provides a big performance boost, make no mistake, but I think it's best left as a power user only option.

I also made one other change in this, which is that until now, targets which implemented split heap still had to provide the __end__ and __HeapLimit symbols in the linker script in order for the `mbed_heap_start/size` variables to be correct, even though the actual heap allocator did not use them.  This consolidates those so that only the "new style" symbols are needed if you have split heap, and only the "old style" symbols are needed if you don't.  I like this because __end__ is a super vague name and while Mbed only uses it as the start of heap, it's hard to say if everyone agrees that's what it means, so I would rather move away from using it.

#### Impact of changes <!-- Optional -->
- Fixes crashes and broken stuff when using heap allocated buffers on STM32H7
- For targets defining `MBED_SPLIT_HEAP`, the linker script only needs to define __mbed_sbrk_start/__mbed_sbrk_start_0 and __mbed_krbs_start/__mbed_krbs_start_0, not __end__ and __HeapLimit.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
The following tests passed on NUCLEO_H743ZI2:
```
        test-mbed-platform-stats-heap
        test-mbed-rtos-heap-and-stack
        test-mbed-storage-blockdevice-heap_block_device

```
----------------------------------------------------------------------------------------------------------------
