### PR TITLE
Stop Greentea tests if a fatal error occurs

### DIFF
--- a/TESTS/configs/greentea_baremetal.json5
+++ b/TESTS/configs/greentea_baremetal.json5
@@ -15,7 +15,10 @@
         // Allow lots of reboots so that we don't get in a situation where the MCU refuses to boot
         // after crashing and being reflashed (since some MCUs/flash tools don't reset the
         // crash data RAM)
-        "platform.error-reboot-max": 99999,
+        "platform.error-reboot-max": 2147483648,
+
+        // Emit a KV pair when an assert fail or hardfault occurs
+        "platform.mbed-error-emit-greentea-kv": true,
 
         // Enable mbed trace prints for tests that use it
         "mbed-trace.enable": true,

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -11,6 +11,9 @@
         // crash data RAM)
         "platform.error-reboot-max": 99999,
 
+        // Emit a KV pair when an assert fail or hardfault occurs
+        "platform.mbed-error-emit-greentea-kv": true,
+
         // Enable mbed trace prints for tests that use it
         "mbed-trace.enable": true,
 

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -9,7 +9,7 @@
         // Allow lots of reboots so that we don't get in a situation where the MCU refuses to boot
         // after crashing and being reflashed (since some MCUs/flash tools don't reset the
         // crash data RAM)
-        "platform.error-reboot-max": 99999,
+        "platform.error-reboot-max": 2147483648,
 
         // Emit a KV pair when an assert fail or hardfault occurs
         "platform.mbed-error-emit-greentea-kv": true,

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -164,6 +164,10 @@
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed when using minimal printf library",
             "value": 6
+        },
+        "mbed-error-emit-greentea-kv": {
+            "help": "Option that can be used when building Greentea tests. Causes the mbed_error() function (caused by assert failures and HardFaults) to emit a Greentea key-value pair indicating that an error has occurred.",
+            "value": null
         }
     },
     "target_overrides": {

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -661,6 +661,18 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg,
 #endif
 
     mbed_error_printf("\n-- MbedOS Error Info --\n");
+
+    // Print error summary for Greentea tests if desired.
+#ifdef MBED_CONF_PLATFORM_MBED_ERROR_EMIT_GREENTEA_KV
+    // Flag that error occurred. Print this first because the default test runner
+    // just ends the test right away when it sees this.
+    mbed_error_printf("{{mbed_error;1}}\r\n"); 
+
+    mbed_error_printf("{{mbed_error_module;%d}}\r\n", error_module);
+    mbed_error_printf("{{mbed_error_code;%d}}\r\n", error_code);
+    mbed_error_printf("{{mbed_error_message;%s}}\r\n", error_msg);
+    mbed_error_printf("{{mbed_error_location;0x%" PRIx32 "}}\r\n", ctx->error_address);
+#endif
 }
 #endif //ifndef NDEBUG
 

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -666,7 +666,7 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg,
 #ifdef MBED_CONF_PLATFORM_MBED_ERROR_EMIT_GREENTEA_KV
     // Flag that error occurred. Print this first because the default test runner
     // just ends the test right away when it sees this.
-    mbed_error_printf("{{mbed_error;1}}\r\n"); 
+    mbed_error_printf("{{mbed_error;1}}\r\n");
 
     mbed_error_printf("{{mbed_error_module;%d}}\r\n", error_module);
     mbed_error_printf("{{mbed_error_code;%d}}\r\n", error_code);

--- a/tools/python/mbed_os_tools/test/host_tests/base_host_test.py
+++ b/tools/python/mbed_os_tools/test/host_tests/base_host_test.py
@@ -171,12 +171,24 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         """
         self.notify_complete(value == 'success')
 
+    def _default_mbed_error_callback(self, key: str, value: str, timestamp: float):
+        # End the test immediately on error by default. This prevents wasting test runner time
+        # by waiting for the timeout to expire!
+        self.log("Detected target fatal error. Failing test...")
+        self.notify_complete(False)
+
     def __assign_default_callbacks(self):
         """! Assigns default callback handlers """
         for key in self.__consume_by_default:
             self.__callbacks[key] = self.__callback_default
         # Register default handler for event 'end' before assigning user defined callbacks to let users over write it.
         self.register_callback('end', self.__default_end_callback)
+        self.register_callback("mbed_error", self._default_mbed_error_callback)
+
+        # Register empty callbacks for the error details, to prevent "orphan event" warnings
+        self.register_callback("mbed_error_module", self.__callback_default)
+        self.register_callback("mbed_error_code", self.__callback_default)
+        self.register_callback("mbed_error_message", self.__callback_default)
 
     def __assign_decorated_callbacks(self):
         """


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
Quick PR to improve quality of life for us devs! Until now, if a Greentea test obviously died (HardFault or assertion failure), the test runner would just keep on truckin', waiting for the timeout to expire before failing the test. Since some tests (esp. network ones) can have timeouts up to 20 minutes, this could result in a lot of wasted time!

With this PR, the mbed_error() handler will now output a Greentea KV pair that tells the test runner "hey, this test crashed", so it can immediately end the test.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
Should save some dev time during testing!

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
