### PR TITLE
Fix code using psa_key_id_t that should be using psa_key_handle_t

### DIFF
--- a/connectivity/mbedtls/include/mbedtls/cipher_internal.h
+++ b/connectivity/mbedtls/include/mbedtls/cipher_internal.h
@@ -134,7 +134,7 @@ typedef enum
 typedef struct
 {
     psa_algorithm_t alg;
-    psa_key_id_t slot;
+    psa_key_handle_t slot;
     mbedtls_cipher_psa_key_ownership slot_state;
 } mbedtls_cipher_context_psa;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/connectivity/mbedtls/include/mbedtls/pk.h
+++ b/connectivity/mbedtls/include/mbedtls/pk.h
@@ -869,7 +869,7 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
  * \return          An Mbed TLS error code otherwise.
  */
 int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
-                               psa_key_id_t *key,
+                               psa_key_handle_t *key,
                                psa_algorithm_t hash_alg );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/connectivity/mbedtls/include/mbedtls/ssl_internal.h
+++ b/connectivity/mbedtls/include/mbedtls/ssl_internal.h
@@ -448,7 +448,7 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_key_type_t ecdh_psa_type;
     uint16_t ecdh_bits;
-    psa_key_id_t ecdh_psa_privkey;
+    psa_key_handle_t ecdh_psa_privkey;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
     size_t ecdh_psa_peerkey_len;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/connectivity/mbedtls/source/pk.c
+++ b/connectivity/mbedtls/source/pk.c
@@ -588,7 +588,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx )
  * Currently only works for EC private keys.
  */
 int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
-                               psa_key_id_t *key,
+                               psa_key_handle_t *key,
                                psa_algorithm_t hash_alg )
 {
 #if !defined(MBEDTLS_ECP_C)

--- a/connectivity/mbedtls/source/pk_wrap.c
+++ b/connectivity/mbedtls/source/pk_wrap.c
@@ -543,7 +543,7 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     mbedtls_ecdsa_context *ctx = ctx_arg;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_key_id_t key_id = 0;
+    psa_key_handle_t key_id = 0;
     psa_status_t status;
     mbedtls_pk_context key;
     int key_len;

--- a/connectivity/mbedtls/source/ssl_tls.c
+++ b/connectivity/mbedtls/source/ssl_tls.c
@@ -506,7 +506,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
 {
     psa_status_t status;
     psa_algorithm_t alg;
-    psa_key_id_t master_key = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_handle_t master_key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_derivation_operation_t derivation =
         PSA_KEY_DERIVATION_OPERATION_INIT;
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I can't build Mbed for targets using PSA with the latest GCC, because they appear to have upgraded a pointer-related warning into an error. It seems that there are several places in the code that pass a pointer to a `psa_key_id_t` (equivalent to uint32_t) to places expecting a `psa_key_handle_t *` (equivalent to uint16_t *), and the compiler will no longer compile this code. Honestly I don't know the deeper meaning behind these two different types, but I believe it was working because there was still enough room in the type it was passing to store the handle. So, I changed all the erroring locations to use the `psa_key_handle_t` type. This should not affect the behavior of the code, but fixes the compiler error.

Note that I did check upstream in the latest version of Mbed TLS 3 (which we really need to upgrade to at some point) and this error seems to appear there too, but not 100% sure due to them moving a lot of files around in the latest release. So we may have to file a bug upstream when we finally upgrade Mbed TLS.

I was able to find one reference to this issue in the Mbed TLS changelog: https://github.com/Mbed-TLS/mbedtls/blob/216c1950f33cc81677ae4e915a94d7fe4fcc689c/ChangeLog#L2335

Looks like this might be a holdover from supporting an older version of PSA, and they consider these two types to be equivalent, even though they actually aren't.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
