### PR TITLE
Fix the slow wake-up of STM32U5 from deep sleep

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -98,8 +98,10 @@ __WEAK void ForceOscOutofDeepSleep(void)
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
     RCC_OscInitStruct.MSIState = RCC_MSI_ON;
     RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-#if defined RCC_MSIRANGE_11
-    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11; // Highest freq, 48MHz range
+#if defined (TARGET_STM32U5)
+    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_0; // Highest freq for U5, 48MHz range
+#elif defined (RCC_MSIRANGE_11)
+    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11; // Highest freq for L4/L5, 48MHz range
 #else
     RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6; // 4MHz range
 #endif

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -109,7 +109,7 @@ __WEAK void ForceOscOutofDeepSleep(void)
 #else /* defined RCC_SYSCLKSOURCE_MSI */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
     RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = 16;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
 #endif /* defined RCC_SYSCLKSOURCE_MSI */
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

On STM32 microcontrollers, the ForceOscOutofDeepSleep function is called after wake-up from deep sleep, to setup an initial system clock. Inside this function, RCC_MSIRANGE_11 is used to specify the MSI clock frequency for STM32L4, STM32L5 and STM32U5 series. Unfortunately, RCC_MSIRANGE_11 has different a meaning in STM32U5 than in STM32L4 and STM32L5. In STM32L4 and STM32L5, RCC_MSIRANGE_11 stands for 48MHz which is the highest MSI frequency. But in STM32U5, RCC_MSIRANGE_11 means just 768KHz. To use the highest MSI clock frequency (48MHz) on STM32U5, we need to change the MSI clock range to RCC_MSIRANGE_0. 

#### Impact of changes <!-- Optional -->

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Greentea test log:
[log.txt](https://github.com/user-attachments/files/21970772/log.txt)

There is one failed test:
25 - test-mbed-hal-common-tickers
Note this test has been modified recently, the earlier version (before commit #469) of the test is passable.

----------------------------------------------------------------------------------------------------------------
