### PR TITLE
Fix heap get for split heap

### DIFF
--- a/cmsis/device/rtos/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
+++ b/cmsis/device/rtos/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
@@ -60,9 +60,13 @@ void software_init_hook(void)
     mbed_heap_size = (uint32_t) &__mbed_krbs_start - (uint32_t) &__mbed_sbrk_start;
     mbed_heap_start_0 = (unsigned char *) &__mbed_sbrk_start_0;
     mbed_heap_size_0 = (uint32_t) &__mbed_krbs_start_0 - (uint32_t) &__mbed_sbrk_start_0;
+
+    mbed_heap_size_total = mbed_heap_size + mbed_heap_size_0;
 #else
     mbed_heap_start = (unsigned char *) &__end__;
     mbed_heap_size = (uint32_t) &__HeapLimit - (uint32_t) &__end__;
+
+    mbed_heap_size_total = mbed_heap_size;
 #endif
 
     mbed_init();

--- a/cmsis/device/rtos/include/mbed_boot.h
+++ b/cmsis/device/rtos/include/mbed_boot.h
@@ -57,6 +57,7 @@ extern "C" {
 /* Heap limits - only used if set */
 extern unsigned char *mbed_heap_start;
 extern uint32_t mbed_heap_size;
+extern uint32_t mbed_heap_size_total;
 
 #if defined(MBED_SPLIT_HEAP)
 extern unsigned char *mbed_heap_start_0;

--- a/platform/source/mbed_alloc_wrappers.cpp
+++ b/platform/source/mbed_alloc_wrappers.cpp
@@ -76,6 +76,11 @@ void mbed_stats_heap_get(mbed_stats_heap_t *stats)
     extern uint32_t mbed_heap_size;
     heap_stats.reserved_size = mbed_heap_size;
 
+#if defined(MBED_SPLIT_HEAP)
+    extern uint32_t mbed_heap_size_0;
+    heap_stats.reserved_size += mbed_heap_size_0;
+#endif
+
     malloc_stats_mutex->lock();
     memcpy(stats, &heap_stats, sizeof(mbed_stats_heap_t));
     malloc_stats_mutex->unlock();

--- a/platform/source/mbed_alloc_wrappers.cpp
+++ b/platform/source/mbed_alloc_wrappers.cpp
@@ -73,13 +73,8 @@ static int get_malloc_block_total_size(void *ptr)
 void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 {
 #if MBED_HEAP_STATS_ENABLED
-    extern uint32_t mbed_heap_size;
-    heap_stats.reserved_size = mbed_heap_size;
-
-#if defined(MBED_SPLIT_HEAP)
-    extern uint32_t mbed_heap_size_0;
-    heap_stats.reserved_size += mbed_heap_size_0;
-#endif
+    extern uint32_t mbed_heap_size_total;
+    heap_stats.reserved_size = mbed_heap_size_total;
 
     malloc_stats_mutex->lock();
     memcpy(stats, &heap_stats, sizeof(mbed_stats_heap_t));

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -119,6 +119,7 @@ extern const char __stderr_name[] = "/stderr";
 
 unsigned char *mbed_heap_start = 0;
 uint32_t mbed_heap_size = 0;
+uint32_t mbed_heap_size_total = 0;
 
 #if defined(MBED_SPLIT_HEAP)
 unsigned char *mbed_heap_start_0 = 0;

--- a/platform/source/mbed_sdk_boot.c
+++ b/platform/source/mbed_sdk_boot.c
@@ -174,9 +174,13 @@ void software_init_hook(void)
     mbed_heap_size = (uint32_t) &__mbed_krbs_start - (uint32_t) &__mbed_sbrk_start;
     mbed_heap_start_0 = (unsigned char *) &__mbed_sbrk_start_0;
     mbed_heap_size_0 = (uint32_t) &__mbed_krbs_start_0 - (uint32_t) &__mbed_sbrk_start_0;
+
+    mbed_heap_size_total = mbed_heap_size + mbed_heap_size_0;
 #else
     mbed_heap_start = (unsigned char *) &__end__;
     mbed_heap_size = (uint32_t) &__HeapLimit - (uint32_t) &__end__;
+
+    mbed_heap_size_total = mbed_heap_size;
 #endif
 
     mbed_init();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

This is a fix for the field heap_stats.reserved_size in the mbed heap statistics. With split heap, the heap can contain two heap areas. In this case, mbed_heap_size changes to be the 2nd heap, and mbed_heap_size_0 will become the first heap part.
The heap statistics did took that change into account, and always used mbed_heap_size for the total heap size.

This PR adds a variable mbed_heap_size_total to reflect the total size, regardless if one or two heaps are used.


#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Heap functions are declared as weak, so a custom implementation could be used for even more heap areas or heap in external SDRAM. In this case, the variable mbed_heap_size_total must be calculated in software_init_hook() in mbed_boot_gcc_arm.c for a correct output in the heap statistics.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
