### PR TITLE
Enable ICACHE, LPTICKER, TRNG and WATCHDOG for STM32H5

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H5/clock_cfg/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/clock_cfg/system_clock.c
@@ -16,7 +16,7 @@
 /**
   * This file configures the system clock as follows:
   *--------------------------------------------------------------------
-  * System clock source   | 1- USE_PLL_HSE_EXTC 
+  * System clock source   | 1- USE_PLL_HSE_EXTC
   *                       | 2- USE_PLL_HSE_XTAL
   *                       | 3- USE_PLL_HSI (internal 64 MHz clock)
   *--------------------------------------------------------------------
@@ -44,6 +44,43 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass);
 #if ((CLOCK_SOURCE) & USE_PLL_HSI)
 uint8_t SetSysClock_PLL_HSI(void);
 #endif /* ((CLOCK_SOURCE) & USE_PLL_HSI) */
+
+/**
+  * @brief  Enable ICACHE
+  * @param  None
+  * @retval None
+  */
+
+static void EnableICache()
+{
+    MPU_Attributes_InitTypeDef   attr;
+    MPU_Region_InitTypeDef       region;
+
+    /* Disable MPU before perloading and config update */
+    HAL_MPU_Disable();
+
+    /* Define cacheable memory via MPU */
+    attr.Number             = MPU_ATTRIBUTES_NUMBER5;
+    attr.Attributes         = INNER_OUTER(MPU_NOT_CACHEABLE);
+    HAL_MPU_ConfigMemoryAttributes(&attr);
+
+    /* BaseAddress-LimitAddress configuration */
+    region.Enable           = MPU_REGION_ENABLE;
+    region.Number           = MPU_REGION_NUMBER5;
+    region.AttributesIndex  = MPU_ATTRIBUTES_NUMBER5;
+    region.BaseAddress      = 0x08FFF800;
+    region.LimitAddress     = 0x08FFFFFF;
+    region.AccessPermission = MPU_REGION_ALL_RW;
+    region.DisableExec      = MPU_INSTRUCTION_ACCESS_DISABLE;
+    region.IsShareable      = MPU_ACCESS_NOT_SHAREABLE;
+    HAL_MPU_ConfigRegion(&region);
+
+    /* Enable the MPU */
+    HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
+
+    /* Enable ICACHE */
+    HAL_ICACHE_Enable();
+}
 
 /**
   * @brief  Configures the System clock source
@@ -74,6 +111,7 @@ void SetSysClock(void)
             }
         }
     }
+    EnableICache();
 }
 
 
@@ -108,7 +146,7 @@ MBED_WEAK uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
 #endif
 if(HSE_VALUE % 2000000 == 0)
 {
-    RCC_OscInitStruct.PLL.PLLM = HSE_VALUE / 2000000; // Divide down input clock to 2MHz 
+    RCC_OscInitStruct.PLL.PLLM = HSE_VALUE / 2000000; // Divide down input clock to 2MHz
     RCC_OscInitStruct.PLL.PLLN = 250; // Multiply up to 500MHz VCO clock
     RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1_VCIRANGE_1;
 }

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -266,7 +266,7 @@ void lp_ticker_init(void)
 #if defined (LPTIM_ACTIVEEDGE_FALLING)
     LptimHandle.Init.Trigger.ActiveEdge = LPTIM_ACTIVEEDGE_FALLING;
 #endif
-#if defined(TARGET_STM32U5) || defined(TARGET_STM32U0)
+#if defined(TARGET_STM32U5) || defined(TARGET_STM32H5) || defined(TARGET_STM32U0)
     LptimHandle.Init.Period = 0xFFFF;
 #endif
 #if defined (LPTIM_TRIGSAMPLETIME_DIRECTTRANSITION)

--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -88,7 +88,7 @@ void trng_init(trng_t *obj)
         }
     }
 
-#elif defined(TARGET_STM32G4) || defined(TARGET_STM32U0)
+#elif defined(TARGET_STM32G4) || defined(TARGET_STM32H5) || defined(TARGET_STM32U0)
     /* RNG and USB clocks have the same HSI48 source which has been enabled in SetSysClock */
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
 

--- a/targets/TARGET_STM/watchdog_api.c
+++ b/targets/TARGET_STM/watchdog_api.c
@@ -137,7 +137,7 @@ watchdog_features_t hal_watchdog_get_platform_features(void)
     features.clock_max_frequency = 47000;
 #elif defined(STM32F0) || defined(STM32F3)
     features.clock_max_frequency = 50000;
-#elif defined(STM32H7) || defined(STM32L4) || defined(STM32U5)
+#elif defined(STM32H7) || defined(STM32L4) || defined(STM32U5) || defined(STM32H5)
     features.clock_max_frequency = 33600;
 #elif defined(STM32G0) || defined(STM32L5) || defined(STM32G4) || defined(STM32WB) || defined(STM32WL) || defined(STM32U0)
     features.clock_max_frequency = 34000;

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3060,7 +3060,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "STM32G4A1xx"
         ]
     },
-	
+
     // STM32H5 Targets -------------------------------------------------------------------------------------------------
 	"MCU_STM32H5": {
         "inherits": [
@@ -3104,14 +3104,13 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "device_has_add": [
             "MPU",
             "ANALOGOUT",
-            "SPI_32BIT_WORDS"
+            "SPI_32BIT_WORDS",
+            "TRNG"
         ],
         "device_has_remove": [
             "FLASH",
-            "LPTICKER",
             "CAN",
-			"SERIAL_FC",
-            "WATCHDOG"
+			"SERIAL_FC"
         ],
         "is_mcu_family_target": true
     },
@@ -3193,7 +3192,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "device_name": "STM32H563ZITx",
         "image_url": "https://www.st.com/bin/ecommerce/api/image.PF274337.en.feature-description-include-personalized-no-cpn-medium.jpg"
     },
-	
+
     // STM32H7 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32H7": {
         "inherits": [
@@ -3435,7 +3434,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         ],
         "device_name": "STM32H745ZITx"
     },
-	
+
 	// These targets contain the extra bits to add to the MCU_STM32H745xI target to set it for the
 	// CM4 or CM7 core.
     "MCU_STM32H745xI_CM4": {
@@ -4894,7 +4893,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         ],
         "image_url": "https://www.st.com/bin/ecommerce/api/image.PF273876.en.feature-description-include-personalized-no-cpn-large.jpg"
     },
-  
+
     // STM32U5 Targets -------------------------------------------------------------------------------------------------
     "MCU_STM32U5": {
         "inherits": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Enables ICACHE, LPTICKER, TRNG and WATCHDOG features for the STM32H5 family.
MPU Region 5 is used to avoid hardfaults when ICACHE is enabled:
https://community.st.com/t5/stm32-mcus/how-to-avoid-a-hardfault-when-icache-is-enabled-on-the-stm32h5/ta-p/630085

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I run GreenTea tests on a NUCLEO-H563ZI board and passed the LPTICKER, TRNG and WATCHDOG tests.
The hal-sleep test failed when LPTICKER is used as wakup source from deepsleep mode, but it seems unrelated to LPTICKER itself: even if I comment out the code that setup the LPTICKER interrupt, the system will still wake up from deepsleep mode after 309 ticks. The netsocket related tests failed with Hard Faults. I'm not sure how to setup the test environments for netsocket tests or skip them.

[greentea-log-nucleo-h563zi.txt](https://github.com/user-attachments/files/20429751/greentea-log-nucleo-h563zi.txt)

----------------------------------------------------------------------------------------------------------------
