### PR TITLE
Fix UART Hang on Apollo3, fix a few other test issues

### DIFF
--- a/features/frameworks/unity/source/unity.c
+++ b/features/frameworks/unity/source/unity.c
@@ -1240,6 +1240,7 @@ void UnitySkipPrint(const char* msg, const UNITY_LINE_TYPE line)
       UNITY_OUTPUT_CHAR(' ');
       UnityPrint(msg);
     }
+    UNITY_OUTPUT_CHAR('\n');
 }
 
 /*-----------------------------------------------*/

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/PeripheralPins.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/PeripheralPins.c
@@ -312,3 +312,68 @@ const PinMap PinMap_PWM_OUT[] = {
 
     {NC, NC, 0}
 };
+
+/************ GPIO ***************/
+
+// Note that this is only used for testing, so that the test knows what are valid GPIO pins.
+// It's not used in normal usage.
+// Also, only the "pin" field is significant here. Other fields are don't cares.
+
+const PinMap PinMap_GPIO[] = {
+    {IO_0, 0, 0},
+    {IO_1, 0, 0},
+    {IO_2, 0, 0},
+    {IO_3, 0, 0},
+    {IO_4, 0, 0},
+    {IO_5, 0, 0},
+    {IO_6, 0, 0},
+    {IO_7, 0, 0},
+    {IO_8, 0, 0},
+    {IO_9, 0, 0},
+    {IO_10, 0, 0},
+    {IO_11, 0, 0},
+    {IO_12, 0, 0},
+    {IO_13, 0, 0},
+    {IO_14, 0, 0},
+    {IO_15, 0, 0},
+    {IO_16, 0, 0},
+    {IO_17, 0, 0},
+    {IO_18, 0, 0},
+    {IO_19, 0, 0},
+    {IO_20, 0, 0},
+    {IO_21, 0, 0},
+    {IO_22, 0, 0},
+    {IO_23, 0, 0},
+    {IO_24, 0, 0},
+    {IO_25, 0, 0},
+    {IO_26, 0, 0},
+    {IO_27, 0, 0},
+    {IO_28, 0, 0},
+    {IO_29, 0, 0},
+    {IO_39, 0, 0},
+    {IO_40, 0, 0},
+    {IO_41, 0, 0},
+    {IO_44, 0, 0},
+    {IO_47, 0, 0},
+    {IO_48, 0, 0},
+    {IO_49, 0, 0},
+
+    // Apollo3 I/O pins - BGA package only
+    {IO_30, 0, 0},
+    {IO_31, 0, 0},
+    {IO_32, 0, 0},
+    {IO_33, 0, 0},
+    {IO_34, 0, 0},
+    {IO_35, 0, 0},
+    {IO_36, 0, 0},
+    {IO_37, 0, 0},
+    {IO_38, 0, 0},
+    {IO_42, 0, 0},
+    {IO_43, 0, 0},
+    {IO_45, 0, 0},
+    {IO_46, 0, 0},
+
+    {NC, NC, 0}
+};
+
+

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/PeripheralPins.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/PeripheralPins.h
@@ -23,6 +23,7 @@
 #include "pinmap.h"
 #include "PeripheralNames.h"
 
+
 //*** I2C ***
 #if DEVICE_I2C
 extern const PinMap PinMap_I2C_SDA[];
@@ -69,5 +70,7 @@ extern const PinMap PinMap_QSPI_DATA1[];
 extern const PinMap PinMap_QSPI_DATA2[];
 extern const PinMap PinMap_QSPI_DATA3[];
 #endif
+
+extern const PinMap PinMap_GPIO[];
 
 #endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -23,6 +23,7 @@
 
 #include "mbed_assert.h"
 #include "gpio_api.h"
