### PR TITLE
Upgrades Docker image to Ubuntu 24.04 and Python 3.12.

### DIFF
--- a/docker_images/mbed-os-env/Dockerfile
+++ b/docker_images/mbed-os-env/Dockerfile
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Pull base image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # ------------------------------------------------------------------------------
 # set locale
@@ -36,7 +36,7 @@ RUN set -x \
     ccache \
     gcovr \
     && apt clean && rm -rf /var/lib/apt/lists \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 \
     && : # last line
 
 RUN set -x \

--- a/docker_images/mbed-os-env/README.md
+++ b/docker_images/mbed-os-env/README.md
@@ -2,7 +2,7 @@
 
 This Docker image is the official Mbed OS development environment.
 
-* It is based on Ubuntu 20.04
+* It is based on Ubuntu 24.04
 * Python and CMake are installed
 * Arm-none-eabi-gcc toolchain is installed
 * Latest released version of mbed-cli and mbed-greentea are installed


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR updates the Mbed CE development Docker image from Ubuntu 20.04 to Ubuntu 24.04. The main motivation for this MR was to allow for using Python features for versions > 3.8, but since Ubuntu 20.04 was EoLed in May 2025, I figured this might feed two birds with one scone since it will update the Python version to 3.12 as well. 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

- Users building or running the Docker image will now be on Ubuntu 24.04 and Python 3.12.
- Scripts with dependencies pinned to Python <=3.8 may need to be updated to allow for Python 3.12

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

N/A

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

`docker_images/mbed-os-env/README.md` was updated to reflect the change from Ubuntu 20.04 to 24.04.

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
<p>I am expecting the update to Ubuntu 24.04 to be fine since other CI tests seem to use `ubuntu-latest` already which would be 24.04.</p>
----------------------------------------------------------------------------------------------------------------
