### PR TITLE
LPC1768: Update linker script, support split heap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ cmake_install.cmake
 CMakeFiles/
 cmake_build/
 Testing/
+cmake-variants.yaml
+CMakeUserPresets.json
 
 # CLion
 cmake-build-*/

--- a/connectivity/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/connectivity/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -37,7 +37,7 @@
 #  elif defined(TOOLCHAIN_GCC_CR)
 #     define ETHMEM_SECTION __attribute__((section(".data.$RamPeriph32")))
 #  else
-#     define ETHMEM_SECTION __attribute__((section("AHBSRAM0"),aligned))
+#     define ETHMEM_SECTION __attribute__((section("AHBSRAM"),aligned))
 #  endif
 #elif defined(TARGET_STM32H7)
 #  if defined (__ICCARM__)

--- a/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -117,7 +117,7 @@ void rcv_n_chk_against_rfc864_pattern(TCPSocket &sock)
         recvd_size += rd;
     }
     timer.stop();
-    tr_info("MBED: Time taken: %fs", timer.read());
+    tr_info("MBED: Time taken: %" PRIi64 "ms", std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()).count());
 }
 
 void TCPSOCKET_RECV_100K()
@@ -172,7 +172,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
         }
     }
     timer.stop();
-    tr_info("MBED: Time taken: %fs", timer.read());
+    tr_info("MBED: Time taken: %" PRIi64 "ms", std::chrono::duration_cast<std::chrono::milliseconds>(timer.elapsed_time()).count());
 }
 
 static void _sigio_handler(osThreadId id)

--- a/connectivity/netsocket/tests/emac_test_utils/EmacTestMemoryManager.cpp
+++ b/connectivity/netsocket/tests/emac_test_utils/EmacTestMemoryManager.cpp
@@ -51,7 +51,7 @@ char s_trace_buffer[100] = MEM_MNGR_TRACE;
 #  elif defined(TOOLCHAIN_GCC_CR)
 #     define ETHMEM_SECTION __attribute__((section(".data.$RamPeriph32")))
 #  else
-#     define ETHMEM_SECTION __attribute__((section("AHBSRAM0"),aligned))
+#     define ETHMEM_SECTION __attribute__((section("AHBSRAM"),aligned))
 #  endif
 #endif
 #endif

--- a/drivers/tests/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/drivers/tests/TESTS/mbed_drivers/flashiap/main.cpp
@@ -294,9 +294,8 @@ void flashiap_timing_test()
             }
             timer.reset();
             ret = flash_device.program(buf, address, write_size);
-            
-            if(ret)
-            {
+
+            if (ret) {
                 printf("Failed programming %" PRIu32 " bytes at address 0x%" PRIx32 "\n!", write_size, address);
                 TEST_FAIL();
             }

--- a/drivers/tests/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/drivers/tests/TESTS/mbed_drivers/flashiap/main.cpp
@@ -249,11 +249,11 @@ void flashiap_timing_test()
     std::chrono::microseconds curr_time{};
     std::chrono::microseconds avg_erase_time{};
     unsigned int num_write_sizes;
-    unsigned int byte_usec_ratio;
+    float byte_sec_ratio;
     std::chrono::microseconds max_erase_time(0), min_erase_time(-1);
     const unsigned int max_writes = 128;
     const unsigned int max_write_sizes = 6;
-    const unsigned int max_byte_usec_ratio = 200;
+    const unsigned int max_byte_sec_ratio = 200000000;
 
     uint32_t page_size = flash_device.get_page_size();
     uint32_t write_size = page_size;
@@ -294,28 +294,34 @@ void flashiap_timing_test()
             }
             timer.reset();
             ret = flash_device.program(buf, address, write_size);
+            
+            if(ret)
+            {
+                printf("Failed programming %" PRIu32 " bytes at address 0x%" PRIx32 "\n!", write_size, address);
+                TEST_FAIL();
+            }
+
             curr_time = timer.elapsed_time();
             avg_write_time += curr_time;
