### PR TITLE
Add VSCode option to flash only without starting debugger & Add crash reporting for STM32F446

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TOOLCHAIN_GCC_ARM/stm32f446xe.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TOOLCHAIN_GCC_ARM/stm32f446xe.ld
@@ -32,6 +32,8 @@
     #define MBED_CONF_TARGET_BOOT_STACK_SIZE  0x400
 #endif
 
+M_CRASH_DATA_RAM_SIZE = 0x100;
+
 /* Round up VECTORS_SIZE to 8 bytes */
 #define VECTORS_SIZE  (((NVIC_NUM_VECTORS * 4) + 7) & 0xFFFFFFF8)
 
@@ -113,7 +115,19 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-    
+
+    .crash_data_ram :
+    {
+        . = ALIGN(8);
+        __CRASH_DATA_RAM__ = .;
+        __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
+        KEEP(*(.keep.crash_data_ram))
+        *(.m_crash_data_ram)     /* This is a user defined section */
+        . += M_CRASH_DATA_RAM_SIZE;
+        . = ALIGN(8);
+        __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+    } > RAM
+
     .data : AT (__etext)
     {
         __data_start__ = .;

--- a/tools/cmake/mbed_ide_debug_cfg_generator.cmake
+++ b/tools/cmake/mbed_ide_debug_cfg_generator.cmake
@@ -180,6 +180,13 @@ elseif(MBED_GENERATE_VS_CODE_DEBUG_CFGS)
 			\"label\": \"Build ${CMAKE_TARGET} and start GDB server\",
 			\"dependsOn\": [\"Build ${CMAKE_TARGET}\", \"GDB Server\"],
 			\"dependsOrder\": \"sequence\",
+		},
+		// Flash ${CMAKE_TARGET} without debugging (builds first via the flash-${CMAKE_TARGET} CMake target)
+		{
+			\"label\": \"Flash ${CMAKE_TARGET}\",
+			\"type\": \"shell\",
+			\"command\": \"${CMAKE_COMMAND}\",
+			\"args\": [\"--build\", \"${CMAKE_BINARY_DIR}\", \"--target\", \"flash-${CMAKE_TARGET}\"],
 		},")
 
 	endfunction(mbed_generate_ide_debug_configuration)


### PR DESCRIPTION
### Summary of changes <!-- Required -->
 - For users using VSCode, sometimes you just want to quickly flash the firmware to a target without launching the debugger.
    - This PR modifies the tasks.json that CMake generates for VSCode to add "Flash without debugging" option.
    - Tested on STM32 but should work across the whole set of platforms / upload methods because it is just providing a button in vscode to access the underlying cmake command inside mbed which already exists.
- enable crash reporting for F446. 
    - When ARM introduced the Crash Reporting feature (around Mbed OS 5.11), the platform maintainers (ST) manually updated hundreds of linker scripts across their MCU portfolio. While doing this, they updated some of the popular target boards (such as the STM32F411xE, STM32F429xI, and STM32F439xI), but missed others. When users raised issues for the missing boards [example](https://github.com/ARMmbed/mbed-os/issues/10226) the solution at the time was to override the mbed provided linker script with a custom linker script.
    - This PR adds support crash reporting support for the F446 as that is what I have on my desk. However other STM32 boards could be added with a similar change. Tested using [mbed crash reporting example](https://github.com/ARMmbed/mbed-os-example-crash-reporting/blob/master/main.cpp) inside my [mbed ce example project](https://github.com/mtc-creations/mbed-ce-example/blob/master/apps/crash-report-test/main.cpp).


#### Impact of changes <!-- Optional -->
Users using the F446 have 0.2kB less ram. Likely not a big deal on a 128kB chip.

### Documentation <!-- Required -->
none

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
