### PR TITLE
Enable CRC, FLASHIAP and CAN for STM32H5 

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H5/CMakeLists.txt
+++ b/targets/TARGET_STM/TARGET_STM32H5/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(mbed-stm32h5
     spi_api.c
     pwmout_device.c
     cache.c
+    flash_api.c
 )
 
 target_include_directories(mbed-stm32h5

--- a/targets/TARGET_STM/TARGET_STM32H5/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32H5/flash_api.c
@@ -1,0 +1,277 @@
+/* mbed Microcontroller Library
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ *
+ * Copyright (c) 2015-2020 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "flash_api.h"
+#include "platform/mbed_critical.h"
+
+#if DEVICE_FLASH
+#include "mbed_assert.h"
+#include "cmsis.h"
+#include "stdio.h"
+
+/**
+  * @brief  Gets the bank of a given address
+  * @param  Addr: Address of the FLASH Memory
+  * @retval The bank of a given address
+  */
+static uint32_t GetBank(uint32_t Addr)
+{
+    uint32_t bank = 0;
+
+    if (Addr < (FLASH_BASE + FLASH_BANK_SIZE)) {
+        bank = FLASH_BANK_1;
+    } else {
+        bank = FLASH_BANK_2;
+    }
+
+    return bank;
+}
+
+/**
+  * @brief  Gets the sector of a given address
+  * @param  Address: Flash address
+  * @retval The sector of a given address
+  */
+static uint32_t GetSector(uint32_t Address)
+{
+    uint32_t sector = 0;
+
+    if (Address < (FLASH_BASE + FLASH_BANK_SIZE)) {
+        sector = (Address - FLASH_BASE) / FLASH_SECTOR_SIZE;
+    } else {
+        sector = (Address - (FLASH_BASE + FLASH_BANK_SIZE)) / FLASH_SECTOR_SIZE;
+    }
+
+    return sector;
+}
+
+/** Initialize the flash peripheral and the flash_t object
+ *
+ * @param obj The flash object
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_init(flash_t *obj)
+{
+    return 0;
+}
+
+/** Uninitialize the flash peripheral and the flash_t object
+ *
+ * @param obj The flash object
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_free(flash_t *obj)
+{
+    return 0;
+}
+
+/** Erase one sector starting at defined address
+ *
+ * The address should be at sector boundary. This function does not do any check for address alignments
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_erase_sector(flash_t *obj, uint32_t address)
+{
+    uint32_t PAGEError = 0;
+    FLASH_EraseInitTypeDef EraseInitStruct;
+    int32_t status = 0;
+
+    if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
+        return -1;
+    }
+
+    if (HAL_ICACHE_Disable() != HAL_OK)
+    {
+        return -1;
+    }
+
+    if (HAL_FLASH_Unlock() != HAL_OK) {
+        return -1;
+    }
+
+    core_util_critical_section_enter();
+
+    /* Clear error programming flags */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+
+    /* MBED HAL erases 1 page  / sector at a time */
+    /* Fill EraseInit structure*/
+    EraseInitStruct.TypeErase   = FLASH_TYPEERASE_SECTORS;
+    EraseInitStruct.Banks       = GetBank(address);
+    EraseInitStruct.Sector      = GetSector(address);
+    EraseInitStruct.NbSectors   = 1;
+
+    /* Note: If an erase operation in Flash memory also concerns data in the data or instruction cache,
+     you have to make sure that these data are rewritten before they are accessed during code
+     execution. If this cannot be done safely, it is recommended to flush the caches by setting the
+     DCRST and ICRST bits in the FLASH_CR register. */
+
+    if (HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError) != HAL_OK) {
+        status = -1;
+    }
+
+    core_util_critical_section_exit();
+
+    if (HAL_FLASH_Lock() != HAL_OK) {
+        return -1;
+    }
+
+    if (HAL_ICACHE_Enable() != HAL_OK)
+    {
+        return -1;
+    }
+
+    return status;
+}
+
+/** Program one page starting at defined address
+ *
+ * The page should be at page boundary, should not cross multiple sectors.
+ * This function does not do any check for address alignments or if size
+ * is aligned to a page size.
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @param data The data buffer to be programmed
+ * @param size The number of bytes to program
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_program_page(flash_t *obj, uint32_t address,
+                           const uint8_t *data, uint32_t size)
+{
+    uint32_t StartAddress = 0;
+    int32_t status = 0;
+
+    if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
+        return -1;
+    }
+
+    if ((size % 16) != 0) {
+        /* H5 flash devices can only be programmed 128bits/16 bytes at a time */
+        return -1;
+    }
+
+    if (HAL_ICACHE_Disable() != HAL_OK)
+    {
+        return -1;
+    }
+
+    if (HAL_FLASH_Unlock() != HAL_OK) {
+        return -1;
+    }
+
+    /* Clear error programming flags */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+
+    /* Program the user Flash area word by word */
+    StartAddress = address;
+
+    /*  HW needs an aligned address to program flash, which data
+     *  parameters doesn't ensure  */
+    if ((uint32_t) data % 16 != 0) {
+        volatile uint64_t data128[2];
+        while ((address < (StartAddress + size)) && (status == 0)) {
+            for (uint8_t i = 0; i < 16; i++) {
+                *(((uint8_t *) data128) + i) = *(data + i);
+            }
+
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_QUADWORD, address, (uint32_t) data128)
+                    == HAL_OK) {
+                address = address + 16;
+                data = data + 16;
+            } else {
+                status = -1;
+            }
+        }
+    } else { /*  case where data is aligned, so let's avoid any copy */
+        while ((address < (StartAddress + size)) && (status == 0)) {
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_QUADWORD, address,
+                                  (uint32_t) data)
+                    == HAL_OK) {
+                address = address + 16;
+                data = data + 16;
+            } else {
+                status = -1;
+            }
+        }
+    }
+
+    if (HAL_FLASH_Lock() != HAL_OK) {
+        return -1;
+    }
+
+    if (HAL_ICACHE_Enable() != HAL_OK)
+    {
+        return -1;
+    }
+
+    return status;
+}
+
+/** Get sector size
+ *
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @return The size of a sector
+ */
+uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
+{
+    if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
+        return MBED_FLASH_INVALID_SIZE;
+    }
+    return (FLASH_SECTOR_SIZE);
+}
+
+/** Get page size
+ *
+ * @param obj The flash object
+ * @param address The page starting address
+ * @return The size of a page
+ */
+uint32_t flash_get_page_size(const flash_t *obj)
+{
+    /*  Page size is the minimum programable size, which 16 bytes */
+    return 16;
+}
+
+/** Get start address for the flash region
+ *
+ * @param obj The flash object
+ * @return The start address for the flash region
+ */
+uint32_t flash_get_start_address(const flash_t *obj)
+{
+    return FLASH_BASE;
+}
+
+/** Get the flash region size
+ *
+ * @param obj The flash object
+ * @return The flash region size
+ */
+uint32_t flash_get_size(const flash_t *obj)
+{
+    return FLASH_SIZE;
+}
+
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
+#endif

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3105,12 +3105,13 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "MPU",
             "ANALOGOUT",
             "SPI_32BIT_WORDS",
-            "TRNG"
+            "TRNG",
+            "FLASH",
+            "CAN",
+            "CRC"
         ],
         "device_has_remove": [
-            "FLASH",
             "LPTICKER",
-            "CAN",
 			"SERIAL_FC"
         ],
         "is_mcu_family_target": true


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Enables CRC, FLASHIAP and CAN features for the STM32H5 family.

This PR passed the CRC and FLASHIAP Greentea tests on NUCLEO-H563ZI.

The CAN part was tested using a modified "CAN hello, world" program that uses CAN1 to send data frames to CAN2 on the same board, and verify the id, length and content of the received frames. The test was done on a custom STM32H563VI board and also on a custom STM32H723ZG board with two external TJA1050 modules, in three baud rates(250kbps, 500kbps, 1Mbps) and two frame formats(Standard and Extended). STM32H7 is affected by this PR because it fixed the wrong values used in the DataLength field of FDCAN_TxHeaderTypeDef structs(The FDCAN data length code values are different in the H5, H7, U5 series and in the L5, G0, G4 series). 

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
[test-results.txt](https://github.com/user-attachments/files/20852855/test-results.txt)

  
----------------------------------------------------------------------------------------------------------------
