### PR TITLE
Apollo3: fix Mbed not booting in release mode

### DIFF
--- a/platform/include/platform/mbed_assert.h
+++ b/platform/include/platform/mbed_assert.h
@@ -50,7 +50,8 @@ MBED_NORETURN void mbed_assert_internal(const char *expr, const char *file, int 
  *  Declare runtime assertions: results in runtime error if condition is false
  *
  *  @note
- *  Use of MBED_ASSERT is limited to Debug and Develop builds.
+ *  Use of MBED_ASSERT is limited to Debug and Develop builds. Code inside an MBED_ASSERT block
+ *  will not be executed at all in Release builds.
  *
  *  @code
  *

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/analogin_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/analogin_api.c
@@ -110,11 +110,11 @@ static void ap3_config_channel(am_hal_adc_slot_chan_e channel){
     ADCSlotConfig.bWindowCompare = false;
     ADCSlotConfig.bEnabled = true;
 
-    MBED_ASSERT(am_hal_adc_disable(am_adc_handle) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_disable(am_adc_handle));
 
-    MBED_ASSERT(am_hal_adc_configure_slot(am_adc_handle, 0, &ADCSlotConfig) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_configure_slot(am_adc_handle, 0, &ADCSlotConfig));
 
-    MBED_ASSERT(am_hal_adc_enable(am_adc_handle) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_enable(am_adc_handle));
 }
 
 // Read an analog in channel as a 14-bit number
@@ -126,19 +126,19 @@ static uint16_t readAnalogIn(analogin_t *obj)
     // Clear any set interrupt flags
     uint32_t intStatus;
     am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false);
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
 
     // Issue SW trigger
     am_hal_adc_sw_trigger(am_adc_handle);
 
     do { // Wait for conversion complete interrupt
-        MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false));
+        MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false));
     } while(!(intStatus & AM_HAL_ADC_INT_CNVCMP));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
 
     uint32_t numSamplesToRead = 1;
     am_hal_adc_sample_t sample;
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_adc_samples_read(am_adc_handle, false, NULL, &numSamplesToRead, &sample));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_samples_read(am_adc_handle, false, NULL, &numSamplesToRead, &sample));
 
     return sample.ui32Sample;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/analogin_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/analogin_api.c
@@ -110,11 +110,11 @@ static void ap3_config_channel(am_hal_adc_slot_chan_e channel){
     ADCSlotConfig.bWindowCompare = false;
     ADCSlotConfig.bEnabled = true;
 
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_disable(am_adc_handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_disable(am_adc_handle));
 
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_configure_slot(am_adc_handle, 0, &ADCSlotConfig));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_configure_slot(am_adc_handle, 0, &ADCSlotConfig));
 
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_enable(am_adc_handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_enable(am_adc_handle));
 }
 
 // Read an analog in channel as a 14-bit number
@@ -126,19 +126,19 @@ static uint16_t readAnalogIn(analogin_t *obj)
     // Clear any set interrupt flags
     uint32_t intStatus;
     am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false);
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
 
     // Issue SW trigger
     am_hal_adc_sw_trigger(am_adc_handle);
 
     do { // Wait for conversion complete interrupt
-        MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false));
+        MBED_CHECK_AM_HAL_CALL(am_hal_adc_interrupt_status(am_adc_handle, &intStatus, false));
     } while(!(intStatus & AM_HAL_ADC_INT_CNVCMP));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_interrupt_clear(am_adc_handle, intStatus));
 
     uint32_t numSamplesToRead = 1;
     am_hal_adc_sample_t sample;
-    MBED_CHECK_AM3_HAL_CALL(am_hal_adc_samples_read(am_adc_handle, false, NULL, &numSamplesToRead, &sample));
+    MBED_CHECK_AM_HAL_CALL(am_hal_adc_samples_read(am_adc_handle, false, NULL, &numSamplesToRead, &sample));
 
     return sample.ui32Sample;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/device.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/device.h
@@ -39,11 +39,5 @@
 #include "objects.h"
 #include "extensions.h"
 #include "us_ticker_defines.h"
-#include "mbed_error.h"
-
-#define MBED_CHECK_AM3_HAL_CALL(call) \
-    if((call) != AM_HAL_STATUS_SUCCESS) { \
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_INVALID_OPERATION), "AM3 HAL Call Failed!"); \
-    }
 
 #endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/device.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/device.h
@@ -39,5 +39,11 @@
 #include "objects.h"
 #include "extensions.h"
 #include "us_ticker_defines.h"
+#include "mbed_error.h"
+
+#define MBED_CHECK_AM3_HAL_CALL(call) \
+    if((call) != AM_HAL_STATUS_SUCCESS) { \
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_INVALID_OPERATION), "AM3 HAL Call Failed!"); \
+    }
 
 #endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -109,7 +109,7 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     }
 
 
