### PR TITLE
Fix application profile link mess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ endif()
 # These targets are made visible here so their source files which
 # are spread in different directories can be referenced and can be linked against
 # by libraries that depend on them.
-add_library(mbed-rtos-flags INTERFACE) # Collects source files that are in mbed-os but not mbed-baremetal
-add_library(mbed-rtos-sources INTERFACE) # Collects flags that are in mbed-os but not mbed-baremetal
+add_library(mbed-rtos-flags INTERFACE) # Collects flags that are in mbed-os but not mbed-baremetal
+add_library(mbed-rtos-sources INTERFACE) # Collects source files that are in mbed-os but not mbed-baremetal
 add_library(mbed-core-flags INTERFACE) # Collects flags common to mbed-baremetal and mbed-os
 add_library(mbed-core-sources INTERFACE) # Collects source files common to mbed-baremetal and mbed-os
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ if(NOT MBED_IS_NATIVE_BUILD)
     mbed_create_distro(mbed-os ${MBED_TARGET_CMAKE_NAME} mbed-core-flags mbed-core-sources mbed-rtos-flags mbed-rtos-sources)
 
     # Set up the linker script and hook it up to the top-level OS targets
-    mbed_setup_linker_script(mbed-baremetal mbed-os ${CMAKE_CURRENT_BINARY_DIR}/generated-headers/mbed-target-config.h)
+    mbed_setup_linker_script(mbed-os mbed-baremetal ${CMAKE_CURRENT_BINARY_DIR}/generated-headers/mbed-target-config.h)
 
     # Make sure that things linking mbed-core-flags can also get the target-specific include dirs and flags.
     mbed_extract_flags(${MBED_TARGET_CMAKE_NAME}-flags ${MBED_TARGET_CMAKE_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,7 @@ if(NOT MBED_IS_NATIVE_BUILD)
     # Note that many different source files will compile differently depending on if the RTOS is in use.
     # So, it's needed to compile the core sources twice, once for RTOS and once for non-RTOS.
     mbed_create_distro(mbed-baremetal ${MBED_TARGET_CMAKE_NAME} mbed-core-flags mbed-core-sources)
-    mbed_create_distro(mbed-os ${MBED_TARGET_CMAKE_NAME} mbed-core-flags mbed-core-sources mbed-rtos-flags mbed-rtos-sources)
+    mbed_create_distro(mbed-os ${MBED_TARGET_CMAKE_NAME} mbed-core-flags mbed-core-sources)
 
     # Set up the linker script and hook it up to the top-level OS targets
     mbed_setup_linker_script(mbed-os mbed-baremetal ${CMAKE_CURRENT_BINARY_DIR}/generated-headers/mbed-target-config.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,40 @@ endif()
 # by libraries that depend on them.
 add_library(mbed-rtos-flags INTERFACE) # Collects flags that are in mbed-os but not mbed-baremetal
 add_library(mbed-rtos-sources INTERFACE) # Collects source files that are in mbed-os but not mbed-baremetal
-add_library(mbed-core-flags INTERFACE) # Collects flags common to mbed-baremetal and mbed-os
-add_library(mbed-core-sources INTERFACE) # Collects source files common to mbed-baremetal and mbed-os
+add_library(mbed-core-flags INTERFACE) # Collects flags that are in mbed-os or mbed-baremetal
+                                       # depending on target.application-profile setting
+add_library(mbed-core-sources INTERFACE) # Collects source files that are in mbed-os or mbed-baremetal
+                                         # depending on target.application-profile setting
+
+if("MBED_CONF_TARGET_APPLICATION_PROFILE=full" IN_LIST MBED_CONFIG_DEFINITIONS)
+    set(APPLICATION_PROFILE_CONFIG_FULL TRUE)
+endif()
+if("MBED_CONF_TARGET_APPLICATION_PROFILE=bare-metal" IN_LIST MBED_CONFIG_DEFINITIONS)
+    set(APPLICATION_PROFILE_CONFIG_BAREMETAL TRUE)
+endif()
+if(NOT APPLICATION_PROFILE_CONFIG_FULL AND NOT APPLICATION_PROFILE_CONFIG_BAREMETAL)
+    set(APPLICATION_PROFILE_CONFIG_AUTO TRUE)
+endif()
+
+# mbed-core-flags/mbed-core-sources link mbed-rtos-flags/mbed-rtos-sources or not
+if((APPLICATION_PROFILE_CONFIG_AUTO OR APPLICATION_PROFILE_CONFIG_FULL) AND
+    (NOT MBED_ENABLE_OS_INTERNAL_TESTS OR NOT MBED_BUILD_GREENTEA_TESTS OR NOT MBED_GREENTEA_TEST_BAREMETAL))
+    target_link_libraries(mbed-core-flags INTERFACE mbed-rtos-flags)
+    target_link_libraries(mbed-core-sources INTERFACE mbed-rtos-sources)
+endif()
+
+# Check if target.application-profile matches MBED_GREENTEA_TEST_BAREMETAL
+if(MBED_ENABLE_OS_INTERNAL_TESTS AND MBED_BUILD_GREENTEA_TESTS)
+    if(APPLICATION_PROFILE_CONFIG_FULL AND MBED_GREENTEA_TEST_BAREMETAL)
+        message(FATAL_ERROR
+            "target.application-profile (full) doesn't match MBED_GREENTEA_TEST_BAREMETAL (TRUE)"
+        )
+    elseif(APPLICATION_PROFILE_CONFIG_BAREMETAL AND NOT MBED_GREENTEA_TEST_BAREMETAL)
+        message(FATAL_ERROR
+            "target.application-profile (bare-metal) doesn't match MBED_GREENTEA_TEST_BAREMETAL (FALSE)"
+        )
+    endif()
+endif()
 
 # Validate selected C library type
 # The C library type selected has to match the library that the target can support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,23 +134,9 @@ if(NOT APPLICATION_PROFILE_CONFIG_FULL AND NOT APPLICATION_PROFILE_CONFIG_BAREME
 endif()
 
 # mbed-core-flags/mbed-core-sources link mbed-rtos-flags/mbed-rtos-sources or not
-if((APPLICATION_PROFILE_CONFIG_AUTO OR APPLICATION_PROFILE_CONFIG_FULL) AND
-    (NOT MBED_ENABLE_OS_INTERNAL_TESTS OR NOT MBED_BUILD_GREENTEA_TESTS OR NOT MBED_GREENTEA_TEST_BAREMETAL))
+if(APPLICATION_PROFILE_CONFIG_AUTO OR APPLICATION_PROFILE_CONFIG_FULL)
     target_link_libraries(mbed-core-flags INTERFACE mbed-rtos-flags)
     target_link_libraries(mbed-core-sources INTERFACE mbed-rtos-sources)
-endif()
-
-# Check if target.application-profile matches MBED_GREENTEA_TEST_BAREMETAL
-if(MBED_ENABLE_OS_INTERNAL_TESTS AND MBED_BUILD_GREENTEA_TESTS)
-    if(APPLICATION_PROFILE_CONFIG_FULL AND MBED_GREENTEA_TEST_BAREMETAL)
-        message(FATAL_ERROR
-            "target.application-profile (full) doesn't match MBED_GREENTEA_TEST_BAREMETAL (TRUE)"
-        )
-    elseif(APPLICATION_PROFILE_CONFIG_BAREMETAL AND NOT MBED_GREENTEA_TEST_BAREMETAL)
-        message(FATAL_ERROR
-            "target.application-profile (bare-metal) doesn't match MBED_GREENTEA_TEST_BAREMETAL (FALSE)"
-        )
-    endif()
 endif()
 
 # Validate selected C library type

--- a/TESTS/configs/greentea_baremetal.json5
+++ b/TESTS/configs/greentea_baremetal.json5
@@ -1,7 +1,8 @@
 {
     "target_overrides": {
         "*": {
-            "target.c_lib": "small"
+            "target.c_lib": "small",
+            "target.application-profile": "bare-metal"
         }
     },
     "overrides": {

--- a/connectivity/cellular/CMakeLists.txt
+++ b/connectivity/cellular/CMakeLists.txt
@@ -39,6 +39,5 @@ target_link_libraries(mbed-cellular
     PUBLIC
         mbed-netsocket-api
         mbed-core-flags
-        mbed-rtos-flags
         mbed-randlib
 )

--- a/connectivity/drivers/802.15.4_RF/CMakeLists.txt
+++ b/connectivity/drivers/802.15.4_RF/CMakeLists.txt
@@ -7,7 +7,7 @@ macro(create_mbed_802_15_4_target)
 		add_library(mbed-802.15.4-rf STATIC EXCLUDE_FROM_ALL)
 
 		# Nanostack drivers always require Mbed RTOS
-		target_link_libraries(mbed-802.15.4-rf PUBLIC mbed-core-flags mbed-rtos-flags)
+		target_link_libraries(mbed-802.15.4-rf PUBLIC mbed-core-flags)
 
 		# For NanostackRfPhy.h
 		target_link_libraries(mbed-802.15.4-rf PUBLIC mbed-nanostack)

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/CMakeLists.txt
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_2/CMakeLists.txt
@@ -8,8 +8,7 @@ target_link_libraries(mbed-bluenrg2
     PUBLIC
         mbed-core-flags
         mbed-ble
-    PRIVATE
-        mbed-rtos-flags)
+)
 
 # circular dependency between mbed-ble and the BlueNRG driver, because of the ble_cordio_get_hci_driver() implementation
 target_link_libraries(mbed-ble PUBLIC mbed-bluenrg2)

--- a/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/CMakeLists.txt
+++ b/connectivity/drivers/ble/FEATURE_BLE/COMPONENT_BlueNRG_MS/CMakeLists.txt
@@ -8,8 +8,7 @@ target_link_libraries(mbed-bluenrg-ms
     PUBLIC
         mbed-core-flags
         mbed-ble
-    PRIVATE
-        mbed-rtos-flags)
+)
 
 
 # circular dependency between mbed-ble and the BlueNRG driver, because of the ble_cordio_get_hci_driver() implementation

--- a/connectivity/drivers/emac/CMakeLists.txt
+++ b/connectivity/drivers/emac/CMakeLists.txt
@@ -33,5 +33,5 @@ target_link_libraries(mbed-emac
     PUBLIC
         mbed-netsocket-api
     PRIVATE
-        mbed-rtos-flags
+        mbed-core-flags
 )

--- a/connectivity/drivers/wifi/CMakeLists.txt
+++ b/connectivity/drivers/wifi/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(create_mbed_wifi_target)
 
 		target_link_libraries(mbed-wifi
 		    PUBLIC
-		        mbed-rtos-flags
+		        mbed-core-flags
 		        mbed-netsocket-api
 		)
 	endif()

--- a/connectivity/drivers/wifi/COMPONENT_WHD/whd-bsp-integration/CMakeLists.txt
+++ b/connectivity/drivers/wifi/COMPONENT_WHD/whd-bsp-integration/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(mbed-wifi
 target_link_libraries(mbed-wifi
     PUBLIC
         mbed-lwipstack
-		mbed-rtos-flags
+		mbed-core-flags
 )
 
 if("DEVICE_EMAC=1" IN_LIST MBED_TARGET_DEFINITIONS)

--- a/connectivity/libraries/ppp/CMakeLists.txt
+++ b/connectivity/libraries/ppp/CMakeLists.txt
@@ -57,5 +57,5 @@ target_link_libraries(mbed-ppp
     PUBLIC
         mbed-netsocket-api
     PRIVATE
-        mbed-rtos-flags
+        mbed-core-flags
 )

--- a/connectivity/lwipstack/CMakeLists.txt
+++ b/connectivity/lwipstack/CMakeLists.txt
@@ -100,6 +100,6 @@ target_link_libraries(mbed-lwipstack
         mbed-ppp
         mbed-randlib
     PRIVATE
-        mbed-rtos-flags
+        mbed-core-flags
 )
 

--- a/connectivity/nanostack/mbed-mesh-api/CMakeLists.txt
+++ b/connectivity/nanostack/mbed-mesh-api/CMakeLists.txt
@@ -37,8 +37,6 @@ target_link_libraries(mbed-nanostack-mbed_mesh_api
 		mbed-nanostack
         mbed-netsocket-api
         mbed-core-flags
-    PRIVATE
-        mbed-rtos-flags
 )
 
 # Since there are a lot of circular references between this library and mbed-netsocket-api,

--- a/connectivity/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
+++ b/connectivity/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
@@ -29,6 +29,4 @@ target_link_libraries(mbed-nanostack-hal_mbed_cmsis_rtos
         mbed-nanostack-sal_stack-event_loop
         mbed-nanostack-libservice
         mbed-nanostack-sal_stack
-    PRIVATE
-        mbed-rtos-flags
 )

--- a/connectivity/netsocket/tests/emac_test_utils/CMakeLists.txt
+++ b/connectivity/netsocket/tests/emac_test_utils/CMakeLists.txt
@@ -8,7 +8,6 @@ target_sources(mbed-emac-test-utils PRIVATE
 target_include_directories(mbed-emac-test-utils PUBLIC .)
 target_link_libraries(mbed-emac-test-utils PUBLIC
     mbed-core-flags
-    mbed-rtos-flags
     mbed-netsocket-api
 	mbed-nanostack-libservice
 	mbed-nanostack-hal_mbed_cmsis_rtos)

--- a/drivers/usb/CMakeLists.txt
+++ b/drivers/usb/CMakeLists.txt
@@ -56,5 +56,5 @@ if("DEVICE_USBDEVICE=1" IN_LIST MBED_TARGET_DEFINITIONS)
             include/usb/cdc_ecm
     )
 
-    target_link_libraries(mbed-usb-cdc-ecm PUBLIC mbed-usb mbed-rtos-flags)
+    target_link_libraries(mbed-usb-cdc-ecm PUBLIC mbed-usb mbed-core-flags)
 endif()

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -103,10 +103,9 @@
             },
             "application-profile": {
                 "help": "Select application profile. Options: auto, full, bare-metal. 'auto' mode will check other build options and resolve to\
-                'full' mode by default or 'bare-metal' mode, for example, MBED_GREENTEA_TEST_BAREMETAL being ON for Greentea test. 'full' mode\
-                enables the real-time OS and enables all features of Mbed to be used. 'bare-metal' mode disables the real-time OS, preventing you\
-                from using threads and libraries that depend on them. 'bare-metal' mode is recommended for target MCUs with small amounts of flash\
-                and RAM.",
+                'full' mode by default or 'bare-metal' mode. 'full' mode enables the real-time OS and enables all features of Mbed to be used.\
+                'bare-metal' mode disables the real-time OS, preventing you from using threads and libraries that depend on them. 'bare-metal'\
+                mode is recommended for target MCUs with small amounts of flash and RAM.",
                 "value": "auto"
             }
         }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -100,6 +100,14 @@
             "semihosting-enabled": {
                 "help": "Enable ARM Semihosting protocol.  This uses a magic breakpoint instruction to enable the MCU to print data to and access files on a host machine.  However, it can interfere with debuggers that are not semihost aware.",
                 "value": false
+            },
+            "application-profile": {
+                "help": "Select application profile. Options: auto, full, bare-metal. 'auto' mode will check other build options and resolve to\
+                'full' mode by default or 'bare-metal' mode, for example, MBED_GREENTEA_TEST_BAREMETAL being ON for Greentea test. 'full' mode\
+                enables the real-time OS and enables all features of Mbed to be used. 'bare-metal' mode disables the real-time OS, preventing you\
+                from using threads and libraries that depend on them. 'bare-metal' mode is recommended for target MCUs with small amounts of flash\
+                and RAM.",
+                "value": "auto"
             }
         }
     },

