### PR TITLE
littlefs2: Properly init class variables

### DIFF
--- a/storage/filesystem/littlefsv2/include/littlefsv2/LittleFileSystem2.h
+++ b/storage/filesystem/littlefsv2/include/littlefsv2/LittleFileSystem2.h
@@ -289,9 +289,9 @@ protected:
 #endif //!(DOXYGEN_ONLY)
 
 private:
-    lfs2_t _lfs; // The actual file system
-    struct lfs2_config _config;
-    mbed::BlockDevice *_bd; // The block device
+    lfs2_t _lfs{}; // The actual file system
+    struct lfs2_config _config{};
+    mbed::BlockDevice *_bd = nullptr; // The block device
 
     // thread-safe locking
     rtos::Mutex _mutex;

--- a/storage/filesystem/littlefsv2/include/littlefsv2/LittleFileSystem2.h
+++ b/storage/filesystem/littlefsv2/include/littlefsv2/LittleFileSystem2.h
@@ -290,7 +290,7 @@ protected:
 
 private:
     lfs2_t _lfs{}; // The actual file system
-    struct lfs2_config _config{};
+    struct lfs2_config _config {};
     mbed::BlockDevice *_bd = nullptr; // The block device
 
     // thread-safe locking

--- a/storage/filesystem/littlefsv2/source/LittleFileSystem2.cpp
+++ b/storage/filesystem/littlefsv2/source/LittleFileSystem2.cpp
@@ -149,7 +149,6 @@ LittleFileSystem2::LittleFileSystem2(const char *name, BlockDevice *bd,
                                      lfs2_size_t cache_size, lfs2_size_t lookahead_size)
     : FileSystem(name)
 {
-    memset(&_config, 0, sizeof(_config));
     _config.block_size = block_size;
     _config.block_cycles = block_cycles;
     _config.cache_size = cache_size;


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Noticed this [bug](https://github.com/arduino/ArduinoCore-mbed/issues/1042) on the Arduino bug tracker which is happening due to `this->_bd` being uninitialized in `LittleFileSystem2`, leading to undefined behavior if `unmount()` is called after constructing the class.

#### Impact of changes <!-- Optional -->
Should no longer crash in this situation.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