-            TEST_ASSERT_EQUAL_INT32(0, ret);
             max_write_time = us_max(max_write_time, curr_time);
             min_write_time = us_min(min_write_time, curr_time);
             address += write_size;
         }
         delete[] buf;
         avg_write_time /= num_writes;
-        byte_usec_ratio = write_size / avg_write_time.count();
-        utest_printf("Write size %6u bytes: avg %10" PRIi64 ", min %10" PRIi64 ", max %10" PRIi64 " (usec), rate %10u bytes/usec\n",
-                     write_size, avg_write_time.count(), min_write_time.count(), max_write_time.count(), byte_usec_ratio);
-        TEST_ASSERT(byte_usec_ratio < max_byte_usec_ratio);
+        byte_sec_ratio = write_size / std::chrono::duration_cast<std::chrono::duration<float>>(avg_write_time).count();
+        utest_printf("Write size %6u bytes: avg %10" PRIi64 ", min %10" PRIi64 ", max %10" PRIi64 " (usec), rate %.01f bytes/sec\n",
+                     write_size, avg_write_time.count(), min_write_time.count(), max_write_time.count(), byte_sec_ratio);
+        TEST_ASSERT(byte_sec_ratio < max_byte_sec_ratio);
         write_size *= 4;
     }
 
     if (num_write_sizes) {
         avg_erase_time /= num_write_sizes;
-        byte_usec_ratio = sector_size / avg_erase_time.count();
-        utest_printf("\nErase size %6u bytes: avg %10" PRIi64 ", min %10" PRIi64 ", max %10" PRIi64" (usec), rate %10u bytes/usec\n\n",
-                     sector_size, avg_erase_time.count(), min_erase_time.count(), max_erase_time.count(), byte_usec_ratio);
-        TEST_ASSERT(byte_usec_ratio < max_byte_usec_ratio);
+        byte_sec_ratio = sector_size / std::chrono::duration_cast<std::chrono::duration<float>>(avg_erase_time).count();
+        utest_printf("\nErase size %6u bytes: avg %10" PRIi64 ", min %10" PRIi64 ", max %10" PRIi64" (usec), rate %.01f bytes/sec\n\n",
+                     sector_size, avg_erase_time.count(), min_erase_time.count(), max_erase_time.count(), byte_sec_ratio);
+        TEST_ASSERT(byte_sec_ratio < max_byte_sec_ratio);
     }
 
     ret = flash_device.deinit();

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -1,11 +1,21 @@
-/* Linker script for mbed LPC1768 */
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x00000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 512K
-#endif
+/* mbed Microcontroller Library
+ * Copyright (c) 2025 Jamie Smith
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+  
+#include "../cmsis_nvic.h"
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
     #define MBED_CONF_TARGET_BOOT_STACK_SIZE 0x400
@@ -13,14 +23,16 @@
 
 STACK_SIZE = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 
+#define VTORS_NEEDED_SPACE NVIC_NUM_VECTORS * 4
+
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx) : ORIGIN = 0x100000C8, LENGTH = (32K - 0xC8 - 32)  /* topmost 32 bytes used by IAP functions */
+  FLASH (rx) : ORIGIN = MBED_CONFIGURED_ROM_BANK_IROM1_START, LENGTH = MBED_CONFIGURED_ROM_BANK_IROM1_SIZE
+  RAM (rwx) : ORIGIN = MBED_RAM_BANK_IRAM1_START + VTORS_NEEDED_SPACE, LENGTH = (MBED_RAM_BANK_IRAM1_SIZE - VTORS_NEEDED_SPACE - 32)  /* topmost 32 bytes used by IAP functions */
 
