### PR TITLE
Fix cysecuretools always being installed

### DIFF
--- a/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
+++ b/targets/TARGET_Cypress/scripts/mbed_set_post_build_cypress.cmake
@@ -3,12 +3,6 @@
 
 include(mbed_target_functions)
 
-# Make sure we have the python packages we need
-mbed_check_or_install_python_package(HAVE_PYTHON_CYSECURETOOLS cysecuretools "cysecuretools~=6.0")
-if(NOT HAVE_PYTHON_CYSECURETOOLS)
-    message(FATAL_ERROR "Python package required for signing not found.")
-endif()
-
 #
 # Merge Cortex-M4 HEX and a Cortex-M0 HEX.
 #
@@ -68,6 +62,13 @@ macro(mbed_post_build_psoc6_sign_image
     cortex_m0_hex
 )
     if("${cypress_psoc6_target}" STREQUAL "${MBED_TARGET}")
+
+        # Make sure we have the python packages we need
+        mbed_check_or_install_python_package(HAVE_PYTHON_CYSECURETOOLS cysecuretools "cysecuretools~=6.0")
+        if(NOT HAVE_PYTHON_CYSECURETOOLS)
+            message(FATAL_ERROR "Python package required for signing not found.")
+        endif()
+
         function(mbed_post_build_function target)
             set(post_build_command
                 ${Python3_EXECUTABLE} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/PSOC6.py


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

The intention of this CMake script was to install cysecuretools only if needed. However, I missed the fact that the block of code I added always gets executed because the script always gets included regardless of target. This PR moves the python package to be installed inside the post build function itself, ensuring that it will only be installed for Cypress targets.

This is an important fix because [cysecuretools currently fails to install on Python 3.13 on Macs and Arm Linux](https://github.com/Infineon/cysecuretools/issues/9).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
none

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
