### PR TITLE
Some fixes for NUMAKER_PFM_M487

### DIFF
--- a/connectivity/drivers/emac/sources/CompositeEMAC.cpp
+++ b/connectivity/drivers/emac/sources/CompositeEMAC.cpp
@@ -82,6 +82,7 @@ namespace mbed {
                     return;
                 }
 
+#if MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_INFO
                 char const * speedStr;
                 if(speed == LinkSpeed::LINK_10MBIT) {
                     speedStr = "10Mbps";
@@ -94,6 +95,7 @@ namespace mbed {
                 }
 
                 tr_info("Link up at %s %s duplex", speedStr, duplex == Duplex::FULL ? "full" : "half");
+#endif
 
                 linkState = LinkState::UP;
                 if(mac.enable(speed, duplex) != ErrCode::SUCCESS) {

--- a/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
+++ b/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
@@ -70,6 +70,12 @@
        },
        "ARDUINO_NICLA_SENSE_ME": {
           "SPI_CS":   "CS_FLASH"
-       }
+       },
+       "NUMAKER_PFM_M487": {
+           "SPI_MOSI": "PC_0",
+           "SPI_MISO": "PC_1",
+           "SPI_CLK":  "PC_2",
+           "SPI_CS":   "PC_3"
+      }
     }
 }

--- a/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
+++ b/storage/blockdevice/tests/TESTS/blockdevice/general_block_device/main.cpp
@@ -738,7 +738,7 @@ void test_contiguous_erase_write_read()
         }
     }
 
-    free(write_read_buf);
+    delete[] write_read_buf;
 }
 
 void test_program_read_small_data_sizes()
