### PR TITLE
K64F linker script refactor, also fix some misc bugs

### DIFF
--- a/connectivity/drivers/emac/TARGET_Freescale_EMAC/kinetis_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_Freescale_EMAC/kinetis_emac.cpp
@@ -409,7 +409,7 @@ bool Kinetis_EMAC::link_out(emac_mem_buf_t *buf)
     }
 
     /* Check if a descriptor is available for the transfer (wait 10ms before dropping the buffer) */
-    if (!xTXDCountSem.try_acquire_for(10)) {
+    if (!xTXDCountSem.try_acquire_for(10ms)) {
         memory_manager->free(buf);
         return false;
     }

--- a/platform/mbed-trace/include/mbed-trace/mbed_trace.h
+++ b/platform/mbed-trace/include/mbed-trace/mbed_trace.h
@@ -278,7 +278,7 @@ const char *mbed_trace_exclude_filters_get(void);
  *  mbed_tracef(TRACE_ACTIVE_LEVEL_DEBUG, "mygr", "Hi There");
  *  mbed_tracef(TRACE_ACTIVE_LEVEL_DEBUG, "grp2", "This is not printed");
  */
-void mbed_trace_include_filters_set(char *filters);
+void mbed_trace_include_filters_set(char const *filters);
 /** get trace include filters
  */
 const char *mbed_trace_include_filters_get(void);

--- a/platform/mbed-trace/source/mbed_trace.c
+++ b/platform/mbed-trace/source/mbed_trace.c
@@ -282,7 +282,7 @@ const char *mbed_trace_include_filters_get(void)
 {
     return m_trace.filters_include;
 }
-void mbed_trace_include_filters_set(char *filters)
+void mbed_trace_include_filters_set(char const *filters)
 {
     if (filters) {
         (void)strncpy(m_trace.filters_include, filters, m_trace.filters_length);

--- a/storage/blockdevice/include/blockdevice/BufferedBlockDevice.h
+++ b/storage/blockdevice/include/blockdevice/BufferedBlockDevice.h
@@ -26,8 +26,15 @@ namespace mbed {
 /** \addtogroup storage-blockdevice */
 /** @{*/
 
-/** Block device for allowing minimal read and program sizes (of 1) for the underlying BD,
- *  using a buffer on the heap.
+/**
+ * Block device which allows minimal read and program sizes (of 1) for the underlying BD
+ * using a buffer on the heap.  This essentially "simulates" a byte-programmable device
+ * like a NOR flash or an EEPROM, using a non-byte-programmable device like an SD card or
+ * NAND flash.
+ *
+ * @note While the read and write size of the buffered block device will always be 1,
+ *     the erase size is the same as the underlying block device.  In other words, you
+ *     still must erase in the hardware erase sector size.
  */
 class BufferedBlockDevice : public BlockDevice {
 public:

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -82,11 +82,11 @@ FLASH_CONFIG_FIELD_SIZE = 0x10;
 /* Specify the ELF segments (program headers) */
 PHDRS
 {
-    text PT_LOAD FLAGS(5); /* read + execute */
-    ram_vector_table PT_LOAD FLAGS(6); /* read + write */
-	ram_noinit PT_LOAD FLAGS(6); /* read + write */
-	ram_init PT_LOAD FLAGS(6); /* read + write */
-	sram_l PT_LOAD FLAGS(6); /* read + write */
+  text PT_LOAD FLAGS(5); /* read + execute */
+  ram_vector_table PT_LOAD FLAGS(6); /* read + write */
+  ram_noinit PT_LOAD FLAGS(6); /* read + write */
+  ram_init PT_LOAD FLAGS(6); /* read + write */
+  sram_l PT_LOAD FLAGS(6); /* read + write */
 }
 
 /* Specify the memory areas */
@@ -116,7 +116,7 @@ SECTIONS
 
   /* FCF to absolute address of 0x400, but only if bootloader is not present. */
 #if !IS_BOOTLOADER_PRESENT
-  .flash_config VTOR_TABLE_SIZE :
+  .flash_config FLASH_VTOR_TABLE_SIZE :
   {
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
   } > m_text AT> m_text :text

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -53,15 +53,7 @@ ENTRY(Reset_Handler)
 
 __ram_vector_table__ = 1;
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0
-#elif MBED_APP_START > 0 && MBED_APP_START < 0x410
-    #error MBED_APP_START too small and will overwrite interrupts and flash config
-#endif
 
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x100000
-#endif
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
     #define MBED_CONF_TARGET_BOOT_STACK_SIZE 0x400
@@ -72,19 +64,32 @@ __stack_size__ = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 M_CRASH_DATA_RAM_SIZE = 0x100;
+FLASH_VTOR_TABLE_SIZE = 0x400;
+FLASH_CONFIG_FIELD_SIZE = 0x10;
+
+/* If we are not configured to execute out of the start of ROM, then a bootloader is
+ * present.  This tells us whether we need to add the Flash Configuration Field at the start of flash. */
+#if MBED_CONFIGURED_ROM_BANK_IROM1_START == 0
+#define IS_BOOTLOADER_PRESENT 0
+#else
+#define IS_BOOTLOADER_PRESENT 1
+#endif
+
+#if IS_BOOTLOADER_PRESENT && MBED_CONFIGURED_ROM_BANK_IROM1_START < 0x410
+#error MBED_CONFIGURED_ROM_BANK_IROM1_START too small and will overwrite interrupts and flash config
+#endif
 
 /* Specify the memory areas */
 MEMORY
 {
-#if MBED_APP_START == 0
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
-  m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
-#else
-  m_text                (RX)  : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-#endif
-  m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
-  m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
+  m_text   (RX)  : ORIGIN = MBED_CONFIGURED_ROM_BANK_IROM1_START, LENGTH = MBED_CONFIGURED_ROM_BANK_IROM1_SIZE
+
+  /*
+   * Note: while these two SRAMs occupy a contiguous address space, we have to keep them as
+   * separate memory banks because the MCU doesn't support accesses that bridge the two banks.
+   */
+  m_sram_l (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_L_START, LENGTH = MBED_RAM_BANK_SRAM_L_SIZE
+  m_sram_u (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_U_START, LENGTH = MBED_RAM_BANK_SRAM_U_SIZE
 }
 
 /* Define output sections */
@@ -97,18 +102,20 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-#if MBED_APP_START == 0
-  } > m_interrupts
+  } > m_text AT> m_text
 
-  .flash_config :
+  /* FCF to absolute address of 0x400, but only if bootloader is not present. */
+#if !IS_BOOTLOADER_PRESENT
+  .flash_config VTOR_TABLE_SIZE :
   {
-    . = ALIGN(8);
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
-    . = ALIGN(8);
-  } > m_flash_config
+  } > m_text AT> m_text
 #else
-  } > m_text
+  /DISCARD/ : {
+    *(.FlashConfig)
+  }
 #endif
+
   .text :
   {
 
@@ -204,11 +211,12 @@ SECTIONS
     . += M_VECTOR_RAM_SIZE;
     . = ALIGN(8);
     __interrupts_ram_end__ = .; /* Define a global symbol at data end */
-  } > m_data
+  } > m_sram_u
 
-  .crash_data_ram :
+#if MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
+  /* Stick the crash data ram at the start of sram_l */
+  .crash_data_ram : ALIGN(8)
   {
-    . = ALIGN(8);
     __CRASH_DATA_RAM__ = .;
     __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
     KEEP(*(.keep.crash_data_ram))
@@ -216,24 +224,24 @@ SECTIONS
     . += M_CRASH_DATA_RAM_SIZE;
     . = ALIGN(8);
     __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
-  } > m_data
+  } > m_sram_u
+#endif
 
-  .heap_0 :
+  /* Fill the entire sram_l with the heap 0 section. */
+  .heap_0 (NOLOAD): ALIGN(8)
   {
-    . = ALIGN(8);
     __mbed_sbrk_start_0 = .;
-    . += (ORIGIN(m_data) + LENGTH(m_data) - .);
+    . += (ORIGIN(m_sram_l) + LENGTH(m_sram_l) - .);
     __mbed_krbs_start_0 = .;
-  } > m_data
+  } > m_sram_l
 
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
 
