### PR TITLE
Add support for Telit Cinterion TX62

### DIFF
--- a/connectivity/cellular/include/cellular/framework/API/ATHandler.h
+++ b/connectivity/cellular/include/cellular/framework/API/ATHandler.h
@@ -363,6 +363,12 @@ public:
      */
     void write_hex_string(const char *str, size_t size, bool quote_string = true);
 
+    /** Get the error detected during read_int()
+     *
+     *  @return the latest negative integer error got from read_int().
+     */
+    int32_t get_last_read_error() const;
+
     /** Reads as string and converts result to integer. Supports only non-negative integers.
      *
      *  @return the non-negative integer or -1 in case of error.
@@ -599,6 +605,7 @@ private: //Member variables
     nsapi_error_t _last_err;
     int _last_3gpp_error;
     device_err_t  _last_at_err;
+    int32_t _last_read_error{};
     uint16_t _oob_string_max_length;
     char *_output_delimiter;
 

--- a/connectivity/cellular/include/cellular/framework/API/CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/API/CellularContext.h
@@ -41,6 +41,29 @@ namespace mbed {
  * @{
  */
 
+/// Radio Access Technology type
+enum RadioAccessTechnologyType {
+    CATM1 = 7, ///< LTE CAT-M or LTE-M
+    CATNB = 8 ///< NB-IoT (Narrowband IoT)
+};
+
+enum FrequencyBand {
+    BAND_1 = 0x01,
+    BAND_2 = 0x02,
+    BAND_3 = 0x04,
+    BAND_4 = 0x08,
+    BAND_5 = 0x10,
+    BAND_8 = 0x80,
+    BAND_12 = 0x800,
+    BAND_13 = 0x1000,
+    BAND_18 = 0x20000,
+    BAND_19 = 0x40000,
+    BAND_20 = 0x80000,
+    BAND_25 = 0x1000000,
+    BAND_26 = 0x2000000,
+    BAND_28 = 0x8000000
+};
+
 /// CellularContext is CellularInterface/NetworkInterface with extensions for cellular connectivity
 class CellularContext : public CellularInterface {
 
@@ -158,6 +181,8 @@ public: // from NetworkInterface
     virtual nsapi_error_t connect(const char *sim_pin, const char *apn = 0, const char *uname = 0,
                                   const char *pwd = 0) = 0;
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0) = 0;
+    virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1) = 0;
+    virtual void set_band(FrequencyBand band = BAND_20) = 0;
     virtual bool is_connected() = 0;
 
     /** Same as NetworkInterface::get_default_instance()

--- a/connectivity/cellular/include/cellular/framework/API/CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/API/CellularContext.h
@@ -43,25 +43,8 @@ namespace mbed {
 
 /// Radio Access Technology type
 enum RadioAccessTechnologyType {
-    CATM1 = 7, ///< LTE CAT-M or LTE-M
-    CATNB = 8 ///< NB-IoT (Narrowband IoT)
-};
-
-enum FrequencyBand {
-    BAND_1 = 0x01,
-    BAND_2 = 0x02,
-    BAND_3 = 0x04,
-    BAND_4 = 0x08,
-    BAND_5 = 0x10,
-    BAND_8 = 0x80,
-    BAND_12 = 0x800,
-    BAND_13 = 0x1000,
-    BAND_18 = 0x20000,
-    BAND_19 = 0x40000,
-    BAND_20 = 0x80000,
-    BAND_25 = 0x1000000,
-    BAND_26 = 0x2000000,
-    BAND_28 = 0x8000000
+    CATM1, ///< LTE CAT-M or LTE-M
+    CATNB  ///< NB-IoT (Narrowband IoT)
 };
 
 /// CellularContext is CellularInterface/NetworkInterface with extensions for cellular connectivity
@@ -182,7 +165,6 @@ public: // from NetworkInterface
                                   const char *pwd = 0) = 0;
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0) = 0;
     virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1) = 0;
-    virtual void set_band(FrequencyBand band = BAND_20) = 0;
     virtual bool is_connected() = 0;
 
     /** Same as NetworkInterface::get_default_instance()

--- a/connectivity/cellular/include/cellular/framework/API/CellularDevice.h
+++ b/connectivity/cellular/include/cellular/framework/API/CellularDevice.h
@@ -424,6 +424,14 @@ public: //Common functions
      */
     void set_retry_timeout_array(const uint16_t timeout[], int array_len);
 
+    /**
+     * @brief Enable serial multiplexing according to <a href="https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=1516">3GPP TS 27.010</a>, if implemented
+     *     on this modem.
+     *
+     * @return Error code or success
+     */
+    virtual nsapi_error_t enable_cmux() { return NSAPI_ERROR_UNSUPPORTED;};
+
 protected: //Common functions
     friend class AT_CellularNetwork;
     friend class AT_CellularContext;
