### PR TITLE
Tweak upload method dependencies to be specified at a higher level, add LinkServer version check

### DIFF
--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -146,4 +146,10 @@ function(mbed_generate_upload_target target)
 	else()
 		gen_upload_target(${target} ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${target}>.hex)
 	endif()
+
+	# Make sure building the upload target causes the target to be built first
+	if(TARGET flash-${target})
+		add_dependencies(flash-${target} ${target})
+	endif()
+
 endfunction()

--- a/tools/cmake/upload_methods/FindLinkServer.cmake
+++ b/tools/cmake/upload_methods/FindLinkServer.cmake
@@ -7,6 +7,7 @@
 # This module defines:
 # LinkServer - Whether the reqested tools were found.
 # LinkServer_PATH - full path to the LinkServer command line tool.
+# LinkServer_VERSION - version number of LinkServer
 
 # Check for LinkServer install folders on Windows
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
@@ -26,6 +27,16 @@ find_program(LinkServer_PATH
     HINTS ${LINKSERVER_HINTS}
 )
 
-find_package_handle_standard_args(LinkServer REQUIRED_VARS LinkServer_PATH)
+if(EXISTS "${LinkServer_PATH}")
+	# Detect version
+	execute_process(COMMAND ${LinkServer_PATH} --version
+			OUTPUT_VARIABLE LinkServer_VERSION_OUTPUT)
+
+	# The output looks like "LinkServer v1.2.45 [Build 45] [2023-07-25 09:54:50]", so use a regex to grab the version
+	string(REGEX REPLACE "LinkServer v([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" LinkServer_VERSION ${LinkServer_VERSION_OUTPUT})
+endif()
+
+
+find_package_handle_standard_args(LinkServer REQUIRED_VARS LinkServer_PATH VERSION_VAR LinkServer_VERSION)
 
 

--- a/tools/cmake/upload_methods/UploadMethodARDUINO_BOSSAC.cmake
+++ b/tools/cmake/upload_methods/UploadMethodARDUINO_BOSSAC.cmake
@@ -28,6 +28,4 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		--write ${BINARY_FILE}
 		--reset)
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
-
 endfunction(gen_upload_target)

--- a/tools/cmake/upload_methods/UploadMethodJLINK.cmake
+++ b/tools/cmake/upload_methods/UploadMethodJLINK.cmake
@@ -71,9 +71,6 @@ exit
 		-ExitOnError
 		-CommandFile ${COMMAND_FILE_PATH})
 
-
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
-
 endfunction(gen_upload_target)
 
 ### Commands to run the debug server.

--- a/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
+++ b/tools/cmake/upload_methods/UploadMethodLINKSERVER.cmake
@@ -23,6 +23,12 @@ endif()
 find_package(LinkServer)
 set(UPLOAD_LINKSERVER_FOUND ${LinkServer_FOUND})
 
+if(LinkServer_FOUND)
+	if(${LinkServer_VERSION} VERSION_LESS 1.5.30 AND "${MBED_OUTPUT_EXT}" STREQUAL "hex")
+		message(FATAL_ERROR "LinkServer <1.5.30 does not support flashing hex files! Please upgrade LinkServer and then clean and rebuild the project.")
+	endif()
+endif()
+
 ### Function to generate upload target
 
 function(gen_upload_target TARGET_NAME BINARY_FILE)
@@ -36,8 +42,6 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 			load
 			--addr ${MBED_UPLOAD_BASE_ADDR}
 			${BINARY_FILE})
-
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 
 endfunction(gen_upload_target)
 

--- a/tools/cmake/upload_methods/UploadMethodMBED.cmake
+++ b/tools/cmake/upload_methods/UploadMethodMBED.cmake
@@ -25,6 +25,4 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 			${mbed-os_SOURCE_DIR}/tools/python
 		VERBATIM)
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
-
 endfunction(gen_upload_target)

--- a/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
@@ -41,7 +41,6 @@ endif()
 
 function(gen_upload_target TARGET_NAME BINARY_FILE)
 
-	# unlike other upload methods, OpenOCD uses the elf file
 	add_custom_target(flash-${TARGET_NAME}
 		COMMENT "Flashing ${TARGET_NAME} with OpenOCD..."
 		COMMAND ${OpenOCD}
@@ -51,7 +50,6 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		-c "program ${BINARY_FILE} ${MBED_UPLOAD_BASE_ADDR} reset exit"
 		VERBATIM)
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)
 
 ### Commands to run the debug server.

--- a/tools/cmake/upload_methods/UploadMethodPICOTOOL.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPICOTOOL.cmake
@@ -29,12 +29,16 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		list(APPEND PICOTOOL_TARGET_ARGS --address ${PICOTOOL_TARGET_ADDRESS})
 	endif()
 
+	if("${MBED_OUTPUT_EXT}" STREQUAL "hex")
+        message(FATAL_ERROR "Bin file output must be enabled to use picotool.  Set MBED_OUTPUT_EXT to empty string or to 'bin' in your top level CMakeLists.txt!")
+    endif()
+
 	add_custom_target(flash-${TARGET_NAME}
 		COMMAND ${Picotool}
 			load
+			--verify
 		    --execute
-			$<TARGET_FILE:${TARGET_NAME}>)
-
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
+			--offset ${MBED_UPLOAD_BASE_ADDR}
+			${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET_NAME}>.bin)
 
 endfunction(gen_upload_target)

--- a/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodPYOCD.cmake
@@ -34,7 +34,6 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		--base-address ${MBED_UPLOAD_BASE_ADDR}
 		${BINARY_FILE})
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)
 
 ### Commands to run the debug server.

--- a/tools/cmake/upload_methods/UploadMethodSTLINK.cmake
+++ b/tools/cmake/upload_methods/UploadMethodSTLINK.cmake
@@ -32,7 +32,6 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		${STLINK_ARGS}
 		write ${BINARY_FILE} ${MBED_UPLOAD_BASE_ADDR})
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
 endfunction(gen_upload_target)
 
 ### Commands to run the debug server.

--- a/tools/cmake/upload_methods/UploadMethodSTM32CUBE.cmake
+++ b/tools/cmake/upload_methods/UploadMethodSTM32CUBE.cmake
@@ -36,8 +36,6 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		-w ${BINARY_FILE} ${MBED_UPLOAD_BASE_ADDR}
 		-rst)
 
-	add_dependencies(flash-${TARGET_NAME} ${TARGET_NAME})
-
 endfunction(gen_upload_target)
 
 ### Commands to run the debug server.


### PR DESCRIPTION
### Summary of changes <!-- Required -->

As part of mcuboot support, we need a way to generate upload targets for things that aren't actual CMake build targets.  We can alllllmost do that with the existing code, but not quite!  Needed to move the add_dependencies() call to the upper level function.

I also noticed a bug while working on this: if old versions of LinkServer are given a hex file, they just treat it as a bin file and _flash the ASCII text of the hex file into memory_!!!!  It's extremely confusing when it happens, and I added a check to catch this situation.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->


#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Used this branch to successfully upload a bootloader and application to a target!  Also verified on my machine that the LinkServer check works.
----------------------------------------------------------------------------------------------------------------