--- a/tools/cmake/mbed_greentea.cmake
+++ b/tools/cmake/mbed_greentea.cmake
@@ -92,7 +92,9 @@ function(mbed_greentea_add_test)
             ${MBED_GREENTEA_TEST_SOURCES}
     )
 
-    if(MBED_GREENTEA_TEST_BAREMETAL)
+    # Resolve link library based on target.application-profile setting
+    get_target_property(MBED_CORE_FLAGS_TARGET_LINK_LIBRARIES mbed-core-flags INTERFACE_LINK_LIBRARIES)
+    if(NOT "mbed-rtos-flags" IN_LIST MBED_CORE_FLAGS_TARGET_LINK_LIBRARIES)
         list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-baremetal)
     else()
         list(APPEND MBED_GREENTEA_TEST_REQUIRED_LIBS mbed-os)

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -136,9 +136,20 @@ function(mbed_set_post_build target)
     if (NOT MBED_IS_STANDALONE)
         if("${ARGN}" STREQUAL "")
             get_target_property(POST_BUILD_TARGET_LINK_LIBRARIES ${target} LINK_LIBRARIES)
+            get_target_property(MBED_CORE_FLAGS_TARGET_LINK_LIBRARIES mbed-core-flags INTERFACE_LINK_LIBRARIES)
             if("mbed-os" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
+                if(NOT "mbed-rtos-flags" IN_LIST MBED_CORE_FLAGS_TARGET_LINK_LIBRARIES)
+                    message(FATAL_ERROR
+                        "Target ${target} links to mbed-os, but Mbed is configured for a baremetal build. Please set \"target.application-profile\": \"full\" in JSON to enable the mbed-os target, or link your application to mbed-baremetal instead of mbed-os."
+                    )
+                endif()
                 get_target_property(LINKER_SCRIPT_PATH mbed-os LINKER_SCRIPT_PATH)
             elseif("mbed-baremetal" IN_LIST POST_BUILD_TARGET_LINK_LIBRARIES)
+                if("mbed-rtos-flags" IN_LIST MBED_CORE_FLAGS_TARGET_LINK_LIBRARIES)
+                    message(FATAL_ERROR
+                        "Target ${target} links to mbed-baremetal, but Mbed is configured for a full build. Please set \"target.application-profile\": \"bare-metal\" in JSON to enable the mbed-baremetal target, or link your application to mbed-os instead of mbed-baremetal."
+                    )
+                endif()
                 get_target_property(LINKER_SCRIPT_PATH mbed-baremetal LINKER_SCRIPT_PATH)
             else()
                 message(FATAL_ERROR "Target ${target} used with mbed_set_post_build() but does not link to mbed-os or mbed-baremetal!")


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to address #407, including:
1.  Provide one approach to address cmake link mess with `mbed-core-flags`/
    `mbed-rtos-flags` whose links or not depends on selected application profile,
    `full` or `bare-metal`.
    1.  Add target config option `application-profile` for application to
        select which application profile to use. Applications are responsible
        for make this target config option consitent with link selection of
        mbed-os/mbed-baremetal.
    2.  Add cmake interface library `mbed-application-profile-flags`. It is to
        substitute for mbed-core-flags/mbed-rtos-flags. Library camke targets
        should change to link this one to build upon correct application profile
        selection.
2.  All in-tree library targets link `mbed-application-profile-flags` instead of `mbed-core-flags`/`mbed-rtos-flags` to build upon correct application profile.


#### Impact of changes <!-- Optional -->

To link mbed-baremetal, `target.application-profile` must be set to `bare-metal` in mbed_app.json5.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