-  .data :
+  .data : ALIGN(8)
   {
     PROVIDE(__etext = LOADADDR(.data));    /* Define a global symbol at end of code, */
     PROVIDE(__DATA_ROM = LOADADDR(.data)); /* Symbol is used by startup for data initialization. */
-    . = ALIGN(8);
     __DATA_RAM = .;
     __data_start__ = .;      /* create a global symbol at data start */
     *(.data)                 /* .data sections */
@@ -241,7 +249,7 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_data_2 AT > m_text
+  } > m_sram_u AT > m_text
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
   text_end = ORIGIN(m_text) + LENGTH(m_text);
@@ -259,15 +267,14 @@ SECTIONS
     KEEP(*(.keep.uninitialized))
     . = ALIGN(32);
     __uninitialized_end = .;
-  } > m_data_2
+  } > m_sram_u
 
   USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
 
   /* Uninitialized data section */
-  .bss :
+  .bss : ALIGN(8)
   {
     /* This is used by the startup in order to initialize the .bss section */
-    . = ALIGN(8);
     __START_BSS = .;
     __bss_start__ = .;
     *(.bss)
@@ -279,39 +286,41 @@ SECTIONS
     . = ALIGN(8);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data_2
+  } > m_sram_u
 
-  .heap :
+  .heap : ALIGN(8)
   {
-    . = ALIGN(8);
     __end__ = .;
     PROVIDE(end = .);
+
+    ASSERT((__end__ - ORIGIN(m_sram_u)) + STACK_SIZE <= LENGTH(m_sram_u), "SRAM_U is not large enough to contain globals and boot stack!");
+
     __mbed_sbrk_start = .;
     __HeapBase = .;
-    . = ORIGIN(m_data_2) + LENGTH(m_data_2) - STACK_SIZE;
+    . = ORIGIN(m_sram_u) + LENGTH(m_sram_u) - STACK_SIZE;
     __mbed_krbs_start = .;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
-  } > m_data_2
+  } > m_sram_u
 
