### PR TITLE
Upload method support for Nucleo WL55JC, fix common tickers test for STM32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ CMakeUserPresets.json
 
 # CLion
 cmake-build-*/
+
+# Test executor runs
+test-executor-build/
+test-executor-results/

--- a/hal/include/hal/lp_ticker_api.h
+++ b/hal/include/hal/lp_ticker_api.h
@@ -188,6 +188,11 @@ uint32_t lp_ticker_read(void);
  *    we want to wake up far in the future, we will instead set a wakeup for about (rollover period/2) ticks
  *    in the future, then reschedule the timer for the correct time.
  *
+ * @note Some hardware implementations do not support setting an interrupt for after the ticker rolls over
+ *   (e.g. the STM32 LPTIM, which implements a >= comparison for interrupts rather than an == comparison).
+ *   For these implementations, it is acceptable to schedule the interrupt for the time that the ticker
+ *   rolls over. Higher level code will then reschedule the interrupt for the correct time.
+ *
  * Calling this function with timestamp of more than the supported
  * number of bits returned by ::lp_ticker_get_info results in undefined
  * behavior.

--- a/hal/include/hal/us_ticker_api.h
+++ b/hal/include/hal/us_ticker_api.h
@@ -247,6 +247,11 @@ uint32_t (us_ticker_read)(void);
  *    we want to wake up far in the future, we will instead set a wakeup for about (rollover period/2) ticks
  *    in the future, then reschedule the timer for the correct time.
  *
+ * @note Some hardware implementations do not support setting an interrupt for after the ticker rolls over
+  *   (e.g. the STM32 LPTIM, which implements a >= comparison for interrupts rather than an == comparison).
+  *   For these implementations, it is acceptable to schedule the interrupt for the time that the ticker
+  *   rolls over. Higher level code will then reschedule the interrupt for the correct time.
+ *
  * Calling this function with timestamp of more than the supported
  * number of bits returned by ::us_ticker_get_info results in undefined
  * behavior.

--- a/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/common_tickers/main.cpp
@@ -398,8 +398,8 @@ void ticker_overflow_test(void)
 
     const uint32_t after_overflow = intf->read();
 
-    // Interrupt should NOT have fired yet
-    TEST_ASSERT_EQUAL_INT(0, intFlag);
+    // Note: at this point the interrupt may or may not have fired, depending on implementation.
+    // See lp_ticker_set_interrupt() docs for details.
 
     /* Now we are just after overflow. Wait a while assuming that ticker still counts. */
     while (intf->read() < isrTicksAfterOverflow + TICKER_DELTA) {

--- a/hal/tests/TESTS/mbed_hal/rtc_reset/CMakeLists.txt
+++ b/hal/tests/TESTS/mbed_hal/rtc_reset/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT "DEVICE_RTC=1" IN_LIST MBED_TARGET_DEFINITIONS)
 	set(TEST_SKIPPED "RTC is not supported for this target")
 endif()
 
-if(NOT "TARGET_K64F" IN_LIST MBED_TARGET_DEFINITIONS)
+if("TARGET_K64F" IN_LIST MBED_TARGET_DEFINITIONS)
 	# Currently this test works OK, but causes the next 5-10 programming operations with OpenOCD to fail
 	set(TEST_SKIPPED "This test causes issues with this target's debug interface")
 endif()

--- a/targets/upload_method_cfg/NUCLEO_WL55JC.cmake
+++ b/targets/upload_method_cfg/NUCLEO_WL55JC.cmake
@@ -1,0 +1,46 @@
+# Mbed OS upload method configuration file for target NUCLEO_WL55JC.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. Using this device with PyOCD requires installing a pack:
+#    $ pyocd pack install stm32wl55jcix
+#    However, in my testing, PyOCD appeared to flash successfully but the code does not run correctly.
+
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+#set(PYOCD_UPLOAD_ENABLED TRUE)
+#set(PYOCD_TARGET_NAME stm32wl55jcix)
+#set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f ${CMAKE_CURRENT_LIST_DIR}/openocd_cfgs/st_nucleo_wlx.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/openocd_cfgs/st_nucleo_wlx.cfg
+++ b/targets/upload_method_cfg/openocd_cfgs/st_nucleo_wlx.cfg
@@ -1,0 +1,12 @@
+# OpenOCD config file for Nucleo WLx boards
+
+adapter driver hla
+hla_layout stlink
+hla_device_desc "ST-LINK/V3"
+
+# ST-LINK V3 0483:374e
+hla_vid_pid 0x0483 0x374e
+
+transport select hla_swd
+
+source [find target/stm32wlx.cfg]


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR adds upload method support for STM32WL. I picked up one of these boards a while back, and finally this week had time to try it out!

I also noticed that the common tickers LP ticker rollover test was failing for this target, and did some digging into what was going on. Turns out that the code was fine, and this was just my stricter test failing due to a limitation of this target's HW (+ also this behavior was not documented well). 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

Marked STM32WL as tested! https://github.com/mbed-ce/mbed-ce-dot-dev/commit/6d80c9cc9bc6bcb2192b82acfcfdcd80829a971b

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Did a greentea run, and everything passes!
```
100% tests passed, 0 tests failed out of 120

Total Test time (real) = 562.94 sec
```

----------------------------------------------------------------------------------------------------------------
