### PR TITLE
Fix incorrect DMA ISR handlers being used on STM32U0

### DIFF
--- a/targets/TARGET_STM/stm_dma_utils.c
+++ b/targets/TARGET_STM/stm_dma_utils.c
@@ -399,7 +399,7 @@ IRQn_Type stm_get_dma_irqn(const DMALinkInfo *dmaLink)
         case 2:
             switch(dmaLink->channelIdx)
             {
-#ifdef TARGET_MCU_STM32G0
+#if defined(TARGET_MCU_STM32G0)
                 // STM32G0 does its own thing and has all DMA2 channels under 1 IRQ
                 case 1:
                 case 2:
@@ -914,6 +914,77 @@ void DMA1_Ch4_7_DMAMUX1_OVR_IRQHandler(void)
 }
 #else
 void DMA1_Ch4_5_DMAMUX1_OVR_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+    }
+}
+#endif
+
+#elif defined(TARGET_MCU_STM32U0)
+
+void DMA1_Channel2_3_IRQHandler(void)
+{
+    if(stmDMAHandles[0][1] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][1]);
+    }
+    if(stmDMAHandles[0][2] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][2]);
+    }
+}
+
+#ifdef DMA2
+void DMA1_Ch4_7_DMA2_Ch1_5_DMAMUX_OVR_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+    }
+    if(stmDMAHandles[0][5] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+    }
+    if(stmDMAHandles[0][6] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+    }
+    if(stmDMAHandles[1][0] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[1][0]);
+    }
+    if(stmDMAHandles[1][1] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[1][1]);
+    }
+    if(stmDMAHandles[1][2] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[1][2]);
+    }
+    if(stmDMAHandles[1][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[1][3]);
+    }
+    if(stmDMAHandles[1][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[1][4]);
+    }
+}
+#elif defined(DMA1_Channel7)
+void DMA1_Ch4_7_DMAMUX_OVR_IRQHandler(void)
+{
+    if(stmDMAHandles[0][3] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][3]);
+    }
+    if(stmDMAHandles[0][4] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][4]);
+    }
+    if(stmDMAHandles[0][5] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][5]);
+    }
+    if(stmDMAHandles[0][6] != NULL) {
+        HAL_DMA_IRQHandler(stmDMAHandles[0][6]);
+    }
+}
+#else
+void DMA1_Ch4_5_DMAMUX_OVR_IRQHandler(void)
 {
     if(stmDMAHandles[0][3] != NULL) {
         HAL_DMA_IRQHandler(stmDMAHandles[0][3]);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This fixes the DMA ISR handlers not being defined with the right names for STM32U0.

#### Impact of changes <!-- Optional -->
Attempting to use DMA SPI on STM32U0 no longer causes a chip crash due to hitting a default IRQ handler

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
All but one DMA SPI test now passes on STM32U0 (and I don't believe the failure is related to this).

----------------------------------------------------------------------------------------------------------------