@@ -867,7 +867,7 @@ void test_write_deinit_init()
 
     for (int i = 0; i < 3; i++) {
         // Generate test pattern
-        for (int j = 0; j < prog_size; j++) {
+        for (bd_size_t j = 0; j < prog_size; j++) {
             prog[j] = (uint8_t)'0' + i + j;
         }
 

--- a/targets/TARGET_NUVOTON/nu_miscutil.c
+++ b/targets/TARGET_NUVOTON/nu_miscutil.c
@@ -40,22 +40,31 @@ void nu_nop(uint32_t n)
     switch (rmn) {
         case 9:
             __NOP();
+            // fall through
         case 8:
             __NOP();
+            // fall through
         case 7:
             __NOP();
+            // fall through
         case 6:
             __NOP();
+            // fall through
         case 5:
             __NOP();
+            // fall through
         case 4:
             __NOP();
+            // fall through
         case 3:
             __NOP();
+            // fall through
         case 2:
             __NOP();
+            // fall through
         case 1:
             __NOP();
+            // fall through
         default:
             break;
     }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8230,6 +8230,12 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "detect_code": [
             "1304"
         ],
+        "components_add": [
+            "SPIF" // 4MiB SPI flash.
+
+            // Note that this board also has a MicroSD slot, but it is not hooked up to the right pins for SPI
+            // operation, so Mbed currently cannot use it.
+        ],
         "overrides": {
             "hxt-present": false,
             "lxt-present": true,

--- a/targets/upload_method_cfg/NUMAKER_IOT_M487.cmake
+++ b/targets/upload_method_cfg/NUMAKER_IOT_M487.cmake
@@ -2,6 +2,16 @@
 # To change any of these parameters from their default values, set them in your build script between where you
 # include app.cmake and where you add mbed os as a subdirectory.
 
+# Notes:
+# 1. The Nuvoton fork of OpenOCD is required: https://github.com/OpenNuvoton/OpenOCD-Nuvoton/releases .
+#    Point CMake to it via setting the OpenOCD option:
+#    -DOpenOCD="C:/Program Files (x86)/OpenOCD-nuvoton/bin/openocd.exe"
+# 2. Take note of the "MSG" switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
+#    mass storage mode and can only work with the "MBED" upload method. If set to OFF, the Nu-Link will run in
+#    Nu-Link mode and only works with Nuvoton OpenOCD.
+# 3. On Windows you will need to install the Nu-Link Keil USB driver, which can be found near the bottom here:
+#    https://www.nuvoton.com/tool-and-software/ide-and-compiler/
+
 # General config parameters
 # -------------------------------------------------------------
 set(UPLOAD_METHOD_DEFAULT MBED)
@@ -10,12 +20,6 @@ set(UPLOAD_METHOD_DEFAULT MBED)
 # -------------------------------------------------------------
 set(MBED_UPLOAD_ENABLED TRUE)
 set(MBED_RESET_BAUDRATE 115200)
-
-# Config options for PYOCD
-# -------------------------------------------------------------
-set(PYOCD_UPLOAD_ENABLED TRUE)
-set(PYOCD_TARGET_NAME m487jidae)
-set(PYOCD_CLOCK_SPEED 4000k)
 
 # Config options for OPENOCD
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUMAKER_IOT_M487.cmake
+++ b/targets/upload_method_cfg/NUMAKER_IOT_M487.cmake
@@ -6,11 +6,14 @@
 # 1. The Nuvoton fork of OpenOCD is required: https://github.com/OpenNuvoton/OpenOCD-Nuvoton/releases .
 #    Point CMake to it via setting the OpenOCD option:
 #    -DOpenOCD="C:/Program Files (x86)/OpenOCD-nuvoton/bin/openocd.exe"
-# 2. Take note of the "MSG" switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
+# 2. Take note of the "MSG" DIP switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
 #    mass storage mode and can only work with the "MBED" upload method. If set to OFF, the Nu-Link will run in
 #    Nu-Link mode and only works with Nuvoton OpenOCD.
 # 3. On Windows you will need to install the Nu-Link Keil USB driver, which can be found near the bottom here:
 #    https://www.nuvoton.com/tool-and-software/ide-and-compiler/
+# 4. The onboard nu-link does not have a unique USB serial number configured, so the MBED_UPLOAD_SERIAL_NUMBER
+#    option will not work (and it doesn't seem to work with OpenOCD 0.10.x anyway). This means, sadly, it's impossible
+#    to work with more than one Nuvoton board at a time on a given machine.
 
 # General config parameters
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
+++ b/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
@@ -2,6 +2,16 @@
 # To change any of these parameters from their default values, set them in your build script between where you
 # include app.cmake and where you add mbed os as a subdirectory.
 
+# Notes:
+# 1. The Nuvoton fork of OpenOCD is required: https://github.com/OpenNuvoton/OpenOCD-Nuvoton/releases .
+#    Point CMake to it via setting the OpenOCD option:
+#    -DOpenOCD="C:/Program Files (x86)/OpenOCD-nuvoton/bin/openocd.exe"
+# 2. Take note of the "MSG" switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
+#    mass storage mode and can only work with the "MBED" upload method. If set to OFF, the Nu-Link will run in
+#    Nu-Link mode and only works with Nuvoton OpenOCD.
+# 3. On Windows you will need to install the Nu-Link Keil USB driver, which can be found near the bottom here:
+#    https://www.nuvoton.com/tool-and-software/ide-and-compiler/
+
 # General config parameters
 # -------------------------------------------------------------
 set(UPLOAD_METHOD_DEFAULT MBED)
@@ -10,12 +20,6 @@ set(UPLOAD_METHOD_DEFAULT MBED)
 # -------------------------------------------------------------
 set(MBED_UPLOAD_ENABLED TRUE)
 set(MBED_RESET_BAUDRATE 115200)
-
-# Config options for PYOCD
-# -------------------------------------------------------------
-set(PYOCD_UPLOAD_ENABLED TRUE)
-set(PYOCD_TARGET_NAME m487jidae)
-set(PYOCD_CLOCK_SPEED 4000k)
 
 # Config options for OPENOCD
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
+++ b/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
@@ -6,11 +6,18 @@
 # 1. The Nuvoton fork of OpenOCD is required: https://github.com/OpenNuvoton/OpenOCD-Nuvoton/releases .
 #    Point CMake to it via setting the OpenOCD option:
 #    -DOpenOCD="C:/Program Files (x86)/OpenOCD-nuvoton/bin/openocd.exe"
-# 2. Take note of the "MSG" switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
+# 2. Take note of the "MSG" DIP switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
 #    mass storage mode and can only work with the "MBED" upload method. If set to OFF, the Nu-Link will run in
 #    Nu-Link mode and only works with Nuvoton OpenOCD.
 # 3. On Windows you will need to install the Nu-Link Keil USB driver, which can be found near the bottom here:
 #    https://www.nuvoton.com/tool-and-software/ide-and-compiler/
+# 4. The onboard nu-link does not have a unique USB serial number configured, so the MBED_UPLOAD_SERIAL_NUMBER
+#    option will not work (and it doesn't seem to work with OpenOCD 0.10.x anyway). This means, sadly, it's impossible
+#    to work with more than one Nuvoton board at a time on a given machine.
+# 5. To upgrade the Nu-Link firmware, the official instructions didn't work for me at first -- I had to use
+#    the ICP Programming Tool to get to a newer version. Then I could use the method of holding down the
+#    DAP button to get into bootloader mod, and flash the binary from here:
+#    https://github.com/OpenNuvoton/Nuvoton_Tools/blob/master/Latest_NuLink_Firmware/NuLink1FW.bin
 
 # General config parameters
 # -------------------------------------------------------------

--- a/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
+++ b/targets/upload_method_cfg/NUMAKER_PFM_M487.cmake
@@ -4,7 +4,7 @@
 
 # Notes:
 # 1. The Nuvoton fork of OpenOCD is required: https://github.com/OpenNuvoton/OpenOCD-Nuvoton/releases .
-#    Point CMake to it via setting the OpenOCD option:
+#    Point CMake to it via setting the OpenOCD option. For example:
 #    -DOpenOCD="C:/Program Files (x86)/OpenOCD-nuvoton/bin/openocd.exe"
 # 2. Take note of the "MSG" DIP switch on the Nu-Link section of the board. If set to ON, the Nu-Link will run in
 #    mass storage mode and can only work with the "MBED" upload method. If set to OFF, the Nu-Link will run in


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I picked up an NUMAKER_PFM_M487 board last week and hooked it up to my greentea setup. It passed almost all the greentea tests! However, I did make some fixes:

- Added `COMPONENT_SPIF` since this board has an SPI flash -- now Mbed applications can use the flash easily!
- Remove PyOCD support as I was not able to get PyOCD to detect this board, and it didn't seem to me like it was supported
- Add some notes about upload methods for the board

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->
### Documentation <!-- Required -->


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
96% tests passed, 4 tests failed out of 114

Total Test time (real) = 2484.03 sec

The following tests did not run:
         11 - test-mbed-drivers-mem-trace (Skipped)
         27 - test-mbed-hal-crc (Skipped)
         33 - test-mbed-hal-ospi (Skipped)
         35 - test-mbed-hal-qspi (Skipped)
         46 - test-mbed-hal-trng (Skipped)
         51 - test-mbed-hal-verify-arduino-pinmap (Skipped)
         97 - test-mbed-connectivity-mbedtls-sanity (Skipped)
         98 - test-mbed-connectivity-mbedtls-selftest (Skipped)
         99 - test-mbed-connectivity-nfc-eeprom (Skipped)
        102 - test-mbed-connectivity-netsocket-nidd (Skipped)
        105 - test-mbed-connectivity-netsocket-lwipstack-tls (Skipped)
        106 - test-mbed-connectivity-netsocket-nanostack-tls (Skipped)
        112 - test-mbed-connectivity-network-lwipstack-wifi (Skipped)
        113 - test-mbed-connectivity-network-nanostack-wifi (Skipped)
        114 - test-mbed-device_key-functionality (Skipped)

The following tests FAILED:
         13 - test-mbed-drivers-reset-reason (Failed)
         21 - test-mbed-usb-device-basic (Failed)
         36 - test-mbed-hal-reset-reason (Failed)
        109 - test-mbed-connectivity-network-emac (Failed) 
```

Failure reasons:
- `test-mbed-drivers-reset-reason` and `test-mbed-hal-reset-reason`: Looks like the MCU is not getting reset when the test runner tries to send a break over the serial port. Is this supported for Nu-Link?
- `test-mbed-usb-device-basic`:
```
[+45324ms][CONN][RXD] >>> Running case #13: 'endpoint test data toggle reset'...
[+45334ms][CONN][INF] found KV pair in stream: {{__testcase_start;endpoint test data toggle reset}}, queued...
[+45692ms][CONN][INF] found KV pair in stream: {{ep_test_data_toggle;0123456789}}, queued...
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
interface 0, alt 2 -- running tests
interface 0, alt 3 -- running tests
interface 0, alt 4 -- running tests
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
interface 0, alt 2 -- running tests
interface 0, alt 3 -- running tests
interface 0, alt 4 -- running tests
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
interface 0, alt 2 -- running tests
interface 0, alt 3 -- running tests
interface 0, alt 4 -- running tests
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
interface 0, alt 2 -- running tests
interface 0, alt 3 -- running tests
interface 0, alt 4 -- running tests
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
interface 0, alt 2 -- running tests
interface 0, alt 3 -- running tests
interface 0, alt 4 -- running tests
interface 0, alt 0 -- skipping the default AlternateSetting
interface 0, alt 1 -- running tests
[+46705ms][HTST][INF] TEST FAILED: [/home/jamie/Mbed/mbed-os/drivers/usb/tests/TESTS/host_tests/pyusb_basic.py]:1474, Data toggle not reset when clearing endpoint halt.
[+46707ms][SERI][TXD] {{fail;0}}
[+46717ms][CONN][RXD] <greentea test suite>:425::FAIL: Expected 'pass' Was 'fail'
[+46728ms][CONN][RXD] >>> 'endpoint test data toggle reset': 0 passed, 1 failed with reason 'Assertion Failed'
[+46728ms][CONN][RXD] 
[+46728ms][CONN][RXD] 
[+46728ms][CONN][INF] found KV pair in stream: {{__testcase_finish;endpoint test data toggle reset;0;1}}, queued...
[+46738ms][CONN][RXD] >>> Test cases: 12 passed, 1 failed with reason 'Assertion Failed'
[+46739ms][CONN][RXD] >>> TESTS FAILED!
[+46739ms][CONN][RXD] 
```
- `test-mbed-connectivity-network-emac`: Looks like multicast filtering is not working

----------------------------------------------------------------------------------------------------------------