-  m_usb_bdt USB_RAM_START (NOLOAD) :
+  /* USB RAM sections.  These live inside a "gap" created in .bss. */
+  m_usb_bdt USB_RAM_START (OVERLAY) :
   {
     *(m_usb_bdt)
     USB_RAM_BDT_END = .;
   }
 
-  m_usb_global USB_RAM_BDT_END (NOLOAD) :
+  m_usb_global USB_RAM_BDT_END (OVERLAY) :
   {
     *(m_usb_global)
   }
 
   /* Initializes stack on the end of block */
-  __StackTop = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackTop = ORIGIN(m_sram_u) + LENGTH(m_sram_u);
   __StackLimit = __StackTop - STACK_SIZE;
   PROVIDE(__stack = __StackTop);
 
-  .ARM.attributes 0 : { *(.ARM.attributes) }
-
-  ASSERT(__StackLimit >= __HeapLimit, "Region m_data_2 overflowed with stack and heap")
-
+  /DISCARD/ : {
+    *(.ARM.attributes)
+  }
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -79,6 +79,16 @@ FLASH_CONFIG_FIELD_SIZE = 0x10;
 #error MBED_CONFIGURED_ROM_BANK_IROM1_START too small and will overwrite interrupts and flash config
 #endif
 
+/* Specify the ELF segments (program headers) */
+PHDRS
+{
+    text PT_LOAD FLAGS(5); /* read + execute */
+    ram_vector_table PT_LOAD FLAGS(6); /* read + write */
+	ram_noinit PT_LOAD FLAGS(6); /* read + write */
+	ram_init PT_LOAD FLAGS(6); /* read + write */
+	sram_l PT_LOAD FLAGS(6); /* read + write */
+}
+
 /* Specify the memory areas */
 MEMORY
 {
@@ -102,14 +112,14 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-  } > m_text AT> m_text
+  } > m_text AT> m_text :text
 
   /* FCF to absolute address of 0x400, but only if bootloader is not present. */
 #if !IS_BOOTLOADER_PRESENT
   .flash_config VTOR_TABLE_SIZE :
   {
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
-  } > m_text AT> m_text
+  } > m_text AT> m_text :text
 #else
   /DISCARD/ : {
     *(.FlashConfig)
@@ -130,19 +140,19 @@ SECTIONS
     KEEP (*(.init))
     KEEP (*(.fini))
     . = ALIGN(8);
-  } > m_text
+  } > m_text AT> m_text :text
 
   .ARM.extab :
   {
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-  } > m_text
+  } > m_text AT> m_text :text
 
   .ARM :
   {
     __exidx_start = .;
     *(.ARM.exidx*)
     __exidx_end = .;
-  } > m_text
+  } > m_text AT> m_text :text
 
  .ctors :
   {
@@ -166,7 +176,7 @@ SECTIONS
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
     __CTOR_END__ = .;
-  } > m_text
+  } > m_text AT> m_text :text
 
   .dtors :
   {
@@ -177,14 +187,14 @@ SECTIONS
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
     __DTOR_END__ = .;
-  } > m_text
+  } > m_text AT> m_text :text
 
   .preinit_array :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