-    MBED_ASSERT(ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools));
 }
 
 /** Set the pin direction

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/gpio_api.c
@@ -109,7 +109,7 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     }
 
 
-    MBED_CHECK_AM3_HAL_CALL(ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools));
+    MBED_CHECK_AM_HAL_CALL(ap3_hal_gpio_pinconfig_partial((uint32_t)(obj->pad), obj->cfg, pinConfigBools));
 }
 
 /** Set the pin direction

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
@@ -23,7 +23,6 @@
 
 #include "iom_api.h"
 #include "mbed_assert.h"
-#include "device.h"
 
 void iom_init(iom_t *obj)
 {
@@ -33,10 +32,10 @@ void iom_init(iom_t *obj)
         iom_deinit(obj);
     }
 
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_initialize(obj->iom.inst, &obj->iom.handle));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_WAKE, false));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_configure(obj->iom.handle, &obj->iom.cfg));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_enable(obj->iom.handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_initialize(obj->iom.inst, &obj->iom.handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_WAKE, false));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_configure(obj->iom.handle, &obj->iom.cfg));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_enable(obj->iom.handle));
 
     // this merely configures the internal peripheral - the desired pins still need to be configured
 }
@@ -49,9 +48,9 @@ void iom_deinit(iom_t *obj)
         return;
     }
 
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_disable(obj->iom.handle));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_uninitialize(obj->iom.handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_disable(obj->iom.handle));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false));
+    MBED_CHECK_AM_HAL_CALL(am_hal_iom_uninitialize(obj->iom.handle));
 
     obj->iom.handle = NULL;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
@@ -23,6 +23,7 @@
 
 #include "iom_api.h"
 #include "mbed_assert.h"
+#include "device.h"
 
 void iom_init(iom_t *obj)
 {
@@ -32,10 +33,10 @@ void iom_init(iom_t *obj)
         iom_deinit(obj);
     }
 
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_initialize(obj->iom.inst, &obj->iom.handle));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_WAKE, false));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_configure(obj->iom.handle, &obj->iom.cfg));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_enable(obj->iom.handle));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_initialize(obj->iom.inst, &obj->iom.handle));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_WAKE, false));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_configure(obj->iom.handle, &obj->iom.cfg));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_enable(obj->iom.handle));
 
     // this merely configures the internal peripheral - the desired pins still need to be configured
 }
@@ -48,9 +49,9 @@ void iom_deinit(iom_t *obj)
         return;
     }
 
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_disable(obj->iom.handle));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false));
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_iom_uninitialize(obj->iom.handle));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_disable(obj->iom.handle));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_power_ctrl(obj->iom.handle, AM_HAL_SYSCTRL_DEEPSLEEP, false));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_iom_uninitialize(obj->iom.handle));
 
     obj->iom.handle = NULL;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/iom_api.c
@@ -23,6 +23,7 @@
 
 #include "iom_api.h"
 #include "mbed_assert.h"
+#include "objects.h"
 
 void iom_init(iom_t *obj)
 {

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects.h
@@ -30,4 +30,12 @@
 #include "objects_adc.h"
 #include "objects_pwm.h"
 
+#include "mbed_error.h"
+
+// Macro to check the result of calling am am_hal function and trigger an error if it fails
+#define MBED_CHECK_AM_HAL_CALL(call) \
+    if((call) != AM_HAL_STATUS_SUCCESS) { \
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_INVALID_OPERATION), "AM HAL Call Failed!"); \
+    }
+
 #endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/pinmap.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/pinmap.c
@@ -27,14 +27,14 @@
 #include "mbed_critical.h"
 #include "extensions.h"
 #include "am_mcu_apollo.h"
-#include "device.h"
+#include "objects.h"
 
 void pin_config(PinName pin, am_hal_gpio_pincfg_t pincfg)
 {
     if (pin == (PinName)NC) {
         return;
     }
-    MBED_CHECK_AM3_HAL_CALL(am_hal_gpio_pinconfig(pin, pincfg));
+    MBED_CHECK_AM_HAL_CALL(am_hal_gpio_pinconfig(pin, pincfg));
 }
 
 void pinmap_config(PinName pin, const PinMap *map)

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/pinmap.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/pinmap.c
@@ -27,13 +27,14 @@
 #include "mbed_critical.h"
 #include "extensions.h"
 #include "am_mcu_apollo.h"
+#include "device.h"
 
 void pin_config(PinName pin, am_hal_gpio_pincfg_t pincfg)
 {
     if (pin == (PinName)NC) {
         return;
     }
-    MBED_ASSERT(AM_HAL_STATUS_SUCCESS == am_hal_gpio_pinconfig(pin, pincfg));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_gpio_pinconfig(pin, pincfg));
 }
 
 void pinmap_config(PinName pin, const PinMap *map)

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -147,9 +147,9 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         obj->serial.uart_control->cfg.ui32FifoLevels = AM_HAL_UART_RX_FIFO_1_8;
 
         // start UART instance
-        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle)));
-        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false));
-        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
+        MBED_CHECK_AM_HAL_CALL(am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle)));
+        MBED_CHECK_AM_HAL_CALL(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false));
+        MBED_CHECK_AM_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 
         // set default format
         serial_format(obj, 8, ParityNone, 1);
@@ -165,7 +165,7 @@ void serial_free(serial_t *obj)
 void serial_baud(serial_t *obj, int baudrate)
 {
     obj->serial.uart_control->cfg.ui32BaudRate = (uint32_t)baudrate;
-    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
+    MBED_CHECK_AM_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 }
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
@@ -222,7 +222,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     obj->serial.uart_control->cfg.ui32DataBits = (uint32_t)am_hal_data_bits;
     obj->serial.uart_control->cfg.ui32Parity = (uint32_t)am_hal_parity;
     obj->serial.uart_control->cfg.ui32StopBits = (uint32_t)am_hal_stop_bits;
-    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
+    MBED_CHECK_AM_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 }
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
@@ -237,10 +237,10 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     if (enable) {
         switch (irq) {
             case RxIrq:
-                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
+                MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
                 break;
             case TxIrq:
-                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
+                MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
                 break;
             default:
                 break;
@@ -251,10 +251,10 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     } else { // disable
         switch (irq) {
             case RxIrq:
-                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
+                MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
                 break;
             case TxIrq:
-                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
+                MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
                 break;
             default:
                 break;
@@ -377,8 +377,8 @@ static inline void uart_irq(uint32_t instance)
 
     // check flags
     uint32_t status = 0x00;
-    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_status_get(handle, &status, true));
-    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_clear(handle, status));
+    MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_status_get(handle, &status, true));
+    MBED_CHECK_AM_HAL_CALL(am_hal_uart_interrupt_clear(handle, status));
 
     if (ap3_uart_control[instance].serial_irq_id != 0) {
         if (status & AM_HAL_UART_INT_TXCMP) { // for transmit complete

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -147,9 +147,9 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         obj->serial.uart_control->cfg.ui32FifoLevels = AM_HAL_UART_RX_FIFO_1_8;
 
         // start UART instance
-        MBED_ASSERT(am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle)) == AM_HAL_STATUS_SUCCESS);
-        MBED_ASSERT(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false) == AM_HAL_STATUS_SUCCESS);
-        MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
+        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle)));
+        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false));
+        MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 
         // set default format
         serial_format(obj, 8, ParityNone, 1);
@@ -165,7 +165,7 @@ void serial_free(serial_t *obj)
 void serial_baud(serial_t *obj, int baudrate)
 {
     obj->serial.uart_control->cfg.ui32BaudRate = (uint32_t)baudrate;
-    MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 }
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
@@ -222,7 +222,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     obj->serial.uart_control->cfg.ui32DataBits = (uint32_t)am_hal_data_bits;
     obj->serial.uart_control->cfg.ui32Parity = (uint32_t)am_hal_parity;
     obj->serial.uart_control->cfg.ui32StopBits = (uint32_t)am_hal_stop_bits;
-    MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false));
 }
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
@@ -237,10 +237,10 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     if (enable) {
         switch (irq) {
             case RxIrq:
-                MBED_ASSERT(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX) == AM_HAL_STATUS_SUCCESS);
+                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
                 break;
             case TxIrq:
-                MBED_ASSERT(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP) == AM_HAL_STATUS_SUCCESS);
+                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
                 break;
             default:
                 break;
@@ -251,10 +251,10 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     } else { // disable
         switch (irq) {
             case RxIrq:
-                MBED_ASSERT(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX) == AM_HAL_STATUS_SUCCESS);
+                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_RX));
                 break;
             case TxIrq:
-                MBED_ASSERT(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP) == AM_HAL_STATUS_SUCCESS);
+                MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_disable(obj->serial.uart_control->handle, AM_HAL_UART_INT_TXCMP));
                 break;
             default:
                 break;
@@ -377,8 +377,8 @@ static inline void uart_irq(uint32_t instance)
 
     // check flags
     uint32_t status = 0x00;
-    MBED_ASSERT(am_hal_uart_interrupt_status_get(handle, &status, true) == AM_HAL_STATUS_SUCCESS);
-    MBED_ASSERT(am_hal_uart_interrupt_clear(handle, status) == AM_HAL_STATUS_SUCCESS);
+    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_status_get(handle, &status, true));
+    MBED_CHECK_AM3_HAL_CALL(am_hal_uart_interrupt_clear(handle, status));
 
     if (ap3_uart_control[instance].serial_irq_id != 0) {
         if (status & AM_HAL_UART_INT_TXCMP) { // for transmit complete


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I noticed while doing other testing that code did not run on the Apollo3 when Mbed was configured in Release mode (worked fine in Develop). After a bit of digging, I realized that this was happening because some of the am3 HAL calls weren't being executed. This, in turn, was happening because they were wrapped in `MBED_ASSERT()` expressions, and everything inside MBED_ASSERT is _compiled out_ in Release mode. Apparently the people who developed the HAL layer for this target (including me :cry: ) didn't realize this.

To fix this, I added a new macro called `MBED_CHECK_AM_HAL_CALL` which performs a similar function to the asserts, but always evaluates its arguments. Then I used a regex to replace all of the assert calls with this macro.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
- Code now runs on Apollo3 in Release mode.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Now able to execute code in Release profile!

----------------------------------------------------------------------------------------------------------------
