### PR TITLE
More I2C API Improvements

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -44,7 +44,6 @@ jobs:
           echo $?
           git diff --name-only --diff-filter=d origin/${GITHUB_BASE_REF} \
             | ( grep '.\(c\|cpp\|h\|hpp\|py\)$' || true ) \
-            | ( grep -v '^tools/test/toolchains/api_test.py' || true ) \
             | while read file; do cp --parents "${file}" SCANCODE; done
           ls SCANCODE
           scancode -l --json-pp scancode.json SCANCODE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A message that notes the main changes in the update.
 
 ### Added
 
+- Added `i2c_get_capabilities()` function, which can be used to determine what detailed I2C features the hardware supports. This is primarily intended to be used by the Mbed test suite but can also be used in user applications that want to be cross-platform
 - RP2xxx
   - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board compared to the non-W version is limited).
   - `SFE_THING_PLUS_RP2040` board target added for the [SparkFun Thing Plus RP2040 board](https://www.sparkfun.com/sparkfun-thing-plus-rp2040.html)
@@ -22,6 +23,8 @@ A message that notes the main changes in the update.
 
 ### Changed
 - Reworked targets CMake code to only recurse into the subdir for the current target family, which should speed up the CMake configure a bit
+- The `I2C` class now keeps track of the I2C bus state and prevents you from doing operations that are obviously wrong, such as calling `start()` before `stop()` or calling `write_byte()` before `start()`. Previously these operations would get passed down to the HAL API which may or may not have appropriate error handling for them.
+- The `I2C` class now detects and rejects attempts to perform a zero-length transaction on hardware which does not support it.
 - STM32F4
   - HAL driver update to `stm32f4xx-hal-driver` v1.8.5 (2025), now integrated as a submodule.
   - CMSIS device update to `cmsis-device-f4` v2.6.11 (2025), now integrated as a submodule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ A message that notes the main changes in the update.
   - MIMXRT1050_EVK: Fixed build error due to typos
   - Fixed SPI SCLK frequency being several times higher than set due to clock config error (#564)
 - Fixed memory leak with Nanostack memory manager that caused the stack to run of memory when used with zero-copy Ethernet drivers
+- LPC17xx:
+  - Fixed I2C single-byte API continuing to send bytes after being NACKed
 
 ### Removed
 - Target Uhuru Raven (STM32F7) has been removed due to market availability (it is still possible to use it with release Mbed-os 7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ A message that notes the main changes in the update.
 - Reworked targets CMake code to only recurse into the subdir for the current target family, which should speed up the CMake configure a bit
 - The `I2C` class now keeps track of the I2C bus state and prevents you from doing operations that are obviously wrong, such as calling `start()` before `stop()` or calling `write_byte()` before `start()`. Previously these operations would get passed down to the HAL API which may or may not have appropriate error handling for them.
 - The `I2C` class now detects and rejects attempts to perform a zero-length transaction on hardware which does not support it.
+- Use `-Werror=return-type` in the default GCC flags so that a missing return statement in a function becomes a fatal error 
 - STM32F4
   - HAL driver update to `stm32f4xx-hal-driver` v1.8.5 (2025), now integrated as a submodule.
   - CMSIS device update to `cmsis-device-f4` v2.6.11 (2025), now integrated as a submodule.

--- a/connectivity/drivers/emac/CompositeEMAC.md
+++ b/connectivity/drivers/emac/CompositeEMAC.md
@@ -22,7 +22,7 @@ To run an ethernet connection, two chips need to work together*: the microcontro
 
 *though some MCUs, e.g. TI's TM4C129 line, do have the Ethernet PHY integrated into the MCU.
 
-The PHY and the MCU are connected via a standard called [Reduced Media Independent Interface](https://en.wikipedia.org/wiki/Media-independent_interface#RMII) (RMII), which transfers the Ethernet packets as serialized bytes. This is an 8-wire bus with a 50MHz clock, four receive lines, and three transmit lines. The clock is traditionally either supplied by the PHY or by a dedicated clock generator chip, though some MCUs support supplying this clock as well. In addition to RMII, there's also a two-wire command and control bus called [Management Data IO](https://en.wikipedia.org/wiki/Management_Data_Input/Output) (MDIO) (though it can also be referred to Station Management Interface (SMI) or even "MiiM" for some reason). MDIO is used for talking directly to the PHY, not for sending Ethernet packets. MDIO is an open-drain bus similar to I2C, but with 16-bit words instead of bytes and a specific frame format (referred to as "Clause 22"). Unlike RMII, MDIO is a multi-drop bus, so you can actually connect up to 15 PHYs or other devices to one set of MDIO lines as long as they have different addresses!
+The PHY and the MCU are connected via a standard called [Reduced Media Independent Interface](https://en.wikipedia.org/wiki/Media-independent_interface#RMII) (RMII), which transfers the Ethernet packets as serialized bytes. This is an 8-wire bus with a 50MHz clock, four receive lines, and three transmit lines. The clock is traditionally either supplied by the PHY or by a dedicated clock generator chip, though some MCUs support supplying this clock as well. In addition to RMII, there's also a two-wire command and control bus called [Management Data IO](https://en.wikipedia.org/wiki/Management_Data_Input/Output) (MDIO) (though it can also be referred to Station Management Interface (SMI) or MII Management (MIIM)). MDIO is used for talking directly to the PHY, not for sending Ethernet packets. MDIO is an open-drain bus similar to I2C, but with 16-bit words instead of bytes and a specific frame format (referred to as "Clause 22"). Unlike RMII, MDIO is a multi-drop bus, so you can actually connect up to 15 PHYs or other devices to one set of MDIO lines as long as they have different addresses!
 
 Inside the microcontroller, the bridge between the CPU and Ethernet is a peripheral called the Ethernet MAC. MAC stands for "Media Access Control" and refers to the second layer of the Ethernet protocol stack, the logic which encodes Ethernet packets and decides when to send them across the wire. The MAC has a number of moving parts inside, which are shown in the diagram above. The simplest is the block of configuration registers, which is accessible at a specific memory address and sets up operation of the MAC (e.g. what MAC addresses the hardware should accept and which checksums should be inserted/checked by the MAC). There is also an MDIO master interface, which controls the MDIO lines to talk to the PHY. And then, we have the DMA.
 
@@ -34,7 +34,7 @@ How does the DMA know where in RAM to read and write packets, though? On every e
 
 ![DMA descriptor ring](doc/stm32f2-eth-dma-descriptors.png)
 
-A descriptor is a structure in memory that contains control information and one or more pointers to memory buffers (which contain the actual packet data). For Tx, the DMA will fetch the descriptor, then transmit the data in the buffers. For Rx, the DMA will fetch the descriptor, then write the packet to the descriptor's buffers. Either way, when the MAC is done with the descriptor, the DMA will write back status information (e.g. whether the checksum passed, or what timestamp the packet was sent at) to the descriptor, set a "done" flag, and then interrupt the CPU to tell it it has something to process.
+A descriptor is a structure in memory that contains control information and one or more pointers to memory buffers (which contain the actual packet data). For Tx, the DMA will fetch the descriptor, then transmit the data in the buffers. For Rx, the DMA will fetch the descriptor, then write the packet to the descriptor's buffers. In both cases, when the MAC is done with the descriptor, the DMA will write back status information (e.g. whether the checksum passed, or what timestamp the packet was sent at) to the descriptor, set a "done" flag, and then interrupt the CPU to tell it it has something to process.
 
 But we don't want the DMA to have to wait for the CPU, do we? To avoid this, each descriptor also specifies a "next descriptor", either via an offset or a pointer. The DMA can move to this next descriptor and start processing it right away to send or receive the next packet. The CPU will process the completed descriptor on its own time and give it back to the DMA. In this manner, as long as your ring of descriptors is big enough and your CPU can keep up with the processing them, the CPU and MAC never have to wait for each other!
 
@@ -63,8 +63,8 @@ Unlike the MAC driver and the DMA, the PHY driver does not need to be subclassed
 
 ```json5
 "MY_TARGET": {
-    "nsapi.emac-phy-model": "LAN87XX",
-    "nsapi.emac-phy-mdio-address": 0
+    "ephy.model": "LAN87XX",
+    "ephy.mdio-address": 0
 }
 ```
 

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -249,9 +249,9 @@ void UDPSOCKET_ECHOTEST_NONBLOCK_impl(bool use_sendto)
                         break;
                     }
                     signals.wait_all_for(
-                               SIGNAL_SIGIO_RX,
-                               500ms
-                           );
+                        SIGNAL_SIGIO_RX,
+                        500ms
+                    );
                     --retry_recv;
                     continue;
                 } else if (recvd < 0) {

--- a/connectivity/netsocket/tests/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/connectivity/netsocket/tests/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -249,9 +249,9 @@ void UDPSOCKET_ECHOTEST_NONBLOCK_impl(bool use_sendto)
                         break;
                     }
                     signals.wait_all_for(
-                        SIGNAL_SIGIO_RX,
-                        500ms
-                    );
+                               SIGNAL_SIGIO_RX,
+                               500ms
+                           );
                     --retry_recv;
                     continue;
                 } else if (recvd < 0) {

--- a/drivers/include/drivers/I2C.h
+++ b/drivers/include/drivers/I2C.h
@@ -296,7 +296,7 @@ public:
      * until the address is known. On these MCUs, the start condition will not actually be sent until the first
      * \link write_byte() \endlink call after the start().
      *
-     * @returns 0 if successful or -1 on error
+     * @returns 0 if successful or negative error code on error
      */
     int start();
 
@@ -369,7 +369,7 @@ public:
      * This puts the bus back into an idle state where new transactions can be
      * initiated by this device or others.
      *
-     * @returns 0 if successful or -1 on error
+     * @returns 0 if successful or negative error code on error
      */
     int stop();
 

--- a/drivers/include/drivers/I2C.h
+++ b/drivers/include/drivers/I2C.h
@@ -222,10 +222,13 @@ public:
         NACK,
         /// Timeout waiting for I2C hardware
         TIMEOUT,
-        /// Other error in I2C operation
-        OTHER_ERROR
+        /// Other error in I2C operation (e.g. wrong sequence of single byte calls)
+        OTHER_ERROR,
+        /// Operation not supported (check i2c_get_capabilities())
+        NOT_SUPPORTED,
+        /// You tried to do something while in the wrong state (e.g. calling stop() before start())
+        INVALID_STATE
     };
-
 
     /** Create an I2C Master interface, connected to the specified pins.
      * The new object defaults to 100kHz speed.
@@ -284,10 +287,18 @@ public:
      */
     Result write(int address, const char *data, int length, bool repeated = false);
 
-    /** Creates a start condition on the %I2C bus.  After calling this function, you should call
-     * \link write_byte() \endlink to send the %I2C address.
+    /**
+     * @brief Creates a start condition on the %I2C bus.
+     *
+     * After calling this function, you should call \link write_byte() \endlink to send the %I2C address.
+     *
+     * @note Some I2C peripherals (e.g. RP2xxx, newer STM32s) are not capable of sending a start condition
+     * until the address is known. On these MCUs, the start condition will not actually be sent until the first
+     * \link write_byte() \endlink call after the start().
+     *
+     * @returns 0 if successful or -1 on error
      */
-    void start(void);
+    int start();
 
     /** Read a single byte from the %I2C bus.
      *
@@ -349,27 +360,28 @@ public:
      *    '1' - ACK was received,
      *    '2' - timeout
      */
-    MBED_DEPRECATED_SINCE("mbed-ce", "Use I2C::write_byte() instead for better readability and return codes")
+    MBED_DEPRECATED_SINCE("mbed-os-7.0", "Use I2C::write_byte() instead for better readability and return codes")
     int write(int data);
 
     /**
-     * Creates a stop condition on the %I2C bus. This puts the bus back into an idle state where new transactions can be
+     * @brief Creates a stop condition on the %I2C bus.
+     *
+     * This puts the bus back into an idle state where new transactions can be
      * initiated by this device or others.
+     *
+     * @returns 0 if successful or -1 on error
      */
-    void stop(void);
+    int stop();
 
     /** Acquire exclusive access to this %I2C bus
      */
-    virtual void lock(void);
+    virtual void lock();
 
     /** Release exclusive access to this %I2C bus
      */
-    virtual void unlock(void);
+    virtual void unlock();
 
-    virtual ~I2C()
-    {
-        // Do nothing
-    }
+    virtual ~I2C();
 
 #if DEVICE_I2C_ASYNCH
 
@@ -385,7 +397,7 @@ public:
      * This callback will be called when the transfer completes or errors out.  Be careful: if you
      * only request the I2C_EVENT_TRANSFER_COMPLETE event, and the transfer errors, the callback will never be called.
      *
-     * Internally, the chip vendor may implement this function using either DMA or interrupts.
+     * Internally, the chip HAL may implement this function using either DMA or interrupts.
      *
      * This function locks the deep sleep until any event has occurred.
      *
@@ -403,7 +415,7 @@ public:
      * @param repeated Set up for a repeated start.  If true, the Mbed processor does not relinquish the bus after
      *       this operation.  You may then call write(), read(), start(), or transfer() again to start another operation.
      *
-     * @returns Zero if the transfer has started, or -1 if I2C peripheral is busy
+     * @returns Zero if the transfer has started, or -1 on error
      */
     int transfer(int address, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, const event_callback_t &callback, int event = I2C_EVENT_TRANSFER_COMPLETE, bool repeated = false);
 
@@ -449,6 +461,7 @@ protected:
     CThunk<I2C> _irq;
     DMAUsage _usage;
     bool _deep_sleep_locked;
+    bool _async_transfer_is_repeated; // Flag that the current async transfer is configured for a repeated start
 #endif
 #endif
 

--- a/drivers/include/drivers/I2CSlave.h
+++ b/drivers/include/drivers/I2CSlave.h
@@ -170,10 +170,11 @@ public:
      *
      * Call this function only once \c receive() returns WriteAddressed or WriteGeneral.
      *
-     *  @param data   Pointer to the buffer to read data into.
-     *  @param length Maximum number of bytes to read.
+     * @param data   Pointer to the buffer to read data into.
+     * @param length Maximum number of bytes to read. If the master writes more than this number
+     *    of bytes, the additional bytes are dropped.
      *
-     *  @return The number of bytes read
+     * @return The number of bytes read
      */
     int read(char *data, int length);
 

--- a/drivers/source/I2C.cpp
+++ b/drivers/source/I2C.cpp
@@ -132,7 +132,7 @@ int I2C::start()
         _i2c.state = MBED_HAL_I2C_STATE_STARTED;
     } else {
         // Invalid state for starting
-        ret = -1;
+        ret = I2C_ERROR_INVALID_USAGE;
     }
     unlock();
     return ret;
@@ -208,7 +208,7 @@ int I2C::stop()
         _i2c.state = MBED_HAL_I2C_STATE_IDLE;
     } else {
         // Invalid state for stopping
-        ret = -1;
+        ret = I2C_ERROR_INVALID_USAGE;
     }
     unlock();
 

--- a/drivers/source/I2C.cpp
+++ b/drivers/source/I2C.cpp
@@ -72,10 +72,23 @@ void I2C::frequency(int hz)
 // write - Master Transmitter Mode
 I2C::Result I2C::write(int address, const char *data, int length, bool repeated)
 {
+    // Not all HW supports zero-length transactions
+    if(length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+        return Result::NOT_SUPPORTED;
+    }
+
     lock();
+
+    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        // Invalid state for write
+        unlock();
+        return Result::INVALID_STATE;
+    }
 
     int stop = (repeated) ? 0 : 1;
     int written = i2c_write(&_i2c, address, data, length, stop);
+
+    _i2c.state = (length == written && repeated) ? MBED_HAL_I2C_STATE_HOLDING_BUS : MBED_HAL_I2C_STATE_IDLE;
 
     unlock();
 
@@ -86,10 +99,23 @@ I2C::Result I2C::write(int address, const char *data, int length, bool repeated)
 // read - Master Receiver Mode
 I2C::Result I2C::read(int address, char *data, int length, bool repeated)
 {
+    // Not all HW supports zero-length transactions
+    if(length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+        return Result::NOT_SUPPORTED;
+    }
+
     lock();
+
+    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        // Invalid state for read
+        unlock();
+        return Result::INVALID_STATE;
+    }
 
     int stop = (repeated) ? 0 : 1;
     int read = i2c_read(&_i2c, address, data, length, stop);
+
+    _i2c.state = (length == read && repeated) ? MBED_HAL_I2C_STATE_HOLDING_BUS : MBED_HAL_I2C_STATE_IDLE;
 
     unlock();
 
@@ -97,21 +123,33 @@ I2C::Result I2C::read(int address, char *data, int length, bool repeated)
     return length == read ? Result::ACK : Result::NACK;
 }
 
-void I2C::start(void)
+int I2C::start()
 {
+    int ret = 0;
     lock();
-    i2c_start(&_i2c);
+    if(_i2c.state == MBED_HAL_I2C_STATE_IDLE || _i2c.state == MBED_HAL_I2C_STATE_HOLDING_BUS || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        i2c_start(&_i2c);
+        _i2c.state = MBED_HAL_I2C_STATE_STARTED;
+    }
+    else {
+        // Invalid state for starting
+        ret = -1;
+    }
     unlock();
+    return ret;
 }
 
 int I2C::read_byte(bool ack)
 {
     lock();
     int ret;
-    if (ack) {
-        ret = i2c_byte_read(&_i2c, 0);
-    } else {
-        ret = i2c_byte_read(&_i2c, 1);
+    if(_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ) {
+        ret = i2c_byte_read(&_i2c, !ack);
+        _i2c.state = MBED_HAL_I2C_STATE_BYTE_READ;
+    }
+    else {
+        // Invalid state for reading a byte
+        ret = -1;
     }
     unlock();
     return ret;
@@ -120,7 +158,18 @@ int I2C::read_byte(bool ack)
 I2C::Result I2C::write_byte(int data)
 {
     lock();
-    int ret = i2c_byte_write(&_i2c, data);
+    int ret;
+    if(_i2c.state == MBED_HAL_I2C_STATE_STARTED || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        ret = i2c_byte_write(&_i2c, data);
+
+        // If this was the first byte after a start, change state to ADDRESSED. Otherwise we are in byte write mode.
+        _i2c.state = _i2c.state == MBED_HAL_I2C_STATE_STARTED ? MBED_HAL_I2C_STATE_ADDRESSED : MBED_HAL_I2C_STATE_BYTE_WRITE;
+    }
+    else {
+        // Invalid state for reading a byte
+        unlock();
+        return Result::INVALID_STATE;
+    }
     unlock();
 
     switch (ret) {
@@ -146,17 +195,28 @@ int I2C::write(int data)
         case Result::NACK:
             return 0;
         case Result::TIMEOUT:
-            return 2;
         default:
-            return static_cast<int>(result);
+            return 2;
     }
 }
 
-void I2C::stop(void)
+int I2C::stop()
 {
+    int ret = 0;
     lock();
-    i2c_stop(&_i2c);
+    if((_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED && i2c_get_capabilities()->supports_zero_length_transfer_single_byte) || 
+        _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ || 
+        _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        i2c_stop(&_i2c);
+        _i2c.state = MBED_HAL_I2C_STATE_IDLE;
+    }
+    else {
+        // Invalid state for stopping
+        ret = -1;
+    }
     unlock();
+
+    return ret;
 }
 
 void I2C::lock()
@@ -167,6 +227,11 @@ void I2C::lock()
 void I2C::unlock()
 {
     _mutex->unlock();
+}
+
+I2C::~I2C()
+{
+    i2c_free(&_i2c);
 }
 
 int I2C::recover(PinName sda, PinName scl)
@@ -220,25 +285,32 @@ int I2C::recover(PinName sda, PinName scl)
 int I2C::transfer(int address, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, const event_callback_t &callback, int event, bool repeated)
 {
     lock();
-    if (i2c_active(&_i2c)) {
+
+    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+        // Invalid state for new transaction
         unlock();
-        return -1; // transaction ongoing
+        return -1;
     }
+    
     lock_deep_sleep();
 
     _callback = callback;
+    _async_transfer_is_repeated = repeated;
     int stop = (repeated) ? 0 : 1;
     _irq.callback(&I2C::irq_handler_asynch);
+    _i2c.state = MBED_HAL_I2C_STATE_ASYNC_TRANSACTION;
     i2c_transfer_asynch(&_i2c, (void *)tx_buffer, tx_length, (void *)rx_buffer, rx_length, address, stop, _irq.entry(), event, _usage);
     unlock();
     return 0;
 }
 
-void I2C::abort_transfer(void)
+void I2C::abort_transfer()
 {
     lock();
-    i2c_abort_asynch(&_i2c);
-    unlock_deep_sleep();
+    if(_i2c.state == MBED_HAL_I2C_STATE_ASYNC_TRANSACTION) {
+        i2c_abort_asynch(&_i2c);
+        unlock_deep_sleep();
+    }
     unlock();
 }
 
@@ -252,7 +324,9 @@ I2C::Result I2C::transfer_and_wait(int address, const char *tx_buffer, int tx_le
         transferResultFlags.set(event);
     });
 
-    transfer(address, tx_buffer, tx_length, rx_buffer, rx_length, transferCallback, I2C_EVENT_ALL, repeated);
+    if(transfer(address, tx_buffer, tx_length, rx_buffer, rx_length, transferCallback, I2C_EVENT_ALL, repeated) != 0) {
+        return Result::OTHER_ERROR;
+    }
 
     // Wait until transfer complete, error, or timeout
     uint32_t result = transferResultFlags.wait_any_for(I2C_EVENT_ALL, timeout);
@@ -294,6 +368,9 @@ void I2C::irq_handler_asynch(void)
 
     if (event) {
         unlock_deep_sleep();
+
+        // Reset state, accounting for the repeated start flag
+        _i2c.state = (event & I2C_EVENT_TRANSFER_COMPLETE && _async_transfer_is_repeated) ? MBED_HAL_I2C_STATE_HOLDING_BUS : MBED_HAL_I2C_STATE_IDLE;
     }
 }
 