-  } > m_text
+  } > m_text AT> m_text :text
 
   .init_array :
   {
@@ -192,7 +202,7 @@ SECTIONS
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
-  } > m_text
+  } > m_text AT> m_text :text
 
   .fini_array :
   {
@@ -200,18 +210,7 @@ SECTIONS
     KEEP (*(SORT(.fini_array.*)))
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
-  } > m_text
-
-  .interrupts_ram :
-  {
-    . = ALIGN(8);
-    __VECTOR_RAM__ = .;
-    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
-    *(.m_interrupts_ram)     /* This is a user defined section */
-    . += M_VECTOR_RAM_SIZE;
-    . = ALIGN(8);
-    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
-  } > m_sram_u
+  } > m_text AT> m_text :text
 
 #if MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
   /* Stick the crash data ram at the start of sram_l */
@@ -224,7 +223,7 @@ SECTIONS
     . += M_CRASH_DATA_RAM_SIZE;
     . = ALIGN(8);
     __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
-  } > m_sram_u
+  } > m_sram_l :sram_l
 #endif
 
   /* Fill the entire sram_l with the heap 0 section. */
@@ -233,10 +232,21 @@ SECTIONS
     __mbed_sbrk_start_0 = .;
     . += (ORIGIN(m_sram_l) + LENGTH(m_sram_l) - .);
     __mbed_krbs_start_0 = .;
-  } > m_sram_l
+  } > m_sram_l :sram_l
 
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .interrupts_ram :
+  {
+    . = ALIGN(8);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(8);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_sram_u :ram_vector_table
 
   .data : ALIGN(8)
   {
@@ -249,7 +259,7 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_sram_u AT > m_text
+  } > m_sram_u AT > m_text :ram_init
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
   text_end = ORIGIN(m_text) + LENGTH(m_text);
@@ -267,7 +277,7 @@ SECTIONS
     KEEP(*(.keep.uninitialized))
     . = ALIGN(32);
     __uninitialized_end = .;
-  } > m_sram_u
+  } > m_sram_u AT> m_sram_u :ram_noinit
 
   USB_RAM_GAP = DEFINED(__usb_ram_size__) ? __usb_ram_size__ : 0x800;
 
@@ -286,7 +296,7 @@ SECTIONS
     . = ALIGN(8);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_sram_u
+  } > m_sram_u AT> m_sram_u :ram_noinit
 
   .heap : ALIGN(8)
   {
@@ -301,19 +311,19 @@ SECTIONS
     __mbed_krbs_start = .;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
-  } > m_sram_u
+  } > m_sram_u AT> m_sram_u :ram_noinit
 
   /* USB RAM sections.  These live inside a "gap" created in .bss. */
   m_usb_bdt USB_RAM_START (OVERLAY) :
   {
     *(m_usb_bdt)
     USB_RAM_BDT_END = .;
-  }
+  } :ram_noinit
 
   m_usb_global USB_RAM_BDT_END (OVERLAY) :
   {
     *(m_usb_global)
-  }
+  } :ram_noinit
 
   /* Initializes stack on the end of block */
   __StackTop = ORIGIN(m_sram_u) + LENGTH(m_sram_u);

