### PR TITLE
MIMXRT105x: upgrade linker script to use memory banks, disable SRAM

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -246,6 +246,9 @@
         },
         "MCU_STM32H7": {
             "crash-capture-enabled": true
+        },
+        "MIMXRT105X-P": {
+            "crash-capture-enabled": true
         }
     }
 }

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -247,7 +247,7 @@
         "MCU_STM32H7": {
             "crash-capture-enabled": true
         },
-        "MIMXRT105X-P": {
+        "MIMXRT105X": {
             "crash-capture-enabled": true
         }
     }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -112,14 +112,14 @@ SECTIONS
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   /* FCF to absolute address of 0x400, but only if bootloader is not present. */
 #if !IS_BOOTLOADER_PRESENT
   .flash_config FLASH_VTOR_TABLE_SIZE :
   {
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
-  } > m_text AT> m_text :text
+  } > m_text :text
 #else
   /DISCARD/ : {
     *(.FlashConfig)
@@ -140,19 +140,19 @@ SECTIONS
     KEEP (*(.init))
     KEEP (*(.fini))
     . = ALIGN(8);
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .ARM.extab :
   {
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .ARM :
   {
     __exidx_start = .;
     *(.ARM.exidx*)
     __exidx_end = .;
-  } > m_text AT> m_text :text
+  } > m_text :text
 
  .ctors :
   {
@@ -176,7 +176,7 @@ SECTIONS
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
     __CTOR_END__ = .;
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .dtors :
   {
@@ -187,14 +187,14 @@ SECTIONS
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
     __DTOR_END__ = .;
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .preinit_array :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .init_array :
   {
@@ -202,7 +202,7 @@ SECTIONS
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
-  } > m_text AT> m_text :text
+  } > m_text :text
 
   .fini_array :
   {
@@ -210,7 +210,7 @@ SECTIONS
     KEEP (*(SORT(.fini_array.*)))
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
-  } > m_text AT> m_text :text
+  } > m_text :text
 
 #if MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
   /* Stick the crash data ram at the start of sram_l */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1050_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1050_EVK/xip/evkbimxrt1050_flexspi_nor_config.c
@@ -39,7 +39,7 @@ const flexspi_nor_config_t hyperflash_config = {
         (1u << kFlexSpiMiscOffset_SafeConfigFreqEnable) | (1u << kFlexSpiMiscOffset_DiffClkEnable),
         .sflashPadType = kSerialFlash_8Pads,
         .serialClkFreq = kFlexSpiSerialClk_133MHz,
-        .sflashA1Size = BOARD_FLASH_SIZE,
+        .sflashA1Size = MBED_ROM_BANK_EXT_FLASH_SIZE,
         .dataValidTime = {16u, 16u},
         .lookupTable = {
             // Read LUTs
@@ -68,7 +68,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .sflashPadType = kSerialFlash_4Pads,
         .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .lutCustomSeqEnable = 0u,
-        .sflashA1Size = BOARD_FLASH_SIZE,
+        .sflashA1Size = MBED_ROM_BANK_EXT_FLASH_SIZE,
         .lookupTable = {
             // Fast read sequence
             [0] = FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1060_EVK/xip/evkbmimxrt1060_flexspi_nor_config.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/TARGET_1060_EVK/xip/evkbmimxrt1060_flexspi_nor_config.c
@@ -35,7 +35,7 @@ const flexspi_nor_config_t qspiflash_config = {
             .deviceType           = kFlexSpiDeviceType_SerialNOR,
             .sflashPadType        = kSerialFlash_4Pads,
             .serialClkFreq        = kFlexSpiSerialClk_120MHz,
-            .sflashA1Size         = BOARD_FLASH_SIZE,
+            .sflashA1Size         = MBED_ROM_BANK_EXT_FLASH_SIZE,
             .lookupTable =
                 {
                     // Read LUTs

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_api.c
@@ -655,8 +655,8 @@ int32_t flash_free(flash_t *obj)
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
 {
     uint32_t sectorsize = MBED_FLASH_INVALID_SIZE;
-    uint32_t devicesize = BOARD_FLASH_SIZE;
-    uint32_t startaddr = BOARD_FLASH_START_ADDR;
+    uint32_t devicesize = MBED_ROM_BANK_EXT_FLASH_SIZE;
+    uint32_t startaddr = MBED_ROM_BANK_EXT_FLASH_START;
 
     if ((address >= startaddr) && (address < (startaddr + devicesize))) {
         sectorsize = BOARD_FLASH_SECTOR_SIZE;
@@ -672,12 +672,12 @@ uint32_t flash_get_page_size(const flash_t *obj)
 
 uint32_t flash_get_start_address(const flash_t *obj)
 {
-    return BOARD_FLASH_START_ADDR;
+    return MBED_ROM_BANK_EXT_FLASH_START;
 }
 
 uint32_t flash_get_size(const flash_t *obj)
 {
-    return BOARD_FLASH_SIZE;
+    return MBED_ROM_BANK_EXT_FLASH_SIZE;
 }
 
 uint8_t flash_get_erase_value(const flash_t *obj)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_defines.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/flash_defines.h
@@ -274,7 +274,7 @@ static uint32_t customLUT[CUSTOM_LUT_LENGTH] = {
 
 flexspi_device_config_t deviceconfig = {
     .flexspiRootClk       = 120000000,
-    .flashSize            = (BOARD_FLASH_SIZE/1024),
+    .flashSize            = (MBED_ROM_BANK_EXT_FLASH_SIZE/1024),
     .CSIntervalUnit       = kFLEXSPI_CsIntervalUnit1SckCycle,
     .CSInterval           = 0,
     .CSHoldTime           = 3,

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/fsl_flexspi_nor_boot.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/fsl_flexspi_nor_boot.h
@@ -101,7 +101,7 @@ typedef struct _boot_data_ {
   uint32_t placeholder;		/* placehoder to make even 0x10 size */
 }BOOT_DATA_T;
 
-#define FLASH_SIZE            BOARD_FLASH_SIZE
+#define FLASH_SIZE            MBED_ROM_BANK_EXT_FLASH_SIZE
 #define PLUGIN_FLAG           (uint32_t)0
 
 /* External Variables */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_EVK/mimxrt_memory_info.h
@@ -20,28 +20,12 @@
 
 #ifdef HYPERFLASH_BOOT
 /* 64MB HyperFlash */
-#define BOARD_FLASH_SIZE             (0x4000000)
-#define BOARD_FLASH_START_ADDR       (0x60000000)
 #define BOARD_FLASH_PAGE_SIZE        (512)
 #define BOARD_FLASH_SECTOR_SIZE      (262144)
 #else
 /* 8MB QSPI Flash */
-#define BOARD_FLASH_SIZE             (0x800000)
-#define BOARD_FLASH_START_ADDR       (0x60000000)
 #define BOARD_FLASH_PAGE_SIZE        (256)
 #define BOARD_FLASH_SECTOR_SIZE      (4096)
 #endif
-
-// Unless the user overrides it, define the app to use the entire flash space.
-#ifndef MBED_APP_START
-#define MBED_APP_START BOARD_FLASH_START_ADDR
-#endif
-
-#ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE BOARD_FLASH_SIZE
-#endif
-
-#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 1
-#define MIMXRT105X_EXTERNAL_RAM_SIZE 0x02000000
 
 #endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_40/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_40/mimxrt_memory_info.h
@@ -19,20 +19,7 @@
 #define MBED_OS_MIMXRT_MEMORY_INFO_H
 
 /* 2MB QSPI Flash */
-#define BOARD_FLASH_SIZE             (0x1F0000) // 1984k
-#define BOARD_FLASH_START_ADDR       (0x60000000)
 #define BOARD_FLASH_PAGE_SIZE        (256)
 #define BOARD_FLASH_SECTOR_SIZE      (4096)
-
-// Unless the user overrides it, define the app to use the entire flash space.
-#ifndef MBED_APP_START
-#define MBED_APP_START BOARD_FLASH_START_ADDR
-#endif
-
-#ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE BOARD_FLASH_SIZE
-#endif
-
-#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 0
 
 #endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_41/mimxrt_memory_info.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/TARGET_TEENSY_4X/TARGET_TEENSY_41/mimxrt_memory_info.h
@@ -19,20 +19,7 @@
 #define MBED_OS_MIMXRT_MEMORY_INFO_H
 
 /* 8MB QSPI Flash */
-#define BOARD_FLASH_SIZE             (0x7C0000) // 7936k
-#define BOARD_FLASH_START_ADDR       (0x60000000)
 #define BOARD_FLASH_PAGE_SIZE        (256)
 #define BOARD_FLASH_SECTOR_SIZE      (4096)
-
-// Unless the user overrides it, define the app to use the entire flash space.
-#ifndef MBED_APP_START
-#define MBED_APP_START BOARD_FLASH_START_ADDR
-#endif
-
-#ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE BOARD_FLASH_SIZE
-#endif
-
-#define MIMXRT105X_BOARD_HAS_EXTERNAL_RAM 0
 
 #endif //MBED_OS_MIMXRT_MEMORY_INFO_H

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -25,9 +25,6 @@
 ** ###################################################################
 */
 
-/* Pick up memory info for this specific device */
-#include <mimxrt_memory_info.h>
-
 /* Entry Point */
 ENTRY(Reset_Handler)
 
@@ -42,21 +39,42 @@ __stack_size__ = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 
+M_CRASH_DATA_RAM_SIZE = 0x100;
+
+/* If we are not configured to execute out of the start of ROM, then a bootloader is
+ * present.  This tells us whether we need to add the Flash Configuration Field at the start of flash. */
+#if MBED_CONFIGURED_ROM_BANK_EXT_FLASH_START == MBED_ROM_BANK_EXT_FLASH_START
+#define IS_BOOTLOADER_PRESENT 0
+#else
+#define IS_BOOTLOADER_PRESENT 1
+#endif
+
+/* Specify the ELF segments (program headers) */
+PHDRS
+{
+  text PT_LOAD FLAGS(5); /* read + execute */
+  ram_functions PT_LOAD FLAGS(5); /* read + execute */
+  ram_vector_table PT_LOAD FLAGS(6); /* read + write */
+  ram_noinit PT_LOAD FLAGS(6); /* read + write */
+  ram_init PT_LOAD FLAGS(6); /* read + write */
+  dtcm_stack PT_LOAD FLAGS(6); /* read + write */
+  ram_ncache_noinit PT_LOAD FLAGS(6); /* read + write */
+  ram_ncache_init PT_LOAD FLAGS(6); /* read + write */
+  crash_data_ram PT_LOAD FLAGS(6); /* read + write */
+}
+
 /* Specify the memory areas */
 MEMORY
 {
-  m_flash_config        (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x00001000
-  m_ivt                 (RX)  : ORIGIN = MBED_APP_START + 0x1000, LENGTH = 0x00001000
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START + 0x2000, LENGTH = 0x00000400
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x2400, LENGTH = MBED_APP_SIZE - 0x2400
+  m_text                (RX)  : ORIGIN = MBED_CONFIGURED_ROM_BANK_EXT_FLASH_START, LENGTH = MBED_CONFIGURED_ROM_BANK_EXT_FLASH_SIZE
 
 /* DTCM memory.
      Startup code configures size to 256k (stealing space from OCRAM). */
-  m_dtcm                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00040000
+  m_dtcm                (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_DTC_START, LENGTH = MBED_RAM_BANK_SRAM_DTC_SIZE
 
-#if MIMXRT105X_BOARD_HAS_EXTERNAL_RAM
+#ifdef MBED_RAM_BANK_SDRAM_SIZE
   /* Use the external RAM as main memory */
-  m_data                (RW)  : ORIGIN = 0x80000000, LENGTH = MIMXRT105X_EXTERNAL_RAM_SIZE
+  m_data                (RW)  : ORIGIN = MBED_RAM_BANK_SDRAM_START, LENGTH = MBED_RAM_BANK_SDRAM_SIZE
 #else
   /* No external data memory, store data in DTCM (significantly faster than OCRAM)*/
 #define m_data m_dtcm
@@ -65,54 +83,64 @@ MEMORY
   /* ITCM bank -- used for functions that need to execute from RAM
      (which is faster than having to load them from flash).
      Startup code configures size to 128k. */
-  m_itcm               (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00020000
+  m_itcm               (RX)  : ORIGIN = MBED_RAM_BANK_SRAM_ITC_START, LENGTH = MBED_RAM_BANK_SRAM_ITC_SIZE
 
   /* OCRAM bank -- extra RAM, available for misc storage but slower to access.
      Startup code configures size to 128k.
      Note that address is different on the 105x and the 106x. */
-#if MBED_TARGET_MIMXRT1050
-  m_ocram              (RW)  : ORIGIN = 0x20200000, LENGTH = 0x00020000
-#else /* MIMXRT1060 */
-  m_ocram              (RW)  : ORIGIN = 0x20280000, LENGTH = 0x00020000
-#endif
+  m_ocram              (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_OC_START, LENGTH = MBED_RAM_BANK_SRAM_OC_SIZE
 
 #if MBED_TARGET_MIMXRT1060
   /* OCRAM2 bank -- extra RAM, available on MIMXRT106x only. */
-  m_ocram2             (RW)  : ORIGIN = 0x20200000, LENGTH = 0x00080000
+  m_ocram2             (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_OC2_START, LENGTH = MBED_RAM_BANK_SRAM_OC2_SIZE
 #endif
 }
 
 /* Define output sections */
 SECTIONS
 {
-#if !defined(MBED_APP_COMPILE)
+#if !IS_BOOTLOADER_PRESENT
+  /* Flash config goes first, at the start of flash */
   .flash_config :
   {
-    . = ALIGN(8);
     __FLASH_BASE = .;
     KEEP(* (.boot_hdr.conf))     /* flash config section */
-    . = ALIGN(8);
-  } > m_flash_config
+  } > m_text :text
 
-  ivt_begin = ORIGIN(m_flash_config) + LENGTH(m_flash_config);
-
-  .ivt :
+  /* Then IVT at offset 0x1000 */
+  .ivt MBED_ROM_BANK_EXT_FLASH_START + 0x1000 :
   {
-    . = ALIGN(8);
     KEEP(* (.boot_hdr.ivt))           /* ivt section */
     KEEP(* (.boot_hdr.boot_data))     /* boot section */
     KEEP(* (.boot_hdr.dcd_data))      /* dcd section */
-    . = ALIGN(8);
-  } > m_ivt
+  } > m_text :text
+  /* Note that we do not want to use AT> above, because that would result in this section being
+   * placed in flash immediately after .flash_config.  Instead we don't use AT> to set the LMA equal
+   * to the VMA. */
+
+  /* Interrupts go after that */
+  #define INTERRUPT_TABLE_ADDR MBED_ROM_BANK_EXT_FLASH_START + 0x2000
+#else
+  /* We have a bootloader so we don't need the flash config or IVT */
+  /DISCARD/ : {
+    *(.boot_hdr.conf)
+    *(.boot_hdr.ivt)
+    *(.boot_hdr.boot_data)
+    *(.boot_hdr.dcd_data)
+  }
+
+  /* Interrupts go at the start of flash */
+  #define INTERRUPT_TABLE_ADDR MBED_ROM_BANK_EXT_FLASH_START
 #endif
-  /* The startup code goes first into internal RAM */
-  .interrupts :
+
+  /* Now we have the ISR vector */
+  .interrupts INTERRUPT_TABLE_ADDR :
   {
     __VECTOR_TABLE = .;
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-  } > m_interrupts
+  } > m_text :text
 
   /* The program code and other data goes into internal RAM */
   .text :
@@ -128,19 +156,19 @@ SECTIONS
     KEEP (*(.init))
     KEEP (*(.fini))
     . = ALIGN(8);
-  } > m_text
+  } > m_text :text
 
   .ARM.extab :
   {
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-  } > m_text
+  } > m_text :text
 
   .ARM :
   {
     __exidx_start = .;
     *(.ARM.exidx*)
     __exidx_end = .;
-  } > m_text
+  } > m_text :text
 
  .ctors :
   {
@@ -164,7 +192,7 @@ SECTIONS
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
     __CTOR_END__ = .;
-  } > m_text
+  } > m_text :text
 
   .dtors :
   {
@@ -175,14 +203,14 @@ SECTIONS
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
     __DTOR_END__ = .;
-  } > m_text
+  } > m_text :text
 
   .preinit_array :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
-  } > m_text
+  } > m_text :text
 
   .init_array :
   {
@@ -190,7 +218,7 @@ SECTIONS
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
-  } > m_text
+  } > m_text :text
 
   .fini_array :
   {
@@ -198,7 +226,7 @@ SECTIONS
     KEEP (*(SORT(.fini_array.*)))
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
-  } > m_text
+  } > m_text :text
 
   __etext = .;    /* define a global symbol at end of code */
   __DATA_ROM = .; /* Symbol is used by startup for data initialization */
@@ -212,7 +240,7 @@ SECTIONS
     . += M_VECTOR_RAM_SIZE;
     . = ALIGN(8);
     __interrupts_ram_end__ = .; /* Define a global symbol at data end */
-  } > m_dtcm
+  } > m_dtcm :ram_vector_table
 
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
@@ -228,7 +256,7 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_data AT> m_text
+  } > m_data AT> m_text :ram_init
   __ram_function_flash_start = __DATA_ROM + (__data_end__ - __data_start__); /* Symbol is used by startup for TCM data initialization */
 
   .ram_function :