+#include "PeripheralPins.h"
 
 /** Set the given pin as GPIO
  *
@@ -224,6 +225,5 @@ int gpio_read(gpio_t *obj)
  */
 const PinMap *gpio_pinmap(void)
 {
-    MBED_ASSERT(false);
-    return NULL;
+    return PinMap_GPIO;
 }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -3594,7 +3594,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         // DISCO_H747I's attributes.
         "inherits": [
             "MCU_STM32H747xI_CM7",
-            "DISCO_H747"
+            "DISCO_H747I"
         ]
     },
     "DISCO_H747I_CM4": {

--- a/tools/cmake/mbed_target_functions.cmake
+++ b/tools/cmake/mbed_target_functions.cmake
@@ -187,9 +187,7 @@ function(mbed_set_post_build target)
         mbed_post_build_function(${target})
     endif()
 
-    if(HAVE_MEMAP_DEPS)
-        mbed_generate_map_file(${target})
-    endif()
+    mbed_generate_map_file(${target})
 
     # Give chance to adjust MBED_UPLOAD_LAUNCH_COMMANDS or MBED_UPLOAD_RESTART_COMMANDS
     # for debug launch


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
- Testing with the CI shield, I observed that my Apollo3 board was infinite hanging in an interrupt handler when starting the UART test.
- After some messing around, I figured out that this was due to the test activating the UART lines in hardware after constructing the BufferedSerial object. This was causing a digital glitch on the Rx line, which, well, took out the Apollo3 implementation.
    - I put more info in a comment but basically the hardware is behaving weirdly and it's not documented so I can't say whether this is expected behavior.
- Also added a GPIO pinmap so that the arduino uno pinmap test will pass
- Also fixed another issue with test skipping 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- Apollo3 bug that caused an infinite hang from noise on the Rx line should be fixed
- Skipped tests will now be printed by the test runner and should be detected by the test run parser

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
The UART CI shield test, well, _nearly_ passes now. Not entirely sure what's going on at 921600 baud and I don't have an O-scope handy to check the analog signal. But everything else looks good.

```
13: [+2686ms][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed
13: [+2698ms][CONN][INF] found KV pair in stream: {{__sync;bd3126fd-d433-4b82-abf8-c2514d612ba5}}, queued...
13: [+2698ms][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
13: [+2698ms][CONN][INF] found KV pair in stream: {{__timeout;30}}, queued...
13: [+2698ms][CONN][INF] found KV pair in stream: {{__host_test_name;uart_test}}, queued...
13: [+2698ms][CONN][RXD] >>> Running 11 test cases...
13: [+2698ms][CONN][INF] found SYNC in stream: {{__sync;bd3126fd-d433-4b82-abf8-c2514d612ba5}} it is #0 sent, queued...
13: [+5397ms][HTST][INF] sync KV found, uuid=bd3126fd-d433-4b82-abf8-c2514d612ba5, timestamp=1753427577.923987
13: [+5397ms][HTST][INF] DUT greentea-client version: 1.3.0
13: [+5397ms][HTST][INF] setting timeout to: 30 sec
13: [+5397ms][HTST][INF] host test class: '<class 'uart_test.UARTHostTest'>'
13: [+2709ms][CONN][INF] found KV pair in stream: {{__testcase_name;Send test string from MCU once (1200 baud)}}, queued...
13: [+2709ms][CONN][INF] found KV pair in stream: {{__testcase_name;Receive test string from PC once (1200 baud)}}, queued...
13: [+2721ms][CONN][INF] found KV pair in stream: {{__testcase_name;Send test string from MCU once (9600 baud)}}, queued...
13: [+2721ms][CONN][INF] found KV pair in stream: {{__testcase_name;Receive test string from PC once (9600 baud)}}, queued...
13: [+2732ms][CONN][INF] found KV pair in stream: {{__testcase_name;Send test string from MCU once (115200 baud)}}, queued...
13: [+2743ms][CONN][INF] found KV pair in stream: {{__testcase_name;Receive test string from PC once (115200 baud)}}, queued...
13: [+2743ms][CONN][INF] found KV pair in stream: {{__testcase_name;Send test string from MCU once (921600 baud)}}, queued...
13: [+2754ms][CONN][INF] found KV pair in stream: {{__testcase_name;Receive test string from PC once (921600 baud)}}, queued...
13: [+2754ms][CONN][INF] found KV pair in stream: {{__testcase_name;Send test string from MCU once (3000000 baud)}}, queued...
13: [+2766ms][CONN][INF] found KV pair in stream: {{__testcase_name;Receive test string from PC once (3000000 baud)}}, queued...
13: [+2777ms][CONN][INF] found KV pair in stream: {{__testcase_name;Handle Junk on Serial Rx Line}}, queued...
13: [+2777ms][CONN][RXD] 
13: [+2777ms][CONN][RXD] >>> Running case #1: 'Send test string from MCU once (1200 baud)'...
13: [+2788ms][CONN][INF] found KV pair in stream: {{__testcase_start;Send test string from MCU once (1200 baud)}}, queued...
13: [+2788ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;1200}}, queued...
13: [+5507ms][TEST][INF] UART Test host test setup complete.
13: [+5507ms][HTST][INF] host test setup() call...
13: [+5507ms][HTST][INF] CALLBACKs updated
13: [+5507ms][HTST][INF] host test detected: uart_test
13: [+2820ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+3573ms][CONN][INF] found KV pair in stream: {{verify_repeated_test_string;1}}, queued...
13: [+3584ms][SERI][TXD] {{verify_repeated_test_string;complete}}
13: [+3606ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Send test string from MCU once (1200 baud);1;0}}, queued...
13: [+3606ms][CONN][RXD] >>> 'Send test string from MCU once (1200 baud)': 1 passed, 0 failed
13: [+3606ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+3606ms][CONN][RXD]
13: [+3618ms][CONN][RXD] >>> Running case #2: 'Receive test string from PC once (1200 baud)'...
13: [+3629ms][CONN][INF] found KV pair in stream: {{__testcase_start;Receive test string from PC once (1200 baud)}}, queued...
13: [+3629ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;1200}}, queued...
13: [+3640ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+3653ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+3665ms][SERI][TXD] {{send_test_string;started}}
13: [+4085ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Receive test string from PC once (1200 baud);1;0}}, queued...
13: [+4086ms][CONN][RXD] >>> 'Receive test string from PC once (1200 baud)': 1 passed, 0 failed
13: [+4098ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4098ms][CONN][RXD]
13: [+4099ms][CONN][RXD] >>> Running case #3: 'Send test string from MCU once (9600 baud)'...
13: [+4099ms][CONN][INF] found KV pair in stream: {{__testcase_start;Send test string from MCU once (9600 baud)}}, queued...
13: [+4109ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;9600}}, queued...
13: [+4121ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4228ms][CONN][INF] found KV pair in stream: {{verify_repeated_test_string;1}}, queued...
13: [+4239ms][SERI][TXD] {{verify_repeated_test_string;complete}}
13: [+4262ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Send test string from MCU once (9600 baud);1;0}}, queued...
13: [+4262ms][CONN][RXD] >>> 'Send test string from MCU once (9600 baud)': 1 passed, 0 failed
13: [+4262ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4262ms][CONN][RXD]
13: [+4274ms][CONN][RXD] >>> Running case #4: 'Receive test string from PC once (9600 baud)'...
13: [+4285ms][CONN][INF] found KV pair in stream: {{__testcase_start;Receive test string from PC once (9600 baud)}}, queued...
13: [+4286ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;9600}}, queued...
13: [+4298ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4308ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+4320ms][SERI][TXD] {{send_test_string;started}}
13: [+4442ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Receive test string from PC once (9600 baud);1;0}}, queued...
13: [+4442ms][CONN][RXD] >>> 'Receive test string from PC once (9600 baud)': 1 passed, 0 failed
13: [+4442ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4442ms][CONN][RXD]
13: [+4453ms][CONN][RXD] >>> Running case #5: 'Send test string from MCU once (115200 baud)'...
13: [+4453ms][CONN][INF] found KV pair in stream: {{__testcase_start;Send test string from MCU once (115200 baud)}}, queued...
13: [+4465ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;115200}}, queued...
13: [+4476ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4497ms][CONN][INF] found KV pair in stream: {{verify_repeated_test_string;1}}, queued...
13: [+4509ms][SERI][TXD] {{verify_repeated_test_string;complete}}
13: [+4530ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Send test string from MCU once (115200 baud);1;0}}, queued...
13: [+4530ms][CONN][RXD] >>> 'Send test string from MCU once (115200 baud)': 1 passed, 0 failed
13: [+4541ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4541ms][CONN][RXD]
13: [+4542ms][CONN][RXD] >>> Running case #6: 'Receive test string from PC once (115200 baud)'...
13: [+4555ms][CONN][INF] found KV pair in stream: {{__testcase_start;Receive test string from PC once (115200 baud)}}, queued...
13: [+4555ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;115200}}, queued...
13: [+4568ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4578ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+4590ms][SERI][TXD] {{send_test_string;started}}
13: [+4611ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Receive test string from PC once (115200 baud);1;0}}, queued...
13: [+4611ms][CONN][RXD] >>> 'Receive test string from PC once (115200 baud)': 1 passed, 0 failed
13: [+4622ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4622ms][CONN][RXD]
13: [+4622ms][CONN][RXD] >>> Running case #7: 'Send test string from MCU once (921600 baud)'...
13: [+4634ms][CONN][INF] found KV pair in stream: {{__testcase_start;Send test string from MCU once (921600 baud)}}, queued...
13: [+4634ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;921600}}, queued...
13: [+4645ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4656ms][CONN][INF] found KV pair in stream: {{verify_repeated_test_string;1}}, queued...
13: [+4668ms][SERI][TXD] {{verify_repeated_test_string;complete}}
13: [+4689ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Send test string from MCU once (921600 baud);1;0}}, queued...
13: [+4689ms][CONN][RXD] >>> 'Send test string from MCU once (921600 baud)': 1 passed, 0 failed
13: [+4701ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4701ms][CONN][RXD]
13: [+4701ms][CONN][RXD] >>> Running case #8: 'Receive test string from PC once (921600 baud)'...
13: [+4712ms][CONN][INF] found KV pair in stream: {{__testcase_start;Receive test string from PC once (921600 baud)}}, queued...
13: [+4712ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;921600}}, queued...
13: [+4723ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4734ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+4745ms][SERI][TXD] {{send_test_string;started}}
13: [+4767ms][CONN][RXD] Receive timed out after 2030ms, only received 18 chars.
13: [+4767ms][CONN][RXD] <greentea test suite>:144::FAIL: Receive timed out
13: [+4779ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Receive test string from PC once (921600 baud);0;1}}, queued...
13: [+4779ms][CONN][RXD] >>> 'Receive test string from PC once (921600 baud)': 0 passed, 1 failed with reason 'Test Cases Failed'
13: [+4779ms][CONN][RXD]
13: [+4790ms][CONN][RXD] 
13: [+4790ms][CONN][RXD] >>> Running case #9: 'Send test string from MCU once (3000000 baud)'...
13: [+4801ms][CONN][INF] found KV pair in stream: {{__testcase_start;Send test string from MCU once (3000000 baud)}}, queued...
13: [+4801ms][CONN][RXD] <greentea test suite>:83::SKIP: Baudrate unsupported
13: [+4812ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Send test string from MCU once (3000000 baud);1;0}}, queued...
13: [+4812ms][CONN][RXD] >>> 'Send test string from MCU once (3000000 baud)': 1 passed, 0 failed
13: [+4823ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4824ms][CONN][RXD]
13: [+4824ms][CONN][RXD] >>> Running case #10: 'Receive test string from PC once (3000000 baud)'...
13: [+4834ms][CONN][INF] found KV pair in stream: {{__testcase_start;Receive test string from PC once (3000000 baud)}}, queued...
13: [+4834ms][CONN][RXD] <greentea test suite>:103::SKIP: Baudrate unsupported
13: [+4845ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Receive test string from PC once (3000000 baud);1;0}}, queued...
13: [+4856ms][CONN][RXD] >>> 'Receive test string from PC once (3000000 baud)': 1 passed, 0 failed
13: [+4856ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+4856ms][CONN][RXD]
13: [+4868ms][CONN][RXD] >>> Running case #11: 'Handle Junk on Serial Rx Line'...
13: [+4868ms][CONN][INF] found KV pair in stream: {{__testcase_start;Handle Junk on Serial Rx Line}}, queued...
13: [+4868ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;9600}}, queued...
13: [+4880ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4891ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+4902ms][SERI][TXD] {{send_test_string;started}}
13: [+4966ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;921600}}, queued...
13: [+4977ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+4988ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+4999ms][SERI][TXD] {{send_test_string;started}}
13: [+5010ms][CONN][RXD] UART received 139 junk chars
13: [+5021ms][CONN][INF] found KV pair in stream: {{setup_port_at_baud;115200}}, queued...
13: [+5033ms][SERI][TXD] {{setup_port_at_baud;complete}}
13: [+5044ms][CONN][INF] found KV pair in stream: {{send_test_string;1}}, queued...
13: [+5056ms][SERI][TXD] {{send_test_string;started}}
13: [+5066ms][CONN][INF] found KV pair in stream: {{__testcase_finish;Handle Junk on Serial Rx Line;1;0}}, queued...
13: [+5077ms][CONN][RXD] >>> 'Handle Junk on Serial Rx Line': 1 passed, 0 failed
13: [+5077ms][CONN][RXD] <greentea test suite>:0::PASS
13: [+5077ms][CONN][RXD]
13: [+5088ms][CONN][RXD] >>> Test cases: 10 passed, 1 failed with reason 'Test Cases Failed'
13: [+5089ms][CONN][RXD] >>> TESTS FAILED!
13: [+5089ms][CONN][RXD]
13: [+5089ms][CONN][RXD] -----------------------
13: [+5089ms][CONN][RXD] 0 Tests 1 Failures 0 Ignored
13: [+5100ms][CONN][RXD] FAIL
13: [+5100ms][CONN][INF] found KV pair in stream: {{__testcase_summary;10;1}}, queued...
13: [+5100ms][CONN][INF] found KV pair in stream: {{end;failure}}, queued...
13: [+5100ms][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
13: [+7800ms][HTST][INF] __exit(0)
```

----------------------------------------------------------------------------------------------------------------
