### PR TITLE
Added support for WPA3 by ESP32 WiFi Driver

### DIFF
--- a/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP32/ESP32Interface.cpp
+++ b/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP32/ESP32Interface.cpp
@@ -163,6 +163,8 @@ int ESP32Interface::set_credentials(const char *ssid, const char *pass, nsapi_se
         case NSAPI_SECURITY_WPA:
         case NSAPI_SECURITY_WPA2:
         case NSAPI_SECURITY_WPA_WPA2:
+        case NSAPI_SECURITY_WPA3:
+        case NSAPI_SECURITY_WPA3_WPA2:
             if ((pass_len < 8) || (pass_len > 63)) {
                 ret = NSAPI_ERROR_PARAMETER;
             }

--- a/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP32/ESP32InterfaceAP.cpp
+++ b/connectivity/drivers/wifi/COMPONENT_ESPRESSIF_ESP32/ESP32InterfaceAP.cpp
@@ -135,6 +135,8 @@ int ESP32InterfaceAP::set_credentials(const char *ssid, const char *pass, nsapi_
         case NSAPI_SECURITY_WPA:
         case NSAPI_SECURITY_WPA2:
         case NSAPI_SECURITY_WPA_WPA2:
+        case NSAPI_SECURITY_WPA3:
+        case NSAPI_SECURITY_WPA3_WPA2:
             _own_sec = security;
             break;
         case NSAPI_SECURITY_UNKNOWN:


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->
As of ESP32-AT firmware v3.4.0 and v4.1.1, WPA3 support has been added, and WPA3 seems gaining adoption by newer routers as well. Without this fix, if a user sets WiFi security is set to NSAPI_SECURITY_WPA3 or NSAPI_SECURITY_WPA3_WPA2 and attempts to connect to a router that supports WPA3, a -3002 error will be thrown. This fix has been tested working on ESP32-S2 with ESP32-AT firmware v3.4.0 and v4.1.1. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->
None to existing application.
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->
None needed by existing application.
### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