@@ -238,28 +266,42 @@ SECTIONS
     *(CodeQuickAccess)
     . = ALIGN(128);
     __ram_function_end__ = .;
-  } > m_itcm AT> m_text
+  } > m_itcm AT> m_text :ram_functions
 
   __ram_function_size = SIZEOF(.ram_function);
 
   __NDATA_ROM = __ram_function_flash_start + SIZEOF(.ram_function);
 
+  /* Store crash data RAM at the end of OCRAM (which is otherwise unused).
+     Note that the ROM bootloader clobbers the first part of OCRAM, so we have to put this at the end. */
+  __CRASH_DATA_RAM_START__ = ORIGIN(m_ocram) + LENGTH(m_ocram) - M_CRASH_DATA_RAM_SIZE; /* Create a global symbol at data start */
+  .crash_data_ram __CRASH_DATA_RAM_START__ :
+  {
+    . = ALIGN(8);
+    __CRASH_DATA_RAM__ = .;
+    KEEP(*(.keep.crash_data_ram))
+    *(.m_crash_data_ram)     /* This is a user defined section */
+    . += M_CRASH_DATA_RAM_SIZE;
+    . = ALIGN(8);
+    __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+  } > m_ocram :crash_data_ram
+
   /* Always store noncacheable data (e.g. DMA descriptors) in DTCM, since this memory
-     does not use a cache. */
+     is always cache coherent. */
   .ncache.init :
   {
     __noncachedata_start__ = .;   /* create a global symbol at ncache data start */
     *(NonCacheable.init)
     . = ALIGN(8);
     __noncachedata_init_end__ = .;   /* create a global symbol at initialized ncache data end */
-  } > m_dtcm AT> m_text
+  } > m_dtcm AT> m_text :ram_ncache_init
   . = __noncachedata_init_end__;
   .ncache :
   {
     *(NonCacheable)
     . = ALIGN(8);
     __noncachedata_end__ = .;     /* define a global symbol at ncache data end */
-  } > m_dtcm
+  } > m_dtcm :ram_ncache_noinit
 
   __TEXT_CSF_ROM = __NDATA_ROM + (__noncachedata_init_end__ - __noncachedata_start__);
 
