### PR TITLE
Fix initializing Macronix QSPI flashes with only 2 status registers

### DIFF
--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1118,7 +1118,7 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             tr_debug("Applying quirks for macronix");
             _num_status_registers = MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
-            if(MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
+            if (MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
                 _needs_fast_mode = true;
             }
             break;

--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1119,7 +1119,7 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             tr_debug("Applying quirks for macronix");
             _num_status_registers = MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
-            if(MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
+            if (MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
                 _needs_fast_mode = true;
             }
             _attempt_4_byte_addressing = false;

--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1123,6 +1123,7 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
                 _needs_fast_mode = true;
             }
             _attempt_4_byte_addressing = false;
+            break;
         case 0x9d:
             // ISSI devices have only one status register
             tr_debug("Applying quirks for ISSI");

--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1113,12 +1113,14 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
         case 0xc2:
             // Macronix devices have several quirks:
             // 1. Have one status register and several config registers, with a nonstandard instruction for reading the config registers
-            // 2. Require setting a "fast mode" bit in config register 2 to operate at higher clock rates
+            // 2. Require setting a "fast mode" bit in config register 2 to operate at higher clock rates (if config register 2 exists)
             // 3. Should never attempt to enable 4-byte addressing (it causes reads and writes to fail)
             tr_debug("Applying quirks for macronix");
-            _needs_fast_mode = true;
             _num_status_registers = MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
+            if(MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
+                _needs_fast_mode = true;
+            }
             break;
         case 0x9d:
             // ISSI devices have only one status register

--- a/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp
@@ -1114,14 +1114,15 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             // Macronix devices have several quirks:
             // 1. Have one status register and several config registers, with a nonstandard instruction for reading the config registers
             // 2. Require setting a "fast mode" bit in config register 2 to operate at higher clock rates (if config register 2 exists)
-            // 3. Should never attempt to enable 4-byte addressing (it causes reads and writes to fail)
+            // 3. Should never attempt to enable 4-byte addressing (it causes reads and writes to fail). On MX25L12833F at least, the
+            //    SFDP table claims to have 4-byte support but it actually does not!
             tr_debug("Applying quirks for macronix");
             _num_status_registers = MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER;
             _read_status_reg_2_inst = QSPIF_INST_RDCR;
-            if (MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
+            if(MBED_CONF_QSPI_MACRONIX_NUM_STATUS_REGISTER >= 3) {
                 _needs_fast_mode = true;
             }
-            break;
+            _attempt_4_byte_addressing = false;
         case 0x9d:
             // ISSI devices have only one status register
             tr_debug("Applying quirks for ISSI");


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Testing code for the Arduino Portenta, I noticed that its QSPI flash (MX25L12833F) was failing to init. Digging a bit deeper, it appears that it's hitting an [assert failure](https://github.com/mbed-ce/mbed-os/blob/7d6a1feee409954601d301769d476c32f116ea46/storage/blockdevice/COMPONENT_QSPIF/source/QSPIFBlockDevice.cpp#L1242) in `QSPIFBlockDevice::_enable_fast_mode()`. This function is trying to enable fast mode using the 3rd status register, but the flash only has 2 status registers, so it dies.

As [this comment](https://github.com/mbed-ce/mbed-os/blob/7d6a1feee409954601d301769d476c32f116ea46/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json#L23) explains, some flashes need this fast mode to hit their full clock frequency. However, MX25L12833F does not have a third status register and does not need fast mode -- it can run at up to 84MHz for a QSPI read without any special configuration (as far as I can tell from the datasheet).

The issue is that the logic in `QSPIFBlockDevice::_handle_vendor_quirks()` always sets `_needs_fast_mode` to true for Macronix devices, even if the `QSPI_MACRONIX_NUM_STATUS_REGISTER` option is set to 2. This makes it impossible to set `QSPI_MACRONIX_NUM_STATUS_REGISTER` to 2, because you will always get an assert failure.

To fix this, I tweaked the logic so that `_needs_fast_mode` is only set to 2 if we have 3 or more status registers, so we (think we) have the needed flag.  Otherwise, we don't try to enable fast mode. I am not sure that this will work for all Macronix flashes, but it seems to work for the ones already supported and the MX25L12833F.

Update: Made a second fix after some more testing. The comment says that 4 byte mode does not work with Macronix devices, but the code did not actually follow through with that by setting `_attempt_4_byte_addressing` to false. Without this setting, testing on Arduino Portenta, the flash inits fine but data programmed to it is not actually saved and/or cannot be read back. So I went ahead and added `_attempt_4_byte_addressing = false`, and it completely fixed the issue.

#### Impact of changes <!-- Optional -->
- Now possible to use Macronix QSPI flashes with `QSPI_MACRONIX_NUM_STATUS_REGISTER` set to 2 without hitting an assert failure.
- 4 byte addressing mode is now disabled for Macronix devices, regardless of SFDP table data
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Able to init the flash on an Arduino Portenta with this change.

----------------------------------------------------------------------------------------------------------------
