### PR TITLE
Fix heap allocation on STM32H7Ax family

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
@@ -34,8 +34,8 @@ MEMORY
 {
     FLASH       (rx)  : ORIGIN = MBED_CONFIGURED_ROM_BANK_IROM1_START, LENGTH = MBED_CONFIGURED_ROM_BANK_IROM1_SIZE
     SRAM_DTC   (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_DTC_START + MBED_VECTTABLE_RAM_SIZE, LENGTH = MBED_RAM_BANK_SRAM_DTC_SIZE - MBED_VECTTABLE_RAM_SIZE
-    SRAM       (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_AHB_START, LENGTH = MBED_RAM_BANK_SRAM_AHB_SIZE
-    SRAM_AXI   (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_AXI_START, LENGTH = MBED_RAM_BANK_SRAM_AXI_SIZE
+    SRAM_AHB   (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_AHB_START, LENGTH = MBED_RAM_BANK_SRAM_AHB_SIZE
+    SRAM       (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_AXI_START, LENGTH = MBED_RAM_BANK_SRAM_AXI_SIZE
     SRAM_D3    (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_D3_START, LENGTH = MBED_RAM_BANK_SRAM_D3_SIZE
     SRAM_ITC   (xrw)  : ORIGIN = MBED_RAM_BANK_SRAM_ITC_START, LENGTH = MBED_RAM_BANK_SRAM_ITC_SIZE
 }
@@ -112,7 +112,7 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-    
+
     .data : AT (__etext)
     {
         __data_start__ = .;
@@ -160,7 +160,7 @@ SECTIONS
         . = ALIGN(32);
         __uninitialized_end = .;
     } > SRAM
-    
+
     .bss :
     {
         . = ALIGN(8);
@@ -211,11 +211,11 @@ SECTIONS
         __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
     } > SRAM_D3
 
-    /* Use SRAM_AXI as additional heap */
+    /* Use SRAM_AHB as additional heap */
     .heap (NOLOAD):
     {
         PROVIDE(__mbed_sbrk_start = .);
-        . += (ORIGIN(SRAM_AXI) + LENGTH(SRAM_AXI) - .);
+        . += (ORIGIN(SRAM_AHB) + LENGTH(SRAM_AHB) - .);
         PROVIDE(__mbed_krbs_start = .);
-    } > SRAM_AXI
+    } > SRAM_AHB
 }

--- a/targets/cmsis_mcu_descriptions.json5
+++ b/targets/cmsis_mcu_descriptions.json5
@@ -9381,7 +9381,7 @@
                     "write": false
                 },
                 "default": true,
-                "size": 0x20000,
+                "size": 0x200000,
                 "start": 0x08000000,
                 "startup": true
             },
@@ -11621,7 +11621,7 @@
         ],
         "sub_family": "STM32L562",
         "vendor": "STMicroelectronics:13"
-    },    
+    },
 	"STM32U083RCTx": {
         "algorithms": [
             {

--- a/targets/cmsis_mcu_descriptions.json5
+++ b/targets/cmsis_mcu_descriptions.json5
@@ -9650,7 +9650,7 @@
                     "write": false
                 },
                 "default": true,
-                "size": 0x20000,
+                "size": 0x200000,
                 "start": 0x08000000,
                 "startup": true
             },


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Use AXI SRAM for main memory and AHB SRAM for additional heap on STM32H7Ax family.
Fix wrong IROM1 size on STM32H7A3ZITxQ and STM32H7B3ZITxQ(was 128KB, should be 2MB).

After Split Heap was implemented on STM32H7, any heap allocation on STM32H7Ax family will fail with an "Out of Memory" error. Comparing the linker script of STM32H7Ax_FAMILY and STM32H743_STM32H72x_FAMILIES, I found the former script uses AHB SRAM as main memory and AXI SRAM as additional heap, but the latter one uses AXI SRAM as main memory and AHB SRAM as additional heap. The current Split Heap implementation requires the additional heap to be placed at a higher address than the main memory. Given the fact that AXI SRAM starts at 0x24000000 and AHB SRAM starts at 0x30000000, the current linker script of STM32H7Ax_FAMILY does not meet the requirement and needs to be modified.

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    Tested by calling malloc() to allocate 16KB heap memory and check if the pointer address returned by malloc is within the AXI SRAM range(0x24000000-0x240FFFFF).
    Tested on NUCLEO-H7A3ZI-Q and a custom board with STM32H7B0VB.
----------------------------------------------------------------------------------------------------------------