@@ -452,6 +460,8 @@ protected: //Member variables
     events::EventQueue _queue;
     CellularStateMachine *_state_machine;
     Callback<void(nsapi_event_t, intptr_t)> _status_cb;
+
+    bool _cmux_enabled = false;
 
 private: //Member variables
     CellularNetwork *_nw;

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
@@ -56,7 +56,6 @@ public:
                                   const char *pwd = 0);
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0);
     virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1);
-    virtual void set_band(FrequencyBand band = BAND_20);
 
 // from CellularContext
     virtual nsapi_error_t get_pdpcontext_params(pdpContextList_t &params_list);
@@ -157,7 +156,6 @@ protected:
     bool _is_connected;
     ATHandler &_at;
     std::optional<RadioAccessTechnologyType> _rat;
-    std::optional<FrequencyBand> _band;
 };
 
 /**

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
@@ -139,6 +139,8 @@ private:
     nsapi_error_t check_operation(nsapi_error_t err, ContextOperation op);
     void ciot_opt_cb(mbed::CellularNetwork::CIoT_Supported_Opt ciot_opt);
     virtual void do_connect_with_retry();
+
+protected:
     void set_cid(int cid);
 
 private:

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
@@ -22,6 +22,7 @@
 #include "rtos/Semaphore.h"
 #include "AT_CellularDevice.h"
 
+#include <optional>
 
 const int MAX_APN_LENGTH = 63 + 1;
 
@@ -54,6 +55,8 @@ public:
     virtual nsapi_error_t connect(const char *sim_pin, const char *apn = 0, const char *uname = 0,
                                   const char *pwd = 0);
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0);
+    virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1);
+    virtual void set_band(FrequencyBand band = BAND_20);
 
 // from CellularContext
     virtual nsapi_error_t get_pdpcontext_params(pdpContextList_t &params_list);
@@ -115,6 +118,13 @@ protected:
      */
     virtual const char *get_nonip_context_type_str();
 
+    /**
+     * @brief Set the cellular technology and band based on the \c _rat and \c _band class variables.
+     *
+     * Modems which support this functionality should override this in their CellularContext implementations.
+     */
+    virtual void enable_access_technology() {}
+
 private:
 #if NSAPI_PPP_AVAILABLE
     nsapi_error_t open_data_channel();
@@ -146,6 +156,8 @@ protected:
     bool _cp_req;
     bool _is_connected;
     ATHandler &_at;