-  USB_RAM(rwx) : ORIGIN = 0x2007C000, LENGTH = 16K
-  ETH_RAM(rwx) : ORIGIN = 0x20080000, LENGTH = 16K
+  AHBSRAM0(rwx) : ORIGIN = MBED_RAM_BANK_IRAM2_START, LENGTH = 16K
+  AHBSRAM1(rwx) : ORIGIN = MBED_RAM_BANK_IRAM2_START + 16K, LENGTH = 16K
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -56,9 +68,13 @@ SECTIONS
     .text :
     {
         KEEP(*(.isr_vector))
-        /* Code Read Protect data */
+
+#if MBED_CONFIGURED_ROM_BANK_IROM1_START == MBED_ROM_BANK_IROM1_START
+        /* Code Read Protect data, if this is at the start of flash*/
         . = 0x000002FC ;
         KEEP(*(.CRPSection))
+#endif
+
         /* End of Code Read Protect */
         *(.text*)
 
@@ -144,14 +160,13 @@ SECTIONS
         Image$$RW_IRAM1$$ZI$$Limit = . ;
     } > RAM
 
-    
-    .heap (NOLOAD):
+    .heap_0 (NOLOAD): ALIGN(8)
     {
         __end__ = .;
         end = __end__;
-        *(.heap*)
-        . = ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE;
-        __HeapLimit = .;
+        __mbed_sbrk_start_0 = .;
+        . = (ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE);
+        __mbed_krbs_start_0 = .;
     } > RAM
 
     /* .stack_dummy section doesn't contains any symbols. It is only
@@ -173,7 +188,7 @@ SECTIONS
 
 
     /* Code can explicitly ask for data to be 
-       placed in these higher RAM banks where
+       placed in this higher RAM bank where
        they will be left uninitialized. 
     */
     .AHBSRAM0 (NOLOAD):
@@ -181,12 +196,13 @@ SECTIONS
         Image$$RW_IRAM2$$Base = . ;
         *(AHBSRAM0)
         Image$$RW_IRAM2$$ZI$$Limit = .;
-    } > USB_RAM
+    } > AHBSRAM0
 
-    .AHBSRAM1 (NOLOAD):
+    /* Fill all of AHBSRAM1 with additional heap */
+    .heap (NOLOAD): ALIGN(8)
     {
-        Image$$RW_IRAM3$$Base = . ;
-        *(AHBSRAM1)
-        Image$$RW_IRAM3$$ZI$$Limit = .;
-    } > ETH_RAM
+        __mbed_sbrk_start = .;
+        . = ORIGIN(AHBSRAM1) + LENGTH(AHBSRAM1);
+        __mbed_krbs_start = .;
+    } > AHBSRAM1
 }

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -30,9 +30,7 @@ MEMORY
 {
   FLASH (rx) : ORIGIN = MBED_CONFIGURED_ROM_BANK_IROM1_START, LENGTH = MBED_CONFIGURED_ROM_BANK_IROM1_SIZE
   RAM (rwx) : ORIGIN = MBED_RAM_BANK_IRAM1_START + VTORS_NEEDED_SPACE, LENGTH = (MBED_RAM_BANK_IRAM1_SIZE - VTORS_NEEDED_SPACE - 32)  /* topmost 32 bytes used by IAP functions */
-
-  AHBSRAM0(rwx) : ORIGIN = MBED_RAM_BANK_IRAM2_START, LENGTH = 16K
-  AHBSRAM1(rwx) : ORIGIN = MBED_RAM_BANK_IRAM2_START + 16K, LENGTH = 16K
+  AHBSRAM(rwx) : ORIGIN = MBED_RAM_BANK_IRAM2_START, LENGTH = MBED_RAM_BANK_IRAM2_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -191,18 +189,16 @@ SECTIONS
        placed in this higher RAM bank where
        they will be left uninitialized. 
     */
-    .AHBSRAM0 (NOLOAD):
+    .AHBSRAM_bss (NOLOAD):
     {
-        Image$$RW_IRAM2$$Base = . ;
-        *(AHBSRAM0)
-        Image$$RW_IRAM2$$ZI$$Limit = .;
-    } > AHBSRAM0
+        *(AHBSRAM)
+    } > AHBSRAM
 