--- a/drivers/source/I2C.cpp
+++ b/drivers/source/I2C.cpp
@@ -73,13 +73,13 @@ void I2C::frequency(int hz)
 I2C::Result I2C::write(int address, const char *data, int length, bool repeated)
 {
     // Not all HW supports zero-length transactions
-    if(length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+    if (length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
         return Result::NOT_SUPPORTED;
     }
 
     lock();
 
-    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if (_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
         // Invalid state for write
         unlock();
         return Result::INVALID_STATE;
@@ -100,13 +100,13 @@ I2C::Result I2C::write(int address, const char *data, int length, bool repeated)
 I2C::Result I2C::read(int address, char *data, int length, bool repeated)
 {
     // Not all HW supports zero-length transactions
-    if(length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+    if (length == 0 && !i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
         return Result::NOT_SUPPORTED;
     }
 
     lock();
 
-    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if (_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
         // Invalid state for read
         unlock();
         return Result::INVALID_STATE;
@@ -127,11 +127,10 @@ int I2C::start()
 {
     int ret = 0;
     lock();
-    if(_i2c.state == MBED_HAL_I2C_STATE_IDLE || _i2c.state == MBED_HAL_I2C_STATE_HOLDING_BUS || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if (_i2c.state == MBED_HAL_I2C_STATE_IDLE || _i2c.state == MBED_HAL_I2C_STATE_HOLDING_BUS || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
         i2c_start(&_i2c);
         _i2c.state = MBED_HAL_I2C_STATE_STARTED;
-    }
-    else {
+    } else {
         // Invalid state for starting
         ret = -1;
     }
@@ -143,11 +142,10 @@ int I2C::read_byte(bool ack)
 {
     lock();
     int ret;
-    if(_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ) {
+    if (_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ) {
         ret = i2c_byte_read(&_i2c, !ack);
         _i2c.state = MBED_HAL_I2C_STATE_BYTE_READ;
-    }
-    else {
+    } else {
         // Invalid state for reading a byte
         ret = -1;
     }
@@ -159,13 +157,12 @@ I2C::Result I2C::write_byte(int data)
 {
     lock();
     int ret;
-    if(_i2c.state == MBED_HAL_I2C_STATE_STARTED || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if (_i2c.state == MBED_HAL_I2C_STATE_STARTED || _i2c.state == MBED_HAL_I2C_STATE_ADDRESSED || _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
         ret = i2c_byte_write(&_i2c, data);
 
         // If this was the first byte after a start, change state to ADDRESSED. Otherwise we are in byte write mode.
         _i2c.state = _i2c.state == MBED_HAL_I2C_STATE_STARTED ? MBED_HAL_I2C_STATE_ADDRESSED : MBED_HAL_I2C_STATE_BYTE_WRITE;
-    }
-    else {
+    } else {
         // Invalid state for reading a byte
         unlock();
         return Result::INVALID_STATE;
@@ -204,13 +201,12 @@ int I2C::stop()
 {
     int ret = 0;
     lock();
-    if((_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED && i2c_get_capabilities()->supports_zero_length_transfer_single_byte) || 
-        _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ || 
-        _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if ((_i2c.state == MBED_HAL_I2C_STATE_ADDRESSED && i2c_get_capabilities()->supports_zero_length_transfer_single_byte) ||
+            _i2c.state == MBED_HAL_I2C_STATE_BYTE_READ ||
+            _i2c.state == MBED_HAL_I2C_STATE_BYTE_WRITE) {
         i2c_stop(&_i2c);
         _i2c.state = MBED_HAL_I2C_STATE_IDLE;
-    }
-    else {
+    } else {
         // Invalid state for stopping
         ret = -1;
     }
@@ -286,12 +282,12 @@ int I2C::transfer(int address, const char *tx_buffer, int tx_length, char *rx_bu
 {
     lock();
 
-    if(_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
+    if (_i2c.state != MBED_HAL_I2C_STATE_IDLE && _i2c.state != MBED_HAL_I2C_STATE_HOLDING_BUS && _i2c.state != MBED_HAL_I2C_STATE_BYTE_READ && _i2c.state != MBED_HAL_I2C_STATE_BYTE_WRITE) {
         // Invalid state for new transaction
         unlock();
         return -1;
     }
-    
+
     lock_deep_sleep();
 
     _callback = callback;
@@ -307,7 +303,7 @@ int I2C::transfer(int address, const char *tx_buffer, int tx_length, char *rx_bu
 void I2C::abort_transfer()
 {
     lock();
-    if(_i2c.state == MBED_HAL_I2C_STATE_ASYNC_TRANSACTION) {
+    if (_i2c.state == MBED_HAL_I2C_STATE_ASYNC_TRANSACTION) {
         i2c_abort_asynch(&_i2c);
         unlock_deep_sleep();
     }
@@ -324,7 +320,7 @@ I2C::Result I2C::transfer_and_wait(int address, const char *tx_buffer, int tx_le
         transferResultFlags.set(event);
     });
 
-    if(transfer(address, tx_buffer, tx_length, rx_buffer, rx_length, transferCallback, I2C_EVENT_ALL, repeated) != 0) {
+    if (transfer(address, tx_buffer, tx_length, rx_buffer, rx_length, transferCallback, I2C_EVENT_ALL, repeated) != 0) {
         return Result::OTHER_ERROR;
     }
 

--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -69,26 +69,32 @@
 
 /**@}*/
 
-#if DEVICE_I2C_ASYNCH
-/** Asynch I2C HAL structure
- */
+/// Enumeration of states the I2C HAL can be in
+enum mbed_hal_i2c_state {
+    MBED_HAL_I2C_STATE_IDLE, ///< Not in the middle of a transaction
+    MBED_HAL_I2C_STATE_STARTED, ///< start() has been called but not write_byte() or read_byte()
+    MBED_HAL_I2C_STATE_ADDRESSED, ///< write_byte() has been called after start()
+    MBED_HAL_I2C_STATE_BYTE_READ, ///< In the middle of a single-byte read
+    MBED_HAL_I2C_STATE_BYTE_WRITE, ///< In the middle of a single-byte read
+    MBED_HAL_I2C_STATE_HOLDING_BUS, ///< We just completed a transaction with the repeated option set, so we are still holding the bus
+    MBED_HAL_I2C_STATE_ASYNC_TRANSACTION, ///< In an async transaction
+};
+
+
 typedef struct {
     struct i2c_s    i2c;     /**< Target specific I2C structure */
+    volatile enum mbed_hal_i2c_state state; ///< I2C state. Managed by the I2C class, available for use by the HAL.
+#if DEVICE_I2C_ASYNCH
     struct buffer_s tx_buff; /**< Tx buffer */
     struct buffer_s rx_buff; /**< Rx buffer */
-} i2c_t;
-
-#else
-/** Non-asynch I2C HAL structure
- */
-typedef struct i2c_s i2c_t;
-
 #endif
+} i2c_t;
 
 enum {
     I2C_ERROR_NO_SLAVE = -1,
     I2C_ERROR_BUS_BUSY = -2,
-    I2C_ERROR_INVALID_USAGE = -3 // Invalid usage of the I2C API, e.g. by mixing single-byte and transactional function calls.
+    I2C_ERROR_INVALID_USAGE = -3, // Invalid usage of the I2C API, e.g. by mixing single-byte and transactional function calls.
+    I2C_ERROR_OTHER = -4, ///< Other internal error
 };
 
 typedef struct {
@@ -98,6 +104,35 @@ typedef struct {
     PinName scl_pin;
     int scl_function;
 } i2c_pinmap_t;
+
+/**
+ * Describes the capabilities of an I2C peripheral
+ */
+typedef struct {
+    /// If true, generation of the start condition in single-byte mode is delayed until the address is transmitted.
+    /// If single-byte is not supported this is a don't care.
+    bool        single_byte_start_cond_delayed;
+
+    /// If true, transmission of the address in single-byte mode is delayed until the first data byte is read/written.
+    /// For write transactions, the ACK/NACK from the address byte will be reported in the status of the first data byte.
+    /// Note that this means there is no way to detect a NACK of the address for a single-byte read operation.
+    /// If single-byte is not supported this is a don't care.
+    bool        single_byte_address_delayed;
+
+    bool        supports_single_byte; ///< If true, the single-byte API is implemented. Otherwise, it is a no-op.
+
+    /// If true, the single-byte API supports a zero-length transfer (one that has only a start, then an address, then a stop).
+    /// If single-byte is not supported this is a don't care.
+    bool        supports_zero_length_transfer_single_byte;
+
+    /// If true, the transaction-based API supports a zero-length transfer (one that has only a start, then an address, then a stop).
+    bool        supports_zero_length_transfer_transaction;
+
+#if DEVICE_I2C_ASYNCH
+    /// If true, the async API supports a zero-length transfer (one that has only a start, then an address, then a stop).
+    bool        supports_zero_length_transfer_async;
+#endif
+} i2c_capabilities_t;
 
 #ifdef __cplusplus
 extern "C" {
@@ -202,19 +237,14 @@ void i2c_free(i2c_t *obj);
  */
 void i2c_frequency(i2c_t *obj, int hz);
 
-/** Send START command
+/**
+ * @brief Blocking read of data
  *
- *  @param obj The I2C object
- */
-int  i2c_start(i2c_t *obj);
-
-/** Send STOP command
- *
- *  @param obj The I2C object
- */
-int  i2c_stop(i2c_t *obj);
-
-/** Blocking reading data
+ * This function may be called in these I2C states:
+ * - IDLE
+ * - HOLDING_BUS
+ * - BYTE_READ (to do a repeated start after a single byte transaction)
+ * - BYTE_WRITE (to do a repeated start after a single byte transaction)
  *
  *  @param obj     The I2C object
  *  @param address 8/11-bit address (last bit is 1)
@@ -225,18 +255,57 @@ int  i2c_stop(i2c_t *obj);
  */
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop);
 
-/** Blocking sending data
+/**
+ * @brief Blocking write of data
  *
- *  @param obj     The I2C object
- *  @param address 8/11-bit address (last bit is 0)
- *  @param data    The buffer for sending
- *  @param length  Number of bytes to write
- *  @param stop    Stop to be generated after the transfer is done
- *  @return
- *      zero or non-zero - Number of written bytes
- *      negative - I2C_ERROR_XXX status
+ * This function may be called in these I2C states:
+ * - IDLE
+ * - HOLDING_BUS
+ * - BYTE_READ (to do a repeated start after a single byte transaction)
+ * - BYTE_WRITE (to do a repeated start after a single byte transaction)
+ *
+ * @param obj     The I2C object
+ * @param address 8/11-bit address (last bit is 0)
+ * @param data    The buffer for sending
+ * @param length  Number of bytes to write
+ * @param stop    Stop to be generated after the transfer is done
+ * @retval zero or non-zero - Number of written bytes
+ * @retval negative - I2C_ERROR_XXX status
  */
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop);
+
+/**
+ * @brief Send START command
+ *
+ * The I2C class guarantees that this will only be called at appropriate times (when the bus is idle or
+ * during an existing single-byte transaction to do a repeated start).
+ *
+ * Note that some I2C peripherals (e.g. RP2xxx, newer STM32s) are not capable of sending a start condition
+ * until the address is known. On these MCUs, the start condition will not actually be sent until the first write_byte()
+ * call after the start().
+ *
+ * This function may be called in these I2C states:
+ * - IDLE
+ * - HOLDING_BUS
+ * - ADDRESSED (to do a repeated start after a zero length transaction, if supported)
+ * - BYTE_READ
+ * - BYTE_WRITE
+ *
+ * @param obj The I2C object
+ */
+int i2c_start(i2c_t *obj);
+
+/**
+ * @brief Send STOP command
+ *
+ * This function may be called in these I2C states:
+ * - ADDRESSED (to complete a zero length transaction, if supported)
+ * - BYTE_READ
+ * - BYTE_WRITE
+ *
+ * @param obj The I2C object
+ */
+int i2c_stop(i2c_t *obj);
 
 /** Reset I2C peripheral. TODO: The action here. Most of the implementation sends stop()
  *
@@ -244,7 +313,12 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop);
  */
 void i2c_reset(i2c_t *obj);
 
-/** Read one byte
+/**
+ * @brief Read one byte
+ *
+ * This function may be called in these I2C states:
+ * - ADDRESSED
+ * - BYTE_READ
  *
  *  @param obj The I2C object
  *  @param last Acknoledge
@@ -252,7 +326,13 @@ void i2c_reset(i2c_t *obj);
  */
 int i2c_byte_read(i2c_t *obj, int last);
 
-/** Write one byte
+/**
+ * @brief Write one byte
+ *
+ * This function may be called in these I2C states:
+ * - STARTED (to send the address byte)
+ * - ADDRESSED
+ * - BYTE_WRITE
  *
  *  @param obj The I2C object
  *  @param data Byte to be written
@@ -296,6 +376,13 @@ const PinMap *i2c_slave_sda_pinmap(void);
  */
 const PinMap *i2c_slave_scl_pinmap(void);
 
+/**
+ * Fills the given i2c_capabilities_t structure with the capabilities of the I2C peripheral.
+ * 
+ * @returns Pointer to constant capabilities data
+ */
+i2c_capabilities_t const * i2c_get_capabilities();
+
 /**@}*/
 
 #if DEVICE_I2CSLAVE
@@ -320,9 +407,14 @@ int  i2c_slave_receive(i2c_t *obj);
 
 /**
  *  @brief Read specified number of bytes from an I2C master.
+ *
+ * This function shall be called only after ::i2c_slave_receive() has returned 2 or 3.
+ *  
  *  @param obj The I2C object
- *  @param data    The buffer for receiving
- *  @param length  Number of bytes to read
+ *  @param data The buffer for receiving
+ *  @param length  Number of bytes to read. If the master writes more than this number
+ *    of bytes, the additional bytes are dropped.
+ * 
  *  @return Number of bytes read, or zero on error
  */
 int  i2c_slave_read(i2c_t *obj, char *data, int length);

--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -128,10 +128,6 @@ typedef struct {
     /// If true, the transaction-based API supports a zero-length transfer (one that has only a start, then an address, then a stop).
     bool        supports_zero_length_transfer_transaction;
 
-#if DEVICE_I2C_ASYNCH
-    /// If true, the async API supports a zero-length transfer (one that has only a start, then an address, then a stop).
-    bool        supports_zero_length_transfer_async;
-#endif
 } i2c_capabilities_t;
 
 #ifdef __cplusplus
@@ -249,7 +245,8 @@ void i2c_frequency(i2c_t *obj, int hz);
  *  @param obj     The I2C object
  *  @param address 8/11-bit address (last bit is 1)
  *  @param data    The buffer for receiving
- *  @param length  Number of bytes to read
+ *  @param length  Number of bytes to read. Allowed to be 0 *only* if the \c supports_zero_length_transfer_transaction
+ *     capability is true.
  *  @param stop    Stop to be generated after the transfer is done
  *  @return Number of read bytes
  */
@@ -267,7 +264,8 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop);
  * @param obj     The I2C object
  * @param address 8/11-bit address (last bit is 0)
  * @param data    The buffer for sending
- * @param length  Number of bytes to write
+ *  @param length  Number of bytes to write. Allowed to be 0 *only* if the \c supports_zero_length_transfer_transaction
+ *     capability is true.
  * @param stop    Stop to be generated after the transfer is done
  * @retval zero or non-zero - Number of written bytes
  * @retval negative - I2C_ERROR_XXX status
@@ -299,7 +297,7 @@ int i2c_start(i2c_t *obj);
  * @brief Send STOP command
  *
  * This function may be called in these I2C states:
- * - ADDRESSED (to complete a zero length transaction, if supported)
+ * - ADDRESSED (to complete a zero length transaction, *only* allowed if the \c supports_zero_length_transfer_single_byte capability is enabled)
  * - BYTE_READ
  * - BYTE_WRITE
  *

--- a/hal/include/hal/i2c_api.h
+++ b/hal/include/hal/i2c_api.h
@@ -378,10 +378,10 @@ const PinMap *i2c_slave_scl_pinmap(void);
 
 /**
  * Fills the given i2c_capabilities_t structure with the capabilities of the I2C peripheral.
- * 
+ *
  * @returns Pointer to constant capabilities data
  */
-i2c_capabilities_t const * i2c_get_capabilities();
+i2c_capabilities_t const *i2c_get_capabilities();
 
 /**@}*/
 
@@ -409,12 +409,12 @@ int  i2c_slave_receive(i2c_t *obj);
  *  @brief Read specified number of bytes from an I2C master.
  *
  * This function shall be called only after ::i2c_slave_receive() has returned 2 or 3.
- *  
+ *
  *  @param obj The I2C object
  *  @param data The buffer for receiving
  *  @param length  Number of bytes to read. If the master writes more than this number
  *    of bytes, the additional bytes are dropped.
- * 
+ *
  *  @return Number of bytes read, or zero on error
  */
 int  i2c_slave_read(i2c_t *obj, char *data, int length);

--- a/hal/source/mbed_compat.c
+++ b/hal/source/mbed_compat.c
@@ -102,7 +102,7 @@ static const i2c_capabilities_t default_i2c_caps = {
     .supports_zero_length_transfer_single_byte = true,
     .supports_zero_length_transfer_transaction = true
 };
-MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+MBED_WEAK i2c_capabilities_t const *i2c_get_capabilities()
 {
     return &default_i2c_caps;
 }

--- a/hal/source/mbed_compat.c
+++ b/hal/source/mbed_compat.c
@@ -91,6 +91,21 @@ MBED_WEAK void spi_get_capabilities(PinName ssel, bool slave, spi_capabilities_t
         cs_pins++;
     }
 }
+#endif
+
+#if DEVICE_I2C
+// Default I2C capabilities: no quirks, everything supported
+static const i2c_capabilities_t default_i2c_caps = {
+    .single_byte_address_delayed = false,
+    .single_byte_start_cond_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &default_i2c_caps;
+}
 
 #endif
 

--- a/storage/blockdevice/COMPONENT_I2CEE/source/I2CEEBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_I2CEE/source/I2CEEBlockDevice.cpp
@@ -161,10 +161,23 @@ int I2CEEBlockDevice::_sync()
     // The chip doesn't ACK while writing to the actual EEPROM
     // so loop trying to do a zero byte write until it is ACKed
     // by the chip.
+    // Note that not all I2C hardware supports zero length writes,
+    // so if it doesn't, we need to transfer one byte instead. Note that
+    // this will clobber the address pointer, but that's OK because we always
+    // reset it before using the EEPROM again.
+    char dummy_buffer = 0;
     for (int i = 0; i < I2CEE_TIMEOUT; i++) {
-        if (_i2c->write(_i2c_addr | 0, 0, 0) == I2C::ACK) {
-            return 0;
+        if(i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+            if (_i2c->write(_i2c_addr | 0, 0, 0) == I2C::ACK) {
+                return 0;
+            }
         }
+        else {
+            if (_i2c->write(_i2c_addr | 0, &dummy_buffer, 1) == I2C::ACK) {
+                return 0;
+            }
+        }
+        
         wait_us(100);
     }
 

--- a/storage/blockdevice/COMPONENT_I2CEE/source/I2CEEBlockDevice.cpp
+++ b/storage/blockdevice/COMPONENT_I2CEE/source/I2CEEBlockDevice.cpp
@@ -167,17 +167,16 @@ int I2CEEBlockDevice::_sync()
     // reset it before using the EEPROM again.
     char dummy_buffer = 0;
     for (int i = 0; i < I2CEE_TIMEOUT; i++) {
-        if(i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
+        if (i2c_get_capabilities()->supports_zero_length_transfer_transaction) {
             if (_i2c->write(_i2c_addr | 0, 0, 0) == I2C::ACK) {
                 return 0;
             }
-        }
-        else {
+        } else {
             if (_i2c->write(_i2c_addr | 0, &dummy_buffer, 1) == I2C::ACK) {
                 return 0;
             }
         }
-        
+
         wait_us(100);
     }
 

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/i2c_api.c
@@ -276,6 +276,19 @@ int i2c_byte_write(i2c_t *obj, int data)
     return ack;
 }
 
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
+
 const PinMap *i2c_master_sda_pinmap()
 {
     return PinMap_I2C_SDA;

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/i2c_api.c
@@ -75,7 +75,7 @@ static inline void i2c_send_byte(i2c_t *obj, unsigned char c)
 {
     int loop;
     switch ((int)obj->i2c) {
-        case I2C_0: 
+        case I2C_0:
             obj->i2c->CONTROLC = SCL;
             i2c_delay(TSC_TSU);
 
@@ -85,7 +85,7 @@ static inline void i2c_send_byte(i2c_t *obj, unsigned char c)
                     obj->i2c->CONTROLS = SDA;
                 else
                     obj->i2c->CONTROLC = SDA;
-                
+
                 i2c_delay(TSC_TSU);
                 obj->i2c->CONTROLS = SCL;
                 i2c_delay(TSC_TSU);
@@ -105,7 +105,7 @@ static inline void i2c_send_byte(i2c_t *obj, unsigned char c)
                     obj->i2c->CONTROLS = SDA;
                 else
                     obj->i2c->CONTROLC = SDA;
-                
+
                 i2c_delay(AAIC_TSU);
                 obj->i2c->CONTROLS = SCL;
                 i2c_delay(AAIC_TSU);
@@ -116,8 +116,8 @@ static inline void i2c_send_byte(i2c_t *obj, unsigned char c)
             obj->i2c->CONTROLS = SDA;
             i2c_delay(AAIC_TSU);
         break;
-        case I2C_2: 
-        case I2C_3: 
+        case I2C_2:
+        case I2C_3:
             obj->i2c->CONTROLC = SCL;
             i2c_delay(SHIELD_TSU);
 
@@ -127,7 +127,7 @@ static inline void i2c_send_byte(i2c_t *obj, unsigned char c)
                     obj->i2c->CONTROLS = SDA;
                 else
                     obj->i2c->CONTROLC = SDA;
-                
+
                 i2c_delay(SHIELD_TSU);
                 obj->i2c->CONTROLS = SCL;
                 i2c_delay(SHIELD_TSU);
@@ -145,7 +145,7 @@ static inline unsigned char i2c_receive_byte(i2c_t *obj)
 {
     int data_receive_byte, loop;
     switch ((int)obj->i2c) {
-        case I2C_0: 
+        case I2C_0:
             obj->i2c->CONTROLS = SDA;
             i2c_delay(TSC_TSU);
 
@@ -157,7 +157,7 @@ static inline unsigned char i2c_receive_byte(i2c_t *obj)
                 i2c_delay(TSC_TSU);
                 if ((obj->i2c->CONTROL & SDA))
                     data_receive_byte += (1 << (7 - loop));
-                
+
                 obj->i2c->CONTROLC = SCL;
                 i2c_delay(TSC_TSU);
             }
@@ -177,7 +177,7 @@ static inline unsigned char i2c_receive_byte(i2c_t *obj)
                 i2c_delay(AAIC_TSU);
                 if ((obj->i2c->CONTROL & SDA))
                     data_receive_byte += (1 << (7 - loop));
-                
+
                 i2c_delay(AAIC_TSU);
                 obj->i2c->CONTROLC = SCL;
             }
@@ -186,7 +186,7 @@ static inline unsigned char i2c_receive_byte(i2c_t *obj)
             obj->i2c->CONTROLC = SDA;
             i2c_delay(AAIC_TSU);
         break;
-        case I2C_2: 
+        case I2C_2:
         case I2C_3:
             obj->i2c->CONTROLS = SDA;
             i2c_delay(SHIELD_TSU);
@@ -199,7 +199,7 @@ static inline unsigned char i2c_receive_byte(i2c_t *obj)
                 i2c_delay(SHIELD_TSU);
                 if ((obj->i2c->CONTROL & SDA))
                     data_receive_byte += (1 << (7 - loop));
-                
+
                 obj->i2c->CONTROLC = SCL;
                 i2c_delay(SHIELD_TSU);
             }
@@ -242,7 +242,7 @@ static inline int i2c_receive_ack(i2c_t *obj)
 }
 
 
-static inline void i2c_send_nack(i2c_t *obj) 
+static inline void i2c_send_nack(i2c_t *obj)
 {
     int delay_value;
     switch ((int)obj->i2c) {
@@ -266,7 +266,7 @@ static inline void i2c_send_nack(i2c_t *obj)
 
 }
 
-static inline void i2c_send_ack(i2c_t *obj) 
+static inline void i2c_send_ack(i2c_t *obj)
 {
     int delay_value;
     switch ((int)obj->i2c) {
@@ -292,21 +292,21 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
     I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
     obj->i2c = (MPS2_I2C_TypeDef *)pinmap_merge(i2c_sda, i2c_scl);
-    
+
     if ((int)obj->i2c == NC) {
         error("I2C pin mapping failed");
     }
-        
+
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
-        
+
     switch ((int)obj->i2c) {
         case I2C_2: CMSDK_GPIO0->ALTFUNCSET |= 0x8020; break;
-        case I2C_3: CMSDK_GPIO1->ALTFUNCSET |= 0x8000; 
+        case I2C_3: CMSDK_GPIO1->ALTFUNCSET |= 0x8000;
                                         CMSDK_GPIO2->ALTFUNCSET |= 0x0200; break;
     }
-        
-        
+
+
 }
 
 int i2c_start(i2c_t *obj)
@@ -318,7 +318,7 @@ int i2c_start(i2c_t *obj)
         case I2C_2: delay_value = SHIELD_TSU; break;
         case I2C_3: delay_value = SHIELD_TSU; break;
     }
-    
+
     i2c_delay(delay_value);
     obj->i2c->CONTROLS = SDA | SCL;
     i2c_delay(delay_value);
@@ -337,7 +337,7 @@ int i2c_start_tsc(i2c_t *obj)
         case I2C_2: delay_value = SHIELD_TSU; break;
         case I2C_3: delay_value = SHIELD_TSU; break;
     }
-    
+
     i2c_delay(delay_value);
     obj->i2c->CONTROLC = SDA;
     i2c_delay(delay_value);
@@ -348,7 +348,7 @@ int i2c_start_tsc(i2c_t *obj)
 }
 
 int i2c_stop(i2c_t *obj)
-{    
+{
     int delay_value;
     switch ((int)obj->i2c) {
         case I2C_0: delay_value = TSC_TSU; break;
@@ -379,14 +379,14 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     int sadr, ack, bytes_read;
     rxdata=0;
     switch ((int)obj->i2c) {
-        case I2C_0: 
-            sadr = TSC_I2C_ADDR; 
+        case I2C_0:
+            sadr = TSC_I2C_ADDR;
             break;
-        case I2C_1: 
-            sadr = AAIC_I2C_ADDR; 
+        case I2C_1:
+            sadr = AAIC_I2C_ADDR;
             break;
-        case I2C_2: 
-        case I2C_3: 
+        case I2C_2:
+        case I2C_3:
             sadr = address;     //LM75_I2C_ADDR; or MMA7660_I2C_ADDR;
             break;
          }
@@ -395,7 +395,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     i2c_start(obj);
 
     switch ((int)obj->i2c) {
-        case I2C_0: 
+        case I2C_0:
             // Set serial and register address
             i2c_send_byte(obj,sadr);
             ack += i2c_receive_ack(obj);
@@ -429,7 +429,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
                     rxdata = i2c_receive_byte(obj);
                     data[(length-1)-bytes_read] = (char)rxdata;
                     bytes_read++;
-                            
+
                 }
             }
             break;
@@ -467,12 +467,12 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
                     rxdata = i2c_receive_byte(obj);
                     data[loop] = (char)rxdata;
                     bytes_read++;
-                            
+
                 }
             }
             break;
     }
-    i2c_send_nack(obj);  
+    i2c_send_nack(obj);
 
     i2c_stop(obj);    // Actual stop bit
 
@@ -534,6 +534,19 @@ int i2c_byte_read(i2c_t *obj, int last) {
 
 int i2c_byte_write(i2c_t *obj, int data) {
     return 0;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = false,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 const PinMap *i2c_master_sda_pinmap()

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/i2c_api.c
@@ -67,26 +67,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     switch (i2c) {
 #ifdef I2C0_IP6510_DEV
         case I2C_0:
-            obj->dev = &I2C0_IP6510_DEV;
+            obj->i2c.dev = &I2C0_IP6510_DEV;
             break;
 #endif
 #ifdef I2C1_IP6510_DEV
         case I2C_1:
-            obj->dev = &I2C1_IP6510_DEV;
+            obj->i2c.dev = &I2C1_IP6510_DEV;
             break;
 #endif
         default:
             error("Failed to initialize I2C, bad reference.");
             return;
     }
-    obj->last_address = 0U;
-    obj->sda = sda;
-    obj->scl = scl;
-    obj->byte_state = BYTE_TRANSFER_STATE_NONE;
+    obj->i2c.last_address = 0U;
+    obj->i2c.sda = sda;
+    obj->i2c.scl = scl;
+    obj->i2c.byte_state = BYTE_TRANSFER_STATE_NONE;
 
     /* If already init, uninit */
-    if (i2c_ip6510_get_state(obj->dev) == I2C_IP6510_INITIALIZED) {
-        i2c_ip6510_uninit(obj->dev);
+    if (i2c_ip6510_get_state(obj->i2c.dev) == I2C_IP6510_INITIALIZED) {
+        i2c_ip6510_uninit(obj->i2c.dev);
     }
 
     /* Set the GPIO pins */
@@ -94,9 +94,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     pinmap_pinout(scl, PinMap_I2C_SCL);
 
     /* Initialize peripheral */
-    ret = i2c_ip6510_init(obj->dev, SystemCoreClock);
-    i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_100KHZ);
-    i2c_ip6510_set_timeout(obj->dev, 0xFFU);
+    ret = i2c_ip6510_init(obj->i2c.dev, SystemCoreClock);
+    i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_100KHZ);
+    i2c_ip6510_set_timeout(obj->i2c.dev, 0xFFU);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         error("Failed to initialize I2C, error occured in native driver.");
@@ -109,11 +109,11 @@ void i2c_frequency(i2c_t *obj, int hz)
     /* The peripheral only supports 100k and 400k clock in master mode */
     switch (hz) {
         case I2C_SPEED_100KHZ:
-            i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_100KHZ);
+            i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_100KHZ);
             break;
 
         case I2C_SPEED_400KHZ:
-            i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_400KHZ);
+            i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_400KHZ);
             break;
 
         default:
@@ -124,8 +124,8 @@ void i2c_frequency(i2c_t *obj, int hz)
 
 void i2c_reset(i2c_t *obj)
 {
-    i2c_ip6510_uninit(obj->dev);
-    i2c_init(obj, obj->sda, obj->scl);
+    i2c_ip6510_uninit(obj->i2c.dev);
+    i2c_init(obj, obj->i2c.sda, obj->i2c.scl);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
@@ -135,7 +135,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     /* Shifted 8 bit address is used in upper layer */
     address = ((uint32_t)address)>>1;
 
-    ret = i2c_ip6510_master_read(obj->dev, (uint16_t)address, (uint8_t*)data,
+    ret = i2c_ip6510_master_read(obj->i2c.dev, (uint16_t)address, (uint8_t*)data,
             stop, (uint32_t*)(&length));
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -154,14 +154,14 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
     /* Parameter checking */
     if (data == NULL || length == 0) {
-        ret = i2c_ip6510_monitor_slave(obj->dev, (uint16_t)address);
+        ret = i2c_ip6510_monitor_slave(obj->i2c.dev, (uint16_t)address);
         if (ret != I2C_IP6510_ERR_NONE) {
             return I2C_ERROR_NO_SLAVE;
         }
         return length;
     }
 
-    ret = i2c_ip6510_master_write(obj->dev, (uint16_t)address, (uint8_t*)data,
+    ret = i2c_ip6510_master_write(obj->i2c.dev, (uint16_t)address, (uint8_t*)data,
             stop, (uint32_t*)(&length));
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -178,9 +178,9 @@ int i2c_start(i2c_t *obj)
      *        The i2c transaction is started later, when the address and the
      *        first data byte is written.
      */
-    obj->byte_state = BYTE_TRANSFER_STATE_START;
-    obj->last_address = 0U;
-    i2c_ip6510_hold_enable(obj->dev);
+    obj->i2c.byte_state = BYTE_TRANSFER_STATE_START;
+    obj->i2c.last_address = 0U;
+    i2c_ip6510_hold_enable(obj->i2c.dev);
 
     return I2C_ERROR_NONE;
 }
@@ -188,35 +188,35 @@ int i2c_start(i2c_t *obj)
 int i2c_stop(i2c_t *obj)
 {
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          *        STOP condition is generated on hold disable.
          */
-        i2c_ip6510_hold_disable(obj->dev);
+        i2c_ip6510_hold_disable(obj->i2c.dev);
 
         /* If there was only one byte written (the slave address) before calling
          * stop, the state machine is in ADDRESS state. Writing just the address
          * is equal to a slave monitoring
          */
-        if (obj->byte_state == BYTE_TRANSFER_STATE_ADDRESS) {
+        if (obj->i2c.byte_state == BYTE_TRANSFER_STATE_ADDRESS) {
             /* Return value is not needed because signalling to the caller is
              * not defined
              */
-            (void)i2c_ip6510_monitor_slave(obj->dev, obj->last_address);
+            (void)i2c_ip6510_monitor_slave(obj->i2c.dev, obj->i2c.last_address);
         }
 
-        obj->byte_state = BYTE_TRANSFER_STATE_NONE;
-        obj->last_address = 0U;
+        obj->i2c.byte_state = BYTE_TRANSFER_STATE_NONE;
+        obj->i2c.last_address = 0U;
 
     } else {
         /* In slave mode the the I2C controller only writes and reads data from
          * the I2C bus. The function just clears the interrupts for
          * further adressing detection.
          */
-        i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+        i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
     }
     return I2C_ERROR_NONE;
 }
@@ -227,22 +227,22 @@ int i2c_byte_read(i2c_t *obj, int last)
     uint32_t slave_read_cntr = 1U;
 
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          */
-        switch (obj->byte_state) {
+        switch (obj->i2c.byte_state) {
             case BYTE_TRANSFER_STATE_ADDRESS:
-                obj->byte_state = BYTE_TRANSFER_STATE_DATA;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_DATA;
                 i2c_ip6510_master_byte_read(
-                        obj->dev, obj->last_address, last, true, &read_byte);
+                        obj->i2c.dev, obj->i2c.last_address, last, true, &read_byte);
                 return read_byte;
 
             case BYTE_TRANSFER_STATE_DATA:
                 i2c_ip6510_master_byte_read(
-                        obj->dev, obj->last_address, last, false, &read_byte);
+                        obj->i2c.dev, obj->i2c.last_address, last, false, &read_byte);
                 return read_byte;
 
             case BYTE_TRANSFER_STATE_NONE:
@@ -256,7 +256,7 @@ int i2c_byte_read(i2c_t *obj, int last)
          * I2C controller, no need to track states.
          */
         i2c_ip6510_slave_read(
-                            obj->dev, &read_byte, &slave_read_cntr);
+                            obj->i2c.dev, &read_byte, &slave_read_cntr);
         return read_byte;
     }
 }
@@ -267,13 +267,13 @@ int i2c_byte_write(i2c_t *obj, int data)
     uint32_t slave_write_cntr = 1U;
 
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          */
-        switch (obj->byte_state) {
+        switch (obj->i2c.byte_state) {
             case BYTE_TRANSFER_STATE_NONE:
                 /* Writing is invalid before start symbol
                  * BYTE_TRANSFER_ERR_TIMEOUT is the only error code mbed defines,
@@ -282,19 +282,19 @@ int i2c_byte_write(i2c_t *obj, int data)
                 return BYTE_TRANSFER_ERR_TIMEOUT;
 
             case BYTE_TRANSFER_STATE_START:
-                obj->byte_state = BYTE_TRANSFER_STATE_ADDRESS;
-                obj->last_address = ((uint32_t)data)>>1;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_ADDRESS;
+                obj->i2c.last_address = ((uint32_t)data)>>1;
                 return BYTE_TRANSFER_ERR_NONE;
 
             case BYTE_TRANSFER_STATE_ADDRESS:
-                obj->byte_state = BYTE_TRANSFER_STATE_DATA;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_DATA;
                 ret = i2c_ip6510_master_byte_write(
-                        obj->dev, obj->last_address, (uint8_t*)&data, true);
+                        obj->i2c.dev, obj->i2c.last_address, (uint8_t*)&data, true);
                 break;
 
             case BYTE_TRANSFER_STATE_DATA:
                 ret = i2c_ip6510_master_byte_write(
-                        obj->dev, obj->last_address, (uint8_t*)&data, false);
+                        obj->i2c.dev, obj->i2c.last_address, (uint8_t*)&data, false);
                 break;
 
             default:
@@ -305,7 +305,7 @@ int i2c_byte_write(i2c_t *obj, int data)
          * I2C controller, no need to track states.
          */
         ret = i2c_ip6510_slave_write(
-                    obj->dev, (uint8_t*)&data, &slave_write_cntr);
+                    obj->i2c.dev, (uint8_t*)&data, &slave_write_cntr);
     }
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -326,24 +326,24 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
     if (!enable_slave) {
         /* Check if master mode is already set */
-        if (i2c_ip6510_get_device_mode(obj->dev) != I2C_IP6510_MASTER_MODE) {
+        if (i2c_ip6510_get_device_mode(obj->i2c.dev) != I2C_IP6510_MASTER_MODE) {
             /* Set Master Mode */
-            i2c_ip6510_set_master_mode(obj->dev);
+            i2c_ip6510_set_master_mode(obj->i2c.dev);
         }
     } else {
         /* Check if slave mode is already set */
-        if (i2c_ip6510_get_device_mode(obj->dev) != I2C_IP6510_SLAVE_MODE) {
+        if (i2c_ip6510_get_device_mode(obj->i2c.dev) != I2C_IP6510_SLAVE_MODE) {
             /* Set Slave Mode */
-            i2c_ip6510_set_slave_mode(obj->dev, obj->last_address);
+            i2c_ip6510_set_slave_mode(obj->i2c.dev, obj->i2c.last_address);
         }
     }
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
-    uint32_t irq_status = i2c_ip6510_get_irq_status(obj->dev);
-    enum i2c_ip6510_transf_dir_t dir = i2c_ip6510_get_slave_tranf_dir(obj->dev);
-    uint32_t transfer_size = i2c_ip6510_get_transfer_size(obj->dev);
+    uint32_t irq_status = i2c_ip6510_get_irq_status(obj->i2c.dev);
+    enum i2c_ip6510_transf_dir_t dir = i2c_ip6510_get_slave_tranf_dir(obj->i2c.dev);
+    uint32_t transfer_size = i2c_ip6510_get_transfer_size(obj->i2c.dev);
 
     if (irq_status & I2C_IP6510_INTR_DATA_MASK) {
 
@@ -371,8 +371,8 @@ int  i2c_slave_read(i2c_t *obj, char *data, int length)
     enum i2c_ip6510_error_t ret;
 
     ret = i2c_ip6510_slave_read(
-            obj->dev, (uint8_t*)data, (uint32_t*)&length);
-    i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+            obj->i2c.dev, (uint8_t*)data, (uint32_t*)&length);
+    i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         return 0;
@@ -386,8 +386,8 @@ int  i2c_slave_write(i2c_t *obj, const char *data, int length)
     enum i2c_ip6510_error_t ret;
 
     ret = i2c_ip6510_slave_write(
-            obj->dev, (uint8_t*)data, (uint32_t*)&length);
-    i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+            obj->i2c.dev, (uint8_t*)data, (uint32_t*)&length);
+    i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         return 0;
@@ -399,8 +399,8 @@ int  i2c_slave_write(i2c_t *obj, const char *data, int length)
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
     /* Shifted 8 bit address is used in upper layer */
-    i2c_ip6510_set_slave_mode(obj->dev, ((uint16_t)address)>>1);
-    obj->last_address = address>>1;
+    i2c_ip6510_set_slave_mode(obj->i2c.dev, ((uint16_t)address)>>1);
+    obj->i2c.last_address = address>>1;
 }
 
 const PinMap *i2c_slave_sda_pinmap()
@@ -423,4 +423,17 @@ const PinMap *i2c_master_sda_pinmap()
 const PinMap *i2c_master_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = true,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }

--- a/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/i2c_api.c
@@ -68,26 +68,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     switch (i2c) {
 #ifdef I2C0_IP6510_DEV
         case I2C_0:
-            obj->dev = &I2C0_IP6510_DEV;
+            obj->i2c.dev = &I2C0_IP6510_DEV;
             break;
 #endif
 #ifdef I2C1_IP6510_DEV
         case I2C_1:
-            obj->dev = &I2C1_IP6510_DEV;
+            obj->i2c.dev = &I2C1_IP6510_DEV;
             break;
 #endif
         default:
             error("Failed to initialize I2C, bad reference.");
             return;
     }
-    obj->last_address = 0U;
-    obj->sda = sda;
-    obj->scl = scl;
-    obj->byte_state = BYTE_TRANSFER_STATE_NONE;
+    obj->i2c.last_address = 0U;
+    obj->i2c.sda = sda;
+    obj->i2c.scl = scl;
+    obj->i2c.byte_state = BYTE_TRANSFER_STATE_NONE;
 
     /* If already init, uninit */
-    if (i2c_ip6510_get_state(obj->dev) == I2C_IP6510_INITIALIZED) {
-        i2c_ip6510_uninit(obj->dev);
+    if (i2c_ip6510_get_state(obj->i2c.dev) == I2C_IP6510_INITIALIZED) {
+        i2c_ip6510_uninit(obj->i2c.dev);
     }
 
     /* Set the GPIO pins */
@@ -95,9 +95,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     pinmap_pinout(scl, PinMap_I2C_SCL);
 
     /* Initialize peripheral */
-    ret = i2c_ip6510_init(obj->dev, SystemCoreClock);
-    i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_100KHZ);
-    i2c_ip6510_set_timeout(obj->dev, 0xFFU);
+    ret = i2c_ip6510_init(obj->i2c.dev, SystemCoreClock);
+    i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_100KHZ);
+    i2c_ip6510_set_timeout(obj->i2c.dev, 0xFFU);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         error("Failed to initialize I2C, error occured in native driver.");
@@ -110,11 +110,11 @@ void i2c_frequency(i2c_t *obj, int hz)
     /* The peripheral only supports 100k and 400k clock in master mode */
     switch (hz) {
         case I2C_SPEED_100KHZ:
-            i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_100KHZ);
+            i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_100KHZ);
             break;
 
         case I2C_SPEED_400KHZ:
-            i2c_ip6510_set_speed(obj->dev, I2C_IP6510_SPEED_400KHZ);
+            i2c_ip6510_set_speed(obj->i2c.dev, I2C_IP6510_SPEED_400KHZ);
             break;
 
         default:
@@ -125,8 +125,8 @@ void i2c_frequency(i2c_t *obj, int hz)
 
 void i2c_reset(i2c_t *obj)
 {
-    i2c_ip6510_uninit(obj->dev);
-    i2c_init(obj, obj->sda, obj->scl);
+    i2c_ip6510_uninit(obj->i2c.dev);
+    i2c_init(obj, obj->i2c.sda, obj->i2c.scl);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
@@ -136,7 +136,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     /* Shifted 8 bit address is used in upper layer */
     address = ((uint32_t)address)>>1;
 
-    ret = i2c_ip6510_master_read(obj->dev, (uint16_t)address, (uint8_t*)data,
+    ret = i2c_ip6510_master_read(obj->i2c.dev, (uint16_t)address, (uint8_t*)data,
             stop, (uint32_t*)(&length));
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -155,14 +155,14 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
     /* Parameter checking */
     if (data == NULL || length == 0) {
-        ret = i2c_ip6510_monitor_slave(obj->dev, (uint16_t)address);
+        ret = i2c_ip6510_monitor_slave(obj->i2c.dev, (uint16_t)address);
         if (ret != I2C_IP6510_ERR_NONE) {
             return I2C_ERROR_NO_SLAVE;
         }
         return length;
     }
 
-    ret = i2c_ip6510_master_write(obj->dev, (uint16_t)address, (uint8_t*)data,
+    ret = i2c_ip6510_master_write(obj->i2c.dev, (uint16_t)address, (uint8_t*)data,
             stop, (uint32_t*)(&length));
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -179,9 +179,9 @@ int i2c_start(i2c_t *obj)
      *        The i2c transaction is started later, when the address and the
      *        first data byte is written.
      */
-    obj->byte_state = BYTE_TRANSFER_STATE_START;
-    obj->last_address = 0U;
-    i2c_ip6510_hold_enable(obj->dev);
+    obj->i2c.byte_state = BYTE_TRANSFER_STATE_START;
+    obj->i2c.last_address = 0U;
+    i2c_ip6510_hold_enable(obj->i2c.dev);
 
     return I2C_ERROR_NONE;
 }
@@ -189,35 +189,35 @@ int i2c_start(i2c_t *obj)
 int i2c_stop(i2c_t *obj)
 {
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          *        STOP condition is generated on hold disable.
          */
-        i2c_ip6510_hold_disable(obj->dev);
+        i2c_ip6510_hold_disable(obj->i2c.dev);
 
         /* If there was only one byte written (the slave address) before calling
          * stop, the state machine is in ADDRESS state. Writing just the address
          * is equal to a slave monitoring
          */
-        if (obj->byte_state == BYTE_TRANSFER_STATE_ADDRESS) {
+        if (obj->i2c.byte_state == BYTE_TRANSFER_STATE_ADDRESS) {
             /* Return value is not needed because signalling to the caller is
              * not defined
              */
-            (void)i2c_ip6510_monitor_slave(obj->dev, obj->last_address);
+            (void)i2c_ip6510_monitor_slave(obj->i2c.dev, obj->i2c.last_address);
         }
 
-        obj->byte_state = BYTE_TRANSFER_STATE_NONE;
-        obj->last_address = 0U;
+        obj->i2c.byte_state = BYTE_TRANSFER_STATE_NONE;
+        obj->i2c.last_address = 0U;
 
     } else {
         /* In slave mode the the I2C controller only writes and reads data from
          * the I2C bus. The function just clears the interrupts for
          * further adressing detection.
          */
-        i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+        i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
     }
     return I2C_ERROR_NONE;
 }
@@ -228,22 +228,22 @@ int i2c_byte_read(i2c_t *obj, int last)
     uint32_t slave_read_cntr = 1U;
 
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          */
-        switch (obj->byte_state) {
+        switch (obj->i2c.byte_state) {
             case BYTE_TRANSFER_STATE_ADDRESS:
-                obj->byte_state = BYTE_TRANSFER_STATE_DATA;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_DATA;
                 i2c_ip6510_master_byte_read(
-                        obj->dev, obj->last_address, last, true, &read_byte);
+                        obj->i2c.dev, obj->i2c.last_address, last, true, &read_byte);
                 return read_byte;
 
             case BYTE_TRANSFER_STATE_DATA:
                 i2c_ip6510_master_byte_read(
-                        obj->dev, obj->last_address, last, false, &read_byte);
+                        obj->i2c.dev, obj->i2c.last_address, last, false, &read_byte);
                 return read_byte;
 
             case BYTE_TRANSFER_STATE_NONE:
@@ -257,7 +257,7 @@ int i2c_byte_read(i2c_t *obj, int last)
          * I2C controller, no need to track states.
          */
         i2c_ip6510_slave_read(
-                            obj->dev, &read_byte, &slave_read_cntr);
+                            obj->i2c.dev, &read_byte, &slave_read_cntr);
         return read_byte;
     }
 }
@@ -268,13 +268,13 @@ int i2c_byte_write(i2c_t *obj, int data)
     uint32_t slave_write_cntr = 1U;
 
     /* Both the master and slave api calls this function */
-    if (i2c_ip6510_get_device_mode(obj->dev) == I2C_IP6510_MASTER_MODE) {
+    if (i2c_ip6510_get_device_mode(obj->i2c.dev) == I2C_IP6510_MASTER_MODE) {
 
         /** \note The peripheral does not support building up the transaction by
          *        instructions. The functionality is achieved with a software
          *        state machine.
          */
-        switch (obj->byte_state) {
+        switch (obj->i2c.byte_state) {
             case BYTE_TRANSFER_STATE_NONE:
                 /* Writing is invalid before start symbol
                  * BYTE_TRANSFER_ERR_TIMEOUT is the only error code mbed defines,
@@ -283,19 +283,19 @@ int i2c_byte_write(i2c_t *obj, int data)
                 return BYTE_TRANSFER_ERR_TIMEOUT;
 
             case BYTE_TRANSFER_STATE_START:
-                obj->byte_state = BYTE_TRANSFER_STATE_ADDRESS;
-                obj->last_address = ((uint32_t)data)>>1;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_ADDRESS;
+                obj->i2c.last_address = ((uint32_t)data)>>1;
                 return BYTE_TRANSFER_ERR_NONE;
 
             case BYTE_TRANSFER_STATE_ADDRESS:
-                obj->byte_state = BYTE_TRANSFER_STATE_DATA;
+                obj->i2c.byte_state = BYTE_TRANSFER_STATE_DATA;
                 ret = i2c_ip6510_master_byte_write(
-                        obj->dev, obj->last_address, (uint8_t*)&data, true);
+                        obj->i2c.dev, obj->i2c.last_address, (uint8_t*)&data, true);
                 break;
 
             case BYTE_TRANSFER_STATE_DATA:
                 ret = i2c_ip6510_master_byte_write(
-                        obj->dev, obj->last_address, (uint8_t*)&data, false);
+                        obj->i2c.dev, obj->i2c.last_address, (uint8_t*)&data, false);
                 break;
 
             default:
@@ -306,7 +306,7 @@ int i2c_byte_write(i2c_t *obj, int data)
          * I2C controller, no need to track states.
          */
         ret = i2c_ip6510_slave_write(
-                    obj->dev, (uint8_t*)&data, &slave_write_cntr);
+                    obj->i2c.dev, (uint8_t*)&data, &slave_write_cntr);
     }
 
     if (ret != I2C_IP6510_ERR_NONE) {
@@ -327,24 +327,24 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
     if (!enable_slave) {
         /* Check if master mode is already set */
-        if (i2c_ip6510_get_device_mode(obj->dev) != I2C_IP6510_MASTER_MODE) {
+        if (i2c_ip6510_get_device_mode(obj->i2c.dev) != I2C_IP6510_MASTER_MODE) {
             /* Set Master Mode */
-            i2c_ip6510_set_master_mode(obj->dev);
+            i2c_ip6510_set_master_mode(obj->i2c.dev);
         }
     } else {
         /* Check if slave mode is already set */
-        if (i2c_ip6510_get_device_mode(obj->dev) != I2C_IP6510_SLAVE_MODE) {
+        if (i2c_ip6510_get_device_mode(obj->i2c.dev) != I2C_IP6510_SLAVE_MODE) {
             /* Set Slave Mode */
-            i2c_ip6510_set_slave_mode(obj->dev, obj->last_address);
+            i2c_ip6510_set_slave_mode(obj->i2c.dev, obj->i2c.last_address);
         }
     }
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
-    uint32_t irq_status = i2c_ip6510_get_irq_status(obj->dev);
-    enum i2c_ip6510_transf_dir_t dir = i2c_ip6510_get_slave_tranf_dir(obj->dev);
-    uint32_t transfer_size = i2c_ip6510_get_transfer_size(obj->dev);
+    uint32_t irq_status = i2c_ip6510_get_irq_status(obj->i2c.dev);
+    enum i2c_ip6510_transf_dir_t dir = i2c_ip6510_get_slave_tranf_dir(obj->i2c.dev);
+    uint32_t transfer_size = i2c_ip6510_get_transfer_size(obj->i2c.dev);
 
     if (irq_status & I2C_IP6510_INTR_DATA_MASK) {
 
@@ -372,8 +372,8 @@ int  i2c_slave_read(i2c_t *obj, char *data, int length)
     enum i2c_ip6510_error_t ret;
 
     ret = i2c_ip6510_slave_read(
-            obj->dev, (uint8_t*)data, (uint32_t*)&length);
-    i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+            obj->i2c.dev, (uint8_t*)data, (uint32_t*)&length);
+    i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         return 0;
@@ -387,8 +387,8 @@ int  i2c_slave_write(i2c_t *obj, const char *data, int length)
     enum i2c_ip6510_error_t ret;
 
     ret = i2c_ip6510_slave_write(
-            obj->dev, (uint8_t*)data, (uint32_t*)&length);
-    i2c_ip6510_clear_irq(obj->dev, I2C_IP6510_ALL_INTR_MASK);
+            obj->i2c.dev, (uint8_t*)data, (uint32_t*)&length);
+    i2c_ip6510_clear_irq(obj->i2c.dev, I2C_IP6510_ALL_INTR_MASK);
 
     if (ret != I2C_IP6510_ERR_NONE) {
         return 0;
@@ -400,8 +400,8 @@ int  i2c_slave_write(i2c_t *obj, const char *data, int length)
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
     /* Shifted 8 bit address is used in upper layer */
-    i2c_ip6510_set_slave_mode(obj->dev, ((uint16_t)address)>>1);
-    obj->last_address = address>>1;
+    i2c_ip6510_set_slave_mode(obj->i2c.dev, ((uint16_t)address)>>1);
+    obj->i2c.last_address = address>>1;
 }
 
 const PinMap *i2c_slave_sda_pinmap()
@@ -424,4 +424,17 @@ const PinMap *i2c_master_sda_pinmap()
 const PinMap *i2c_master_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = true,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/i2c_api.c
@@ -30,8 +30,6 @@
 
 #define DEFAULT_CLK_FREQ (AM_HAL_IOM_400KHZ)
 
-static am_hal_iom_transfer_t xfer = {0};
-
 I2CName i2c_get_peripheral_name(PinName sda, PinName scl)
 {
     uint32_t iom_sda = pinmap_peripheral(sda, i2c_master_sda_pinmap());
@@ -55,11 +53,11 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     MBED_ASSERT((int)iom != IOM_NUM);
 
     // iom configuration
-    obj->i2c.iom_obj.iom.inst = (uint32_t)iom;
-    obj->i2c.iom_obj.iom.cfg.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
-    obj->i2c.iom_obj.iom.cfg.ui32ClockFreq = DEFAULT_CLK_FREQ;
-    obj->i2c.iom_obj.iom.cfg.pNBTxnBuf = NULL;
-    obj->i2c.iom_obj.iom.cfg.ui32NBTxnBufLength = 0;
+    obj->i2c.i2c.iom_obj.iom.inst = (uint32_t)iom;
+    obj->i2c.i2c.iom_obj.iom.cfg.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
+    obj->i2c.i2c.iom_obj.iom.cfg.ui32ClockFreq = DEFAULT_CLK_FREQ;
+    obj->i2c.i2c.iom_obj.iom.cfg.pNBTxnBuf = NULL;
+    obj->i2c.i2c.iom_obj.iom.cfg.ui32NBTxnBufLength = 0;
 
     // pin configuration
     if ((int)sda != NC) {
@@ -69,22 +67,14 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
         pinmap_config(scl, i2c_master_scl_pinmap());
     }
 
-    // invariant xfer settings
-    xfer.ui32InstrLen = 0;
-    xfer.ui32Instr = 0;
-    xfer.ui8RepeatCount = 0;
-    xfer.ui8Priority = 1;
-    xfer.ui32PauseCondition = 0;
-    xfer.ui32StatusSetClr = 0;
-
     // initialization
-    iom_init(&obj->i2c.iom_obj);
+    iom_init(&obj->i2c.i2c.iom_obj);
 }
 
 void i2c_free(i2c_t *obj)
 {
     MBED_ASSERT(obj);
-    iom_deinit(&obj->i2c.iom_obj);
+    iom_deinit(&obj->i2c.i2c.iom_obj);
 }
 
 void i2c_frequency(i2c_t *obj, int hz)
@@ -93,8 +83,8 @@ void i2c_frequency(i2c_t *obj, int hz)
     if (hz > AM_HAL_IOM_MAX_FREQ) {
         hz = AM_HAL_IOM_MAX_FREQ;
     }
-    obj->i2c.iom_obj.iom.cfg.ui32ClockFreq = hz;
-    iom_init(&obj->i2c.iom_obj);
+    obj->i2c.i2c.iom_obj.iom.cfg.ui32ClockFreq = hz;
+    iom_init(&obj->i2c.i2c.iom_obj);
 }
 
 int  i2c_start(i2c_t *obj)
@@ -117,13 +107,15 @@ int i2c_read(i2c_t *obj, int address8bit, char *data, int length, int stop)
 
     int handled_chars = 0;
 
+    am_hal_iom_transfer_t xfer = {0};
+    xfer.ui8Priority = 1;
     xfer.uPeerInfo.ui32I2CDevAddr = (address8bit >> 1);
     xfer.eDirection = AM_HAL_IOM_RX;
     xfer.ui32NumBytes = length;
     xfer.pui32RxBuffer = (uint32_t *)data;
     xfer.pui32TxBuffer = NULL;
     xfer.bContinue = (stop) ? false : true;
-    uint32_t status = am_hal_iom_blocking_transfer(obj->i2c.iom_obj.iom.handle, &xfer);
+    uint32_t status = am_hal_iom_blocking_transfer(obj->i2c.i2c.iom_obj.iom.handle, &xfer);
     if (AM_HAL_STATUS_SUCCESS != status) {
         return I2C_ERROR_NO_SLAVE;
     }
@@ -138,13 +130,15 @@ int i2c_write(i2c_t *obj, int address8bit, const char *data, int length, int sto
 
     int handled_chars = 0;
 
+    am_hal_iom_transfer_t xfer = {0};
+    xfer.ui8Priority = 1;
     xfer.uPeerInfo.ui32I2CDevAddr = (address8bit >> 1);
     xfer.eDirection = AM_HAL_IOM_TX;
     xfer.ui32NumBytes = length;
     xfer.pui32TxBuffer = (uint32_t *)data;
     xfer.pui32RxBuffer = NULL;
     xfer.bContinue = (stop) ? false : true;
-    uint32_t status = am_hal_iom_blocking_transfer(obj->i2c.iom_obj.iom.handle, &xfer);
+    uint32_t status = am_hal_iom_blocking_transfer(obj->i2c.i2c.iom_obj.iom.handle, &xfer);
     if (AM_HAL_STATUS_SUCCESS != status) {
         return I2C_ERROR_NO_SLAVE;
     }
@@ -191,6 +185,19 @@ const PinMap *i2c_slave_sda_pinmap(void)
 const PinMap *i2c_slave_scl_pinmap(void)
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_address_delayed = false,
+    .single_byte_start_cond_delayed = false,
+    .supports_single_byte = false,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/objects.h
@@ -34,8 +34,11 @@
 
 // Macro to check the result of calling am am_hal function and trigger an error if it fails
 #define MBED_CHECK_AM_HAL_CALL(call) \
-    if((call) != AM_HAL_STATUS_SUCCESS) { \
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_INVALID_OPERATION), "AM HAL Call Failed!"); \
+    { \
+        const uint32_t _ret = (call); \
+        if(_ret != AM_HAL_STATUS_SUCCESS) { \
+            MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_INVALID_OPERATION), "AM HAL Call Failed!", _ret); \
+        } \
     }
 
 #endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/CMSIS/AmbiqMicro/Include/apollo3.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/CMSIS/AmbiqMicro/Include/apollo3.h
@@ -134,8 +134,9 @@ typedef enum {
 #define __NVIC_PRIO_BITS               3        /*!< Number of Bits used for Priority Levels                                   */
 #define __Vendor_SysTickConfig         0        /*!< Set to 1 if different SysTick Config is used                              */
 #define __MPU_PRESENT                  1        /*!< MPU present                                                               */
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT                  1        /*!< FPU present                                                               */
-
+#endif
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/analogin_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/analogin_api.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * SPDX-License-Identifier: adi-bsd
  *
  * All rights reserved.
  *

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/analogin_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/analogin_api.c
@@ -40,6 +40,7 @@
 
 #include "mbed_assert.h"
 #include "analogin_api.h"
+#include <string.h>
 
 #if DEVICE_ANALOGIN
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * SPDX-License-Identifier: adi-bsd
  *
  * All rights reserved.
  *

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
@@ -83,30 +83,30 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 #if defined(BUILD_I2C_MI_DYNAMIC)
     I2C_DevNum = I2C_0;
-    pI2C_Handle = &obj->I2C_Handle;
-    obj->pI2C_Handle = pI2C_Handle;
-    I2C_Mem = obj->I2C_Mem;
+    pI2C_Handle = &obj->i2c.I2C_Handle;
+    obj->i2c.pI2C_Handle = pI2C_Handle;
+    I2C_Mem = obj->i2c.I2C_Mem;
 #else
     I2C_DevNum = I2C_0;
     pI2C_Handle = &i2c_Handle;
-    obj->pI2C_Handle = pI2C_Handle;
+    obj->i2c.pI2C_Handle = pI2C_Handle;
     I2C_Mem = &i2c_Mem[0];
 #endif
 
 
-    obj->instance = pinmap_merge(i2c_sda, i2c_scl);
-    MBED_ASSERT((int)obj->instance != NC);
+    obj->i2c.instance = pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT((int)obj->i2c.instance != NC);
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
     SystemCoreClockUpdate();
     I2C_Return = adi_i2c_Open(I2C_DevNum, I2C_Mem, ADI_I2C_MEMORY_SIZE, pI2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
     I2C_Return = adi_i2c_Reset(*pI2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -132,10 +132,10 @@ void i2c_frequency(i2c_t *obj, int hz)
     ADI_I2C_RESULT  I2C_Return = ADI_I2C_SUCCESS;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetBitRate(I2C_Handle, (uint32_t) hz);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -150,7 +150,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     ADI_I2C_HANDLE      I2C_Handle;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetSlaveAddress(I2C_Handle, (address & 0x0000FFFF));
     I2C_inst.pPrologue     = &I2C_PrologueData;
     I2C_inst.nPrologueSize = 0;
@@ -160,7 +160,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     I2C_inst.bRepeatStart  = stop;
     I2C_Return = adi_i2c_ReadWrite(I2C_Handle, &I2C_inst, &I2C_Errors);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return -1;
     } else {
         return length;
@@ -177,7 +177,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     ADI_I2C_HANDLE      I2C_Handle;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetSlaveAddress(I2C_Handle, (address & 0x0000FFFF));
     I2C_inst.pPrologue      = &I2C_PrologueData;
     I2C_inst.nPrologueSize  = 0;
@@ -187,7 +187,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     I2C_inst.bRepeatStart   = stop;
     I2C_Return = adi_i2c_ReadWrite(I2C_Handle, &I2C_inst, &I2C_Errors);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return -1;
     } else {
         return length;
@@ -198,11 +198,11 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 void i2c_reset(i2c_t *obj)
 {
     ADI_I2C_RESULT      I2C_Return;
-    ADI_I2C_HANDLE      I2C_Handle = *obj->pI2C_Handle;
+    ADI_I2C_HANDLE      I2C_Handle = *obj->i2c.pI2C_Handle;
 
     I2C_Return = adi_i2c_Reset(I2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -239,6 +239,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = false,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/analogin_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/analogin_api.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * SPDX-License-Identifier: adi-bsd
  *
  * All rights reserved.
  *

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/analogin_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/analogin_api.c
@@ -41,6 +41,8 @@
 #include "mbed_assert.h"
 #include "analogin_api.h"
 
+#include <string.h>
+
 #if DEVICE_ANALOGIN
 
 #include "adi_adc_def.h"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
@@ -83,9 +83,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 #if defined(BUILD_I2C_MI_DYNAMIC)
     I2C_DevNum = I2C_0;
-    pI2C_Handle = &obj->I2C_Handle;
-    obj->pI2C_Handle = pI2C_Handle;
-    I2C_Mem = obj->I2C_Mem;
+    pI2C_Handle = &obj->i2c.I2C_Handle;
+    obj->i2c.pI2C_Handle = pI2C_Handle;
+    I2C_Mem = obj->i2c.I2C_Mem;
 #else
     I2C_DevNum = I2C_0;
     pI2C_Handle = &i2c_Handle;
@@ -94,19 +94,19 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 #endif
 
 
-    obj->instance = pinmap_merge(i2c_sda, i2c_scl);
-    MBED_ASSERT((int)obj->instance != NC);
+    obj->i2c.instance = pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT((int)obj->i2c.instance != NC);
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
     SystemCoreClockUpdate();
     I2C_Return = adi_i2c_Open(I2C_DevNum, I2C_Mem, ADI_I2C_MEMORY_SIZE, pI2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
     I2C_Return = adi_i2c_Reset(*pI2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -132,10 +132,10 @@ void i2c_frequency(i2c_t *obj, int hz)
     ADI_I2C_RESULT  I2C_Return = ADI_I2C_SUCCESS;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetBitRate(I2C_Handle, (uint32_t) hz);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -150,7 +150,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     ADI_I2C_HANDLE      I2C_Handle;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetSlaveAddress(I2C_Handle, (address & 0x0000FFFF));
     I2C_inst.pPrologue     = &I2C_PrologueData;
     I2C_inst.nPrologueSize = 0;
@@ -160,7 +160,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     I2C_inst.bRepeatStart  = stop;
     I2C_Return = adi_i2c_ReadWrite(I2C_Handle, &I2C_inst, &I2C_Errors);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return -1;
     } else {
         return length;
@@ -177,7 +177,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     ADI_I2C_HANDLE      I2C_Handle;
 
 
-    I2C_Handle = *obj->pI2C_Handle;
+    I2C_Handle = *obj->i2c.pI2C_Handle;
     I2C_Return = adi_i2c_SetSlaveAddress(I2C_Handle, (address & 0x0000FFFF));
     I2C_inst.pPrologue      = &I2C_PrologueData;
     I2C_inst.nPrologueSize  = 0;
@@ -187,7 +187,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     I2C_inst.bRepeatStart   = stop;
     I2C_Return = adi_i2c_ReadWrite(I2C_Handle, &I2C_inst, &I2C_Errors);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return -1;
     } else {
         return length;
@@ -198,11 +198,11 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 void i2c_reset(i2c_t *obj)
 {
     ADI_I2C_RESULT      I2C_Return;
-    ADI_I2C_HANDLE      I2C_Handle = *obj->pI2C_Handle;
+    ADI_I2C_HANDLE      I2C_Handle = *obj->i2c.pI2C_Handle;
 
     I2C_Return = adi_i2c_Reset(I2C_Handle);
     if (I2C_Return) {
-        obj->error = I2C_EVENT_ERROR;
+        obj->i2c.error = I2C_EVENT_ERROR;
         return;
     }
 }
@@ -239,6 +239,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = false,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * SPDX-License-Identifier: adi-bsd
  *
  * All rights reserved.
  *

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_i2c_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_i2c_api.c
@@ -87,25 +87,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
     struct i2c_s *i2c = cy_get_i2c(obj);
     cy_rslt_t result = cyhal_i2c_init(&(i2c->hal_i2c), sda, scl, NULL);
-    if (result == CYHAL_HWMGR_RSLT_ERR_INUSE) {
-        // MBED I2C driver currently does not support free, so we will allow I2C to be reallocated.
-        // TODO: once the the I2C driver properly supports free, this need to be fixed so that clocks and pins are no longer leaked.
-        cyhal_hwmgr_free(&(i2c->hal_i2c.resource));
-        cyhal_resource_inst_t pin_rsc = cyhal_utils_get_gpio_resource(sda);
-        cyhal_hwmgr_free(&pin_rsc);
-        pin_rsc = cyhal_utils_get_gpio_resource(scl);
-        cyhal_hwmgr_free(&pin_rsc);
-        result = cyhal_i2c_init(&(i2c->hal_i2c), sda, scl, NULL);
-    }
     if (CY_RSLT_SUCCESS != result) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_I2C, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_i2c_init");
     }
+    i2c->pin_scl = scl;
+    i2c->pin_sda = sda;
     i2c->cfg.is_slave = false;
     i2c->cfg.address = 0;
     i2c->cfg.frequencyhal_hz = 400000;
     i2c->async_handler = NULL;
     cyhal_i2c_register_callback(&(i2c->hal_i2c), &cy_i2c_event_handler, obj);
     cyhal_i2c_enable_event(&(i2c->hal_i2c), (cyhal_i2c_event_t)(CYHAL_I2C_SLAVE_READ_EVENT | CYHAL_I2C_SLAVE_WRITE_EVENT | CYHAL_I2C_SLAVE_ERR_EVENT | CYHAL_I2C_SLAVE_RD_CMPLT_EVENT | CYHAL_I2C_SLAVE_WR_CMPLT_EVENT | CYHAL_I2C_MASTER_ERR_EVENT | CYHAL_I2C_MASTER_RD_CMPLT_EVENT | CYHAL_I2C_MASTER_WR_CMPLT_EVENT), CYHAL_ISR_PRIORITY_DEFAULT, true);
+}
+
+void i2c_free(i2c_t *obj) {
+    struct i2c_s *i2c = cy_get_i2c(obj);
+    cyhal_hwmgr_free(&(i2c->hal_i2c.resource));
+    cyhal_resource_inst_t pin_rsc = cyhal_utils_get_gpio_resource(i2c->pin_sda);
+    cyhal_hwmgr_free(&pin_rsc);
+    pin_rsc = cyhal_utils_get_gpio_resource(i2c->pin_scl);
+    cyhal_hwmgr_free(&pin_rsc);
 }
 
 void i2c_frequency(i2c_t *obj, int hz)
@@ -327,5 +328,18 @@ void i2c_free(i2c_t *obj)
 #ifdef __cplusplus
 }
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = true,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_i2c_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_i2c_api.c
@@ -317,12 +317,6 @@ void i2c_abort_asynch(i2c_t *obj)
     }
 }
 
-void i2c_free(i2c_t *obj)
-{
-    struct i2c_s *i2c = cy_get_i2c(obj);
-    cyhal_i2c_free(&i2c->hal_i2c);
-}
-
 #endif
 
 #ifdef __cplusplus

--- a/targets/TARGET_Cypress/TARGET_PSOC6/mtb-pdl-cat1/devices/COMPONENT_CAT1A/include/cy8c624abzi_d44.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/mtb-pdl-cat1/devices/COMPONENT_CAT1A/include/cy8c624abzi_d44.h
@@ -467,7 +467,9 @@ typedef enum {
 #define __Vendor_SysTickConfig          0       /*!< Set to 1 if different SysTick Config is used */
 #define __VTOR_PRESENT                  1       /*!< Set to 1 if CPU supports Vector Table Offset Register */
 #define __MPU_PRESENT                   1       /*!< MPU present or not */
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT                   1       /*!< FPU present or not */
+#endif
 #define __CM0P_PRESENT                  1       /*!< CM0P present or not */
 #define __DTCM_PRESENT                  0       /*!< DTCM present or not */
 #define __ICACHE_PRESENT                0       /*!< ICACHE present or not */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
@@ -87,6 +87,8 @@ struct trng_s {
 #if DEVICE_I2C
 struct i2c_s {
     cyhal_i2c_t hal_i2c;
+    PinName pin_scl;
+    PinName pin_sda;
     cyhal_i2c_cfg_t cfg;
 #ifdef DEVICE_I2C_ASYNCH
     void (*async_handler)(void);

--- a/targets/TARGET_Freescale/TARGET_KLXX/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/i2c_api.c
@@ -45,11 +45,11 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     // determine the I2C to use
     I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
     I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
-    obj->i2c = (I2C_Type*)pinmap_merge(i2c_sda, i2c_scl);
-    MBED_ASSERT((int)obj->i2c != NC);
+    obj->i2c.i2c = (I2C_Type*)pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT((int)obj->i2c.i2c != NC);
 
     // enable power
-    switch ((int)obj->i2c) {
+    switch ((int)obj->i2c.i2c) {
         case I2C_0: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 6; break;
         case I2C_1: SIM->SCGC5 |= 1 << 11; SIM->SCGC4 |= 1 << 7; break;
     }
@@ -58,7 +58,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     i2c_frequency(obj, 100000);
 
     // enable I2C interface
-    obj->i2c->C1 |= 0x80;
+    obj->i2c.i2c->C1 |= 0x80;
 
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -69,25 +69,25 @@ int i2c_start(i2c_t *obj) {
     volatile int i;
     // if we are in the middle of a transaction
     // activate the repeat_start flag
-    if (obj->i2c->S & I2C_S_BUSY_MASK) {
+    if (obj->i2c.i2c->S & I2C_S_BUSY_MASK) {
         // KL25Z errata sheet: repeat start cannot be generated if the
         // I2Cx_F[MULT] field is set to a non-zero value
-        temp = obj->i2c->F >> 6;
-        obj->i2c->F &= 0x3F;
-        obj->i2c->C1 |= 0x04;
+        temp = obj->i2c.i2c->F >> 6;
+        obj->i2c.i2c->F &= 0x3F;
+        obj->i2c.i2c->C1 |= 0x04;
         for (i = 0; i < 100; i ++) __NOP();
-        obj->i2c->F |= temp << 6;
+        obj->i2c.i2c->F |= temp << 6;
     } else {
-        obj->i2c->C1 |= I2C_C1_MST_MASK;
-        obj->i2c->C1 |= I2C_C1_TX_MASK;
+        obj->i2c.i2c->C1 |= I2C_C1_MST_MASK;
+        obj->i2c.i2c->C1 |= I2C_C1_TX_MASK;
     }
     return 0;
 }
 
 int i2c_stop(i2c_t *obj) {
     volatile uint32_t n = 0;
-    obj->i2c->C1 &= ~I2C_C1_MST_MASK;
-    obj->i2c->C1 &= ~I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_MST_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_TX_MASK;
 
     // It seems that there are timing problems
     // when there is no waiting time after a STOP.
@@ -101,7 +101,7 @@ static int timeout_status_poll(i2c_t *obj, uint32_t mask) {
     uint32_t i, timeout = 100000;
     
     for (i = 0; i < timeout; i++) {
-        if (obj->i2c->S & mask)
+        if (obj->i2c.i2c->S & mask)
             return 0;
     }
     
@@ -119,7 +119,7 @@ static int i2c_wait_end_tx_transfer(i2c_t *obj) {
         return 2;
     }
     
-    obj->i2c->S |= I2C_S_IICIF_MASK;
+    obj->i2c.i2c->S |= I2C_S_IICIF_MASK;
     
     // wait transfer complete
     if (timeout_status_poll(obj, I2C_S_TCF_MASK)) {
@@ -127,7 +127,7 @@ static int i2c_wait_end_tx_transfer(i2c_t *obj) {
     }
 
     // check if we received the ACK or not
-    return obj->i2c->S & I2C_S_RXAK_MASK ? 1 : 0;
+    return obj->i2c.i2c->S & I2C_S_RXAK_MASK ? 1 : 0;
 }
 
 // this function waits the end of a rx transfer and return the status of the transaction:
@@ -139,22 +139,22 @@ static int i2c_wait_end_rx_transfer(i2c_t *obj) {
         return 1;
     }
     
-    obj->i2c->S |= I2C_S_IICIF_MASK;
+    obj->i2c.i2c->S |= I2C_S_IICIF_MASK;
     
     return 0;
 }
 
 static void i2c_send_nack(i2c_t *obj) {
-    obj->i2c->C1 |= I2C_C1_TXAK_MASK; // NACK
+    obj->i2c.i2c->C1 |= I2C_C1_TXAK_MASK; // NACK
 }
 
 static void i2c_send_ack(i2c_t *obj) {
-    obj->i2c->C1 &= ~I2C_C1_TXAK_MASK; // ACK
+    obj->i2c.i2c->C1 &= ~I2C_C1_TXAK_MASK; // ACK
 }
 
 static int i2c_do_write(i2c_t *obj, int value) {
     // write the data
-    obj->i2c->D = value;
+    obj->i2c.i2c->D = value;
 
     // init and wait the end of the transfer
     return i2c_wait_end_tx_transfer(obj);
@@ -166,7 +166,7 @@ static int i2c_do_read(i2c_t *obj, char * data, int last) {
     else
         i2c_send_ack(obj);
 
-    *data = (obj->i2c->D & 0xFF);
+    *data = (obj->i2c.i2c->D & 0xFF);
 
     // start rx transfer and wait the end of the transfer
     return i2c_wait_end_rx_transfer(obj);
@@ -202,7 +202,7 @@ void i2c_frequency(i2c_t *obj, int hz) {
     pulse = icr | (mult << 6);
 
     // I2C Rate
-    obj->i2c->F = pulse;
+    obj->i2c.i2c->F = pulse;
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
@@ -220,7 +220,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     }
 
     // set rx mode
-    obj->i2c->C1 &= ~I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_TX_MASK;
 
     // Read in bytes
     for (count = 0; count < (length); count++) {
@@ -238,7 +238,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     }
 
     // last read
-    data[count-1] = obj->i2c->D;
+    data[count-1] = obj->i2c.i2c->D;
 
     return length;
 }
@@ -277,19 +277,19 @@ int i2c_byte_read(i2c_t *obj, int last) {
     char data;
     
     // set rx mode
-    obj->i2c->C1 &= ~I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_TX_MASK;
     
     // Setup read
     i2c_do_read(obj, &data, last);
 
     // set tx mode
-    obj->i2c->C1 |= I2C_C1_TX_MASK;
-    return obj->i2c->D;
+    obj->i2c.i2c->C1 |= I2C_C1_TX_MASK;
+    return obj->i2c.i2c->D;
 }
 
 int i2c_byte_write(i2c_t *obj, int data) {
     // set tx mode
-    obj->i2c->C1 |= I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 |= I2C_C1_TX_MASK;
     
     return !i2c_do_write(obj, (data & 0xFF));
 }
@@ -319,16 +319,16 @@ const PinMap *i2c_slave_scl_pinmap()
 void i2c_slave_mode(i2c_t *obj, int enable_slave) {
     if (enable_slave) {
         // set slave mode
-        obj->i2c->C1 &= ~I2C_C1_MST_MASK;
-        obj->i2c->C1 |= I2C_C1_IICIE_MASK;
+        obj->i2c.i2c->C1 &= ~I2C_C1_MST_MASK;
+        obj->i2c.i2c->C1 |= I2C_C1_IICIE_MASK;
     } else {
         // set master mode
-        obj->i2c->C1 |= I2C_C1_MST_MASK;
+        obj->i2c.i2c->C1 |= I2C_C1_MST_MASK;
     }
 }
 
 int i2c_slave_receive(i2c_t *obj) {
-    switch(obj->i2c->S) {
+    switch(obj->i2c.i2c->S) {
         // read addressed
         case 0xE6: return 1;
         
@@ -345,23 +345,23 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
     int count;
     
     // set rx mode
-    obj->i2c->C1 &= ~I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_TX_MASK;
     
     // first dummy read
-    dummy_read = obj->i2c->D;
+    dummy_read = obj->i2c.i2c->D;
     if(i2c_wait_end_rx_transfer(obj)) {
         return 0;
     }
     
     // read address
-    dummy_read = obj->i2c->D;
+    dummy_read = obj->i2c.i2c->D;
     if(i2c_wait_end_rx_transfer(obj)) {
         return 0;
     }
     
     // read (length - 1) bytes
     for (count = 0; count < (length - 1); count++) {
-        data[count] = obj->i2c->D;
+        data[count] = obj->i2c.i2c->D;
         if(i2c_wait_end_rx_transfer(obj)) {
             return count;
         }
@@ -369,7 +369,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
 
     // read last byte
     ptr = (length == 0) ? &dummy_read : (uint8_t *)&data[count];
-    *ptr = obj->i2c->D;
+    *ptr = obj->i2c.i2c->D;
     
     return (length) ? (count + 1) : 0;
 }
@@ -378,7 +378,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
     int i, count = 0;
     
     // set tx mode
-    obj->i2c->C1 |= I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 |= I2C_C1_TX_MASK;
     
     for (i = 0; i < length; i++) {
         if(i2c_do_write(obj, data[count++]) == 2) {
@@ -387,11 +387,11 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
     }
     
     // set rx mode
-    obj->i2c->C1 &= ~I2C_C1_TX_MASK;
+    obj->i2c.i2c->C1 &= ~I2C_C1_TX_MASK;
     
     // dummy rx transfer needed
     // otherwise the master cannot generate a stop bit
-    obj->i2c->D;
+    obj->i2c.i2c->D;
     if(i2c_wait_end_rx_transfer(obj) == 2) {
         return count;
     }
@@ -400,8 +400,21 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
 }
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
-    obj->i2c->A1 = address & 0xfe;
+    obj->i2c.i2c->A1 = address & 0xfe;
 }
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
@@ -44,15 +44,15 @@ static void _i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
     PORT_Type *port_addrs[] = PORT_BASE_PTRS;
     PORT_Type *base = port_addrs[pinmap->sda_pin >> GPIO_PORT_SHIFT];
 
-    obj->instance = (uint32_t) pinmap->peripheral;
-    obj->next_repeated_start = 0;
-    MBED_ASSERT((int)obj->instance != NC);
+    obj->i2c.instance = (uint32_t) pinmap->peripheral;
+    obj->i2c.next_repeated_start = 0;
+    MBED_ASSERT((int)obj->i2c.instance != NC);
 
     i2c_master_config_t master_config;
 
     I2C_MasterGetDefaultConfig(&master_config);
-    I2C_MasterInit(i2c_addrs[obj->instance], &master_config, CLOCK_GetFreq(i2c_clocks[obj->instance]));
-    I2C_EnableInterrupts(i2c_addrs[obj->instance], kI2C_GlobalInterruptEnable);
+    I2C_MasterInit(i2c_addrs[obj->i2c.instance], &master_config, CLOCK_GetFreq(i2c_clocks[obj->i2c.instance]));
+    I2C_EnableInterrupts(i2c_addrs[obj->i2c.instance], kI2C_GlobalInterruptEnable);
 
     pin_function(pinmap->sda_pin, pinmap->sda_function);
     pin_mode(pinmap->sda_pin, PullNone);
@@ -86,7 +86,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 int i2c_start(i2c_t *obj)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t statusFlags = I2C_MasterGetStatusFlags(base);
 
     /* Check if the bus is already in use. */
@@ -108,7 +108,7 @@ int i2c_start(i2c_t *obj)
 
 int i2c_stop(i2c_t *obj)
 {
-    if (I2C_MasterStop(i2c_addrs[obj->instance]) != kStatus_Success) {
+    if (I2C_MasterStop(i2c_addrs[obj->i2c.instance]) != kStatus_Success) {
         return 1;
     }
 
@@ -119,13 +119,13 @@ void i2c_frequency(i2c_t *obj, int hz)
 {
     uint32_t busClock;
 
-    busClock = CLOCK_GetFreq(i2c_clocks[obj->instance]);
-    I2C_MasterSetBaudRate(i2c_addrs[obj->instance], hz, busClock);
+    busClock = CLOCK_GetFreq(i2c_clocks[obj->i2c.instance]);
+    I2C_MasterSetBaudRate(i2c_addrs[obj->i2c.instance], hz, busClock);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     i2c_master_transfer_t master_xfer;
 
     i2c_address = address >> 1;
@@ -134,13 +134,13 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     master_xfer.direction = kI2C_Read;
     master_xfer.data = (uint8_t *)data;
     master_xfer.dataSize = length;
-    if (obj->next_repeated_start) {
+    if (obj->i2c.next_repeated_start) {
         master_xfer.flags |= kI2C_TransferRepeatedStartFlag;
     }
     if (!stop) {
         master_xfer.flags |= kI2C_TransferNoStopFlag;
     }
-    obj->next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
+    obj->i2c.next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
 
     /* The below function will issue a STOP signal at the end of the transfer.
      * This is required by the hardware in order to receive the last byte
@@ -154,7 +154,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     i2c_master_transfer_t master_xfer;
 
     if (length == 0) {
@@ -181,13 +181,13 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     master_xfer.direction = kI2C_Write;
     master_xfer.data = (uint8_t *)data;
     master_xfer.dataSize = length;
-    if (obj->next_repeated_start) {
+    if (obj->i2c.next_repeated_start) {
         master_xfer.flags |= kI2C_TransferRepeatedStartFlag;
     }
     if (!stop) {
         master_xfer.flags |= kI2C_TransferNoStopFlag;
     }
-    obj->next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
+    obj->i2c.next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
 
     if (I2C_MasterTransferBlocking(base, &master_xfer) != kStatus_Success) {
         return I2C_ERROR_NO_SLAVE;
@@ -204,7 +204,7 @@ void i2c_reset(i2c_t *obj)
 int i2c_byte_read(i2c_t *obj, int last)
 {
     uint8_t data;
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     /* Setup the I2C peripheral to receive data. */
     base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
@@ -235,7 +235,7 @@ int i2c_byte_write(i2c_t *obj, int data)
 {
     int ret_value = 1;
     uint8_t statusFlags = 0;
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     /* Setup the I2C peripheral to transmit data. */
     base->C1 |= I2C_C1_TX_MASK;
@@ -296,15 +296,15 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
     slave_config.slaveAddress = 0;
     slave_config.enableSlave = (bool)enable_slave;
 #if FSL_I2C_DRIVER_VERSION > MAKE_VERSION(2, 0, 1)
-    I2C_SlaveInit(i2c_addrs[obj->instance], &slave_config, CLOCK_GetFreq(i2c_clocks[obj->instance]));
+    I2C_SlaveInit(i2c_addrs[obj->i2c.instance], &slave_config, CLOCK_GetFreq(i2c_clocks[obj->i2c.instance]));
 #else
-    I2C_SlaveInit(i2c_addrs[obj->instance], &slave_config);
+    I2C_SlaveInit(i2c_addrs[obj->i2c.instance], &slave_config);
 #endif
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
-    uint32_t status_flags = I2C_SlaveGetStatusFlags(i2c_addrs[obj->instance]);
+    uint32_t status_flags = I2C_SlaveGetStatusFlags(i2c_addrs[obj->i2c.instance]);
 
     if (status_flags & kI2C_AddressMatchFlag) {
         if (status_flags & kI2C_TransferDirectionFlag) {
@@ -322,7 +322,7 @@ int i2c_slave_receive(i2c_t *obj)
 
 int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     if (base->S & kI2C_AddressMatchFlag) {
         /* Slave receive, master writing to slave. */
@@ -338,7 +338,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
 
 int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     I2C_SlaveWriteBlocking(base, (uint8_t *)data, length);
 
@@ -352,8 +352,21 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
-    i2c_addrs[obj->instance]->A1 = address & 0xfe;
+    i2c_addrs[obj->i2c.instance]->A1 = address & 0xfe;
 }
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
@@ -58,9 +58,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     mxc_i2cm_regs_t *i2c = (mxc_i2cm_regs_t*)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT((int)i2c != NC);
 
-    obj->i2c = i2c;
-    obj->fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
-    obj->start_pending = 0;
+    obj->i2c.i2c = i2c;
+    obj->i2c.fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
+    obj->i2c.start_pending = 0;
 
     // Merge pin function requests for use with CMSIS init func
     ioman_req_t io_req;
@@ -70,47 +70,47 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     pin_func = (pin_function_t *)pinmap_find_function(scl, PinMap_I2C_SCL);
     io_req.value |= pin_func->req_val;
 
-    obj->sys_cfg.io_cfg.req_reg = pin_func->reg_req;
-    obj->sys_cfg.io_cfg.ack_reg = pin_func->reg_ack;
-    obj->sys_cfg.io_cfg.req_val = io_req;
-    obj->sys_cfg.clk_scale = CLKMAN_SCALE_DIV_1;
+    obj->i2c.sys_cfg.io_cfg.req_reg = pin_func->reg_req;
+    obj->i2c.sys_cfg.io_cfg.ack_reg = pin_func->reg_ack;
+    obj->i2c.sys_cfg.io_cfg.req_val = io_req;
+    obj->i2c.sys_cfg.clk_scale = CLKMAN_SCALE_DIV_1;
 
-    I2CM_Init(obj->i2c, &obj->sys_cfg, I2CM_SPEED_100KHZ);
+    I2CM_Init(obj->i2c.i2c, &obj->i2c.sys_cfg, I2CM_SPEED_100KHZ);
 }
 
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_Init(obj->i2c, &obj->sys_cfg, (i2cm_speed_t)hz);
+    I2CM_Init(obj->i2c.i2c, &obj->i2c.sys_cfg, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************
 int i2c_start(i2c_t *obj)
 {
-    obj->start_pending = 1;
+    obj->i2c.start_pending = 1;
     return 0;
 }
 
 //******************************************************************************
 int i2c_stop(i2c_t *obj)
 {
-    obj->start_pending = 0;
-    I2CM_WriteTxFifo(obj->i2c, obj->fifo, MXC_S_I2CM_TRANS_TAG_STOP);
-    I2CM_TxInProgress(obj->i2c);
+    obj->i2c.start_pending = 0;
+    I2CM_WriteTxFifo(obj->i2c.i2c, obj->i2c.fifo, MXC_S_I2CM_TRANS_TAG_STOP);
+    I2CM_TxInProgress(obj->i2c.i2c);
     return 0;
 }
 
 //******************************************************************************
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    return I2CM_Read(obj->i2c, address >> 1, NULL, 0, (uint8_t *)data, length, stop);
+    return I2CM_Read(obj->i2c.i2c, address >> 1, NULL, 0, (uint8_t *)data, length, stop);
 }
 
 //******************************************************************************
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
 
     if (stop) {
         return I2CM_Write(i2cm, address >> 1, NULL, 0, (uint8_t *)data, length);
@@ -128,14 +128,14 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 //******************************************************************************
 void i2c_reset(i2c_t *obj)
 {
-    I2CM_Recover(obj->i2c);
+    I2CM_Recover(obj->i2c.i2c);
 }
 
 //******************************************************************************
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int tmp;
 
     // Start the transaction if it is not currently ongoing
@@ -182,12 +182,12 @@ byte_read_err:
 //******************************************************************************
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int result;
 
-    if (obj->start_pending) {
-        obj->start_pending = 0;
+    if (obj->i2c.start_pending) {
+        obj->i2c.start_pending = 0;
         data |= MXC_S_I2CM_TRANS_TAG_START;
     } else {
         data |= MXC_S_I2CM_TRANS_TAG_TXDATA_ACK;
@@ -227,6 +227,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2016 Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/max32625.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/max32625.h
@@ -136,7 +136,10 @@ typedef enum {
 #define __MPU_PRESENT                  0            /*!< MPU present or not                                     */
 #define __NVIC_PRIO_BITS               3            /*!< Number of Bits used for Priority Levels                */
 #define __Vendor_SysTickConfig         0            /*!< Set to 1 if different SysTick Config is used           */
+
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT                  1            /*!< FPU present or not                                     */
+#endif
 
 #include <core_cm4.h>                               /*!< Cortex-M4 processor and core peripherals               */
 #include "system_max32625.h"                           /*!< System Header                                          */

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/max32625.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/max32625.h
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (C) 2016 Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
@@ -58,9 +58,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     mxc_i2cm_regs_t *i2c = (mxc_i2cm_regs_t*)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT((int)i2c != NC);
 
-    obj->i2c = i2c;
-    obj->fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
-    obj->start_pending = 0;
+    obj->i2c.i2c = i2c;
+    obj->i2c.fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
+    obj->i2c.start_pending = 0;
 
     // Merge pin function requests for use with CMSIS init func
     ioman_req_t io_req;
@@ -76,42 +76,42 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     sys_cfg.io_cfg.req_val = io_req;
     sys_cfg.clk_scale = CLKMAN_SCALE_DIV_1;
 
-    I2CM_Init(obj->i2c, &sys_cfg, I2CM_SPEED_400KHZ);
+    I2CM_Init(obj->i2c.i2c, &sys_cfg, I2CM_SPEED_400KHZ);
 }
 
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_SetFrequency(obj->i2c, (i2cm_speed_t)hz);
+    I2CM_SetFrequency(obj->i2c.i2c, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************
 int i2c_start(i2c_t *obj)
 {
-    obj->start_pending = 1;
+    obj->i2c.start_pending = 1;
     return 0;
 }
 
 //******************************************************************************
 int i2c_stop(i2c_t *obj)
 {
-    obj->start_pending = 0;
-    I2CM_WriteTxFifo(obj->i2c, obj->fifo, MXC_S_I2CM_TRANS_TAG_STOP);
-    I2CM_TxInProgress(obj->i2c);
+    obj->i2c.start_pending = 0;
+    I2CM_WriteTxFifo(obj->i2c.i2c, obj->i2c.fifo, MXC_S_I2CM_TRANS_TAG_STOP);
+    I2CM_TxInProgress(obj->i2c.i2c);
     return 0;
 }
 
 //******************************************************************************
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    return I2CM_Read(obj->i2c, address >> 1, NULL, 0, (uint8_t *)data, length);
+    return I2CM_Read(obj->i2c.i2c, address >> 1, NULL, 0, (uint8_t *)data, length);
 }
 
 //******************************************************************************
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
 
     if (stop) {
         return I2CM_Write(i2cm, address >> 1, NULL, 0, (uint8_t *)data, length);
@@ -129,14 +129,14 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 //******************************************************************************
 void i2c_reset(i2c_t *obj)
 {
-    I2CM_Recover(obj->i2c);
+    I2CM_Recover(obj->i2c.i2c);
 }
 
 //******************************************************************************
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int tmp;
 
     // Start the transaction if it is not currently ongoing
@@ -183,12 +183,12 @@ byte_write_err:
 //******************************************************************************
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int result;
 
-    if (obj->start_pending) {
-        obj->start_pending = 0;
+    if (obj->i2c.start_pending) {
+        obj->i2c.start_pending = 0;
         data |= MXC_S_I2CM_TRANS_TAG_START;
     } else {
         data |= MXC_S_I2CM_TRANS_TAG_TXDATA_ACK;
@@ -228,6 +228,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2016 Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
@@ -58,9 +58,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     mxc_i2cm_regs_t *i2c = (mxc_i2cm_regs_t*)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT((int)i2c != NC);
 
-    obj->i2c = i2c;
-    obj->fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
-    obj->start_pending = 0;
+    obj->i2c.i2c = i2c;
+    obj->i2c.fifo = MXC_I2CM_GET_FIFO(MXC_I2CM_GET_IDX(i2c));
+    obj->i2c.start_pending = 0;
 
     // Merge pin function requests for use with CMSIS init func
     ioman_req_t io_req;
@@ -70,47 +70,47 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     pin_func = (pin_function_t *)pinmap_find_function(scl, PinMap_I2C_SCL);
     io_req.value |= pin_func->req_val;
 
-    obj->sys_cfg.io_cfg.req_reg = pin_func->reg_req;
-    obj->sys_cfg.io_cfg.ack_reg = pin_func->reg_ack;
-    obj->sys_cfg.io_cfg.req_val = io_req;
-    obj->sys_cfg.clk_scale = CLKMAN_SCALE_DIV_1;
+    obj->i2c.sys_cfg.io_cfg.req_reg = pin_func->reg_req;
+    obj->i2c.sys_cfg.io_cfg.ack_reg = pin_func->reg_ack;
+    obj->i2c.sys_cfg.io_cfg.req_val = io_req;
+    obj->i2c.sys_cfg.clk_scale = CLKMAN_SCALE_DIV_1;
 
-    I2CM_Init(obj->i2c, &obj->sys_cfg, I2CM_SPEED_400KHZ);
+    I2CM_Init(obj->i2c.i2c, &obj->i2c.sys_cfg, I2CM_SPEED_400KHZ);
 }
 
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_Init(obj->i2c, &obj->sys_cfg, (i2cm_speed_t)hz);
+    I2CM_Init(obj->i2c.i2c, &obj->i2c.sys_cfg, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************
 int i2c_start(i2c_t *obj)
 {
-    obj->start_pending = 1;
+    obj->i2c.start_pending = 1;
     return 0;
 }
 
 //******************************************************************************
 int i2c_stop(i2c_t *obj)
 {
-    obj->start_pending = 0;
-    I2CM_WriteTxFifo(obj->i2c, obj->fifo, MXC_S_I2CM_TRANS_TAG_STOP);
-    I2CM_TxInProgress(obj->i2c);
+    obj->i2c.start_pending = 0;
+    I2CM_WriteTxFifo(obj->i2c.i2c, obj->i2c.fifo, MXC_S_I2CM_TRANS_TAG_STOP);
+    I2CM_TxInProgress(obj->i2c.i2c);
     return 0;
 }
 
 //******************************************************************************
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    return I2CM_Read(obj->i2c, address >> 1, NULL, 0, (uint8_t *)data, length);
+    return I2CM_Read(obj->i2c.i2c, address >> 1, NULL, 0, (uint8_t *)data, length);
 }
 
 //******************************************************************************
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
 
     if (stop) {
         return I2CM_Write(i2cm, address >> 1, NULL, 0, (uint8_t *)data, length);
@@ -128,14 +128,14 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 //******************************************************************************
 void i2c_reset(i2c_t *obj)
 {
-    I2CM_Recover(obj->i2c);
+    I2CM_Recover(obj->i2c.i2c);
 }
 
 //******************************************************************************
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int tmp;
 
     // Start the transaction if it is not currently ongoing
@@ -182,12 +182,12 @@ byte_read_err:
 //******************************************************************************
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    mxc_i2cm_regs_t *i2cm = obj->i2c;
-    mxc_i2cm_fifo_regs_t *fifo = obj->fifo;
+    mxc_i2cm_regs_t *i2cm = obj->i2c.i2c;
+    mxc_i2cm_fifo_regs_t *fifo = obj->i2c.fifo;
     int result;
 
-    if (obj->start_pending) {
-        obj->start_pending = 0;
+    if (obj->i2c.start_pending) {
+        obj->i2c.start_pending = 0;
         data |= MXC_S_I2CM_TRANS_TAG_START;
     } else {
         data |= MXC_S_I2CM_TRANS_TAG_TXDATA_ACK;
@@ -227,6 +227,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2016 Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_Maxim/TARGET_MAX32660/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32660/i2c_api.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (c) Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_Maxim/TARGET_MAX32660/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32660/i2c_api.c
@@ -64,24 +64,24 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     mxc_i2c_regs_t *i2c = (mxc_i2c_regs_t*)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT((int)i2c != NC);
 
-    obj->i2c = i2c;
-    obj->start_pending = 0;
+    obj->i2c.i2c = i2c;
+    obj->i2c.start_pending = 0;
 
-    MXC_I2C_Shutdown(obj->i2c);
-    MXC_I2C_Init(obj->i2c, 1, 0);// configure as master
+    MXC_I2C_Shutdown(obj->i2c.i2c);
+    MXC_I2C_Init(obj->i2c.i2c, 1, 0);// configure as master
 }
 
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    MXC_I2C_SetFrequency(obj->i2c, hz);
+    MXC_I2C_SetFrequency(obj->i2c.i2c, hz);
 }
 
 //******************************************************************************
 int i2c_start(i2c_t *obj)
 { 
     int ret;
-    ret = MXC_I2C_Start(obj->i2c);
+    ret = MXC_I2C_Start(obj->i2c.i2c);
     if (ret != 0) {
         //...
     }
@@ -92,7 +92,7 @@ int i2c_start(i2c_t *obj)
 int i2c_stop(i2c_t *obj)
 { 
     int ret;
-    ret = MXC_I2C_Stop(obj->i2c);
+    ret = MXC_I2C_Stop(obj->i2c.i2c);
     if (ret != 0) {
         //...
     }
@@ -105,7 +105,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     int ret = 0;
     mxc_i2c_req_t reqMaster;
 
-    reqMaster.i2c = obj->i2c;
+    reqMaster.i2c = obj->i2c.i2c;
     reqMaster.addr = address;
     reqMaster.tx_buf = NULL;
     reqMaster.tx_len = 0;
@@ -128,7 +128,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     int ret = 0;
     mxc_i2c_req_t reqMaster;
 
-    reqMaster.i2c = obj->i2c;
+    reqMaster.i2c = obj->i2c.i2c;
     reqMaster.addr = address;
     reqMaster.tx_buf = (unsigned char *)data;
     reqMaster.tx_len = length;
@@ -148,7 +148,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 //******************************************************************************
 void i2c_reset(i2c_t *obj)
 {
-    MXC_I2C_Recover(obj->i2c, 5);
+    MXC_I2C_Recover(obj->i2c.i2c, 5);
 }
 
 //******************************************************************************
@@ -156,7 +156,7 @@ int i2c_byte_read(i2c_t *obj, int ack)
 {
     unsigned char byt = 0; 
 
-    MXC_I2C_ReadByte(obj->i2c, &byt, ack);
+    MXC_I2C_ReadByte(obj->i2c.i2c, &byt, ack);
 
     return byt;
 }
@@ -166,7 +166,7 @@ int i2c_byte_write(i2c_t *obj, int data)
 {
     int ret;
 
-    ret = MXC_I2C_WriteByte(obj->i2c, (unsigned char)data);
+    ret = MXC_I2C_WriteByte(obj->i2c.i2c, (unsigned char)data);
 
     /*  
         Functions returns:
@@ -242,5 +242,18 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 }
 
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32670/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32670/i2c_api.c
@@ -54,24 +54,24 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     mxc_i2c_regs_t *i2c = (mxc_i2c_regs_t*)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT((int)i2c != NC);
 
-    obj->i2c = i2c;
-    obj->start_pending = 0;
+    obj->i2c.i2c = i2c;
+    obj->i2c.start_pending = 0;
 
-    MXC_I2C_Shutdown(obj->i2c);
-    MXC_I2C_Init(obj->i2c, 1, 0);// configure as master
+    MXC_I2C_Shutdown(obj->i2c.i2c);
+    MXC_I2C_Init(obj->i2c.i2c, 1, 0);// configure as master
 }
 
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    MXC_I2C_SetFrequency(obj->i2c, hz);
+    MXC_I2C_SetFrequency(obj->i2c.i2c, hz);
 }
 
 //******************************************************************************
 int i2c_start(i2c_t *obj)
 { 
     int ret;
-    ret = MXC_I2C_Start(obj->i2c);
+    ret = MXC_I2C_Start(obj->i2c.i2c);
     if (ret != 0) {
         //...
     }
@@ -82,7 +82,7 @@ int i2c_start(i2c_t *obj)
 int i2c_stop(i2c_t *obj)
 { 
     int ret;
-    ret = MXC_I2C_Stop(obj->i2c);
+    ret = MXC_I2C_Stop(obj->i2c.i2c);
     if (ret != 0) {
         //...
     }
@@ -95,7 +95,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     int ret = 0;
     mxc_i2c_req_t reqMaster;
 
-    reqMaster.i2c = obj->i2c;
+    reqMaster.i2c = obj->i2c.i2c;
     reqMaster.addr = address;
     reqMaster.tx_buf = NULL;
     reqMaster.tx_len = 0;
@@ -118,7 +118,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     int ret = 0;
     mxc_i2c_req_t reqMaster;
 
-    reqMaster.i2c = obj->i2c;
+    reqMaster.i2c = obj->i2c.i2c;
     reqMaster.addr = address;
     reqMaster.tx_buf = (unsigned char *)data;
     reqMaster.tx_len = length;
@@ -138,7 +138,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 //******************************************************************************
 void i2c_reset(i2c_t *obj)
 {
-    MXC_I2C_Recover(obj->i2c, 5);
+    MXC_I2C_Recover(obj->i2c.i2c, 5);
 }
 
 //******************************************************************************
@@ -146,7 +146,7 @@ int i2c_byte_read(i2c_t *obj, int ack)
 {
     unsigned char byt = 0; 
 
-    MXC_I2C_ReadByte(obj->i2c, &byt, ack);
+    MXC_I2C_ReadByte(obj->i2c.i2c, &byt, ack);
 
     return byt;
 }
@@ -156,7 +156,7 @@ int i2c_byte_write(i2c_t *obj, int data)
 {
     int ret;
 
-    ret = MXC_I2C_WriteByte(obj->i2c, (unsigned char)data);
+    ret = MXC_I2C_WriteByte(obj->i2c.i2c, (unsigned char)data);
 
     /*  
         Functions returns:
@@ -198,6 +198,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = false,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #if 0 // DEVICE_I2CSLAVE

--- a/targets/TARGET_Maxim/TARGET_MAX32670/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32670/i2c_api.c
@@ -1,6 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
  *
+ * SPDX-License-Identifier: X11
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation

--- a/targets/TARGET_NXP/TARGET_LPC17XX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC17XX/i2c_api.c
@@ -399,8 +399,8 @@ int i2c_byte_write(i2c_t *obj, int data) {
     printf("i2c_byte_write(): status was originally 0x%x\n", initial_status);
 #endif
 
-    if(initial_status == ADDR_WRITE_TRANSMITTED_NACK) {
-        // Address was previously transmitted and not-acknowledged, do not transmit anything else.
+    if(initial_status == ADDR_WRITE_TRANSMITTED_NACK || initial_status == DATA_TRANSMITTED_NACK) {
+        // Address or data was previously transmitted and not-acknowledged, do not transmit anything else.
         return 0;
     }
 

--- a/targets/TARGET_NXP/TARGET_LPC17XX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC17XX/i2c_api.c
@@ -30,12 +30,43 @@
 #include <inttypes.h>
 #endif
 
-#define I2C_CONSET(x)       (x->i2c->I2CONSET)
-#define I2C_CONCLR(x)       (x->i2c->I2CONCLR)
-#define I2C_STAT(x)         (x->i2c->I2STAT)
-#define I2C_DAT(x)          (x->i2c->I2DAT)
-#define I2C_SCLL(x, val)    (x->i2c->I2SCLL = val)
-#define I2C_SCLH(x, val)    (x->i2c->I2SCLH = val)
+#define I2C_CONSET(x)       (x->i2c.regs->I2CONSET)
+#define I2C_CONCLR(x)       (x->i2c.regs->I2CONCLR)
+#define I2C_STAT(x)         (x->i2c.regs->I2STAT)
+#define I2C_DAT(x)          (x->i2c.regs->I2DAT)
+#define I2C_SCLL(x, val)    (x->i2c.regs->I2SCLL = val)
+#define I2C_SCLH(x, val)    (x->i2c.regs->I2SCLH = val)
+
+// From Table 398 in the user manual
+enum LPC17xxI2cStatus {
+    START_TRANSMITTED = 0x08,
+    REPEATED_START_TRANSMITTED = 0x10,
+    ADDR_WRITE_TRANSMITTED_ACK = 0x18,
+    ADDR_WRITE_TRANSMITTED_NACK = 0x20,
+    DATA_TRANSMITTED_ACK = 0x28,
+    DATA_TRANSMITTED_NACK = 0x30,
+    ARB_LOST = 0x38,
+    ADDR_READ_TRANSMITTED_ACK = 0x40,
+    ADDR_READ_TRANSMITTED_NACK = 0x48,
+    DATA_RECEIVED_ACKED = 0x50,
+    DATA_RECEIVED_NACKED = 0x58,
+    ADDRESSED_FOR_WRITE_ACKED = 0x60,
+    ADDRESSED_FOR_WRITE_ACKED_AFTER_ARB_LOST = 0x68,
+    ADDRESSED_GEN_CALL_ACKED = 0x70,
+    ADDRESSED_GEN_CALL_AFTER_ARB_LOST = 0x78,
+    DATA_RECEIVED_FROM_MASTER_ACKED = 0x80,
+    DATA_RECEIVED_FROM_MASTER_NACKED = 0x88,
+    DATA_RECEIVED_FROM_GEN_CALL_ACKED = 0x90,
+    DATA_RECEIVED_FROM_GEN_CALL_NACKED = 0x98,
+    STOP_RECEIVED = 0xA0,
+    ADDRESSED_FOR_READ_ACKED = 0xA8,
+    ADDRESSED_FOR_READ_ACKED_AFTER_ARB_LOST = 0xB0,
+    DATA_TRANSMITTED_TO_MASTER_ACKED = 0xB8,
+    DATA_TRANSMITTED_TO_MASTER_NACKED = 0xC0,
+    LAST_DATA_BYTE_TRANSMITTED_ACKED = 0xC8,
+    BUSY_OR_NO_TRANSACTION = 0xF8,
+    BUS_ERROR = 0x0
+};
 
 static const uint32_t I2C_addr_offset[2][4] = {
     {0x0C, 0x20, 0x24, 0x28},
@@ -61,7 +92,7 @@ static inline void i2c_clear_SI(i2c_t *obj) {
     i2c_conclr(obj, 0, 0, 1, 0);
 }
 
-static inline int i2c_status(i2c_t *obj) {
+static inline enum LPC17xxI2cStatus i2c_status(i2c_t *obj) {
     return I2C_STAT(obj);
 }
 
@@ -84,7 +115,7 @@ static inline void i2c_interface_enable(i2c_t *obj) {
 }
 
 static inline void i2c_power_enable(i2c_t *obj) {
-    switch ((int)obj->i2c) {
+    switch ((int)obj->i2c.regs) {
         case I2C_0: LPC_SC->PCONP |= 1 << 7; break;
         case I2C_1: LPC_SC->PCONP |= 1 << 19; break;
         case I2C_2: LPC_SC->PCONP |= 1 << 26; break;
@@ -93,7 +124,7 @@ static inline void i2c_power_enable(i2c_t *obj) {
 
 void i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
 {
-    obj->i2c = (LPC_I2C_TypeDef *)pinmap->peripheral;
+    obj->i2c.regs = (LPC_I2C_TypeDef *)pinmap->peripheral;
 
     // enable power
     i2c_power_enable(obj);
@@ -174,8 +205,13 @@ inline int i2c_start(i2c_t *obj) {
 inline int i2c_stop(i2c_t *obj) {
     int timeout = 0;
 
+#if LPC1768_I2C_DEBUG
+    printf("i2c_stop(): status was originally 0x%x\n", i2c_status(obj));
+#endif
+
     // write the stop bit
     i2c_conset(obj, 0, 1, 0, 0);
+    i2c_conclr(obj, 1, 0, 1, 1);
     i2c_clear_SI(obj);
     
     // wait for STO bit to reset
@@ -184,10 +220,14 @@ inline int i2c_stop(i2c_t *obj) {
         if (timeout > 100000) return 1;
     }
 
+#if LPC1768_I2C_DEBUG
+    printf("i2c_stop(): status is now 0x%x\n", i2c_status(obj));
+#endif
+
     return 0;
 }
 
-static inline int i2c_do_write(i2c_t *obj, int value, uint8_t addr) {
+static inline enum LPC17xxI2cStatus i2c_do_write(i2c_t *obj, int value, uint8_t addr) {
     // write the data
     I2C_DAT(obj) = value;
     
@@ -199,7 +239,7 @@ static inline int i2c_do_write(i2c_t *obj, int value, uint8_t addr) {
     return i2c_status(obj);
 }
 
-static inline int i2c_do_read(i2c_t *obj, int last) {
+static inline enum LPC17xxI2cStatus i2c_do_read(i2c_t *obj, int last) {
     // we are in state 0x40 (SLA+R tx'd) or 0x50 (data rx'd and ack)
     if(last) {
         i2c_conclr(obj, 0, 0, 0, 1); // send a NOT ACK
@@ -243,26 +283,27 @@ void i2c_frequency(i2c_t *obj, int hz) {
 // check for that
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
-    int count, status;
+    int count;
+    enum LPC17xxI2cStatus status;
     
     status = i2c_start(obj);
     
-    if ((status != 0x10) && (status != 0x08)) {
+    if ((status != REPEATED_START_TRANSMITTED) && (status != START_TRANSMITTED)) {
         i2c_stop(obj);
         return I2C_ERROR_BUS_BUSY;
     }
     
     status = i2c_do_write(obj, (address | 0x01), 1);
-    if (status != 0x40) {
+    if (status != ADDR_READ_TRANSMITTED_ACK) {
         i2c_stop(obj);
-        return I2C_ERROR_NO_SLAVE;
+        return status == ADDR_READ_TRANSMITTED_NACK ? I2C_ERROR_NO_SLAVE : I2C_ERROR_OTHER;
     }
     
     // Read in all except last byte
     for (count = 0; count < (length - 1); count++) {
         int value = i2c_do_read(obj, 0);
         status = i2c_status(obj);
-        if (status != 0x50) {
+        if (status != DATA_RECEIVED_ACKED) {
             i2c_stop(obj);
             return count;
         }
@@ -272,7 +313,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     // read in last byte
     int value = i2c_do_read(obj, 1);
     status = i2c_status(obj);
-    if (status != 0x58) {
+    if (status != DATA_RECEIVED_NACKED) {
         i2c_stop(obj);
         return length - 1;
     }
@@ -288,24 +329,25 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
 }
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
-    int i, status;
+    int i;
+    enum LPC17xxI2cStatus status;
     
     status = i2c_start(obj);
     
-    if ((status != 0x10) && (status != 0x08)) {
+    if ((status != REPEATED_START_TRANSMITTED) && (status != START_TRANSMITTED)) {
         i2c_stop(obj);
         return I2C_ERROR_BUS_BUSY;
     }
     
     status = i2c_do_write(obj, (address & 0xFE), 1);
-    if (status != 0x18) {
+    if (status != ADDR_WRITE_TRANSMITTED_ACK) {
         i2c_stop(obj);
-        return I2C_ERROR_NO_SLAVE;
+        return status == ADDR_WRITE_TRANSMITTED_NACK ? I2C_ERROR_NO_SLAVE : I2C_ERROR_OTHER;
     }
     
     for (i=0; i<length; i++) {
         status = i2c_do_write(obj, data[i], 0);
-        if(status != 0x28) {
+        if(status != DATA_TRANSMITTED_ACK) {
             i2c_stop(obj);
             return i;
         }
@@ -328,25 +370,51 @@ void i2c_reset(i2c_t *obj) {
 }
 
 int i2c_byte_read(i2c_t *obj, int last) {
-    return (i2c_do_read(obj, last) & 0xFF);
+
+    const enum LPC17xxI2cStatus initial_status = i2c_status(obj);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_byte_read(): status was originally 0x%x\n", initial_status);
+#endif
+
+    if(initial_status == ADDR_READ_TRANSMITTED_NACK) {
+        // Address was previously transmitted and not-acknowledged, do not transmit anything else.
+        return 0;
+    }
+
+    uint8_t result = i2c_do_read(obj, last) & 0xFF;
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_byte_read(): status is now 0x%x\n", i2c_status(obj));
+#endif
+
+    return result;
 }
 
 int i2c_byte_write(i2c_t *obj, int data) {
-    int ack;
-    int status = i2c_do_write(obj, (data & 0xFF), 0);
+
+    const enum LPC17xxI2cStatus initial_status = i2c_status(obj);
 
 #if LPC1768_I2C_DEBUG
-    printf("i2c_do_write(0x%hhx) returned 0x%x\n", data & 0xFF, status);
+    printf("i2c_byte_write(): status was originally 0x%x\n", initial_status);
+#endif
+
+    if(initial_status == ADDR_WRITE_TRANSMITTED_NACK) {
+        // Address was previously transmitted and not-acknowledged, do not transmit anything else.
+        return 0;
+    }
+
+    const enum LPC17xxI2cStatus status = i2c_do_write(obj, (data & 0xFF), 0);
+
+#if LPC1768_I2C_DEBUG
+    printf("i2c_do_write(0x%hhx) returned status 0x%x\n", data & 0xFF, status);
 #endif
     
+    int ack;
     switch(status) {
-        case 0x18: case 0x28:       // Master transmit ACKs
-            ack = 1;
-            break;
-        case 0x40:                  // Master receive address transmitted ACK
-            ack = 1;
-            break;
-        case 0xB8:                  // Slave transmit ACK
+        case ADDR_READ_TRANSMITTED_ACK: 
+        case ADDR_WRITE_TRANSMITTED_ACK:
+        case DATA_TRANSMITTED_ACK:
             ack = 1;
             break;
         default:
@@ -384,12 +452,12 @@ int i2c_slave_receive(i2c_t *obj) {
 int i2c_slave_read(i2c_t *obj, char *data, int length) {
 
     int count = 0;
-
-    if(i2c_status(obj) != 0x60 && i2c_status(obj) != 0x70) {
+    enum LPC17xxI2cStatus status = i2c_status(obj);
+    if(status != ADDRESSED_FOR_WRITE_ACKED && status != ADDRESSED_GEN_CALL_ACKED) {
         return -1; // I2C peripheral not in setup-write-to-slave mode
     }
 
-    if(i2c_status(obj) == 0x70) {
+    if(i2c_status(obj) == ADDRESSED_GEN_CALL_ACKED) {
         // When addressed with the general call address, per the manual we can only receive a max of 1 byte.
         if(length > 1) {
             length = 1;
@@ -410,45 +478,35 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
 #endif
 
         switch(i2c_status(obj)) {
-        case 0x68:
-        case 0x78:
-            // Arbitration Lost event.  I'm a bit confused about how this can happen as a slave device but the manual says it can...
-            i2c_conclr(obj, 1, 0, 0, 1); // Clear start and ack
-            i2c_clear_SI(obj);
-            
-            // Reset the I2C state machine. This doesn't actually send a STOP condition in slave mode.
-            i2c_stop(obj);
-            return -2; // Arbitration lost
-
-        case 0x80:
-        case 0x90:
+        case DATA_RECEIVED_FROM_MASTER_ACKED:
+        case DATA_RECEIVED_FROM_GEN_CALL_ACKED:
             // Received another data byte from master.  ACK has been returned.
-            data[count++] = I2C_DAT(obj) & 0xFF;
-            
-            if(count >= length) {
-                // Out of buffer space, NACK the next byte
-                i2c_conclr(obj, 0, 0, 0, 1);
-                i2c_clear_SI(obj);
+            if(count < length) {
+                data[count++] = I2C_DAT(obj) & 0xFF;
             }
-            else {
-                // Ack the next byte
-                i2c_conset(obj, 0, 0, 0, 1);
-                i2c_clear_SI(obj);
-            }
+
+            // Set up for the next byte
+            i2c_conset(obj, 0, 0, 0, 1);
+            i2c_clear_SI(obj);
+
             break;
 
-        case 0x88:
-        case 0x98:
+        case DATA_RECEIVED_FROM_MASTER_NACKED:
+        case DATA_RECEIVED_FROM_GEN_CALL_NACKED:
             // Master wrote us a byte and we NACKed it.  Slave receive mode has been exited.
             i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
             i2c_clear_SI(obj);
             return count;
 
-        case 0xA0:
+        case STOP_RECEIVED:
             // Stop condition received.  Slave receive mode has been exited.
             i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
             i2c_clear_SI(obj);
             return count;
+
+        default:
+            // Unhandled state entered
+            return 0;
         }
     }
 }
@@ -457,7 +515,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
 
     int next_byte_idx = 0;
 
-    if(i2c_status(obj) != 0xA8) {
+    if(i2c_status(obj) != ADDRESSED_FOR_READ_ACKED) {
         return -1; // I2C peripheral not in setup-read-from-slave mode
     }
     
@@ -476,16 +534,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
         i2c_wait_SI(obj);
 
         switch(i2c_status(obj)) {
-        case 0xB0:
-            // Arbitration Lost event.  I'm a bit confused about how this can happen as a slave device but the manual says it can...
-            i2c_conclr(obj, 1, 0, 0, 1); // Clear start and ack
-            i2c_clear_SI(obj);
-            
-            // Reset the I2C state machine. This doesn't actually send a STOP condition in slave mode.
-            i2c_stop(obj);
-            return -2; // Arbitration lost
-
-        case 0xB8:
+        case DATA_TRANSMITTED_TO_MASTER_ACKED:
             // Prev data byte has been transmitted.  ACK has been received.  Write the next data byte.
             I2C_DAT(obj) = (next_byte_idx < length) ? data[next_byte_idx] : 0;
             ++next_byte_idx;
@@ -494,13 +543,17 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
             i2c_clear_SI(obj);
             break;
 
-        case 0xC0:
-        case 0xC8:
-            // Last data byte transmitted (ended either by us not setting AA, or by the master NACKing)
+        case DATA_TRANSMITTED_TO_MASTER_NACKED:
+        case LAST_DATA_BYTE_TRANSMITTED_ACKED:
+            // Last data byte transmitted (transaction ended either by us or by the master)
             i2c_conset(obj, 0, 0, 0, 1); // Set AA flag so that we go back to idle slave state
             i2c_clear_SI(obj);
 
             return next_byte_idx;
+
+        default:
+            // Unhandled state entered
+            return 0;
         }
     }
 }
@@ -509,9 +562,9 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
     uint32_t addr;
     
     if ((idx >= 0) && (idx <= 3)) {
-        addr = ((uint32_t)obj->i2c) + I2C_addr_offset[0][idx];
+        addr = ((uint32_t)obj->i2c.regs) + I2C_addr_offset[0][idx];
         *((uint32_t *) addr) = address & 0xFF;
-        addr = ((uint32_t)obj->i2c) + I2C_addr_offset[1][idx];
+        addr = ((uint32_t)obj->i2c.regs) + I2C_addr_offset[1][idx];
         *((uint32_t *) addr) = mask & 0xFE;
     }
 }

--- a/targets/TARGET_NXP/TARGET_LPC17XX/objects.h
+++ b/targets/TARGET_NXP/TARGET_LPC17XX/objects.h
@@ -65,7 +65,7 @@ struct can_s {
 };
 
 struct i2c_s {
-    LPC_I2C_TypeDef *i2c;
+    LPC_I2C_TypeDef *regs;
 };
 
 struct spi_s {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/i2c_api.c
@@ -35,16 +35,16 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
     uint32_t i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
     uint32_t i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
-    obj->instance = pinmap_merge(i2c_sda, i2c_scl);
+    obj->i2c.instance = pinmap_merge(i2c_sda, i2c_scl);
 
-    MBED_ASSERT((int)obj->instance != NC);
+    MBED_ASSERT((int)obj->i2c.instance != NC);
 
     lpi2c_master_config_t master_config;
 
     i2c_setup_clock();
 
     LPI2C_MasterGetDefaultConfig(&master_config);
-    LPI2C_MasterInit(i2c_addrs[obj->instance], &master_config, i2c_get_clock());
+    LPI2C_MasterInit(i2c_addrs[obj->i2c.instance], &master_config, i2c_get_clock());
 
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -58,10 +58,10 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 int i2c_start(i2c_t *obj)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     int status = 0;
 
-    obj->address_set = 0;
+    obj->i2c.address_set = 0;
 
     /* Clear all flags. */
     LPI2C_MasterClearStatusFlags(base, kLPI2C_MasterEndOfPacketFlag |
@@ -80,11 +80,11 @@ int i2c_start(i2c_t *obj)
 
 int i2c_stop(i2c_t *obj)
 {
-    if (LPI2C_MasterStop(i2c_addrs[obj->instance]) != kStatus_Success) {
+    if (LPI2C_MasterStop(i2c_addrs[obj->i2c.instance]) != kStatus_Success) {
         return 1;
     }
 
-    obj->address_set = 0;
+    obj->i2c.address_set = 0;
 
     return 0;
 }
@@ -94,12 +94,12 @@ void i2c_frequency(i2c_t *obj, int hz)
     uint32_t busClock;
 
     busClock = i2c_get_clock();
-    LPI2C_MasterSetBaudRate(i2c_addrs[obj->instance], busClock, hz);
+    LPI2C_MasterSetBaudRate(i2c_addrs[obj->i2c.instance], busClock, hz);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     lpi2c_master_transfer_t master_xfer;
 
     memset(&master_xfer, 0, sizeof(master_xfer));
@@ -123,7 +123,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     lpi2c_master_transfer_t master_xfer;
 
     if (length == 0) {
@@ -175,7 +175,7 @@ void i2c_reset(i2c_t *obj)
 int i2c_byte_read(i2c_t *obj, int last)
 {
     uint8_t data;
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     lpi2c_master_transfer_t master_xfer;
 
     memset(&master_xfer, 0, sizeof(master_xfer));
@@ -192,7 +192,7 @@ int i2c_byte_read(i2c_t *obj, int last)
 
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t status;
     size_t txCount;
     size_t txFifoSize = FSL_FEATURE_LPI2C_FIFO_SIZEn(base);
@@ -207,8 +207,8 @@ int i2c_byte_write(i2c_t *obj, int data)
         txCount = txFifoSize - txCount;
     } while (!txCount);
 
-    if (!obj->address_set) {
-        obj->address_set  = 1;
+    if (!obj->i2c.address_set) {
+        obj->i2c.address_set  = 1;
         /* Issue start command. */
         base->MTDR = LPI2C_MTDR_CMD(0x4U) | LPI2C_MTDR_DATA(data);
     } else {
@@ -258,12 +258,12 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
     LPI2C_SlaveGetDefaultConfig(&slave_config);
     slave_config.enableSlave = (bool)enable_slave;
 
-    LPI2C_SlaveInit(i2c_addrs[obj->instance], &slave_config, i2c_get_clock());
+    LPI2C_SlaveInit(i2c_addrs[obj->i2c.instance], &slave_config, i2c_get_clock());
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t status_flags = LPI2C_SlaveGetStatusFlags(base);
 
     if (status_flags & kLPI2C_SlaveAddressValidFlag) {
@@ -282,7 +282,7 @@ int i2c_slave_receive(i2c_t *obj)
 
 int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     int actual_rx;
 
     LPI2C_SlaveReceive(base, (uint8_t *)data, length, (size_t *)&actual_rx);
@@ -292,7 +292,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
 
 int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
-    LPI2C_Type *base = i2c_addrs[obj->instance];
+    LPI2C_Type *base = i2c_addrs[obj->i2c.instance];
     int actual_rx;
 
     LPI2C_SlaveSend(base, (uint8_t *)data, length, (size_t *)&actual_rx);
@@ -302,8 +302,21 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
-    i2c_addrs[obj->instance]->SAMR = LPI2C_SAMR_ADDR0(address & 0xfe);
+    i2c_addrs[obj->i2c.instance]->SAMR = LPI2C_SAMR_ADDR0(address & 0xfe);
 }
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/i2c_api.c
@@ -35,14 +35,14 @@ void i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
 static void _i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
 #endif
 {
-    obj->instance = (uint32_t) pinmap->peripheral;
-    obj->next_repeated_start = 0;
-    obj->issue_start = 0;
-    MBED_ASSERT((int)obj->instance != NC);
+    obj->i2c.instance = (uint32_t) pinmap->peripheral;
+    obj->i2c.next_repeated_start = 0;
+    obj->i2c.issue_start = 0;
+    MBED_ASSERT((int)obj->i2c.instance != NC);
 
     i2c_master_config_t master_config;
 
-    switch (obj->instance) {
+    switch (obj->i2c.instance) {
         case 0:
             CLOCK_AttachClk(kFRO12M_to_FLEXCOMM0);
             RESET_PeripheralReset(kFC0_RST_SHIFT_RSTn);
@@ -90,7 +90,7 @@ static void _i2c_init_direct(i2c_t *obj, const i2c_pinmap_t *pinmap)
     }
 
     I2C_MasterGetDefaultConfig(&master_config);
-    I2C_MasterInit(i2c_addrs[obj->instance], &master_config, 12000000);
+    I2C_MasterInit(i2c_addrs[obj->i2c.instance], &master_config, 12000000);
 
     pin_function(pinmap->sda_pin, pinmap->sda_function);
     pin_mode(pinmap->sda_pin, PullNone);
@@ -115,14 +115,14 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 int i2c_start(i2c_t *obj)
 {
-    obj->issue_start = 1;
+    obj->i2c.issue_start = 1;
 
     return 0;
 }
 
 int i2c_stop(i2c_t *obj)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t status;
 
     do {
@@ -138,19 +138,19 @@ int i2c_stop(i2c_t *obj)
         status = I2C_GetStatusFlags(base);
     } while ((status & I2C_STAT_MSTPENDING_MASK) == 0);
 
-    obj->issue_start = 0;
+    obj->i2c.issue_start = 0;
 
     return 0;
 }
 
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2C_MasterSetBaudRate(i2c_addrs[obj->instance], hz, 12000000);
+    I2C_MasterSetBaudRate(i2c_addrs[obj->i2c.instance], hz, 12000000);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     i2c_master_transfer_t master_xfer;
 
     memset(&master_xfer, 0, sizeof(master_xfer));
@@ -158,13 +158,13 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     master_xfer.direction = kI2C_Read;
     master_xfer.data = (uint8_t *)data;
     master_xfer.dataSize = length;
-    if (obj->next_repeated_start) {
+    if (obj->i2c.next_repeated_start) {
         master_xfer.flags |= kI2C_TransferRepeatedStartFlag;
     }
     if (!stop) {
         master_xfer.flags |= kI2C_TransferNoStopFlag;
     }
-    obj->next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
+    obj->i2c.next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
 
     if (I2C_MasterTransferBlocking(base, &master_xfer) != kStatus_Success) {
         return I2C_ERROR_NO_SLAVE;
@@ -175,7 +175,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     i2c_master_transfer_t master_xfer;
 
     if (length == 0) {
@@ -197,13 +197,13 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     master_xfer.direction = kI2C_Write;
     master_xfer.data = (uint8_t *)data;
     master_xfer.dataSize = length;
-    if (obj->next_repeated_start) {
+    if (obj->i2c.next_repeated_start) {
         master_xfer.flags |= kI2C_TransferRepeatedStartFlag;
     }
     if (!stop) {
         master_xfer.flags |= kI2C_TransferNoStopFlag;
     }
-    obj->next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
+    obj->i2c.next_repeated_start = master_xfer.flags & kI2C_TransferNoStopFlag ? 1 : 0;
 
     if (I2C_MasterTransferBlocking(base, &master_xfer) != kStatus_Success) {
         return I2C_ERROR_NO_SLAVE;
@@ -220,7 +220,7 @@ void i2c_reset(i2c_t *obj)
 int i2c_byte_read(i2c_t *obj, int last)
 {
     uint8_t data;
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t status;
 
     do {
@@ -238,7 +238,7 @@ int i2c_byte_read(i2c_t *obj, int last)
 
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
     uint32_t status;
     int ret_value = 1;
 
@@ -252,10 +252,10 @@ int i2c_byte_write(i2c_t *obj, int data)
     /* Clear controller state. */
     I2C_MasterClearStatusFlags(base, I2C_STAT_MSTARBLOSS_MASK | I2C_STAT_MSTSTSTPERR_MASK);
 
-    if (obj->issue_start) {
+    if (obj->i2c.issue_start) {
         base->MSTCTL = I2C_MSTCTL_MSTSTART_MASK;
         /* Clear the flag */
-        obj->issue_start = 0;
+        obj->i2c.issue_start = 0;
     } else {
         base->MSTCTL = I2C_MSTCTL_MSTCONTINUE_MASK;
     }
@@ -306,12 +306,12 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
     I2C_SlaveGetDefaultConfig(&slave_config);
     slave_config.enableSlave = (bool)enable_slave;
 
-    I2C_SlaveInit(i2c_addrs[obj->instance], &slave_config, 12000000);
+    I2C_SlaveInit(i2c_addrs[obj->i2c.instance], &slave_config, 12000000);
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
-    uint32_t status_flags = I2C_GetStatusFlags(i2c_addrs[obj->instance]);
+    uint32_t status_flags = I2C_GetStatusFlags(i2c_addrs[obj->i2c.instance]);
 
     if (status_flags & kI2C_SlaveSelected) {
         if (((status_flags & I2C_STAT_SLVSTATE_MASK) >> I2C_STAT_SLVSTATE_SHIFT) == 0x1) {
@@ -329,7 +329,7 @@ int i2c_slave_receive(i2c_t *obj)
 
 int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     I2C_SlaveReadBlocking(base, (uint8_t *)data, length);
 
@@ -338,7 +338,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
 
 int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
-    I2C_Type *base = i2c_addrs[obj->instance];
+    I2C_Type *base = i2c_addrs[obj->i2c.instance];
 
     I2C_SlaveWriteBlocking(base, (uint8_t *)data, length);
 
@@ -348,9 +348,22 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
     if ((idx >= 0) && (idx <= 3)) {
-        I2C_SlaveSetAddress(i2c_addrs[obj->instance], (i2c_slave_address_register_t)idx, address, false);
+        I2C_SlaveSetAddress(i2c_addrs[obj->i2c.instance], (i2c_slave_address_register_t)idx, address, false);
     }
 }
 #endif
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
 
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628.h
@@ -15,6 +15,7 @@
 **
 **     Copyright 1997-2016 Freescale Semiconductor, Inc.
 **     Copyright 2016-2017 NXP
+**     SPDX-License-Identifier: BSD-3-Clause
 **     Redistribution and use in source and binary forms, with or without modification,
 **     are permitted provided that the following conditions are met:
 **

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628.h
@@ -180,7 +180,9 @@ typedef enum IRQn {
 #define __MPU_PRESENT                  1         /**< Defines if an MPU is present or not */
 #define __NVIC_PRIO_BITS               3         /**< Number of priority bits implemented in the NVIC */
 #define __Vendor_SysTickConfig         0         /**< Vendor specific implementation of SysTickConfig is defined */
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT                  1         /**< Defines if an FPU is present or not */
+#endif
 
 #include "core_cm4.h"                  /* Core Peripheral Access Layer */
 #include "system_LPC54628.h"           /* Device specific configuration file */

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -64,19 +64,19 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     /** was_slave is used to decide which driver call we need
      * to use when uninitializing a given instance
      */
-    obj->was_slave = false;
-    obj->is_slave = false;
-    obj->slave_addr = 0;
+    obj->i2c.was_slave = false;
+    obj->i2c.is_slave = false;
+    obj->i2c.slave_addr = 0;
 #endif
 
     /* Obtain the pointer to the I2C hardware instance. */
-    obj->dev = (i2c_inst_t *)pinmap_function(sda, PinMap_I2C_SDA);
-    //obj->baudrate = DEFAULT_I2C_BAUDRATE;
+    obj->i2c.dev = (i2c_inst_t *)pinmap_function(sda, PinMap_I2C_SDA);
+    //obj->i2c.baudrate = DEFAULT_I2C_BAUDRATE;
     //Call this function because if we are configuring a slave, we don't have to set the frequency
-    //i2c_frequency(obj->dev, DEFAULT_I2C_BAUDRATE);
+    //i2c_frequency(obj->i2c.dev, DEFAULT_I2C_BAUDRATE);
 
     /* Initialize the I2C module. */
-    pico_sdk_i2c_init(obj->dev, DEFAULT_I2C_BAUDRATE);
+    pico_sdk_i2c_init(obj->i2c.dev, DEFAULT_I2C_BAUDRATE);
 
     /* Configure GPIO for I2C as alternate function. */
     gpio_set_function(sda, GPIO_FUNC_I2C);
@@ -89,20 +89,20 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    DEBUG_PRINTF("obj->is_slave: %d\r\n", obj->is_slave);
+    DEBUG_PRINTF("obj->i2c.is_slave: %d\r\n", obj->i2c.is_slave);
 
 #if DEVICE_I2CSLAVE
     /* Slaves automatically get frequency from master */
-    if(obj->is_slave) {
+    if(obj->i2c.is_slave) {
     		return;
     }
 #endif
-    obj->baudrate = i2c_set_baudrate(obj->dev, hz);
+    obj->i2c.baudrate = i2c_set_baudrate(obj->i2c.dev, hz);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    int const bytes_read = i2c_read_blocking(obj->dev,
+    int const bytes_read = i2c_read_blocking(obj->i2c.dev,
                                              (uint8_t)(address >> 1),
                                              (uint8_t *)data,
                                              (size_t)length,
@@ -124,7 +124,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
         length = 1;
     }
 
-    int const bytes_written = i2c_write_blocking(obj->dev,
+    int const bytes_written = i2c_write_blocking(obj->i2c.dev,
                                                  address >> 1,
                                                  (const uint8_t *)data,
                                                  (size_t)length,
@@ -137,8 +137,8 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
 void i2c_reset(i2c_t *obj)
 {
-    i2c_deinit(obj->dev);
-    pico_sdk_i2c_init(obj->dev, obj->baudrate);
+    i2c_deinit(obj->i2c.dev);
+    pico_sdk_i2c_init(obj->i2c.dev, obj->i2c.baudrate);
 }
 
 const PinMap *i2c_master_sda_pinmap()
@@ -177,7 +177,7 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
     DEBUG_PRINTF("i2c_slave_mode: %p, %d\r\n", obj, enable_slave);
 
-    obj->is_slave = enable_slave;
+    obj->i2c.is_slave = enable_slave;
 }
 
 /** Check to see if the I2C slave has been addressed.
@@ -189,14 +189,14 @@ int i2c_slave_receive(i2c_t *obj)
 {
     int retValue = NoData;
 
-    int rd_req = (obj->dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_RD_REQ_BITS) >> 5;
+    int rd_req = (obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_RD_REQ_BITS) >> 5;
 
     if (rd_req == I2C_IC_RAW_INTR_STAT_RD_REQ_VALUE_ACTIVE) {
         DEBUG_PRINTF("Read addressed\r\n");
         return ReadAddressed;
     }
 
-    int wr_req = (obj->dev->hw->status & I2C_IC_STATUS_RFNE_BITS) >> 3;
+    int wr_req = (obj->i2c.dev->hw->status & I2C_IC_STATUS_RFNE_BITS) >> 3;
 
     if (wr_req == I2C_IC_STATUS_RFNE_VALUE_NOT_EMPTY) {
         DEBUG_PRINTF("Write addressed\r\n");
@@ -214,18 +214,18 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
     int bytes_read = 0;
     for (size_t i = 0; i < (size_t)length; ++i) {
-        while (!i2c_get_read_available(obj->dev)) {
+        while (!i2c_get_read_available(obj->i2c.dev)) {
             tight_loop_contents();
         }
 
-        *data = obj->dev->hw->data_cmd;
+        *data = obj->i2c.dev->hw->data_cmd;
         bytes_read++;
 
         // Check stop condition
-        bool stop = (obj->dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS) != 0;
-        if (stop && !i2c_get_read_available(obj->dev)) {
+        bool stop = (obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS) != 0;
+        if (stop && !i2c_get_read_available(obj->i2c.dev)) {
             // Clear stop (by reading the register)
-            int clear_stop = obj->dev->hw->clr_stop_det;
+            int clear_stop = obj->i2c.dev->hw->clr_stop_det;
             (void)clear_stop;
             break;
         } else {
@@ -246,10 +246,10 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
     DEBUG_PRINTF("i2c_slave_write\r\n");
 
-    i2c_write_raw_blocking(obj->dev, (const uint8_t *)data, (size_t)length);
+    i2c_write_raw_blocking(obj->i2c.dev, (const uint8_t *)data, (size_t)length);
 
     // Clear interrupt (by reading the register)
-    int clear_read_req = i2c_get_hw(obj->dev)->clr_rd_req;
+    int clear_read_req = i2c_get_hw(obj->i2c.dev)->clr_rd_req;
     (void)clear_read_req;
     DEBUG_PRINTF("clear_read_req: %d\n", clear_read_req);
 
@@ -264,11 +264,11 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
  */
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
-    if (obj->is_slave) {
+    if (obj->i2c.is_slave) {
         DEBUG_PRINTF("i2c_slave_address: %p, %d, %d, %d\r\n", obj, idx, address, mask);
 
-        obj->slave_addr = (uint8_t)(address >> 1);
-        i2c_set_slave_mode(obj->dev, true, obj->slave_addr);
+        obj->i2c.slave_addr = (uint8_t)(address >> 1);
+        i2c_set_slave_mode(obj->i2c.dev, true, obj->i2c.slave_addr);
     }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/CMSIS/stm32l452xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/STM32Cube_FW/CMSIS/stm32l452xx.h
@@ -49,7 +49,10 @@
 #define __MPU_PRESENT             1       /*!< STM32L4XX provides an MPU                     */
 #define __NVIC_PRIO_BITS          4       /*!< STM32L4XX uses 4 Bits for the Priority Levels */
 #define __Vendor_SysTickConfig    0       /*!< Set to 1 if different SysTick Config is used  */
+
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT             1       /*!< FPU present                                   */
+#endif
 
 /**
   * @}

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -2434,4 +2434,19 @@ uint32_t i2c_get_timing(I2CName i2c, uint32_t current_timing, int current_hz,
 
 #endif /* I2C_IP_VERSION_V2 */
 
+#ifdef I2C_IP_VERSION_V2
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_address_delayed = false,
+    .single_byte_start_cond_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = true
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
+#endif
+
 #endif // DEVICE_I2C

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/rtcc.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/rtcc.c
@@ -34,6 +34,8 @@
 #include "lp_ticker_api.h"
 #include "clocking.h"
 
+#include <mbed_critical.h>
+
 static bool lptick_inited = false;
 static uint32_t lptick_offset = 0;
 

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -1179,7 +1179,7 @@ bool spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
  */
 bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
-    if( spi_active(obj) ) return;
+    if( spi_active(obj) ) return false;
 
     /* update fill word if on 9-bit frame size */
     if(obj->spi.bits == 9) fill_word = SPI_FILL_WORD & 0x1FF;

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TMPM46B.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TMPM46B.h
@@ -155,7 +155,9 @@ typedef enum IRQn
 #define __MPU_PRESENT             0         /*!< MPU present or not                                */
 #define __NVIC_PRIO_BITS          3         /*!< Number of Bits used for Priority Levels           */
 #define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used      */
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT							1					/*!< FPU present or not                                */
+#endif
 
 /** @} */ /* End of group Configuration_of_CMSIS */
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TMPM46B.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TMPM46B.h
@@ -5,6 +5,8 @@
  *          TOSHIBA 'TMPM46B' Device Series
  * @version V2.0.2.4
  * @date    2015/03/13
+ *
+ * SPDX-License-Identifier: Apache-2.0
  * 
  * DO NOT USE THIS SOFTWARE WITHOUT THE SOFTWARE LICENSE AGREEMENT.
  * 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
@@ -1,6 +1,8 @@
 /* mbed Microcontroller Library
  * (C)Copyright TOSHIBA ELECTRONIC DEVICES & STORAGE CORPORATION 2017 All rights reserved
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
@@ -520,7 +520,7 @@ static inline void state_idle(struct i2c_s *obj_s)
     do {
         flag_state = I2C_GetState(obj_s->i2c);
     } while (flag_state.Bit.BusState);
-    // To satisfy the setup time of restart, at least 4.7µs wait must be created by software (Ref. TRM pg. 561)
+    // To satisfy the setup time of restart, at least 4.7ï¿½s wait must be created by software (Ref. TRM pg. 561)
     wait_us(5);
 }
 
@@ -586,6 +586,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
@@ -522,7 +522,7 @@ static inline void state_idle(struct i2c_s *obj_s)
     do {
         flag_state = I2C_GetState(obj_s->i2c);
     } while (flag_state.Bit.BusState);
-    // To satisfy the setup time of restart, at least 4.7�s wait must be created by software (Ref. TRM pg. 561)
+    // To satisfy the setup time of restart, at least 4.7µs wait must be created by software (Ref. TRM pg. 561)
     wait_us(5);
 }
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
@@ -426,7 +426,7 @@ bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
     // don't do anything, if the buffers aren't valid
     if (!use_tx && !use_rx) {
-        return;
+        return false;
     }
 
     // copy the buffers to the SPI object

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device/TMPM4G9.h
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device/TMPM4G9.h
@@ -215,7 +215,9 @@ typedef enum IRQn
 #define __CM4_REV              0x0001       /*!< Cortex-M4 Core Revision                           */
 #define __NVIC_PRIO_BITS          4         /*!< Number of Bits used for Priority Levels           */
 #define __MPU_PRESENT             1         /*!< MPU present or not                                */
+#ifndef __FPU_PRESENT
 #define __FPU_PRESENT             1         /*!< FPU present or not                                */
+#endif
 #define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used      */
 
 /** @} */ /* End of group Configuration_of_CMSIS */

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/i2c_api.c
@@ -307,4 +307,17 @@ void i2c_abort_asynch(i2c_t *obj)
 
 #endif  // #if DEVICE_I2C_ASYNCH
 
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
+
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/reset_reason_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/reset_reason_api.c
@@ -27,7 +27,7 @@ static uint8_t set_bit_count(uint32_t reg);
 static uint8_t bit_pos(uint32_t reg);
 static bool bit_status(uint32_t reg, uint8_t bit_no);
 
-static reset_reason_t reset_reason1[6] = {
+static const reset_reason_t reset_reason1[6] = {
     RESET_REASON_POWER_ON,
     RESET_REASON_UNKNOWN,
     RESET_REASON_UNKNOWN,
@@ -36,7 +36,7 @@ static reset_reason_t reset_reason1[6] = {
     RESET_REASON_BROWN_OUT
 };
 
-static reset_reason_t reset_reason2[4] = {
+static const reset_reason_t reset_reason2[4] = {
     RESET_REASON_SOFTWARE,
     RESET_REASON_LOCKUP,
     RESET_REASON_WATCHDOG,
@@ -125,13 +125,13 @@ static uint8_t set_bit_count(uint32_t reg)
 
 static uint8_t bit_pos(uint32_t reg)
 {
-    uint8_t bit_no = 0;
-
-    for (bit_no = 0; bit_no < (sizeof(uint32_t) * 8); bit_no++) {
+    for(uint8_t bit_no = 0; bit_no < (sizeof(uint32_t) * 8); bit_no++) {
         if (reg & (1 << bit_no)) {
             return bit_no;
         }
     }
+
+    return UINT8_MAX;
 }
 
 #endif // DEVICE_RESET_REASON

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
@@ -497,7 +497,7 @@ bool spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 
     // don't do anything, if the buffers aren't valid
     if (!use_tx && !use_rx) {
-        return;
+        return false;
     }
 
     // copy the buffers to the SPI object

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4GR/i2c_api.c
@@ -305,4 +305,17 @@ void i2c_abort_asynch(i2c_t *obj)
 
 #endif  // #if DEVICE_I2C_ASYNCH
 
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
+}
+
 #endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4KN/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4KN/i2c_api.c
@@ -49,8 +49,8 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
         case I2C_1:
             TSB_CG_FSYSMENA_IPMENA26     = TXZ_ENABLE; // Enable clock for I2C_1
             TSB_CG_FSYSMENA_IPMENA03     = TXZ_ENABLE; // Enable clock for GPIO D
-            obj->my_i2c.i2c.p_instance = TSB_I2C1;
-            obj->my_i2c.info.irqn      = INTI2C1NST_IRQn;
+            obj->i2c.my_i2c.i2c.p_instance = TSB_I2C1;
+            obj->i2c.my_i2c.info.irqn      = INTI2C1NST_IRQn;
             break;
         default:
             error("I2C is not available");
@@ -68,14 +68,14 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
     i2c_reset(obj);
     i2c_frequency(obj, 100000);
-    I2C_init(&obj->my_i2c.i2c);
+    I2C_init(&obj->i2c.my_i2c.i2c);
 }
 
 // Configure the I2C frequency
 void i2c_frequency(i2c_t *obj, int hz)
 {
     if (hz <= MAX_I2C_FREQ) {
-        i2c_frequency_t(&obj->my_i2c, hz);
+        i2c_frequency_t(&obj->i2c.my_i2c, hz);
     } else {
         error("Failed : Max I2C frequency is 400000");
     }
@@ -83,27 +83,27 @@ void i2c_frequency(i2c_t *obj, int hz)
 
 int i2c_start(i2c_t *obj)
 {
-    i2c_start_t(&obj->my_i2c);
+    i2c_start_t(&obj->i2c.my_i2c);
     return TXZ_SUCCESS;
 }
 
 int i2c_stop(i2c_t *obj)
 {
-    i2c_stop_t(&obj->my_i2c);
+    i2c_stop_t(&obj->i2c.my_i2c);
     return TXZ_SUCCESS;
 }
 
 void i2c_reset(i2c_t *obj)
 {
     // Software reset
-    i2c_reset_t(&obj->my_i2c);
+    i2c_reset_t(&obj->i2c.my_i2c);
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
     int32_t count = 0;
 
-    count = i2c_read_t(&obj->my_i2c, address, (uint8_t *)data, length, stop);
+    count = i2c_read_t(&obj->i2c.my_i2c, address, (uint8_t *)data, length, stop);
 
     return count;
 }
@@ -112,7 +112,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
     int32_t count = 0;
 
-    count = i2c_write_t(&obj->my_i2c, address, (uint8_t *)data, length, stop);
+    count = i2c_write_t(&obj->i2c.my_i2c, address, (uint8_t *)data, length, stop);
 
     return count;
 }
@@ -121,7 +121,7 @@ int i2c_byte_read(i2c_t *obj, int last)
 {
     int32_t data = 0;
 
-    data = i2c_byte_read_t(&obj->my_i2c, last);
+    data = i2c_byte_read_t(&obj->i2c.my_i2c, last);
 
     return data;
 }
@@ -130,26 +130,26 @@ int i2c_byte_write(i2c_t *obj, int data)
 {
     int32_t result = 0;
 
-    result = i2c_byte_write_t(&obj->my_i2c, data);
+    result = i2c_byte_write_t(&obj->i2c.my_i2c, data);
 
     return result;
 }
 
 void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
-    i2c_slave_mode_t(&obj->my_i2c, enable_slave);
+    i2c_slave_mode_t(&obj->i2c.my_i2c, enable_slave);
 }
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 {
-    i2c_slave_address_t(&obj->my_i2c, address);
+    i2c_slave_address_t(&obj->i2c.my_i2c, address);
 }
 
 int i2c_slave_receive(i2c_t *obj)
 {
     int32_t result = 0;
 
-    result = i2c_slave_receive_t(&obj->my_i2c);
+    result = i2c_slave_receive_t(&obj->i2c.my_i2c);
 
     return result;
 }
@@ -158,7 +158,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
     int32_t count = 0;
 
-    count = i2c_slave_read_t(&obj->my_i2c, (uint8_t *)data, length);
+    count = i2c_slave_read_t(&obj->i2c.my_i2c, (uint8_t *)data, length);
 
     return count;
 }
@@ -167,7 +167,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
     int32_t count = 0;
 
-    count = i2c_slave_write_t(&obj->my_i2c, (uint8_t *)data, length);
+    count = i2c_slave_write_t(&obj->i2c.my_i2c, (uint8_t *)data, length);
 
     return count;
 }
@@ -190,4 +190,17 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_start_cond_delayed = true,
+    .single_byte_address_delayed = false,
+    .supports_single_byte = true,
+    .supports_zero_length_transfer_single_byte = true,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8441,8 +8441,6 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "device_has_remove": [
             "ANALOGIN",
             "FLASH",
-            "I2C",
-            "I2CSLAVE",
             "PWMOUT",
             "SERIAL_FC",
             "SPI",

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8441,6 +8441,8 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "device_has_remove": [
             "ANALOGIN",
             "FLASH",
+            "I2C",
+            "I2CSLAVE",
             "PWMOUT",
             "SERIAL_FC",
             "SPI",

--- a/tools/cmake/toolchains/GCC_ARM.cmake
+++ b/tools/cmake/toolchains/GCC_ARM.cmake
@@ -62,6 +62,7 @@ list(APPEND common_options
     "-Wno-missing-field-initializers"
     "-Wno-psabi" # Disable "parameter passing changed in GCC 7.1" warning
     "-Wno-packed-bitfield-compat" # Disable "offset of packed bitfield changed in GCC 4.4" warning
+    "-Werror=return-type" # Turn a missing return statement into a fatal error
     "-fmessage-length=0"
     "-fno-exceptions"
     "-ffunction-sections"

--- a/tools/python/mbed_os_tools/test/host_tests_conn_proxy/conn_proxy.py
+++ b/tools/python/mbed_os_tools/test/host_tests_conn_proxy/conn_proxy.py
@@ -35,15 +35,16 @@ class KiViBufferWalker:
         self.buff = str()
         self.kvl = []
         self.re_kv = re.compile(self.KIVI_REGEX)
+        self.logger = HtrunLogger("CONN")
 
     def append(self, payload: bytes):
         """! Append stream buffer with payload and process. Returns non-KV strings"""
-        logger = HtrunLogger("CONN")
+        
         try:
             self.buff += payload.decode("utf-8")
         except UnicodeDecodeError:
             decoded_payload = payload.decode("utf-8", "ignore")
-            logger.prn_wrn(
+            self.logger.prn_wrn(
                 f'UnicodeDecodeError encountered! Raw bytes were {payload!r} and they decoded to "{decoded_payload}"'
             )
             self.buff += decoded_payload
@@ -65,17 +66,17 @@ class KiViBufferWalker:
                 before = line[:pos]
                 after = line[pos + len(match) :]
                 if len(before) > 0:
-                    logger.prn_rxd(before)
+                    self.logger.prn_rxd(before)
                     discarded.append(before)
                 if len(after) > 0:
                     # not a K,V pair part
-                    logger.prn_rxd(after)
+                    self.logger.prn_rxd(after)
                     discarded.append(after)
-                logger.prn_inf("found KV pair in stream: {{%s;%s}}, queued..." % (key, value))
+                self.logger.prn_inf("found KV pair in stream: {{%s;%s}}, queued..." % (key, value))
             else:
                 # not a K,V pair
                 discarded.append(line)
-                logger.prn_rxd(line)
+                self.logger.prn_rxd(line)
 
         return discarded
 
@@ -83,9 +84,10 @@ class KiViBufferWalker:
         """! Check if there is a KV value in buffer"""
         return len(self.kvl) > 0
 
-    def pop_kv(self):
+    def pop_kv(self) -> tuple[str, str, float]:
         if len(self.kvl):
             return self.kvl.pop(0)
+
         return None, None, time()
 
 

--- a/tools/python/mbed_os_tools/test/host_tests_conn_proxy/conn_proxy.py
+++ b/tools/python/mbed_os_tools/test/host_tests_conn_proxy/conn_proxy.py
@@ -39,7 +39,7 @@ class KiViBufferWalker:
 
     def append(self, payload: bytes):
         """! Append stream buffer with payload and process. Returns non-KV strings"""
-        
+
         try:
             self.buff += payload.decode("utf-8")
         except UnicodeDecodeError:

--- a/tools/python/mbed_os_tools/test/host_tests_runner/host_test_default.py
+++ b/tools/python/mbed_os_tools/test/host_tests_runner/host_test_default.py
@@ -142,7 +142,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         # Flag check if __exit_event_queue event occurred
         callbacks__exit_event_queue = False
         # Handle to dynamically loaded host test object
-        self.test_supervisor = None
+        self.host_test = None
         # Version: greentea-client version from DUT
         self.client_version = None
 
@@ -262,18 +262,18 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         self.logger.prn_inf("DUT greentea-client version: " + self.client_version)
                     elif key == "__host_test_name":
                         # Load dynamically requested host test
-                        self.test_supervisor = self.registry.get_host_test(value)
+                        self.host_test = self.registry.get_host_test(value)
 
                         # Check if host test object loaded is actually host test class
                         # derived from 'mbed_os_tools.test.BaseHostTest()'
                         # Additionaly if host test class implements custom ctor it should
                         # call BaseHostTest().__Init__()
-                        if self.test_supervisor and self.is_host_test_obj_compatible(self.test_supervisor):
+                        if self.host_test and self.is_host_test_obj_compatible(self.host_test):
                             # Pass communication queues and setup() host test
-                            self.test_supervisor.setup_communication(event_queue, dut_event_queue, config)
+                            self.host_test.setup_communication(event_queue, dut_event_queue, config)
                             try:
                                 # After setup() user should already register all callbacks
-                                self.test_supervisor.setup()
+                                self.host_test.setup()
                             except (TypeError, ValueError):
                                 # setup() can throw in normal circumstances TypeError and ValueError
                                 self.logger.prn_err("host test setup() failed, reason:")
@@ -285,8 +285,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                                 event_queue.put(("__exit_event_queue", 0, time()))
 
                             self.logger.prn_inf("host test setup() call...")
-                            if self.test_supervisor.get_callbacks():
-                                callbacks.update(self.test_supervisor.get_callbacks())
+                            if self.host_test.get_callbacks():
+                                callbacks.update(self.host_test.get_callbacks())
                                 self.logger.prn_inf("CALLBACKs updated")
                             else:
                                 self.logger.prn_wrn("no CALLBACKs specified by host test")
@@ -463,8 +463,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             # Here for example we've received some error code like IOERR_COPY
             self.logger.prn_inf("host test result() call skipped, received: %s" % str(result))
         else:
-            if self.test_supervisor:
-                result = self.test_supervisor.result()
+            if self.host_test:
+                result = self.host_test.result()
             self.logger.prn_inf("host test result(): %s" % str(result))
 
         if not callbacks__exit:
@@ -481,8 +481,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             result = self.RESULT_TIMEOUT
 
         self.logger.prn_inf("calling blocking teardown()")
-        if self.test_supervisor:
-            self.test_supervisor.teardown()
+        if self.host_test:
+            self.host_test.teardown()
         self.logger.prn_inf("teardown() finished")
 
         return result


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR makes some further improvements to the I2C API to make it harder to use incorrectly and easier to test. These include:

- Adding an `i2c_capabilities()` function to the HAL so that implementations can declare what they do and do not support
- Adding a new state field to the i2c struct which is checked and updated by the `I2C` class but can also be accessed by HAL drivers
- Adding checks in the I2C class which validate that we are in the correct state and have the correct capabilities before doing anything
- Adding return codes to `I2C::start()` and `I2C::stop()` so it's possible to report errors from these functions
- Fixing the I2C destructor so it actually calls `i2c_free()` (no idea why it was not before).

I did my best to go through the existing HAL drivers and add capabilities based on my best effort analysis of the code. Also, a lot of them had to have their accessor functions updated because the i2c structure is no longer equivalent to `struct i2c_s` anymore.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->
- Using the I2C API wrong should no longer result in the hardware being put in a weird state
- I2C HALs no longer need to implement any error checking for being in the wrong state
- LPC1768 single-byte I2C HAL will no longer continue to send bytes after being NACKed

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Ran CI shield tests on Apollo3, STM32H5, and LPC1768. All pass except one known I2C issue on STM32H5 (also the Apollo3 cannot pass the EEPROM test because it does not support single byte I2C).

----------------------------------------------------------------------------------------------------------------
