### PR TITLE
Fix HAL MPU test on Cortex M7 CPUs

### DIFF
--- a/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
@@ -18,6 +18,7 @@
 #if DEVICE_EMAC
 
 #include <stdlib.h>
+#include <algorithm>
 
 #include "cmsis_os.h"
 

--- a/hal/tests/TESTS/mbed_hal/mpu/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/mpu/main.cpp
@@ -134,7 +134,7 @@ void mpu_fault_test_bss()
 
 void mpu_fault_test_stack()
 {
-    uint16_t stack_function;
+    volatile uint16_t stack_function;
 
     stack_function = ASM_BX_LR;
     clear_caches();
@@ -143,14 +143,14 @@ void mpu_fault_test_stack()
 
 void mpu_fault_test_heap()
 {
-    uint16_t *heap_function = (uint16_t *)malloc(2);
+    uint16_t volatile *heap_function = (uint16_t *)malloc(2);
 
     TEST_ASSERT_NOT_EQUAL(NULL, heap_function);
     *heap_function = ASM_BX_LR;
     clear_caches();
     mpu_fault_test(heap_function);
 
-    free(heap_function);
+    free(const_cast<uint16_t *>(heap_function));
 }
 
 utest::v1::status_t fault_override_setup(const Case *const source, const size_t index_of_case)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Did some checking into *finally* fixing this annoying test failure that has been happening for years. The hal-mpu stack fault test has been dying on most MCUs 100% of the time, and it wasn't super obvious why.

When debugging the test, I noticed that it was dying because it was executing a garbage instruction (NOT because it was executing from RAM -- that's an intended part of the test). Why was this happening? Well, stepping through the disassembly of `mpu_fault_test_stack()`, it looked like the compiler had reordered the instructions, and was executing line 141 before line 147! So it was executing the RAM instruction before said instruction had been initialized with a value.

Why was that happening? Well, I think that the cast that this test does breaks aliasing rules in C++ -- it's casting an integer into a function pointer, and the optimizer is allowed by the standard to not have to consider the case where a function pointer points to a regular variable. So it does not make the connection that the argument to `mpu_fault_test()` is actually used by said function.

Luckily, fixing this is pretty straightforward. We just have to mark the variable as volatile (and apply the same fix to `mpu_fault_test_heap()`). That way the compiler isn't allowed to reorder the access in this manner.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
{{__sync;677f7397-a210-43cf-8efa-d23bf653564a}}
{{__version;1.3.0}}
{{__timeout;20}}
{{__host_test_name;default_auto}}
{{__testcase_count;6}}
>>> Running 6 test cases...
{{__testcase_name;MPU - init}}
{{__testcase_name;MPU - free}}
{{__testcase_name;MPU - data fault}}
{{__testcase_name;MPU - bss fault}}
{{__testcase_name;MPU - stack fault}}
{{__testcase_name;MPU - heap fault}}

>>> Running case #1: 'MPU - init'...
{{__testcase_start;MPU - init}}
{{__testcase_finish;MPU - init;1;0}}
>>> 'MPU - init': 1 passed, 0 failed
<greentea test suite>:0::PASS

>>> Running case #2: 'MPU - free'...
{{__testcase_start;MPU - free}}
{{__testcase_finish;MPU - free;1;0}}
>>> 'MPU - free': 1 passed, 0 failed
<greentea test suite>:0::PASS

>>> Running case #3: 'MPU - data fault'...
{{__testcase_start;MPU - data fault}}
{{__testcase_finish;MPU - data fault;1;0}}
>>> 'MPU - data fault': 1 passed, 0 failed
<greentea test suite>:0::PASS
```
----------------------------------------------------------------------------------------------------------------