-    /* Fill all of AHBSRAM1 with additional heap */
+    /* Fill remaining space in AHBSRAM with additional heap */
     .heap (NOLOAD): ALIGN(8)
     {
         __mbed_sbrk_start = .;
-        . = ORIGIN(AHBSRAM1) + LENGTH(AHBSRAM1);
+        . = ORIGIN(AHBSRAM) + LENGTH(AHBSRAM);
         __mbed_krbs_start = .;
-    } > AHBSRAM1
+    } > AHBSRAM
 }

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -163,7 +163,7 @@ SECTIONS
         __end__ = .;
         end = __end__;
         __mbed_sbrk_start_0 = .;
-        . = (ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE);
+        . += (ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE) - __mbed_sbrk_start_0;
         __mbed_krbs_start_0 = .;
     } > RAM
 
@@ -198,7 +198,7 @@ SECTIONS
     .heap (NOLOAD): ALIGN(8)
     {
         __mbed_sbrk_start = .;
-        . = ORIGIN(AHBSRAM) + LENGTH(AHBSRAM);
+        . += (ORIGIN(AHBSRAM) + LENGTH(AHBSRAM)) - __mbed_sbrk_start;
         __mbed_krbs_start = .;
     } > AHBSRAM
 }

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -182,7 +182,7 @@ SECTIONS
     PROVIDE(__stack = __StackTop);
     
     /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+    ASSERT(__StackLimit >= __end__, "region RAM overflowed with stack")
 
 
     /* Code can explicitly ask for data to be 

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -163,7 +163,7 @@ SECTIONS
         __end__ = .;
         end = __end__;
         __mbed_sbrk_start_0 = .;
-        . += (ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE) - __mbed_sbrk_start_0;
+        . = (ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE);
         __mbed_krbs_start_0 = .;
     } > RAM
 
@@ -198,7 +198,7 @@ SECTIONS
     .heap (NOLOAD): ALIGN(8)
     {
         __mbed_sbrk_start = .;
-        . += (ORIGIN(AHBSRAM) + LENGTH(AHBSRAM)) - __mbed_sbrk_start;
+        . = ORIGIN(AHBSRAM) + LENGTH(AHBSRAM);
         __mbed_krbs_start = .;
     } > AHBSRAM
 }

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/startup_LPC17xx.S
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/startup_LPC17xx.S
@@ -30,21 +30,6 @@
    aborting compilation, it is not the run time limit:
    Heap_Size + Stack_Size = 0x80 + 0x80 = 0x100
  */
-
-    .section .heap
-    .align 3
-#ifdef __HEAP_SIZE
-    .equ    Heap_Size, __HEAP_SIZE
-#else
-    .equ    Heap_Size, 0x800
-#endif
-    .globl    __HeapBase
-    .globl    __HeapLimit
-__HeapBase:
-    .space    Heap_Size
-    .size __HeapBase, . - __HeapBase
-__HeapLimit:
-    .size __HeapLimit, . - __HeapLimit
     
     .section .isr_vector
     .align 2

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/cmsis_nvic.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/cmsis_nvic.h
@@ -31,7 +31,7 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
-#define NVIC_NUM_VECTORS        (16 + 33)
+#define NVIC_NUM_VECTORS        (16 + 35)
 #define NVIC_RAM_VECTOR_ADDRESS 0x10000000    // Location of vectors in RAM
 
 #endif

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -419,6 +419,9 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "supported_toolchains": [
             "GCC_ARM"
         ],
+        "macros": [
+            "MBED_SPLIT_HEAP"
+        ],
         "device_has": [
             "RTC",
             "USTICKER",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I ran into an issue when running the new network tests where the LPC1768 was running out of heap space. This MCU has two 32k banks of RAM, where one bank is used as heap, bss, and stack, half of the other bank is used for Ethernet buffers, and the second half of the third bank is unused.

This PR activates split heap support on the device, enabling all unused space to be used as heap. This nearly triples the amount of available heap on this target (if Ethernet is not used at least)! And it can now run the nanostack TCP test without crashing from running out of memory (though it still doesn't pass...).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- LPC1678 heap space increased to ~48k if Ethernet unused, or ~32k if Ethernet used
- LPC1768 linker script now supports memory bank configuration

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Test run in progress...
----------------------------------------------------------------------------------------------------------------
