### PR TITLE
Fix I2C slave test on STM32

### DIFF
--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -323,7 +323,7 @@ int  i2c_slave_receive(i2c_t *obj);
  *  @param obj The I2C object
  *  @param data    The buffer for receiving
  *  @param length  Number of bytes to read
- *  @return non-zero if a value is available, or zero on error
+ *  @return Number of bytes read, or zero on error
  */
 int  i2c_slave_read(i2c_t *obj, char *data, int length);
 

--- a/targets/TARGET_STM/TARGET_STM32U0/stm_dma_info.h
+++ b/targets/TARGET_STM/TARGET_STM32U0/stm_dma_info.h
@@ -26,10 +26,10 @@
 
 /// Mapping from SPI index to DMA link info for Tx
 static const DMALinkInfo SPITxDMALinks[] = {
-        {1, 0, DMA_REQUEST_SPI1_TX},
-        {1, 2, DMA_REQUEST_SPI2_TX},
+        {1, 2, DMA_REQUEST_SPI1_TX},
+        {1, 4, DMA_REQUEST_SPI2_TX},
 #if defined (SPI3)
-        {1, 4, DMA_REQUEST_SPI3_TX}
+        {1, 6, DMA_REQUEST_SPI3_TX}
 #endif
 };
 

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -1120,11 +1120,11 @@ int i2c_byte_read(i2c_t *obj, int last)
     if (last) {
         /* Disable Address Acknowledge */
         tmpreg = tmpreg & (~I2C_CR2_RELOAD);
-        tmpreg |= I2C_CR2_NACK | (I2C_CR2_NBYTES & (1 << 16));
+        tmpreg |= I2C_CR2_NACK | (1 << I2C_CR2_NBYTES_Pos);
     } else {
         /* Enable reload mode as we don't know how many bytes will be sent */
         /* and set transfer size to 1 */
-        tmpreg |= I2C_CR2_RELOAD | (I2C_CR2_NBYTES & (1 << 16));
+        tmpreg |= I2C_CR2_RELOAD | (1 << I2C_CR2_NBYTES_Pos);
     }
 
     /* Set the prepared configuration */

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -1512,9 +1512,8 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
     uint32_t event_code = 0;
 
 #if DEVICE_I2CSLAVE
-    if(obj_s->slave_rx_transfer_in_progress && handle->ErrorCode == HAL_I2C_ERROR_AF)
-    {
-        // We get here if the master NACKed a write operation after fewer than expected
+    if(obj_s->slave_rx_transfer_in_progress && handle->ErrorCode == HAL_I2C_ERROR_AF) {
+        // We get here if the master ended a write operation after fewer than expected
         // bytes. Just mark the slave transfer as done and return.
         obj_s->slave_rx_transfer_in_progress = 0;
         return;

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -4803,10 +4803,6 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "TRNG",
             //"USBDEVICE" // TODO
         ],
-        "device_has_remove": [
-            "I2C",      // Not tested just prepared
-            "I2CSLAVE"  // Not tested just prepared
-        ],
         "is_mcu_family_target": true
     },
     "MCU_STM32U083xC": {

--- a/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
+++ b/tools/cmake/upload_methods/UploadMethodOPENOCD.cmake
@@ -48,7 +48,8 @@ function(gen_upload_target TARGET_NAME BINARY_FILE)
 		${OPENOCD_ADAPTER_SERIAL_COMMAND}
 		-c "gdb_port disabled" # Don't start a GDB server when just programming
 		-c "program ${BINARY_FILE} ${MBED_UPLOAD_BASE_ADDR} reset exit"
-		VERBATIM)
+		VERBATIM
+		USES_TERMINAL)
 
 endfunction(gen_upload_target)
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR fixes some bugs that were causing the I2C slave test to fail when running on STM32U0:

- Calling I2CSlave::frequency() after constructing the object would wipe out the I2C address in the registers, causing the I2C slave to not respond to any messages on the bus
- The slave read operation would erroneously return an error (0 bytes) if the master transferred less bytes than expected by the slave, instead of returning the actual number of bytes transferred.

This PR also enables I2C on U0 now that we've tested it with the test shield.

#### Impact of changes <!-- Optional -->
- I2C master and slave now supported for STM32U0
- I2C slave bugs fixes as above

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
All I2C tests pass on STM32U0 except for some known I2C master failures with the single byte API.
----------------------------------------------------------------------------------------------------------------