@@ -269,7 +311,7 @@ SECTIONS
     . = ALIGN(1024);
     KEEP(*(.csf))
     __text_csf_end = .;
-  } > m_text
+  } > m_text :text
 
 
   /* __USED_FLASH_END gives the end of all data written to the flash memory, including code and data
@@ -284,7 +326,7 @@ SECTIONS
   ASSERT(__USED_FLASH_END <= text_end, "Code and data initializers exceed flash size!")
 
   /* Uninitialized data section */
-  .bss :
+  .bss (NOLOAD):
   {
     /* This is used by the startup in order to initialize the .bss section */
     . = ALIGN(8);
@@ -297,9 +339,9 @@ SECTIONS
     . = ALIGN(8);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data
+  } > m_data :ram_noinit
 
-  .heap :
+  .heap (NOLOAD):
   {
     . = ALIGN(8);
     __end__ = .;
@@ -308,15 +350,15 @@ SECTIONS
     . =  ORIGIN(m_data) + LENGTH(m_data) - STACK_SIZE;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
-  } > m_data
+  } > m_data :ram_noinit
 
   /* Reserve space for stack (even though stack is always at the end of DTCM regardless
      of where this section is located) */
-  .stack :
+  .stack (NOLOAD):
   {
     . = ALIGN(8);
     . += STACK_SIZE;
-  } > m_dtcm
+  } > m_dtcm :dtcm_stack
 
   /* Initializes stack on the end of block */
   __StackTop   = ORIGIN(m_dtcm) + LENGTH(m_dtcm);

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -74,10 +74,7 @@ MEMORY
 
 #ifdef MBED_RAM_BANK_SDRAM_SIZE
   /* Use the external RAM as main memory */