+    std::optional<RadioAccessTechnologyType> _rat;
+    std::optional<FrequencyBand> _band;
 };
 
 /**

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularDevice.h
@@ -130,6 +130,8 @@ public:
 
     virtual nsapi_error_t set_baud_rate(int baud_rate);
 
+    nsapi_error_t enable_cmux() override;
+
 #if MBED_CONF_CELLULAR_USE_SMS
     virtual CellularSMS *open_sms();
 

--- a/connectivity/cellular/source/framework/AT/AT_CellularContext.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularContext.cpp
@@ -370,7 +370,7 @@ bool AT_CellularContext::get_context()
         int pdp_type_len = _at.read_string(pdp_type_from_context, sizeof(pdp_type_from_context));
         if (pdp_type_len > 0) {
             apn_len = _at.read_string(apn, sizeof(apn));
-            if (apn_len > 0) {
+            if (apn_len >= 0) {
                 if (_apn && (strcmp(apn, _apn) != 0)) {
                     tr_debug("CID %d APN \"%s\"", cid, apn);
                     continue;
@@ -387,9 +387,6 @@ bool AT_CellularContext::get_context()
                     _pdp_type = pdp_type;
                     set_cid(cid);
                 }
-            }
-            else {
-                cid_max = 0;
             }
         }
     }

--- a/connectivity/cellular/source/framework/AT/AT_CellularContext.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularContext.cpp
@@ -296,11 +296,6 @@ void AT_CellularContext::set_access_technology(RadioAccessTechnologyType rat)
     _rat = rat;
 }
 
-void AT_CellularContext::set_band(FrequencyBand band)
-{
-    _band = band;
-}
-
 // PDP Context handling
 void AT_CellularContext::delete_current_context()
 {

--- a/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularDevice.cpp
@@ -414,7 +414,8 @@ nsapi_error_t AT_CellularDevice::init()
         _at.flush();
         _at.at_cmd_discard("E0", "");
         if (_at.get_last_error() == NSAPI_ERROR_OK) {
-            _at.at_cmd_discard("+CMEE", "=1");
+            // Enable verbose error messages
+            _at.at_cmd_discard("+CMEE", "=2");
             _at.at_cmd_discard("+CFUN", "=1");
             if (_at.get_last_error() == NSAPI_ERROR_OK) {
                 break;

--- a/connectivity/cellular/source/framework/AT/AT_CellularNetwork.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularNetwork.cpp
@@ -219,6 +219,7 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (mode != NWModeAutomatic) {
+            // Force operator registration
             return _at.at_cmd_discard("+COPS", "=0");
         }
         return NSAPI_ERROR_OK;

--- a/connectivity/cellular/source/framework/AT/AT_CellularStack.cpp
+++ b/connectivity/cellular/source/framework/AT/AT_CellularStack.cpp
@@ -332,7 +332,7 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
 
     if (socket->closed) {
         tr_info("recvfrom socket %d closed", socket->id);
-        return 0;
+        return NSAPI_ERROR_NO_CONNECTION;
     }
 
     nsapi_size_or_error_t ret_val = NSAPI_ERROR_OK;

--- a/connectivity/cellular/source/framework/device/CellularStateMachine.cpp
+++ b/connectivity/cellular/source/framework/device/CellularStateMachine.cpp
@@ -28,7 +28,7 @@ using namespace std::chrono_literals;
 
 // timeout to wait for AT responses
 #define TIMEOUT_POWER_ON     1s
-#define TIMEOUT_SIM_PIN      1s
+#define TIMEOUT_SIM_PIN      10s
 #define TIMEOUT_NETWORK      10s
 /** CellularStateMachine does connecting up to packet service attach, and
  *  after that it's up to CellularContext::connect() to connect to PDN.

--- a/connectivity/drivers/cellular/GEMALTO/CMakeLists.txt
+++ b/connectivity/drivers/cellular/GEMALTO/CMakeLists.txt
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if("COMPONENT_GEMALTO_CINTERION=1" IN_LIST MBED_TARGET_DEFINITIONS)
-	add_subdirectory(CINTERION)
+	add_subdirectory(COMPONENT_GEMALTO_CINTERION)
 endif()

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
@@ -70,6 +70,8 @@ nsapi_error_t GEMALTO_CINTERION::init()
         init_module_ems31();
     } else if (memcmp(model, "EHS5-E", sizeof("EHS5-E") - 1) == 0) {
         init_module_ehs5e();
+    } else if (memcmp(model, "TX62", sizeof("TX62") - 1) == 0) {
+        init_module_tx62();
     } else {
         tr_error("Cinterion model unsupported %s", model);
         return NSAPI_ERROR_UNSUPPORTED;
@@ -200,6 +202,35 @@ void GEMALTO_CINTERION::init_module_ehs5e()
     };
     set_cellular_properties(cellular_properties);
     _module = ModuleEHS5E;
+}
+
+void GEMALTO_CINTERION::init_module_tx62()
+{
+    // TX-62
+    static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
+        AT_CellularNetwork::RegistrationModeLAC,// C_EREG
+        AT_CellularNetwork::RegistrationModeDisable,    // C_GREG
+        AT_CellularNetwork::RegistrationModeDisable,    // C_REG
+        0,  // AT_CGSN_WITH_TYPE
+        0,  // AT_CGDATA
+        1,  // AT_CGAUTH
+        1,  // AT_CNMI
+        1,  // AT_CSMP
+        1,  // AT_CMGF
+        0,  // AT_CSDH
+        1,  // PROPERTY_IPV4_STACK
+        0,  // PROPERTY_IPV6_STACK
+        0,  // PROPERTY_IPV4V6_STACK
+        0,  // PROPERTY_NON_IP_PDP_TYPE
+        0,  // PROPERTY_AT_CGEREP
+        0,  // PROPERTY_AT_COPS_FALLBACK_AUTO
+        7,  // PROPERTY_SOCKET_COUNT
+        1,  // PROPERTY_IP_TCP
+        1,  // PROPERTY_IP_UDP
+        100,  // PROPERTY_AT_SEND_DELAY
+    };
+    set_cellular_properties(cellular_properties);
+    _module = ModuleTX62;
 }
 
 #if MBED_CONF_GEMALTO_CINTERION_PROVIDE_DEFAULT

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.cpp
@@ -35,9 +35,6 @@ time_t GEMALTO_CINTERION::get_time()
 {
     tr_info("GEMALTO_CINTERION::get_time\n");
 
-    //Enable automatic time zone update:
-    set_automatic_time_zone_update();
-
     _at.lock();
 
     //"+CCLK: \"%y/%m/%d,%H:%M:%S+ZZ"
@@ -299,20 +296,23 @@ void GEMALTO_CINTERION::init_module_tx62()
         1,  // AT_CNMI
         1,  // AT_CSMP
         1,  // AT_CMGF
-        0,  // AT_CSDH
+        1,  // AT_CSDH
         1,  // PROPERTY_IPV4_STACK
         0,  // PROPERTY_IPV6_STACK
         0,  // PROPERTY_IPV4V6_STACK
         0,  // PROPERTY_NON_IP_PDP_TYPE
-        0,  // PROPERTY_AT_CGEREP
-        0,  // PROPERTY_AT_COPS_FALLBACK_AUTO
+        1,  // PROPERTY_AT_CGEREP
+        1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
         7,  // PROPERTY_SOCKET_COUNT
         1,  // PROPERTY_IP_TCP
         1,  // PROPERTY_IP_UDP
-        100,  // PROPERTY_AT_SEND_DELAY
+        0,  // PROPERTY_AT_SEND_DELAY
     };
     set_cellular_properties(cellular_properties);
     _module = ModuleTX62;
+
+    // Enable network time zone updates
+    _at.at_cmd_discard("+CTZU", "=", "%d", 1);
 }
 
 time_t GEMALTO_CINTERION::parse_time(char const *time_str) {

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
@@ -44,6 +44,7 @@ public:
         ModuleBGS2,
         ModuleEMS31,
         ModuleEHS5E,
+        ModuleTX62,
     };
     static Module get_module();
 
@@ -60,6 +61,7 @@ private:
     void init_module_els61();
     void init_module_ems31();
     void init_module_ehs5e();
+    void init_module_tx62();
 };
 
 } // namespace mbed

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
@@ -48,9 +48,31 @@ public:
     };
     static Module get_module();
 
+    /**
+     * @brief Get the RTC time from the Cinterion, as a UNIX seconds timestamp in UTC
+     */
+    time_t get_time();
+
+    /**
+     * @brief Get the RTC time from the Cinterion, as a UNIX seconds timestamp in the local time zone
+     */
+    time_t get_local_time();
+
+    /**
+     * @brief Set the RTC time on the Cinterion.
+     *
+     * Note that any time set will be overwritten once the modem can get time from a cellular network
+     *
+     * @param timestamp UNIX timestamp to set, in the local time zone
+     * @param timezone Local time zone, as a signed number of 15-minute increments from UTC time. Example:
+     *       passing -8 would indicate UTC-2.
+     */
+    virtual void set_time(time_t timestamp, int const timezone = 0);
+
 protected: // AT_CellularDevice
     virtual AT_CellularContext *create_context_impl(ATHandler &at, const char *apn, bool cp_req = false, bool nonip_req = false);
     virtual AT_CellularInformation *open_information_impl(ATHandler &at);
