### PR TITLE
Fix some M480 I2C issues causing test shield test failures

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
@@ -43,29 +43,29 @@ typedef enum {
     PH_0    = NU_PINNAME(7, 0), PH_1, PH_2, PH_3, PH_4, PH_5, PH_6, PH_7, PH_8, PH_9, PH_10, PH_11,
 
     // Arduino UNO naming
-    A0 = PB_6,
-    A1 = PB_7,
-    A2 = PB_8,
-    A3 = PB_9,
-    A4 = PB_0,
-    A5 = PB_1,
+    ARDUINO_UNO_A0 = PB_6,
+    ARDUINO_UNO_A1 = PB_7,
+    ARDUINO_UNO_A2 = PB_8,
+    ARDUINO_UNO_A3 = PB_9,
+    ARDUINO_UNO_A4 = PB_0,
+    ARDUINO_UNO_A5 = PB_1,
 
-    D0 = PB_2,
-    D1 = PB_3,
-    D2 = PC_9,
-    D3 = PC_10,
-    D4 = PC_11,
-    D5 = PC_12,
-    D6 = PE_4,
-    D7 = PE_5,
-    D8 = PA_5,
-    D9 = PA_4,
-    D10 = PA_3,
-    D11 = PA_0,
-    D12 = PA_1,
-    D13 = PA_2,
-    D14 = PG_1,
-    D15 = PG_0,
+    ARDUINO_UNO_D0 = PB_2,
+    ARDUINO_UNO_D1 = PB_3,
+    ARDUINO_UNO_D2 = PC_9,
+    ARDUINO_UNO_D3 = PC_10,
+    ARDUINO_UNO_D4 = PC_11,
+    ARDUINO_UNO_D5 = PC_12,
+    ARDUINO_UNO_D6 = PE_4,
+    ARDUINO_UNO_D7 = PE_5,
+    ARDUINO_UNO_D8 = PA_5,
+    ARDUINO_UNO_D9 = PA_4,
+    ARDUINO_UNO_D10 = PA_3,
+    ARDUINO_UNO_D11 = PA_0,
+    ARDUINO_UNO_D12 = PA_1,
+    ARDUINO_UNO_D13 = PA_2,
+    ARDUINO_UNO_D14 = PG_1,
+    ARDUINO_UNO_D15 = PG_0,
 
     // Note: board-specific
     // UART naming
@@ -89,32 +89,20 @@ typedef enum {
 #else
     STDIO_UART_RX   = CONSOLE_RX,
 #endif
-    SERIAL_TX = D10,
-    SERIAL_RX = D13,
-
-    // I2C naming
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-
-    // LED naming
-    LED_RED = PH_0,
-    LED_YELLOW = PH_1,
-    LED_GREEN = PH_2,
-    LED1 = LED_RED,
-    LED2 = LED_YELLOW,
-    LED3 = LED_GREEN,
-    LED4 = LED1,    // No real LED. Just for passing ATS.
-
-    // Button naming
-    SW2 = PG_15,
-    SW3 = PF_11,
-    BUTTON1 = SW2,
-    BUTTON2 = SW3,
 
     // Force PinName to 32-bit required by NU_PINNAME_BIND(...)
     FORCE_ENUM_PINNAME_32BIT = 0x7FFFFFFF,
 
 } PinName;
+
+// LEDs
+#define LED1 PH_0 // Red LED
+#define LED2 PH_1 // Yellow LED
+#define LED3 PH_2 // Green LED
+
+// Buttons
+#define BUTTON1 PG_15
+#define BUTTON2 PF_11
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
@@ -69,16 +69,8 @@ typedef enum {
 
     // Note: board-specific
     // UART naming
-#if defined(MBED_CONF_TARGET_USB_UART_TX)
     CONSOLE_TX           = MBED_CONF_TARGET_USB_UART_TX,
-#else
-    CONSOLE_TX           = NC,
-#endif
-#if defined(MBED_CONF_TARGET_USB_UART_RX)
     CONSOLE_RX           = MBED_CONF_TARGET_USB_UART_RX,
-#else
-    CONSOLE_RX           = NC,
-#endif
 #if defined(MBED_CONF_TARGET_STDIO_UART_TX)
     STDIO_UART_TX   = MBED_CONF_TARGET_STDIO_UART_TX,
 #else

--- a/targets/TARGET_NUVOTON/TARGET_M480/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/i2c_api.c
@@ -313,7 +313,7 @@ int i2c_slave_receive(i2c_t *obj)
 
 int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
-    return i2c_do_tran(obj, data, length, 1, 1);
+    return i2c_do_tran(obj, data, length, 1, 0);
 }
 
 int i2c_slave_write(i2c_t *obj, const char *data, int length)
@@ -691,7 +691,6 @@ static void i2c_irq(i2c_t *obj)
         }
         obj->i2c.slaveaddr_state = ReadAddressed;
         break;
-    //case 0xA0:  // Slave Transmit Repeat Start or Stop
     case 0xC0:  // Slave Transmit Data NACK
     case 0xC8:  // Slave Transmit Last Data ACK
         obj->i2c.slaveaddr_state = NoData;
