### PR TITLE
Fix multicast filtering on STM32

### DIFF
--- a/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F2/stm32f2_eth_conf.c
+++ b/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F2/stm32f2_eth_conf.c
@@ -37,7 +37,7 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
-        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE,
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0U,
         .HashTableLow = 0x0U,

--- a/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_conf.c
+++ b/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/stm32f4_eth_conf.c
@@ -37,7 +37,7 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
-        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE,
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0U,
         .HashTableLow = 0x0U,

--- a/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_conf.c
+++ b/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/stm32f4_eth_conf.c
@@ -37,7 +37,7 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
-        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE,
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0U,
         .HashTableLow = 0x0U,

--- a/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_conf.c
+++ b/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/stm32f4_eth_conf.c
@@ -37,7 +37,7 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
-        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE,
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0U,
         .HashTableLow = 0x0U,

--- a/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F7/stm32f7_eth_conf.c
+++ b/connectivity/drivers/emac/TARGET_STM/TARGET_STM32F7/stm32f7_eth_conf.c
@@ -39,7 +39,7 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
-        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE,
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0,
         .HashTableLow = 0x0,

--- a/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
+++ b/connectivity/drivers/emac/TARGET_STM/stm32xx_emac.cpp
@@ -299,9 +299,6 @@ bool STM32_EMAC::low_level_init_successful()
     // Set MAC address
     writeMACAddress(MACAddr, &EthHandle.Instance->MACA0HR, &EthHandle.Instance->MACA0LR);
 
-    // Enable multicast hash and perfect filter
-    EthHandle.Instance->MACFFR = ETH_MACFFR_HM | ETH_MACFFR_HPF;
-
     uint32_t TempRegisterValue;
     if (HAL_ETH_ReadPHYRegister(&EthHandle, 2, &TempRegisterValue) != HAL_OK) {
         tr_error("HAL_ETH_ReadPHYRegister 2 issue");
@@ -1076,13 +1073,13 @@ void STM32_EMAC::populateMcastFilterRegs() {
 
 #if defined(ETH_IP_VERSION_V2)
     uint32_t volatile * hashRegs[] = {
-        &EthHandle.Instance->MACHT1R,
-        &EthHandle.Instance->MACHT0R
+        &EthHandle.Instance->MACHT0R,
+        &EthHandle.Instance->MACHT1R
     };
 #else
     uint32_t volatile * hashRegs[] = {
-        &EthHandle.Instance->MACHTHR,
-        &EthHandle.Instance->MACHTLR
+        &EthHandle.Instance->MACHTLR,
+        &EthHandle.Instance->MACHTHR
     };
 #endif
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes two issues with Ethernet multicast filtering on STM32. It's an update to my previous PR which added mcast filtering, but which I wasn't able to easily test the final version of (so some issues slipped through :( )

Issue 1: Hash table registers were swapped, meaning filtering wouldn't work once the perfect filter registers filled up

Issue 2: STM32 Eth IP v1 targets were calling HAL_ETH_ConfigMAC() after the point where I enabled mcast filtering, causing the register settings to get erased and all multicasts to be accepted regardless of filtering.

#### Impact of changes <!-- Optional -->
Multicast filtering should _actually_ work on STM32 targets now!

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Tested using the emac test on STM32F4, it passed!
----------------------------------------------------------------------------------------------------------------
