### PR TITLE
Nuvoton: M487: Fix RTC spare registers cleared with WDT reset from PD

### DIFF
--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8294,6 +8294,11 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "usb-device-hsusbd": {
                 "help": "Select high-speed USB device or not",
                 "value": 0
+            },
+	    "wdt-reset-workaround": {
+                "help": "Workaround to H/W limit with WDT reset from power-down",
+                "options": [false, true],
+                "value": true
             }
         },
         "inherits": [
@@ -8328,7 +8333,6 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "EMAC",
             "MPU",
             "WATCHDOG",
-            "RESET_REASON",
             "USBDEVICE"
         ],
         "release_versions": [


### PR DESCRIPTION
### Summary of changes <!-- Required -->

WDT reset from PD needs workaround in which DPD wake-up reset is set up to run immediately, but it will clear RTC spare registers per test. The solution is to use SPD wake-up reset instead.

**NOTE1**: This workaround is applied only when H/W reset flag is raised. This is to avoid abnormal boot sequence for bootloader-enabled application.

**NOTE2:** This workaround will change `SYS.RSTST`S and influence `RESET_REASON`. To avoid confusion, `RESET_REASON` is disabled by default.

#### Impact of changes <!-- Optional -->

`RESET_REASON` gets to disable by default. And it shouldn't use with `MBED_CONF_TARGET_WDT_RESET_WORKAROUND`  together.

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

