### PR TITLE
Increase default memory size of lwIP stack for STM32F7/H5/H7 MCUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ A message that notes the main changes in the update.
   - Updated STM32F7 config/init files by consolidating Mbed changes with latest upstream templates.
   - Removed unused Ethernet HAL sections from config (Mbed does not use ST Ethernet stack here).
   - Applied interim local HAL fixes until upstream release includes them: https://github.com/STMicroelectronics/stm32f7xx-hal-driver/issues/23
+  - `mem-size` of lwIP stack increased from default 4000 to 16384
 - RP2xxx
   - SDK updated from 1.5.1 to 2.2.0
   - Pin naming scheme changed. Now the MCU I/O pins are named as `IO_xx` instead of `pxx`. Additionally, `PICO_Pxx` constants are added which match the numbering of the header pins on the PCB.
-
+- STM32H5/H7
+  - `mem-size` of lwIP stack increased to 32768 from default 4000
 ### Deprecated
 
 ### Fixed

--- a/connectivity/lwipstack/mbed_lib.json5
+++ b/connectivity/lwipstack/mbed_lib.json5
@@ -196,8 +196,14 @@
         "MIMXRT105X": {
             "mem-size": 36560
         },
-        "STM32H747_ARDUINO": {
-            "mem-size": 16000
+        "MCU_STM32F7": {
+            "mem-size": 16384
+        },
+        "MCU_STM32H5": {
+            "mem-size": 32768
+        },
+        "MCU_STM32H7": {
+            "mem-size": 32768
         },
         "FVP_MPS2_M3": {
             "mem-size": 36560


### PR DESCRIPTION
### Summary of changes <!-- Required -->
The default mem-size of lwIP stack for STM32F7/H5/H7 MCUs are increased to 16K/32K from default 4000B.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

4000B for mem-size in `mbed-ce` (even the 2300B as in mbed-os v6) seems large enough for devices deployed in typical networks and not requiring high performance. But when those devices are deployed into unreliable networks where packet loss can happen frequently, or when those devices require high ethernet performance, the default 4000B seems not adequate. When a STM32F767 based device is connected through a Wi-Fi/Ethernet bridge, system would frequently hang while trying to make HTTPS/WSS requests, sometimes as frequent as once per hour. Increasing `mem-size` to 16K in STM32F767 seems able to eradicate system hangs when connected through the same Wi-Fi/Ethernet bridge, and most likely may also have fixed -3012 errors when connecting through ESP32-S2 Wi-Fi modules.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->
For applications that have already made use of all available RAM on STM32F7/H5/H7 MCUs, the increased 12KB RAM usage by lwIP stack may make system unstable, or cause undefined behavior. In such cases, please provide an override in `mbed_app.json5` to revert `mem-size` of lwIP stack to default or a smaller size the application can afford:
```
"NUCLEO_F767ZI": {
    "lwip.mem-size": 4096,
} 
```
#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

The following thread discusses the impact of lwIP settings on network performance.
https://github.com/mbed-ce/mbed-os/discussions/555

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
