### PR TITLE
Fix build issues with cellular

### DIFF
--- a/connectivity/cellular/CMakeLists.txt
+++ b/connectivity/cellular/CMakeLists.txt
@@ -39,5 +39,6 @@ target_link_libraries(mbed-cellular
     PUBLIC
         mbed-netsocket-api
         mbed-core-flags
+        mbed-rtos-flags
         mbed-randlib
 )

--- a/connectivity/drivers/cellular/Altair/COMPONENT_ALTAIR_ALT1250/PPP/ALT1250_PPP.cpp
+++ b/connectivity/drivers/cellular/Altair/COMPONENT_ALTAIR_ALT1250/PPP/ALT1250_PPP.cpp
@@ -118,5 +118,19 @@ CellularDevice *CellularDevice::get_default_instance()
     static ALT1250_PPP device(&serial, MBED_CONF_ALT1250_PPP_RST, PIN_OUTPUT, OpenDrainNoPull, 1);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_ALT1250_PPP_CPP(void)
+{
+}
 #endif
 

--- a/connectivity/drivers/cellular/Altair/COMPONENT_ALTAIR_ALT1250/PPP/CMakeLists.txt
+++ b/connectivity/drivers/cellular/Altair/COMPONENT_ALTAIR_ALT1250/PPP/CMakeLists.txt
@@ -12,3 +12,15 @@ target_sources(mbed-cellular
         ALT1250_PPP_CellularContext.cpp
         ALT1250_PPP_CellularNetwork.cpp
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_ALT1250_PPP_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/COMPONENT_STMOD_CELLULAR/CMakeLists.txt
+++ b/connectivity/drivers/cellular/COMPONENT_STMOD_CELLULAR/CMakeLists.txt
@@ -10,3 +10,15 @@ target_sources(mbed-cellular
     PRIVATE
         STModCellular.cpp
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_STMODCELLULAR_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/connectivity/drivers/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -179,5 +179,19 @@ CellularDevice *CellularDevice::get_default_instance()
     static STModCellular device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_STMODCELLULAR_CPP(void)
+{
+}
 #endif
 

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/CMakeLists.txt
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/CMakeLists.txt
@@ -13,3 +13,15 @@ target_sources(mbed-cellular
         GEMALTO_CINTERION_CellularInformation.cpp
         GEMALTO_CINTERION_CellularStack.cpp
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_GEMALTO_CINTERION_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
@@ -214,4 +214,18 @@ CellularDevice *CellularDevice::get_default_instance()
     static GEMALTO_CINTERION device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_GEMALTO_CINTERION_CPP(void)
+{
+}
 #endif

--- a/connectivity/drivers/cellular/GENERIC/COMPONENT_GENERIC_AT3GPP/CMakeLists.txt
+++ b/connectivity/drivers/cellular/GENERIC/COMPONENT_GENERIC_AT3GPP/CMakeLists.txt
@@ -10,3 +10,15 @@ target_sources(mbed-cellular
     PRIVATE
         GENERIC_AT3GPP.cpp
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_GENERIC_AT3GPP_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/GENERIC/COMPONENT_GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
+++ b/connectivity/drivers/cellular/GENERIC/COMPONENT_GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
@@ -61,4 +61,18 @@ CellularDevice *CellularDevice::get_default_instance()
     static GENERIC_AT3GPP device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_GENERIC_AT3GPP_CPP(void)
+{
+}
 #endif

--- a/connectivity/drivers/cellular/MultiTech/DragonflyNano/COMPONENT_MULTITECH_DRAGONFLY_NANO_CELLULAR/CMakeLists.txt
+++ b/connectivity/drivers/cellular/MultiTech/DragonflyNano/COMPONENT_MULTITECH_DRAGONFLY_NANO_CELLULAR/CMakeLists.txt
@@ -15,3 +15,15 @@ target_sources(mbed-cellular
 if("MTS_DRAGONFLY_L471QG" IN_LIST MBED_TARGET_LABELS)
 	add_subdirectory(TARGET_MTS_DRAGONFLY_L471QG)
 endif()
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_SARA4_PPP_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/MultiTech/DragonflyNano/COMPONENT_MULTITECH_DRAGONFLY_NANO_CELLULAR/SARA4_PPP.cpp
+++ b/connectivity/drivers/cellular/MultiTech/DragonflyNano/COMPONENT_MULTITECH_DRAGONFLY_NANO_CELLULAR/SARA4_PPP.cpp
@@ -185,4 +185,18 @@ CellularDevice *CellularDevice::get_default_instance()
     static SARA4_PPP device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_SARA4_PPP_CPP(void)
+{
+}
 #endif

--- a/connectivity/drivers/cellular/RiotMicro/COMPONENT_RIOTMICRO_RM1000/CMakeLists.txt
+++ b/connectivity/drivers/cellular/RiotMicro/COMPONENT_RIOTMICRO_RM1000/CMakeLists.txt
@@ -13,3 +13,15 @@ target_sources(mbed-cellular
         RM1000_AT_CellularNetwork.cpp
         RM1000_AT_CellularStack.cpp
 )
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_RM1000_AT_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/RiotMicro/COMPONENT_RIOTMICRO_RM1000/RM1000_AT.cpp
+++ b/connectivity/drivers/cellular/RiotMicro/COMPONENT_RIOTMICRO_RM1000/RM1000_AT.cpp
@@ -103,5 +103,19 @@ CellularDevice *CellularDevice::get_default_instance()
     static RM1000_AT device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_RM1000_AT_CPP(void)
+{
+}
 #endif
 

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_HE910/CMakeLists.txt
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_HE910/CMakeLists.txt
@@ -18,3 +18,15 @@ endif()
 if("TARGET_MTS_DRAGONFLY_F413RH" IN_LIST MBED_TARGET_LABELS)
 	add_subdirectory(TARGET_MTS_DRAGONFLY_F413RH)
 endif()
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_TELIT_HE910_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_HE910/TELIT_HE910.cpp
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_HE910/TELIT_HE910.cpp
@@ -70,4 +70,18 @@ CellularDevice *CellularDevice::get_default_instance()
     static TELIT_HE910 device(&serial);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_TELIT_HE910_CPP(void)
+{
+}
 #endif

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME310/CMakeLists.txt
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME310/CMakeLists.txt
@@ -17,3 +17,15 @@ target_sources(mbed-cellular
 if("TARGET_EP_ATLAS" IN_LIST MBED_TARGET_LABELS)
 	add_subdirectory(TARGET_EP_ATLAS)
 endif()
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_TELIT_ME310_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME310/TELIT_ME310.cpp
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME310/TELIT_ME310.cpp
@@ -153,6 +153,20 @@ CellularDevice *CellularDevice::get_default_instance()
                               MBED_CONF_TELIT_ME310_POLARITY);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_TELIT_ME310_CPP(void)
+{
+}
 #endif
 
 nsapi_error_t TELIT_ME310::hard_power_on()

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME910/CMakeLists.txt
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME910/CMakeLists.txt
@@ -16,3 +16,15 @@ target_sources(mbed-cellular
 if("TARGET_EP_AGORA" IN_LIST MBED_TARGET_LABELS)
 	add_subdirectory(TARGET_EP_AGORA)
 endif()
+
+# Link override object file coming from static library anyway
+#
+# NOTE: This linker option is to pretend undefined symbol and won't cause
+#       undefined symbol error even though the override object file actually
+#       doesn't provide such symbol definition.
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    target_link_options(mbed-cellular
+        INTERFACE
+            LINKER:--undefined=LINK_TELIT_ME910_CPP
+    )
+endif()

--- a/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME910/TELIT_ME910.cpp
+++ b/connectivity/drivers/cellular/TELIT/COMPONENT_TELIT_ME910/TELIT_ME910.cpp
@@ -152,6 +152,20 @@ CellularDevice *CellularDevice::get_default_instance()
                               MBED_CONF_TELIT_ME910_POLARITY);
     return &device;
 }
+
+/*
+ * With e.g. GCC linker option "--undefined=<LINK_FOO>", pull in this
+ * object file anyway for being able to override weak symbol successfully
+ * even though from static library. See:
+ * https://stackoverflow.com/questions/42588983/what-does-the-gnu-ld-undefined-option-do
+ *
+ * NOTE: For C++ name mangling, 'extern "C"' is necessary to match the
+ *       <LINK_FOO> symbol correctly.
+ */
+extern "C"
+void LINK_TELIT_ME910_CPP(void)
+{
+}
 #endif
 
 nsapi_error_t TELIT_ME910::hard_power_on()

--- a/connectivity/netsocket/source/NetworkInterfaceDefaults.cpp
+++ b/connectivity/netsocket/source/NetworkInterfaceDefaults.cpp
@@ -43,6 +43,13 @@ MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
     return get_target_default_instance();
 }
 
+#if MBED_CONF_CELLULAR_PRESENT
+MBED_WEAK CellularInterface *CellularInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+#endif // MBED_CONF_CELLULAR_PRESENT
+
 /* For other types, we can provide a reasonable get_target_default_instance
  * in some cases. This is done in EthernetInterface.cpp, mbed-mesh-api and
  * OnboardCellularInterface.cpp. We have no implementation for WiFi, so a


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes cellular build issues, including:
1. Add back weak `CellularInterface::get_default_instance` so that cellular driver can provide default just overriding `CellularDevice::get_default_instance`.
2. Like #377, fix `CellularDevice::get_default_instance` coming from static library cannot participate in linking and so cannot override.
3. Fix `ThisThread::sleep_until` link error, this is caused by [mismatch on `MBED_CONF_RTOS_PRESENT` defined or not between executable and `mbed-cellular` targets](https://github.com/mbed-ce/mbed-os/blob/2564b2c1bfc78ef8425cc81de34f3cb0d3f90cc4/rtos/include/rtos/Kernel.h#L79-L86).

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