+    AT_CellularNetwork *open_network_impl(ATHandler &at) override;
 
 protected:
     virtual nsapi_error_t init();
@@ -62,6 +84,9 @@ private:
     void init_module_ems31();
     void init_module_ehs5e();
     void init_module_tx62();
+
+    /// Convert time & date string returned by the modem into time_t
+    time_t parse_time(char const * time_str);
 };
 
 } // namespace mbed

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION.h
@@ -74,8 +74,8 @@ protected: // AT_CellularDevice
     virtual AT_CellularInformation *open_information_impl(ATHandler &at);
     AT_CellularNetwork *open_network_impl(ATHandler &at) override;
 
-protected:
-    virtual nsapi_error_t init();
+public:
+    nsapi_error_t init() override;
 
 private:
     static Module _module;

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.cpp
@@ -76,27 +76,24 @@ void GEMALTO_CINTERION_CellularContext::enable_access_technology()
     switch (*_rat)
     {
     case CATM1:
-        _at.at_cmd_discard("^SXRAT", "=","%d", *_rat);
-        _at.cmd_start_stop("^SCFG", "=","%s%d", "Radio/Band/CatM", *_band);
-        _at.resp_start("^SCFG");
-        _at.cmd_start_stop("^SCFG", "=","%s%d%d", "Radio/Band/CatNB",0,0);
+        _at.at_cmd_discard("^SXRAT", "=","%d", 7); // 7 = CAT.M1
+
+        // Ensure all bands are enabled by setting ^SCFG to the bitmask of all valid bands
+        _at.cmd_start_stop("^SCFG", "=","%s%d", "Radio/Band/CatM", "F0E189F");
         _at.resp_start("^SCFG");
         break;
 
     case CATNB:
-        _at.at_cmd_discard("^SXRAT", "=","%d", *_rat);
-        _at.cmd_start_stop("^SCFG", "=","%s%d", "Radio/Band/CatNB", *_band);
-        _at.resp_start("^SCFG");
-        _at.cmd_start_stop("^SCFG", "=","%s%d%d", "Radio/Band/CatM",0,0);
+        _at.at_cmd_discard("^SXRAT", "=","%d", 8); // 8 = CAT.NB1
+
+        // Ensure all bands are enabled by setting ^SCFG to the bitmask of all valid bands
+        _at.cmd_start_stop("^SCFG", "=","%s%s", "Radio/Band/CatNB", "10000200000000");
         _at.resp_start("^SCFG");
         break;
 
     default:
         break;
     }
