### PR TITLE
Add multicast filter support to STM32 EMAC

### DIFF
--- a/connectivity/drivers/emac/TARGET_STM/mbed_lib.json
+++ b/connectivity/drivers/emac/TARGET_STM/mbed_lib.json
@@ -42,6 +42,10 @@
         "eth-phy-duplex-status": {
             "help" : "Duplex mask information in eth-phy-status-register",
             "value" : "0x0010"
+        },
+        "max-mcast-subscribes": {
+            "help" : "Maximum supported number of multicast addresses that the application can subscribe to",
+            "value" : "8"
         }
     },
     "target_overrides": {

--- a/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.h
+++ b/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.h
@@ -162,6 +162,13 @@ private:
     void enable_interrupts();
     void disable_interrupts();
 
+    // Populate multicast filter registers with the contents of mcastMacs.
+    // Uses the perfect filter registers first, then the hash filter.
+    void populateMcastFilterRegs();
+
+    // Write a MAC address into a high and low register pair on the MAC.
+    static void writeMACAddress(uint8_t const * MAC, uint32_t volatile * addrHighReg, uint32_t volatile * addrLowReg);
+
     mbed_rtos_storage_thread_t thread_cb;
 #if defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx)\
     || defined (STM32F779xx)
@@ -176,6 +183,10 @@ private:
 
     uint32_t phy_status;
     int phy_task_handle; /**< Handle for phy task event */
+
+    // Multicast subscribe information
+    std::array<uint8_t, 6> mcastMacs[MBED_CONF_STM32_EMAC_MAX_MCAST_SUBSCRIBES];
+    size_t numSubscribedMcastMacs;
 };
 
 #endif /* STM32_EMAC_H_ */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This MR adds multicast filtering support to all STM32 MCUs that support Ethernet.  It's an offshoot from my ongoing branch to rewrite the STM32 EMAC code (which is making progress, but slooooowly).

STM32 MCUs have both a "perfect" multicast filter and a hash filter.  The perfect filter can match up to 3 mcast addresses exactly, while the hash filter matches mcast MAC addresses using a 64-entry hash table.   The hash table method is obviously limited -- if you subscribe to, say, 32 MAC addresses using the hash table, you will have a 50% false positive rate for all other MAC addresses.  So, this driver uses the perfect filter for the first 3 MAC addresses, then the hash table for any additional MACs.

By default, 8 addresses are supported, but this can be increased via the `stm32-emac.max-mcast-subscribes` JSON option.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

- Multicast subscriptions now supported on STM32
  - Should fix https://github.com/ARMmbed/mbed-os/issues/13233
  - Should fix https://github.com/arduino/ArduinoCore-mbed/issues/629 
- Passing all multicasts is now supported on STM32

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Tested this on my branch on STM32H743 and it passed the multicast filter test.  Sadly this test cannot be run on STM32H7 on master, because the current STM32H7 eth MAC driver is hardcoded to use LwIP only.

----------------------------------------------------------------------------------------------------------------
