### PR TITLE
Add NUCLEO_F401RE.cmake

### DIFF
--- a/targets/upload_method_cfg/NUCLEO_F401RE.cmake
+++ b/targets/upload_method_cfg/NUCLEO_F401RE.cmake
@@ -1,0 +1,56 @@
+# Mbed OS upload method configuration file for target NUCLEO_F401RE.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using the JLINK upload method with your dev board requires converting its ST-LINK into a J-Link.  See here for details: https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32F401RE)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+# If your target is not natively supported by the pyOCD, then you need install a keil package for family of your target by hands. 
+# Type "pyocd pack show" to console and you will see a list of already installed packages.
+# If any package for your family is not on the list, then you need install them via command "pyocd pack install stm32f4".
+# Then just type "pyocd pack find STM32f4" or "pyocd pack find STM32F401" or "pyocd pack find STM32F401RE" and you will see the part name of your target.
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME STM32F401RETx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${OpenOCD_SCRIPT_DIR}/board/st_nucleo_f4.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_LOAD_ADDRESS 0x8000000)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Add Proper Support to NUCLEO_F401RE ()
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

A .cmake file is added for NUCLEO_F401RE so that people with this board no longer have to set a bunch of set() in the top-level CMakeLists.txt.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Kind of. I want to add a section to let people know what to do if there is no .cmake file for their target. But that would be another PR.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

I don't exactly know how to supply test result here. But I did test through all upload methods listed in the .cmake, with VSCodium, Win10 IoT LTSC, and ofc the exact hardware.
    
    
----------------------------------------------------------------------------------------------------------------
Inspired by discussion #504 