### PR TITLE
Fix CMake dependency error with custom linker scripts

### DIFF
--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -115,7 +115,7 @@ endfunction(mbed_setup_linker_script)
 function(mbed_set_custom_linker_script target new_linker_script_path)
 
     set(RAW_LINKER_SCRIPT_PATHS  ${CMAKE_CURRENT_SOURCE_DIR}/${new_linker_script_path})
-    set(CUSTOM_LINKER_SCRIPT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${target}.link_spript.ld)
+    set(CUSTOM_LINKER_SCRIPT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${target}.link_script.ld)
 
     # To avoid path limits on Windows, we create a "response file" and set the path to it as a
     # global property. We need this solely to pass the compile definitions to GCC's preprocessor,
@@ -151,6 +151,5 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
         PRIVATE
             "-T" "${CUSTOM_LINKER_SCRIPT_PATH}"
     )
-    set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS ${CUSTOM_LINKER_SCRIPT_PATH})
 
 endfunction(mbed_set_custom_linker_script)

--- a/tools/cmake/mbed_set_linker_script.cmake
+++ b/tools/cmake/mbed_set_linker_script.cmake
@@ -60,8 +60,7 @@ function(mbed_setup_linker_script mbed_os_target mbed_baremetal_target target_de
     add_custom_command(
         OUTPUT
             ${LINKER_SCRIPT_PATH}
-        PRE_LINK
-        COMMAND 
+        COMMAND
             ${CMAKE_COMMAND} -E echo "Preprocess linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
         COMMAND
             ${CMAKE_C_COMPILER} @${linker_defs_response_file}
@@ -130,7 +129,7 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
             ${target}
         PRE_LINK
         COMMAND 
-            ${CMAKE_COMMAND} -E echo "Preprocess custom linker script: ${RAW_LINKER_SCRIPT_NAME} -> ${LINKER_SCRIPT_NAME}"
+            ${CMAKE_COMMAND} -E echo "Preprocess custom linker script ${RAW_LINKER_SCRIPT_NAME} to ${LINKER_SCRIPT_NAME}"
         COMMAND
             ${CMAKE_C_COMPILER} @${linker_defs_response_file}
             -E -x assembler-with-cpp
@@ -151,5 +150,6 @@ function(mbed_set_custom_linker_script target new_linker_script_path)
         PRIVATE
             "-T" "${CUSTOM_LINKER_SCRIPT_PATH}"
     )
+    set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS ${RAW_LINKER_SCRIPT_PATHS})
 
 endfunction(mbed_set_custom_linker_script)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fix dependency error with custom linker scripts.  Back in #362 I added the LINK_DEPENDS property so that executables would be rebuilt if the linker script changed.  However, it caused a circular dependency error with custom linker scripts, because the linker script was expected to exist before the link command (which generated the linker script) could be run!  This PR fixes this by putting the dependency on the raw file instead of the preprocessed one.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
This can build @JojoS62 's test project for custom linker scripts
    
----------------------------------------------------------------------------------------------------------------