-  m_data                (RW)  : ORIGIN = MBED_RAM_BANK_SDRAM_START, LENGTH = MBED_RAM_BANK_SDRAM_SIZE
-#else
-  /* No external data memory, store data in DTCM (significantly faster than OCRAM)*/
-#define m_data m_dtcm
+  m_sdram               (RW)  : ORIGIN = MBED_RAM_BANK_SDRAM_START, LENGTH = MBED_RAM_BANK_SDRAM_SIZE
 #endif
 
   /* ITCM bank -- used for functions that need to execute from RAM
@@ -256,7 +253,7 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_data AT> m_text :ram_init
+  } > m_dtcm AT> m_text :ram_init
   __ram_function_flash_start = __DATA_ROM + (__data_end__ - __data_start__); /* Symbol is used by startup for TCM data initialization */
 
   .ram_function :
@@ -339,18 +336,19 @@ SECTIONS
     . = ALIGN(8);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data :ram_noinit
+  } > m_dtcm :ram_noinit
+
+  . = ALIGN(8);
+  __end__ = .;
+  PROVIDE(end = .);
 
   .heap (NOLOAD):
   {
-    . = ALIGN(8);
-    __end__ = .;
-    PROVIDE(end = .);
     __HeapBase = .;
-    . =  ORIGIN(m_data) + LENGTH(m_data) - STACK_SIZE;
+    . =  ORIGIN(m_dtcm) + LENGTH(m_dtcm) - STACK_SIZE;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
-  } > m_data :ram_noinit
+  } > m_dtcm :ram_noinit
 
   /* Reserve space for stack (even though stack is always at the end of DTCM regardless
      of where this section is located) */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -87,7 +87,7 @@ MEMORY
      Note that address is different on the 105x and the 106x. */
   m_ocram              (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_OC_START, LENGTH = MBED_RAM_BANK_SRAM_OC_SIZE
 
-#if MBED_TARGET_MIMXRT1060
+#ifdef MBED_RAM_BANK_SRAM_OC2_START
   /* OCRAM2 bank -- extra RAM, available on MIMXRT106x only. */
   m_ocram2             (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_OC2_START, LENGTH = MBED_RAM_BANK_SRAM_OC2_SIZE
 #endif
@@ -269,20 +269,6 @@ SECTIONS
 
   __NDATA_ROM = __ram_function_flash_start + SIZEOF(.ram_function);
 
-  /* Store crash data RAM at the end of OCRAM (which is otherwise unused).
-     Note that the ROM bootloader clobbers the first part of OCRAM, so we have to put this at the end. */
-  __CRASH_DATA_RAM_START__ = ORIGIN(m_ocram) + LENGTH(m_ocram) - M_CRASH_DATA_RAM_SIZE; /* Create a global symbol at data start */
-  .crash_data_ram __CRASH_DATA_RAM_START__ :
-  {
-    . = ALIGN(8);
-    __CRASH_DATA_RAM__ = .;
-    KEEP(*(.keep.crash_data_ram))
-    *(.m_crash_data_ram)     /* This is a user defined section */
-    . += M_CRASH_DATA_RAM_SIZE;
-    . = ALIGN(8);
-    __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
-  } > m_ocram :crash_data_ram
-
   /* Always store noncacheable data (e.g. DMA descriptors) in DTCM, since this memory
      is always cache coherent. */
   .ncache.init :
@@ -342,13 +328,12 @@ SECTIONS
   __end__ = .;
   PROVIDE(end = .);
 
-  .heap (NOLOAD):
+  .heap_0 (NOLOAD):
   {
-    __HeapBase = .;
-    . =  ORIGIN(m_dtcm) + LENGTH(m_dtcm) - STACK_SIZE;
-    __HeapLimit = .;
-    __heap_limit = .; /* Add for _sbrk */
-  } > m_dtcm :ram_noinit
+      PROVIDE(__mbed_sbrk_start_0 = .);
+      . =  ORIGIN(m_dtcm) + LENGTH(m_dtcm) - STACK_SIZE;
+      PROVIDE(__mbed_krbs_start_0 = .);
+  } > m_dtcm
 
   /* Reserve space for stack (even though stack is always at the end of DTCM regardless
      of where this section is located) */
@@ -362,6 +347,39 @@ SECTIONS
   __StackTop   = ORIGIN(m_dtcm) + LENGTH(m_dtcm);
   __StackLimit = __StackTop - STACK_SIZE;
   PROVIDE(__stack = __StackTop);
+
+  /* Store crash data RAM at the end of OCRAM (which is otherwise unused).
+     Note that the ROM bootloader clobbers the first part of OCRAM, so we have to put this at the end. */
+  __CRASH_DATA_RAM_START__ = ORIGIN(m_ocram) + LENGTH(m_ocram) - M_CRASH_DATA_RAM_SIZE; /* Create a global symbol at data start */
+
+  /* Second heap region. Use OCRAM2 if available, otherwise use OCRAM.
+   * TODO https://github.com/mbed-ce/mbed-os/issues/413 Use SDRAM once this bug is fixed. */
+#ifdef MBED_RAM_BANK_SRAM_OC2_START
+  .heap (NOLOAD):
+  {
+      PROVIDE(__mbed_sbrk_start = .);
+      . += (ORIGIN(m_ocram2) + LENGTH(m_ocram2));
+      PROVIDE(__mbed_krbs_start = .);
+  } > m_ocram2
+#else
+  .heap (NOLOAD):
+  {
+      PROVIDE(__mbed_sbrk_start = .);
+      . = __CRASH_DATA_RAM_START__;
+      PROVIDE(__mbed_krbs_start = .);
+  } > m_ocram2
+#endif
+
+  .crash_data_ram __CRASH_DATA_RAM_START__ :
+  {
+    . = ALIGN(8);
+    __CRASH_DATA_RAM__ = .;
+    KEEP(*(.keep.crash_data_ram))
+    *(.m_crash_data_ram)     /* This is a user defined section */
+    . += M_CRASH_DATA_RAM_SIZE;
+    . = ALIGN(8);
+    __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+  } > m_ocram :crash_data_ram
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -5202,7 +5202,8 @@
             "__STARTUP_INITIALIZE_NONCACHEDATA",
             "MBED_MPU_CUSTOM",
             "MBED_TICKLESS",
-            "DATA_SECTION_IS_CACHEABLE=1"
+            "DATA_SECTION_IS_CACHEABLE=1",
+            "MBED_SPLIT_HEAP"
         ],
         "inherits": [
             "Target"

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -5365,6 +5365,30 @@
             "console-usb": true,
             "console-uart": false
         },
