### PR TITLE
LPC1768: Add open drain pull up / pull down / etc modes

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC17XX/TARGET_MBED_LPC1768/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC17XX/TARGET_MBED_LPC1768/PinNames.h
@@ -122,12 +122,18 @@ typedef enum {
 #define I2C_SDA I2C_SDA2
 
 typedef enum {
-    PullUp = 0,
-    PullDown = 3,
-    PullNone = 2,
-    Repeater = 1,
-    OpenDrain = 4,
-    PullDefault = PullDown
+    PullUp = 0, ///< Pull up to VDD with internal resistor of between 59kOhm and 333kOhm. This is the default mode.
+    PullDown = 3, ///< Pull down to GND with internal resistor of between 33kOhm and 500kOhm.
+    PullNone = 2, ///< High impedance, no pull up or pull down
+    Repeater = 1, ///< AKA "keeper" mode. This keeps the pin in the current logic level state (high or low) to prevent it from floating
+
+    OpenDrain = 4,///< Open drain mode with pull-up (default)
+    OpenDrainPullUp = OpenDrain,
+    OpenDrainPullDown = OpenDrain | PullDown, ///< Open-drain mode with pull down
+    OpenDrainNoPull = OpenDrain | PullNone, ///< Open-drain mode with no pullup/pulldown
+    OpenDrainRepeater = OpenDrain | PullNone, ///< Open-drain mode with repeater/keeper
+
+    PullDefault = PullUp
 } PinMode;
 
 // version of PINCON_TypeDef using register arrays


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR adds support on LPC1768 for all four versions of the open drain pin mode: pullup, pulldown, no pull, and repeater/keeper. I noticed while working on a new test that this was not supported in Mbed but did exist in the hardware, so I went ahead and added it.

This also fixes a minor bug: setting the pin mode to open drain did not set the bits in the PINCON register, so if you set a pin to pull down and then set it to open drain, it would end up as open drain with pull down instead of the usual open drain with pull up.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

- `OpenDrainPullUp`, `OpenDrainPullDown`, `OpenDrainNoPull`, and `OpenDrainRepeater` constants added for LPC1768
- Bug fixed where setting `OpenDrain` pin mode did not have consistent behavior if the pin had been set to something other than PullUp previously
- `PullDefault` constant fixed (default pull mode on LPC1768 is pull up)

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Working on it...

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Added a new CI shield test, and it passes! https://github.com/mbed-ce/mbed-ce-test-tools/blob/fcb34c8adba751dfbefb49b3cfc941ac2b9c5e1e/CI-Shield-Tests/DigitalIOTest.cpp#L89

----------------------------------------------------------------------------------------------------------------
