### PR TITLE
Fix CMake not obeying Python aliases

### DIFF
--- a/tools/cmake/mbed_python_interpreter.cmake
+++ b/tools/cmake/mbed_python_interpreter.cmake
@@ -10,6 +10,11 @@ option(MBED_CREATE_PYTHON_VENV "If true, Mbed OS will create its own virtual env
 
 get_filename_component(MBED_CE_TOOLS_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 
+# Tell CMake to prefer whichever python the "python3" or "python" commands point to
+# as long as it meets requirements.
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+set(Python3_FIND_REGISTRY LAST)
+
 if(MBED_CREATE_PYTHON_VENV)
     # Use the venv.
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

Quick fix here. I noticed that on Windows, even if you configure the python install manager to target a specific Python version, Mbed will still use the most recent version installed (which is often undesirable behavior). I believe that the same thing would happen on Linux, and it would not obey the `update-alternatives` setting.

Setting these CMake config options seems to cause FindPython to prefer whichever version of Python is pointed to by the `python3` or `python` aliases (as long as it is in the needed version range), which is generally what you want.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
