### PR TITLE
add jlink and pyocd to lpc1768 upload methods

### DIFF
--- a/targets/upload_method_cfg/LPC1768.cmake
+++ b/targets/upload_method_cfg/LPC1768.cmake
@@ -22,9 +22,10 @@ set(MBED_RESET_BAUDRATE 115200)
 # https://github.com/pyocd/pyOCD/issues/745
 # https://github.com/pyocd/pyOCD/issues/1124
 
-#set(PYOCD_UPLOAD_ENABLED TRUE)
-#set(PYOCD_TARGET_NAME LPC1768)
-#set(PYOCD_CLOCK_SPEED 4000k)
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME LPC1768)
+set(PYOCD_CLOCK_SPEED 4000k)
+set(PYOCD_UPLOAD_INTERFACE SWD)
 
 # Config options for OPENOCD
 # -------------------------------------------------------------
@@ -45,3 +46,10 @@ set(OPENOCD_VERSION_RANGE 0.10...<0.13)
 # -------------------------------------------------------------
 set(LINKSERVER_UPLOAD_ENABLED TRUE)
 set(LINKSERVER_DEVICE LPC1768)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME LPC1768)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

Add JLink and pyocd as upload methods for LPC1768 target

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
