### PR TITLE
Nuvoton: M487: Fix reset loop with target.wdt-reset-workaround

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/watchdog_api.c
@@ -88,6 +88,13 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 
         SYS_UnlockReg();
 
+        /* See mbed_sdk_init (mbed_override.c) on workaround to
+         * H/W limit with WDT reset from PD.
+         */
+#if MBED_CONF_TARGET_WDT_RESET_WORKAROUND
+        CLK->PMUSTS |= (CLK_PMUSTS_CLRWK_Msk | CLK_PMUSTS_TMRWK_Msk);
+#endif
+
         /* Enable IP module clock */
         CLK_EnableModuleClock(WDT_MODULE);
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This is follow-up of #519. We may trap in DPD/SPD wake-up reset loop when multi-level bootloaders (e.g. LDROM and MCUBoot) and application all or partial integrate this workaround. To avoid this, the wake-up flag `CLK_PMUSTS_TMRWK_Msk` is used to guard from duplicate wake-up reset setups and the clear-up of this flag is delayed to `hal_watchdog_init`, which will be invoked via Mbed Watchdog API.

This approach works based on the assumptions:
1. Only application will set up WDT. LDROM and MCUBoot won't.
2. WDT setup is done via Mbed Watchdog API, not direct WDT control.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

