### PR TITLE
MIMXRT1060_EVK: Disable deep sleep by default

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/CMakeLists.txt
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/CMakeLists.txt
@@ -31,8 +31,6 @@ target_sources(mbed-mimxrt105x
         clock_config.c
         PeripheralPins.c
         pinmap.c
-        mimxrt_clock_adjustment.c
-        lpm.c
         mbed_overrides.c
 
         device/system_MIMXRT1052.c
@@ -105,6 +103,14 @@ target_sources(mbed-mimxrt105x
 
         ${STARTUP_FILE}
 )
+
+# Add extra sources used for deep sleep mode
+if("DEVICE_LPTICKER=1" IN_LIST MBED_TARGET_DEFINITIONS)
+    target_sources(mbed-mimxrt105x
+        INTERFACE
+            mimxrt_clock_adjustment.c
+            lpm.c)
+endif()
 
 target_link_libraries(mbed-mimxrt105x
     INTERFACE

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
@@ -206,7 +206,9 @@ void mbed_sdk_init()
     BOARD_Init_PMIC_STBY_REQ();
 #endif
 
+#if DEVICE_LPTICKER
     LPM_Init();
+#endif
 }
 
 void spi_setup_clock()

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/sleep.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/sleep.c
@@ -33,6 +33,7 @@ void hal_sleep(void)
     __ISB();
 }
 
+#if DEVICE_LPTICKER
 void hal_deepsleep(void)
 {
     /* Check if any of the UART's is transmitting data */
@@ -48,4 +49,9 @@ void hal_deepsleep(void)
 
     vPortPOST_SLEEP_PROCESSING(kCLOCK_ModeStop);
 }
-
+#else
+void hal_deepsleep(void)
+{
+    hal_sleep();
+}
+#endif

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -5226,8 +5226,7 @@
             "SPISLAVE",
             "TRNG",
             "WATCHDOG",
-            "USBDEVICE",
-            "LPTICKER"
+            "USBDEVICE"
         ],
         "overrides": {
             "deep-sleep-latency": 10


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Per recent discussion, this disables deep sleep by default on the MIMXRT1060_EVK.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Updated the [info page](https://github.com/mbed-ce/mbed-os/wiki/MCU-Info-Page:-MIMXRT105x-and-106x)

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