--- a/targets/TARGET_NUVOTON/scripts/mbed_set_post_build_nuvoton.cmake
+++ b/targets/TARGET_NUVOTON/scripts/mbed_set_post_build_nuvoton.cmake
@@ -16,6 +16,13 @@ macro(mbed_post_build_nuvoton_tfm_sign_image
         function(mbed_post_build_function target)
             find_package(Python3)
 
+            if("${MBED_OUTPUT_EXT}" STREQUAL "")
+                # If both bin and hex are being generated, just pick one.
+                set(EXT hex)
+            else()
+                set(EXT ${MBED_OUTPUT_EXT})
+            endif()
+
             # NOTE: Macro arguments are not variables and cannot pass to if(<condition>).
             set(signing_key_1_ ${signing_key_1})
             if(signing_key_1_)
@@ -30,7 +37,7 @@ macro(mbed_post_build_nuvoton_tfm_sign_image
                         --tfm-import-path ${tfm_import_path}
                         --signing_key ${signing_key}
                         --signing_key_1 ${signing_key_1}
-                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${MBED_OUTPUT_EXT}
+                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${EXT}
                 )
             else()
                 add_custom_command(
@@ -43,7 +50,7 @@ macro(mbed_post_build_nuvoton_tfm_sign_image
                         tfm_sign_image
                         --tfm-import-path ${tfm_import_path}
                         --signing_key ${signing_key}
-                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${MBED_OUTPUT_EXT}
+                        --non-secure-binhex $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.${EXT}
                 )
             endif()
         endfunction()

--- a/targets/cmsis_mcu_descriptions.json5
+++ b/targets/cmsis_mcu_descriptions.json5
@@ -3088,7 +3088,7 @@
             "version": "1.5.0"
         },
         "memories": {
-            "IRAM1": {
+            "SRAM_U": {
                 "access": {
                     "execute": false,
                     "non_secure": false,
@@ -3099,11 +3099,11 @@
                     "write": true
                 },
                 "default": true,
-                "size": 196608,
-                "start": 536870912,
+                "size": 0x30000,
+                "start": 0x20000000,
                 "startup": false
             },
-            "IRAM2": {
+            "SRAM_L": {
                 "access": {
                     "execute": false,
                     "non_secure": false,
@@ -3114,8 +3114,8 @@
                     "write": true
                 },
                 "default": false,
-                "size": 65536,
-                "start": 536805376,
+                "size": 0x10000,
+                "start": 0x1FFF0000,
                 "startup": false
             },
             "IROM1": {

--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -77,7 +77,7 @@ foreach(LEGACY_VAR_NAME JLINK_USB_SERIAL_NUMBER LINKSERVER_PROBE_SN MBED_TARGET_
 		if(NOT "${${LEGACY_VAR_NAME}}" STREQUAL "")
 			message(WARNING "${LEGACY_VAR_NAME} is deprecated, set the MBED_UPLOAD_SERIAL_NUMBER variable instead. MBED_UPLOAD_SERIAL_NUMBER will be set to the value of ${LEGACY_VAR_NAME}.")
 			set(MBED_UPLOAD_SERIAL_NUMBER ${${LEGACY_VAR_NAME}} CACHE STRING "" FORCE)
-			unset(STLINK_PROBE_SN CACHE)
+			unset(${LEGACY_VAR_NAME} CACHE)
 		endif()
 	endif()
 endforeach()

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -157,16 +157,17 @@ function(mbed_set_post_build target)
     # diagnostic output file for some toolchains.
 
     # copy mapfile .map to .map.old for ram/rom statistics diff in memap.py
-    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map)
-        add_custom_command(
-            TARGET
-                ${target}
-            PRE_BUILD
-            COMMAND
-                ${CMAKE_COMMAND} -E rename "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map" "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map.old"
-        )
-    endif()
-    
+    add_custom_command(
+        TARGET
+            ${target}
+        PRE_BUILD
+        # So that the rename command does not fail on the first build, touch the map file first to create it if it does not exist.
+        COMMAND
+            ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map"
+        COMMAND
+            ${CMAKE_COMMAND} -E rename "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map" "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map.old"
+    )
+
     mbed_configure_memory_map(${target} "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}.map")
     mbed_validate_application_profile(${target})
     mbed_generate_bin_hex(${target})


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This MR refactors the K64F linker script  to support memory bank configuration.  This is needed as I'm using it to test the MCUBoot bootloader.

I also fixed a couple misc bugs I ran into while working on MCUBoot.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

K64F can now be configured to use only a portion of flash using `target_overrides.memory_bank_config` in mbed_app.json.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

I reran the Mbed test suite for K64F.  Results [here](https://mbed-ce.github.io/mbed-ce-test-tools/tests/), don't see any suspicious failures.
    
    
----------------------------------------------------------------------------------------------------------------