@@ -706,20 +705,26 @@ static void i2c_irq(i2c_t *obj)
         obj->i2c.slaveaddr_state = WriteAddressed;
         if ((obj->i2c.tran_ctrl & TRANCTRL_STARTED) && obj->i2c.tran_pos) {
             if (obj->i2c.tran_pos < obj->i2c.tran_end) {
+
+                // Did we receive any data? If so, receive it (if there is space in the buffer) and update tran_pos
                 if (status == 0x80 || status == 0x88) {
                     if (obj->i2c.tran_ctrl & TRANCTRL_RECVDATA) {
-                        *obj->i2c.tran_pos ++ = I2C_GET_DATA(i2c_base);
+                        if(obj->i2c.tran_pos < obj->i2c.tran_end)
+                        {
+                            *obj->i2c.tran_pos ++ = I2C_GET_DATA(i2c_base);
+                        }
+                        
                         obj->i2c.tran_ctrl &= ~TRANCTRL_RECVDATA;
                     }
                 }
 
+                // Did we NACK this byte, ending the transaction? 
                 if (status == 0x88) {
                     obj->i2c.slaveaddr_state = NoData;
                     i2c_fsm_reset(obj, I2C_CTL0_SI_Msk | I2C_CTL0_AA_Msk);
-                } else if (obj->i2c.tran_pos == obj->i2c.tran_end) {
-                    obj->i2c.tran_ctrl &= ~TRANCTRL_STARTED;
-                    i2c_disable_int(obj);
-                } else {
+                }
+                // Otherwise, tell the peripheral to receive the next byte
+                else {
                     uint32_t i2c_ctl = I2C_CTL0_SI_Msk | I2C_CTL0_AA_Msk;
                     if ((obj->i2c.tran_end - obj->i2c.tran_pos) == 1 &&
                             obj->i2c.tran_ctrl & TRANCTRL_NAKLASTDATA) {
@@ -738,7 +743,14 @@ static void i2c_irq(i2c_t *obj)
             i2c_disable_int(obj);
         }
         break;
-    //case 0xA0:  // Slave Receive Repeat Start or Stop
+
+    case 0xA0:  // Slave Operation Complete
+        // Master sent STOP condition, go back to idle state and end the operation
+        obj->i2c.slaveaddr_state = NoData;
+        i2c_fsm_reset(obj, I2C_CTL0_SI_Msk | I2C_CTL0_AA_Msk);
+        obj->i2c.tran_ctrl &= ~TRANCTRL_STARTED;
+        i2c_disable_int(obj);
+        break;
 
     // GC mode
     //case 0xA0:  // GC mode Repeat Start or Stop
@@ -903,6 +915,7 @@ uint32_t i2c_irq_handler_asynch(i2c_t *obj)
             uint8_t *rx = (uint8_t *) obj->rx_buff.buffer;
             rx[obj->rx_buff.pos ++] = I2C_GET_DATA(((I2C_T *) NU_MODBASE(obj->i2c.i2c)));
         }
+        // fall through
     case 0x40:  // Master Receive Address ACK
         I2C_SET_CONTROL_REG(i2c_base, I2C_CTL0_SI_Msk | ((obj->rx_buff.pos != obj->rx_buff.length - 1) ? I2C_CTL0_AA_Msk : 0));
         break;
@@ -915,11 +928,15 @@ uint32_t i2c_irq_handler_asynch(i2c_t *obj)
         break;
 
     case 0x58:  // Master Receive Data NACK
+
+        // We get here after the last byte was transferred in an async read. Save it into the buffer
+        // and end the transaction.
         if (obj->rx_buff.buffer && obj->rx_buff.pos < obj->rx_buff.length) {
             uint8_t *rx = (uint8_t *) obj->rx_buff.buffer;
             rx[obj->rx_buff.pos ++] = I2C_GET_DATA(((I2C_T *) NU_MODBASE(obj->i2c.i2c)));
         }
-        I2C_SET_CONTROL_REG(i2c_base, I2C_CTL0_STA_Msk | I2C_CTL0_SI_Msk);
+        I2C_SET_CONTROL_REG(i2c_base, I2C_CTL0_STO_Msk | I2C_CTL0_SI_Msk);
+        event = I2C_EVENT_TRANSFER_COMPLETE;
         break;
 
     case 0x00:  // Bus error

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8241,6 +8241,9 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "spim-ccm-enable": 1,
             "network-default-interface-type": "ETHERNET"
         },
+        "supported_form_factors": [
+            "ARDUINO_UNO"
+        ],
         "image_url": "https://os.mbed.com/media/cache/platforms/NuMaker-PFM-M487.png.250x250_q85.png"
     },
     "NUMAKER_IOT_M487": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

I am working on testing the M480 board using our [CI Test Shield](https://github.com/mbed-ce/mbed-ce-ci-shield-v2), which can do exhaustive tests of things like I2C, SPI, and PWM to ensure that they are implemented correctly. These tests are much more in-depth than the tests that ARM's CI shield did, and should be able to root out a great deal more issues.

First step was testing I2C, and the M480 was actually VERY close to passing all the tests -- I'm impressed, few boards I've tested have worked this well out of the box!

However, I did find two small issues in the I2C implementation that should be addressed:
- When doing a read with the asynchronous API, the MCU sends a repeated start at the end of the transaction instead of a stop
- When doing a slave receive, the last byte gets NACKed by the slave, which is not supposed to happen

I was able to fix these by making some tweaks to the I2C code, and now all tests pass!

#### Impact of changes <!-- Optional -->
- M480: I2C async reads no longer do a repeated start at the end
- M480: I2C slave receive no longer sends a NACK when it reaches the expected byte count
- Add ARDUINO_UNO form factor for M480 (this is required for the test shield to run)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Test shield I2C tests pass!
```
The following tests passed:
        test-testshield-i2c-basic
        test-testshield-i2c-slave-comms
        test-testshield-i2c-eeprom

100% tests passed, 0 tests failed out of 3
```

----------------------------------------------------------------------------------------------------------------