-
-    _at.cmd_start_stop("^SCFG", "=", "%s%s", "Tcp/withURCs", "on");
-    _at.resp_start("^SCFG");
 }
 
 } /* namespace mbed */

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.cpp
@@ -52,7 +52,7 @@ NetworkStack *GEMALTO_CINTERION_CellularContext::get_stack()
 nsapi_error_t GEMALTO_CINTERION_CellularContext::do_user_authentication()
 {
     // if user has defined user name and password we need to call CGAUTH before activating or modifying context
-    if (_pwd && _uname) {
+    if (_pwd && _uname && (strcmp(_pwd, "") != 0) && (strcmp(_uname, "") != 0)) {
         if (!get_device()->get_property(AT_CellularDevice::PROPERTY_AT_CGAUTH)) {
             return NSAPI_ERROR_UNSUPPORTED;
         }
@@ -62,6 +62,9 @@ nsapi_error_t GEMALTO_CINTERION_CellularContext::do_user_authentication()
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_AUTH_FAILURE;
         }
+    }
+    else {
+        tr_info("Empty pwd and username fields: no need for authentication\n");
     }
 
     return NSAPI_ERROR_OK;
@@ -94,6 +97,60 @@ void GEMALTO_CINTERION_CellularContext::enable_access_technology()
     default:
         break;
     }
+}
+
+bool GEMALTO_CINTERION_CellularContext::get_context()
+{
+    _at.cmd_start_stop("+CGDCONT", "?");
+    _at.resp_start("+CGDCONT:");
+    set_cid(-1);
+    int cid_max = 0; // needed when creating new context
+    char apn[MAX_ACCESSPOINT_NAME_LENGTH];
+    int apn_len = 0;
+
+    while (_at.info_resp()) {
+        int cid = _at.read_int();
+        if (cid > cid_max) {
+            cid_max = cid;
+        }
+        char pdp_type_from_context[10];
+        int pdp_type_len = _at.read_string(pdp_type_from_context, sizeof(pdp_type_from_context));
+        if (pdp_type_len > 0) {
+            apn_len = _at.read_string(apn, sizeof(apn));
+            if (apn_len > 0 && (strcmp(apn, _apn) == 0)) {
+                // APN matched -> Check PDP type
+                pdp_type_t pdp_type = string_to_pdp_type(pdp_type_from_context);
+                tr_debug("CID %d APN \"%s\" pdp_type %u", cid, apn, pdp_type);
+
+                // Accept exact matching PDP context type or dual PDP context for modems that support both IPv4 and IPv6 stacks
+                if (get_device()->get_property(pdp_type_t_to_cellular_property(pdp_type)) ||
+                        ((pdp_type == IPV4V6_PDP_TYPE && (get_device()->get_property(AT_CellularDevice::PROPERTY_IPV4_PDP_TYPE) &&
+                                                          get_device()->get_property(AT_CellularDevice::PROPERTY_IPV6_PDP_TYPE))) && !_nonip_req)) {
+                    _pdp_type = pdp_type;
+                    set_cid(cid);
+                }
+            }
+             else {
+                cid_max = 0;
+            }
+        }
+    }
+
+    _at.resp_stop();
+    if (_cid == -1) { // no suitable context was found so create a new one
+        if (!set_new_context(cid_max + 1)) {
+            return false;
+        }
+    }
+
+    // save the apn
+    if (apn_len > 0 && !_apn) {
+        memcpy(_found_apn, apn, apn_len + 1);
+    }
+
+    tr_info("Found PDP context %d", _cid);
+
+    return true;
 }
 
 } /* namespace mbed */

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularContext.h
@@ -30,6 +30,8 @@ protected:
 #if !NSAPI_PPP_AVAILABLE
     virtual NetworkStack *get_stack();
 #endif // NSAPI_PPP_AVAILABLE
+    nsapi_error_t do_user_authentication() override;
+    void enable_access_technology() override;
 };
 
 } /* namespace mbed */

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularNetwork.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularNetwork.h
@@ -14,27 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GEMALTO_CINTERION_CELLULARCONTEXT_H_
-#define GEMALTO_CINTERION_CELLULARCONTEXT_H_
+#ifndef GEMALTO_CINTERION_CELLULARNETWORK_H_
+#define GEMALTO_CINTERION_CELLULARNETWORK_H_
 
-#include "AT_CellularContext.h"
+#include "AT_CellularNetwork.h"
+#include "GEMALTO_CINTERION.h"
 
 namespace mbed {
 
-class GEMALTO_CINTERION_CellularContext: public AT_CellularContext {
+class GEMALTO_CINTERION_CellularNetwork: public AT_CellularNetwork {
+    const GEMALTO_CINTERION::Module _module;
 public:
-    GEMALTO_CINTERION_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req = false, bool nonip_req = false);
-    virtual ~GEMALTO_CINTERION_CellularContext();
+    GEMALTO_CINTERION_CellularNetwork(ATHandler &at, AT_CellularDevice &device, GEMALTO_CINTERION::Module module):
+    AT_CellularNetwork(at, device),
+    _module(module)
+    {}
+    
+    virtual nsapi_error_t set_attach()
+    {
+        if (_module == GEMALTO_CINTERION::ModuleTX62) {
+            return NSAPI_ERROR_OK;
+        }
+        return AT_CellularNetwork::set_attach();
+    }
 
 protected:
-#if !NSAPI_PPP_AVAILABLE
-    virtual NetworkStack *get_stack();
-#endif // NSAPI_PPP_AVAILABLE
-    nsapi_error_t do_user_authentication() override;
-    void enable_access_technology() override;
-    bool get_context() override;
 };
 
 } /* namespace mbed */
 