+
+        // 2MB QSPI flash
+        "memory_banks": {
+            "EXT_FLASH": {
+                "access": {
+                    "execute": true,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "size": 0x200000,
+                "start": 0x60000000,
+                "startup": true
+            }
+        },
+
+        // The end of flash is used by the Teensy bootloader
+        "memory_bank_config": {
+            "EXT_FLASH": {
+                "size": 0x1F0000, // 1984k
+            }
+        },
         "device_has_remove": [
             "EMAC"
         ],
@@ -5385,6 +5409,31 @@
             "console-uart": false,
             "network-default-interface-type": "ETHERNET"
         },
+
+        // 8MB QSPI flash
+        "memory_banks": {
+            "EXT_FLASH": {
+                "access": {
+                    "execute": true,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "size": 0x800000,
+                "start": 0x60000000,
+                "startup": true
+            }
+        },
+
+        // The end of flash is used by the Teensy bootloader
+        "memory_bank_config": {
+            "EXT_FLASH": {
+                "size": 0x7C0000, // 7936k
+            }
+        },
+
         "device_name": "MIMXRT1062DVL6B",
         "image_url": "https://www.pjrc.com/store/teensy41_4.jpg"
     },


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR upgrades the MIMXRT105x/6x linker script to use memory banks instead of the hand-written header file that it had been using.  This enables bootloader support on the MIMXRT106x, and I also took the chance to enable crash data RAM on it.

Unfortunately, while testing this change, I ran into constant failures on the heap fill test (which I don't think had been reactivated until a couple months ago, so it never got run on this target before).  It showed that there was corruption happening in the external 256MB SDRAM: bytes received didn't always match bytes written back.

For now, I didn't have a ton of time to dig into this, after half an hour of messing around I kinda had to keep moving.  So, I had to disable the SDRAM for now to restore stable operation of the chip.  Thankfully it still has a reasonable amount of on-chip ram (256k usable for MIMXRT105x, 768k usable for MIMXRT106x), so it isn't totally hobbled for most applications. Future tasks would be to do some deeper testing to understand why this corruption is happening (i.e. do A-B testing with IDE projects and Mbed), and to enable split heap for MIMXRT105x so we can take advantage of more of the on-chip RAM.

UPDATE: Split heap support added

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
MIMXRT1050_EVK and MIMXRT1060_EVK RAM space currently reduced to just the DTCM bank (fast on-chip data RAM) pending investigation into external SDRAM errors.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Before merge I will update the MIMXRT105x info page to explain about SDRAM being disabled for now (the corruption, and also it causes debugging issues).

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
 Working a test run with this plus my other PR
----------------------------------------------------------------------------------------------------------------
