### PR TITLE
Apollo3: Simplify and standardize pin modes

### DIFF
--- a/platform/source/mbed_board.c
+++ b/platform/source/mbed_board.c
@@ -31,6 +31,7 @@ WEAK MBED_NORETURN void mbed_die(void)
 
 #ifdef LED1
     gpio_t led_err;
+    memset(&led_err, 0, sizeof(gpio_t));
     gpio_init_out(&led_err, LED1);
 #endif
 

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -25,6 +25,8 @@
 #include "gpio_api.h"
 #include "PeripheralPins.h"
 
+#include <string.h>
+
 /** Set the given pin as GPIO
  *
  * @param pin The pin to be set as GPIO
@@ -55,6 +57,7 @@ int gpio_is_connected(const gpio_t *obj)
 void gpio_init(gpio_t *obj, PinName pin)
 {
     MBED_ASSERT(obj != NULL);
+    memset(obj, 0, sizeof(gpio_t));
     obj->pad = (ap3_uart_pad_t)pin;
     return;
 }
@@ -66,94 +69,50 @@ void gpio_init(gpio_t *obj, PinName pin)
 void gpio_mode(gpio_t *obj, PinMode mode)
 {
     MBED_ASSERT(gpio_is_connected(obj));
-    MBED_ASSERT(mode < (PinMode)PinModeElements);
     am_hal_gpio_pincfg_allow_t pinConfigBools = {0};
 
     obj->cfg.uFuncSel = AP3_PINCFG_FUNCSEL_GPIO; // gpio
 
-    if (mode & (PinMode)PowerSwNone) {
-        obj->cfg.ePowerSw = AM_HAL_GPIO_PIN_POWERSW_NONE;
-        pinConfigBools.ePowerSw = true;
-    }
-    if (mode & (PinMode)PowerSwVDD) {
-        obj->cfg.ePowerSw = AM_HAL_GPIO_PIN_POWERSW_VDD;
-        pinConfigBools.ePowerSw = true;
-    }
-    if (mode & (PinMode)PowerSwVSS) {
-        obj->cfg.ePowerSw = AM_HAL_GPIO_PIN_POWERSW_VSS;
-        pinConfigBools.ePowerSw = true;
-    }
+    // Configure pull-up or pull-down
+    pinConfigBools.ePullup = true;
 
-    if (mode & (PinMode)PullNone) {
+    if(!(mode & OpenDrain) && obj->isOutput) {
+        // Push-pull output, do not allow pullup
         obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_NONE;
-        pinConfigBools.ePullup = true;
     }
-    if (mode & (PinMode)PullUp) {
-        obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_WEAK;
-        pinConfigBools.ePullup = true;
+    else if (mode & (PinMode)PullUp) {
+        MBED_ASSERT(obj->pad != IO_20); // pullup not supported on IO 20
+
+        if(obj->pad == IO_0 || obj->pad == IO_1 || obj->pad == IO_5 || obj->pad == IO_6 || obj->pad == IO_8 
+            || obj->pad == IO_9 || obj->pad == IO_25 || obj->pad == IO_27 || obj->pad == IO_39 || 
+            obj->pad == IO_40 || obj->pad == IO_42 || obj->pad == IO_43 || obj->pad == IO_48 || obj->pad == IO_49) {
+            // These pads (with I2C support) need a different constant to get the same resistance
+            obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_24K;
+        }
+        else{
+            obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_WEAK;
+        }
     }
-    if (mode & (PinMode)PullDown) {
+    else if (mode & (PinMode)PullDown) {
+        MBED_ASSERT(obj->pad == IO_20); // pulldown only supported on IO 20
         obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLDOWN;
-        pinConfigBools.ePullup = true;
+    }
+    else {
+        obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_NONE;
     }
 
-    if (mode & (PinMode)DriveStrength2mA) {
-        obj->cfg.eDriveStrength = AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA;
-        pinConfigBools.eDriveStrength = true;
+    // Configure output type
+    obj->openDrain = mode & OpenDrain;
+    pinConfigBools.eGPOutcfg = true;
+    if(obj->isOutput) {
+        obj->cfg.eGPOutcfg = obj->openDrain ? AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN : AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL;
     }
-    if (mode & (PinMode)DriveStrength4mA) {
-        obj->cfg.eDriveStrength = AM_HAL_GPIO_PIN_DRIVESTRENGTH_4MA;
-        pinConfigBools.eDriveStrength = true;
-    }
-    if (mode & (PinMode)DriveStrength8mA) {
-        obj->cfg.eDriveStrength = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA;
-        pinConfigBools.eDriveStrength = true;
-    }
-    if (mode & (PinMode)DriveStrength12mA) {
-        obj->cfg.eDriveStrength = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA;
-        pinConfigBools.eDriveStrength = true;
-    }
-
-    if (mode & (PinMode)OutDisable) {
+    else {
         obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_DISABLE;
-        pinConfigBools.eGPOutcfg = true;
-    }
-    if (mode & (PinMode)OutPushPull) {
-        obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL;
-        pinConfigBools.eGPOutcfg = true;
-    }
-    if (mode & (PinMode)OutOpenDrain) {
-        obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN;
-        pinConfigBools.eGPOutcfg = true;
-    }
-    if (mode & (PinMode)OutTristate) {
-        obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_TRISTATE;
-        pinConfigBools.eGPOutcfg = true;
     }
 
-    if (mode & (PinMode)InAuto) {
-        obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_AUTO;
-        pinConfigBools.eGPInput = true;
-    }
-    if (mode & (PinMode)InNone) {
-        obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_NONE;
-        pinConfigBools.eGPInput = true;
-    }
-    if (mode & (PinMode)InEnable) {
-        obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_ENABLE;
-        pinConfigBools.eGPInput = true;
-    }
 
-    if (mode & (PinMode)ReadPin) {
-        obj->cfg.eGPRdZero = AM_HAL_GPIO_PIN_RDZERO_READPIN;
-        pinConfigBools.eGPRdZero = true;
-    }
-    if (mode & (PinMode)ReadZero) {
-        obj->cfg.eGPRdZero = AM_HAL_GPIO_PIN_RDZERO_ZERO;
-        pinConfigBools.eGPRdZero = true;
-    }
-
-    ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools); //padRegMsk.byte, GPConfigMsk.byte, padAltCfgMsk.byte); // apply configuration
+    MBED_ASSERT(ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools) == AM_HAL_STATUS_SUCCESS);
 }
 
 /** Set the pin direction
@@ -167,23 +126,33 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
     MBED_ASSERT(direction < (PinDirection)PIN_DIR_ELEMENTS);
     am_hal_gpio_pincfg_allow_t pinConfigBools= {0};
 
+    // Always enable the input on the pin, so that we can read it if it is open drain.
+    pinConfigBools.eGPInput = true;
+    pinConfigBools.eGPRdZero = true;
+    obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_ENABLE;
+    obj->cfg.eGPRdZero = AM_HAL_GPIO_PIN_RDZERO_READPIN;
+
     if (direction == (PinDirection)PIN_INPUT) {
-        obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_ENABLE;
-        pinConfigBools.eGPInput = true;
+        obj->isOutput = false;
         obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_DISABLE;
         pinConfigBools.eGPOutcfg = true;
     } else if (direction == (PinDirection)PIN_OUTPUT) {
-        obj->cfg.eGPOutcfg = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL;
+        obj->isOutput = true;
+        obj->cfg.eGPOutcfg = obj->openDrain ? AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN : AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL;
         pinConfigBools.eGPOutcfg = true;
         obj->cfg.eDriveStrength = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA;
         pinConfigBools.eDriveStrength = true;
-        obj->cfg.eGPInput = AM_HAL_GPIO_PIN_INPUT_NONE;
-        pinConfigBools.eGPInput = true;
+
+        // Clear any configured pullup if set to open-drain
+        if(!obj->openDrain) {
+            pinConfigBools.ePullup = true;
+            obj->cfg.ePullup = AM_HAL_GPIO_PIN_PULLUP_NONE;
+        }
     } else {
         MBED_ASSERT(false);
     }
 
-    ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools); //padRegMsk.byte, GPConfigMsk.byte, padAltCfgMsk.byte); // apply configuration
+    ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools);
 }
 
 /** Set the output value
@@ -205,12 +174,8 @@ void gpio_write(gpio_t *obj, int value)
 int gpio_read(gpio_t *obj)
 {
     MBED_ASSERT(gpio_is_connected(obj));
-    uint32_t ui32BaseAddr = (obj->pad) / 8;
-    uint32_t ui32BaseShift = (((obj->pad) % 8) * 4) + 1;
-    uint8_t output = ((AM_REGVAL(&GPIO->CFGA + ui32BaseAddr) >> ui32BaseShift) & 0x03);
 
-    return (output) ? (int)am_hal_gpio_output_read(obj->pad) : (int)am_hal_gpio_input_read(obj->pad);
-    return 0;
+    return am_hal_gpio_input_read(obj->pad);
 }
 
 /** Get the pins that support all GPIO tests

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -25,8 +25,6 @@
 #include "gpio_api.h"
 #include "PeripheralPins.h"
 
-#include <string.h>
-
 /** Set the given pin as GPIO
  *
  * @param pin The pin to be set as GPIO

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -57,7 +57,6 @@ int gpio_is_connected(const gpio_t *obj)
 void gpio_init(gpio_t *obj, PinName pin)
 {
     MBED_ASSERT(obj != NULL);
-    memset(obj, 0, sizeof(gpio_t));
     obj->pad = (ap3_uart_pad_t)pin;
     return;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
@@ -54,9 +54,9 @@ typedef enum {
     PullDown = 1 << 1,
 
     OpenDrain = 1 << 2,
-    OpenDrainPullUp = OpenDrain | PullUp, ///< Open-drain mode with pull up
-    OpenDrainPullDown = OpenDrain | PullDown, ///< Open-drain mode with pull down
-    OpenDrainNoPull = OpenDrain, ///< Open-drain mode with no pullup/pulldown
+    OpenDrainPullUp = OpenDrain | PullUp, ///< Open-drain mode with pull up. Supported on all IOs except IO 20.
+    OpenDrainPullDown = OpenDrain | PullDown, ///< Open-drain mode with pull down. Only supported on IO 20.
+    OpenDrainNoPull = OpenDrain, ///< Open-drain mode with no pullup/pulldown. Supported on all IOs.
 
     PullDefault = PullNone
 } PinMode;

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
@@ -64,8 +64,8 @@ typedef enum {
 typedef struct _gpio_t {
     ap3_gpio_pad_t pad;
     am_hal_gpio_pincfg_t cfg;
-    bool openDrain;
-    bool isOutput;
+    bool openDrain; ///< Whether the pin is configured open drain as of the last gpio_mode() call
+    bool isOutput; ///< Whether the pin is configured as an output as of the last gpio_dir() call
 } gpio_t;
 
 typedef struct ap3_gpio_irq_control_t {

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects_gpio.h
@@ -43,78 +43,29 @@ typedef enum {
     PIN_DIR_ELEMENTS
 } PinDirection;
 
-enum sPinMode {
-    sPowerSwNone = 0x00,
-    sPowerSwVDD,
-    sPowerSwVSS,
-    sPullNone,
-    sPullUp,
-    sPullDown,
-    sPullUp1K5,
-    sPullUp6K,
-    sPullUp12K,
-    sPullUp24K,
-    sDriveStrength2mA,
-    sDriveStrength4mA,
-    sDriveStrength8mA,
-    sDriveStrength12mA,
-    sOutDisable,
-    sOutPushPull,
-    sOutOpenDrain,
-    sOutTristate,
-    sInAuto,
-    sInNone,
-    sInEnable,
-    sReadPin,
-    sReadZero,
-
-    sPinModeElements
-};
-
-#define PinModeEntry(e) e = (1 << s##e)
-
 typedef enum {
-    PinModeEntry(PowerSwNone),
-    PinModeEntry(PowerSwVDD),
-    PinModeEntry(PowerSwVSS),
-    PowerSwDefault = PowerSwNone,
 
-    PinModeEntry(PullNone),
-    PinModeEntry(PullUp),
-    PinModeEntry(PullDown),
-    PinModeEntry(PullUp1K5),
-    PinModeEntry(PullUp6K),
-    PinModeEntry(PullUp12K),
-    PinModeEntry(PullUp24K),
-    PullDefault = PullNone,
+    PullNone = 0,
 
-    PinModeEntry(DriveStrength2mA),
-    PinModeEntry(DriveStrength4mA),
-    PinModeEntry(DriveStrength8mA),
-    PinModeEntry(DriveStrength12mA),
-    DriveStrengthDefault = DriveStrength12mA,
+    // Supported on all IOs except IO 20. Actual resistance 13-27kOhm
+    PullUp = 1 << 0,
 
-    PinModeEntry(OutDisable),
-    PinModeEntry(OutPushPull),
-    PinModeEntry(OutOpenDrain),
-    PinModeEntry(OutTristate),
-    OutDefault = OutPushPull,
+    // Only supported on IO 20, Actual resistance 26-40kOhm
+    PullDown = 1 << 1,
 
-    PinModeEntry(InAuto),
-    PinModeEntry(InNone),
-    PinModeEntry(InEnable),
-    InDefault = InEnable,
+    OpenDrain = 1 << 2,
+    OpenDrainPullUp = OpenDrain | PullUp, ///< Open-drain mode with pull up
+    OpenDrainPullDown = OpenDrain | PullDown, ///< Open-drain mode with pull down
+    OpenDrainNoPull = OpenDrain, ///< Open-drain mode with no pullup/pulldown
 
-    PinModeEntry(ReadPin),
-    PinModeEntry(ReadZero),
-    ReadDefault = ReadPin,
-
-    PinModeEntry(PinModeElements)
+    PullDefault = PullNone
 } PinMode;
 
 typedef struct _gpio_t {
     ap3_gpio_pad_t pad;
     am_hal_gpio_pincfg_t cfg;
+    bool openDrain;
+    bool isOutput;
 } gpio_t;
 
 typedef struct ap3_gpio_irq_control_t {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR simplifies and standardizes the PinMode enum on Apollo3. Previously, this enum contained every possible pin setting it was possible to set on the device, even ones that didn't really make sense (e.g. disabling the input so it reads as 0). Now, this enum is much simpler and only contains pin modes that are (semi-)standard across other Mbed targets.

I also fixed an issue where if a pin was configured as an open-drain output, reading it would always return the written state of the pin instead of its actual electrical state.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

- Apollo3 pin name constants now have standardized names
- Removed Apollo3 pin name constants whose functions aren't obvious or standardized
- Fixed bug with reading open drain DigitalInOuts on Apollo3

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
I'll add a note to the docs site about how only IO_20 has a pulldown.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Verified that Apollo3 now passes the GPIO test, except that the pull-down test fails as it does not support this.

----------------------------------------------------------------------------------------------------------------
