### PR TITLE
Fix missing SYSCFG_CLK_ENABLE() for STM32H7 Ethernet

### DIFF
--- a/connectivity/drivers/emac/TARGET_STM/STM32EthMACv2.cpp
+++ b/connectivity/drivers/emac/TARGET_STM/STM32EthMACv2.cpp
@@ -254,8 +254,10 @@ namespace mbed {
         // Note: Following code is based on HAL_Eth_Init() from the HAL
         /* Init the low level hardware : GPIO, CLOCK, NVIC. */
         EthInitPinmappings();
-#ifdef TARGET_STM32H7
+
         // Use RMII
+#ifdef TARGET_STM32H7
+        __HAL_RCC_SYSCFG_CLK_ENABLE();
         HAL_SYSCFG_ETHInterfaceSelect(SYSCFG_ETH_RMII);
 
         /* Dummy read to sync with ETH */


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
I found that, with master branch of Mbed, Ethernet did not work on STM32H723. After some debugging and A/B testing, I narrowed it down to this line, which I somehow lost when porting code over from the STM32Cube HAL.

Oddly, without this line, Ethernet still manages to work on STM32H743 and H745/H747. However, it completely can't initialize on STM32H72x.

I also _suspect_ this might be related to a very intermittent issue I've been seeing on STM32H747 where Ethernet sometimes loses packets. However, I'm not totally sure.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
After re-adding this line, Ethernet is able to initialize on NUCLEO_H723ZG. Without it, it fails with a timeout while resetting the MAC (likely because the RMII clocking isn't set up correctly).

----------------------------------------------------------------------------------------------------------------
