### PR TITLE
Fix Nanostack EMAC memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A message that notes the main changes in the update.
 ### Fixed
 - Added fixes aimed at improving Greentea stability for KV/FlashIAP (STM32F7) and USBSerial paths.
 - MIMXRT1050_EVK: Fixed build error due to typos
+- Fixed memory leak with Nanostack memory manager that caused the stack to run of memory when used with zero-copy Ethernet drivers
 
 ### Removed
 - Target Uhuru Raven (STM32F7) has been removed due to market availability (it is still possible to use it with release Mbed-os 7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ _______________________________________________________________________________
   - Fix all DMA SPI transactions being done twice due to incorrect ISR logic
 - NXP `MIMXRT105x` MCU family:
   - Fix setting the serial format putting the UART peripheral in an invalid configuration due to trying to store an 32-bit register value in a 8-bit integer
-  - Fix using a higher core voltage than needed when running at 528MHz, easting energy
+  - Fix using a higher core voltage than needed when running at 528MHz, wasting energy
   - Fix CPU clock always changing to 600MHz when exiting deep sleep, even if configured for 528MHz
 - `K64F` and `MIMXRT105x` MCU families: Fix SPI frequency being reset back to default if you called `SPI::format()` after `SPI::frequency()`
 - Infineon WHD wi-fi driver now uses the Mbed memory manager instead of directly depending on LwIP. This means it can now be used with Nanostack ([kind of](https://github.com/mbed-ce/mbed-os/issues/505)) and the EMAC unit tests

--- a/connectivity/nanostack/mbed-mesh-api/source/NanostackMemoryManager.cpp
+++ b/connectivity/nanostack/mbed-mesh-api/source/NanostackMemoryManager.cpp
@@ -69,10 +69,10 @@ uint32_t NanostackMemoryManager::get_pool_alloc_unit(uint32_t align) const
 
 void NanostackMemoryManager::free(emac_mem_buf_t *mem)
 {
-    ns_stack_mem_t * currBuf = static_cast<ns_stack_mem_t *>(mem);
+    ns_stack_mem_t *currBuf = static_cast<ns_stack_mem_t *>(mem);
 
-    while(currBuf != nullptr) {
-        ns_stack_mem_t * nextBuf = currBuf->next;
+    while (currBuf != nullptr) {
+        ns_stack_mem_t *nextBuf = currBuf->next;
         ns_dyn_mem_free(currBuf);
         currBuf = nextBuf;
     }

--- a/connectivity/nanostack/mbed-mesh-api/source/NanostackMemoryManager.cpp
+++ b/connectivity/nanostack/mbed-mesh-api/source/NanostackMemoryManager.cpp
@@ -69,7 +69,13 @@ uint32_t NanostackMemoryManager::get_pool_alloc_unit(uint32_t align) const
 
 void NanostackMemoryManager::free(emac_mem_buf_t *mem)
 {
-    ns_dyn_mem_free(mem);
+    ns_stack_mem_t * currBuf = static_cast<ns_stack_mem_t *>(mem);
+
+    while(currBuf != nullptr) {
+        ns_stack_mem_t * nextBuf = currBuf->next;
+        ns_dyn_mem_free(currBuf);
+        currBuf = nextBuf;
+    }
 }
 
 uint32_t NanostackMemoryManager::get_total_len(const emac_mem_buf_t *buf) const

--- a/connectivity/netsocket/tests/TESTS/network/emac/emac_test_unicast_long.cpp
+++ b/connectivity/netsocket/tests/TESTS/network/emac/emac_test_unicast_long.cpp
@@ -37,7 +37,6 @@ void test_emac_unicast_long_cb(int opt)
 
     // Timeout
     if (opt == TIMEOUT && send_request) {
-        printf("Sending packet of length %d\n", msg_len);
         CTP_MSG_SEND(msg_len, emac_if_get_echo_server_addr(0), emac_if_get_own_addr(), emac_if_get_own_addr(), 0);
         send_request = false;
         no_response_cnt = 0;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I've noticed for a while that all the Nanostack netsocket tests tend to fail with errors related to running out of memory on certain targets. More recently, I noticed that it was happening only on targets with zero-copy EMACs, and that it was basically unaffected by changing the allocated heap size for Nanostack. This pointed me towards some sort of memory leak in the handling of network buffers.

So, I went looking in that area of the code, and sure enough, I found a leak! The freakin memory manager was completely failing to free any buffer after the first one in a chained buffer! So, the longer the MAC would operate, the more memory would leak, and eventually it would run out. This only happened with zero-copy EMACs because, apparently, they are the only EMACs that use chained buffers at the driver level.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->
Nanostack now works correctly on devices that use Ethernet with zero-copy MAC drivers.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Now the netsocket-nanostack tests pass, with the sole exception of `test-mbed-connectivity-netsocket-nanostack-tcp` which hardfaults immediately, but not when the debugger is connected :((. No idea what's going on with that one, will have to move on for now.
    
----------------------------------------------------------------------------------------------------------------