-#endif // GEMALTO_CINTERION_CELLULARCONTEXT_H_
+#endif // GEMALTO_CINTERION_CELLULARNETWORK_H_

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -100,6 +100,18 @@ void GEMALTO_CINTERION_CellularStack::urc_sisr()
     sisr_urc_handler(sock_id, urc_code);
 }
 
+void GEMALTO_CINTERION_CellularStack::urc_sysstart()
+{
+    // close sockets if open
+    _at.lock();
+    for (int i = 0; i < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT); i++) {
+        _at.clear_error();
+        socket_close_impl(i);
+    }
+    _at.clear_error();
+    _at.unlock();
+}
+
 void GEMALTO_CINTERION_CellularStack::sisr_urc_handler(int sock_id, int urc_code)
 {
     CellularSocket *sock = find_socket(sock_id);
@@ -113,6 +125,86 @@ void GEMALTO_CINTERION_CellularStack::sisr_urc_handler(int sock_id, int urc_code
     }
 }
 
+void GEMALTO_CINTERION_CellularStack::urc_gnss() {
+    char gnss_string[100] = {'$', 'G'};
+    if (_gnss_cb) {
+        _at.set_delimiter('\n');
+        _at.read_string(&gnss_string[2], 98);
+        _at.set_default_delimiter();
+        _gnss_cb(gnss_string);
+    }
+}
+
+void GEMALTO_CINTERION_CellularStack::beginGNSS(mbed::Callback<void(char*)> gnss_cb) {
+    _at.lock();
+    _gnss_cb = gnss_cb;
+    _at.at_cmd_discard("^SGPSC", "=", "%s%d", "Engine/StartMode", 0);
+    _at.at_cmd_discard("^SGPSC", "=", "%s%d", "Engine", 0);
+    _at.at_cmd_discard("^SGPSC", "=", "%s%s", "Nmea/Urc", "off");
+
+    // Set up LNA_ENABLE GPIO
+    _at.at_cmd_discard("^SPIO", "=", "%d", 1);
+    _at.at_cmd_discard("^SCPIN", "=", "%d%d%d%d", 1, 7, 1, 0);
+    _at.clear_error();
+    _at.unlock();
+}
+
+void GEMALTO_CINTERION_CellularStack::endGNSS() {
+    _at.lock();
+    _at.at_cmd_discard("^SSIO", "=", "%d%d", 7, 0);
+    _gnss_cb = nullptr;
+    _at.clear_error();
+    _at.unlock();
+}
+
+void GEMALTO_CINTERION_CellularStack::enableCmux()
+{
+    _at.at_cmd_discard("+CMUX", "=0");
+}
+
+int GEMALTO_CINTERION_CellularStack::startGNSS() {
+    _at.lock();
+    _engine = false;
+    _at.at_cmd_discard("^SSIO", "=", "%d%d", 7, 1);
+    _at.cmd_start_stop("^SGPSC", "=", "%s%d", "Engine", 3);
+    _at.resp_start("^SGPSC: \"Engine\",");
+
+    char respEng[2];
+    int resp_len = _at.read_string(respEng, sizeof(respEng));
+    if (strcmp(respEng, "3") != 0) {
+        _engine = false;
+        _at.at_cmd_discard("^SGPSC", "=", "%s%d", "Engine", 0);
+        _at.at_cmd_discard("^SGPSC", "=", "%s%s", "Nmea/Urc", "off");
+        return 0;
+    }
+    _engine = true;
+    _at.at_cmd_discard("^SGPSC", "=", "%s%s", "Nmea/Urc", "on");
+    _at.clear_error();
+    _at.unlock();
+
+    return 1;
+}
+
+void GEMALTO_CINTERION_CellularStack::stopGNSS() {
+    if(_engine) {
+        _at.lock();
+        _at.at_cmd_discard("^SGPSC", "=", "%s%s", "Nmea/Urc", "off");
+        _at.at_cmd_discard("^SGPSC", "=", "%s%d", "Engine", 0);
+        _at.clear_error();
+        _at.unlock();
+        _engine = false;
+    }
+}
+
+void GEMALTO_CINTERION_CellularStack::setGNSS_PSM(bool const enable) {
+    if(_engine) {
+        _at.lock();
+        _at.at_cmd_discard("^SGPSC", "=", "%s%d", "Power/Psm", enable);
+        _at.clear_error();
+        _at.unlock();
+    }
+}
+
 nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_stack_init()
 {
     _at.lock();
@@ -121,6 +213,9 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_stack_init()
         _at.set_urc_handler("^SIS:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sis));
         _at.set_urc_handler("^SISW:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sisw));
         _at.set_urc_handler("^SISR:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sisr));
+        _at.set_urc_handler("^SYSSTART", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sysstart));
+        _at.set_urc_handler("^SGPSE", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_gnss));
+        _at.set_urc_handler("$G", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_gnss));
     } else { // recovery cleanup
         // close all Internet and connection profiles
         for (int i = 0; i < _device.get_property(AT_CellularDevice::PROPERTY_SOCKET_COUNT); i++) {
@@ -172,7 +267,7 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::gethostbyname(const char *host, S
         _at.resp_start("^SISX: \"HostByName\",");
         char ipAddress[NSAPI_IP_SIZE];
         int size = _at.read_string(ipAddress, sizeof(ipAddress));
-        if (size) {
+        if (size > 0) {
             //Valid string received
             tr_info("Read %d bytes. Valid string: %s\n", size, ipAddress);
             _at.restore_at_timeout();
@@ -199,10 +294,6 @@ retry_open:
     int internet_service_id = find_socket_index(socket);
     bool foundSrvType = false;
     bool foundConIdType = false;
-
-    if (GEMALTO_CINTERION::get_module() == GEMALTO_CINTERION::ModuleTX62) {
-        _at.cmd_start_stop("^SICA", "=", "%d%d", 1, _cid);
-    }
 
     _at.cmd_start_stop("^SISS", "?");
     _at.resp_start("^SISS:");
@@ -438,6 +529,7 @@ nsapi_size_or_error_t GEMALTO_CINTERION_CellularStack::socket_recvfrom_impl(Cell
         size = UDP_PACKET_SIZE;
     }
 
+    tr_info("requesting %d bytes\n", size);
     _at.cmd_start_stop("^SISR", "=", "%d%d", socket->id, size);
 
 sisr_retry:
@@ -467,6 +559,7 @@ sisr_retry:
     }
     if (len == -1) {
         if (GEMALTO_CINTERION::get_module() == GEMALTO_CINTERION::ModuleTX62 && _at.get_last_read_error() == -2) {
+            _at.process_oob();
             tr_error("Socket %d recvfrom finished!", socket->id);
             socket->pending_bytes = 0;
             return NSAPI_ERROR_OK;
@@ -474,19 +567,54 @@ sisr_retry:
         tr_error("Socket %d recvfrom failed!", socket->id);
         return NSAPI_ERROR_DEVICE_ERROR;
     }
-    socket->pending_bytes = 1;
     if (len >= (nsapi_size_or_error_t)size) {
         len = (nsapi_size_or_error_t)size;
     }
 
     // UDP Udp_RemClient
     if (socket->proto == NSAPI_UDP && GEMALTO_CINTERION::get_module() != GEMALTO_CINTERION::ModuleBGS2) {
-        char ip_address[NSAPI_IPv6_SIZE + sizeof("[]:12345") - 1 + 1];
-        int ip_len = _at.read_string(ip_address, sizeof(ip_address));
-        if (ip_len <= 0) {
-            tr_error("Socket %d recvfrom addr (len %d)", socket->id, ip_len);
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
+        size_t ip_address_len = NSAPI_IPv6_SIZE + sizeof("[]:12345") - 1 + 1;
+        char ip_address[ip_address_len];
+
+        if (GEMALTO_CINTERION::get_module() == GEMALTO_CINTERION::ModuleTX62) {
+            // Local buffer for parsing Udp_RemClient for TX62
+            uint8_t at_buf[ip_address_len];
+            size_t ip_len = 0;
+
+            // Skip <remainUdpPacketLength>
+            nsapi_size_or_error_t rem_len = _at.read_int();
+
+            // Wait for full <Udp_RemClient> in the _at buffer
+            do {
+                int len = _at.read_bytes(at_buf + ip_len, 1);
+                if (len <= 0) {
+                    tr_error("Socket %d recvfrom addr (len %d)", socket->id, ip_len);
+                    return NSAPI_ERROR_DEVICE_ERROR;
+                }
+                ip_len += len;
+            } while (ip_len < ip_address_len && at_buf[ip_len - 2] != '\r' && at_buf[ip_len - 1] != '\n');
+
+            // if (ip_len < sizeof("0.0.0.0:0")) {
+            if (ip_len < sizeof("[]:0")) {
+                tr_error("Socket %d has no address", socket->id);
+                goto sisr_retry;
+            }
+
+            // at_buf contains remote client IP information
+            // in the format "<ip address>:<port>"\r\n.
+
+            // Terminate the C string at the closing quotation mark
+            at_buf[ip_len - 3] = '\0';
+            // Skip the opening quotation mark
+            memcpy(ip_address, at_buf + 1, ip_len - 4);
+            tr_info("ip_address %s (%d)", ip_address, ip_len - 4);
+        } else {
+            int ip_len = _at.read_string(ip_address, sizeof(ip_address));
+            if (ip_len <= 0) {
+                tr_error("Socket %d recvfrom addr (len %d)", socket->id, ip_len);
+                return NSAPI_ERROR_DEVICE_ERROR;
+            }
+         }
         if (address) {
             char *ip_start = ip_address;
             char *ip_stop;

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.h
@@ -48,6 +48,10 @@ protected:
 
     virtual nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address);
 
+#ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
+    virtual nsapi_error_t gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version, const char *interface_name);
+#endif
+
 private:
     // socket URC handlers as per Cinterion AT manuals
     void urc_sis();
@@ -67,6 +71,11 @@ private:
     const char *_apn;
     const char *_user;
     const char *_password;
+
+#ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
+    hostbyname_cb_t _dns_callback;
+    nsapi_version_t _dns_version;
+#endif
 };
 
 } // namespace mbed

--- a/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.h
+++ b/connectivity/drivers/cellular/GEMALTO/COMPONENT_GEMALTO_CINTERION/GEMALTO_CINTERION_CellularStack.h
@@ -34,6 +34,21 @@ public:
      */
     nsapi_error_t socket_stack_init();
 
+    /**
+     * @brief Enable GNSS output, if supported by the Cinterion module
+     *
+     * @param gnss_cb Callback which will be called when a new GNSS sentence is received
+     */
+    void beginGNSS(mbed::Callback<void(char*)> gnss_cb);
+
+    void enableCmux();
+    void endGNSS();
+    int startGNSS();
+    void stopGNSS();
+
+    /// Set whether Power Save Mode is enabled for the GNSS in the Cinterion module
+    void setGNSS_PSM(bool enable);
+
 protected:
 
     virtual nsapi_error_t socket_close_impl(int sock_id);
@@ -56,9 +71,11 @@ private:
     // socket URC handlers as per Cinterion AT manuals
     void urc_sis();
     void urc_sisw();
+    void urc_sysstart();
     void sisw_urc_handler(int sock_id, int urc_code);
     void urc_sisr();
     void sisr_urc_handler(int sock_id, int urc_code);
+    void urc_gnss();
 
     // sockets need a connection profile, one profile is enough to support single stack sockets
     nsapi_error_t create_connection_profile(int connection_profile_id);
@@ -71,6 +88,9 @@ private:
     const char *_apn;
     const char *_user;
     const char *_password;
+    bool _engine;
+
+    mbed::Callback<void(char*)> _gnss_cb;
 
 #ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
     hostbyname_cb_t _dns_callback;

--- a/targets/drivers.json5
+++ b/targets/drivers.json5
@@ -74,8 +74,8 @@
             "friendly_name": "STMod Cellular Modules"
         },
         "COMPONENT_GEMALTO_CINTERION": {
-            "description": "Gemalto Cinterion family of cellular modules (ELS61, BGS2, EMS31, and EHS5-E are supported)",
-            "friendly_name": "Gemalto Cinterion"
+            "description": "Telit Cinterion (formerly Thales Cinterion, formerly Gemalto Cinterion) family of cellular modules (TX62, ELS61, BGS2, EMS31, and EHS5-E are supported)",
+            "friendly_name": "Telit/Thales/Gemalto Cinterion"
         },
         "COMPONENT_GENERIC_AT3GPP": {
             "description": "Generic cellular module supporting 3GPP AT command set",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR adds support to Mbed OS for the Telit (formerly Gemalto) Cinterion TX62 modem. This modem is used on the [Arduino Portenta Cat.M1/NB IoT shield](https://store.arduino.cc/products/portenta-catm1), and it's needed in order for the Arduino core to compile against Mbed. I adapted it from a series of patches that Arduino created, starting with [this one](https://github.com/arduino/ArduinoCore-mbed/blob/main/patches/0090-Thales-mbed-library-porting.patch). I have also tried to clean it up somewhat, so that the changes to classes outside of the Cinterion driver are minimized.

One thing I did change verseus the Arduino patches is I removed the ability to select the specific radio band that the modem operates on. This seems like it was kinda complicated to implement, and reading the modem datasheet, it says that it's perfectly capable of selecting its own bands based on what the cell towers in your area offer. So, not adding that unless there's an actual demonstrable reason why someone needs it.

Another note is that the "CMUX" support works together with a bunch of custom logic that Arduino implements in their serial code to basically mux one serial port into three. That logic currently doesn't exist in Mbed, and it would probably take a fair bit of work to port it over in a non janky way. So, for now I am merging their patch that adds a way to turn on CMUX, even though there's no way to actually use it with plain Mbed.

#### Impact of changes <!-- Optional -->
- Support added for Telit Cinterion TX62 modem

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Unfortunately I can't test this at present as I don't have TX62 hardware available...
----------------------------------------------------------------------------------------------------------------
