### PR TITLE
RP2xxx I2C Rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,8 @@ A message that notes the main changes in the update.
 - RP2xxx:
   - Fixed issue where reading from an I2C master in slave mode could put the I2C peripheral in a bad state if the master transferred
     more bytes than expected
-  - Fixed issue where reading from an I2c master in slave mode could hang forever if the master ends the transaction early
-  - 
+  - Fixed issue where reading from an I2C master in slave mode could hang forever if the master ends the transaction early
+  - Fixed issue where writing to an I2C master in slave mode would always return success regardless of success/failure
 
 ### Removed
 - Target Uhuru Raven (STM32F7) has been removed due to market availability (it is still possible to use it with release Mbed-os 7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ A message that notes the main changes in the update.
 - Fixed memory leak with Nanostack memory manager that caused the stack to run of memory when used with zero-copy Ethernet drivers
 - LPC17xx:
   - Fixed I2C single-byte API continuing to send bytes after being NACKed
+- RP2xxx:
+  - Fixed issue where reading from an I2C master in slave mode could put the I2C peripheral in a bad state if the master transferred
+    more bytes than expected
+  - Fixed issue where reading from an I2c master in slave mode could hang forever if the master ends the transaction early
+  - 
 
 ### Removed
 - Target Uhuru Raven (STM32F7) has been removed due to market availability (it is still possible to use it with release Mbed-os 7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A message that notes the main changes in the update.
   - `SFE_THING_PLUS_RP2040` board target added for the [SparkFun Thing Plus RP2040 board](https://www.sparkfun.com/sparkfun-thing-plus-rp2040.html)
   - MPU configuration support added
   - RP235x target family added, containing two boards to start, `RASPBERRY_PI_PICO_2` and `OLIMEX_RP2350_PICO2_XL`
+  - Support for single-byte i2c operations implemented (allowing features like the I2C EEPROM block device to work).
 
 ### Changed
 - Reworked targets CMake code to only recurse into the subdir for the current target family, which should speed up the CMake configure a bit

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -144,8 +144,7 @@ int i2c_byte_write(i2c_t *obj, int data) {
                 ret = 3; // other error
             }
 
-            // Read register to clear abort
-            obj->i2c.dev->hw->clr_tx_abrt;
+            // Don't clear the abort yet as we check this in i2c_stop()
         }
     }
 
@@ -174,9 +173,8 @@ int i2c_byte_read(i2c_t *obj, int last) {
 
     // Did we encounter an error?
     if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
-        // Sadly no way to pass up the abort reason so no reason to read tx_abrt_source
-        // Also don't clear the abort yet!
-
+        // Sadly no way to pass up the abort reason so no reason to read tx_abrt_source.
+        // Also don't clear the abort yet as we check this in i2c_stop()
         return 0;
     }
 
@@ -377,17 +375,17 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
             tight_loop_contents();
         }
 
+        if(obj->i2c.dev->hw->raw_intr_stat & (I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS | I2C_IC_RAW_INTR_STAT_STOP_DET_BITS)) {
+            // Transaction ended
+            break;
+        }
+
         // Feed more bytes into the FIFO if we have them and there's room
         if(i2c_get_write_available(obj->i2c.dev) && bytes_written < length) {
             obj->i2c.dev->hw->data_cmd = data[bytes_written++];
 
             // Tell the hardware we gave it some data
             obj->i2c.dev->hw->clr_rd_req;
-        }
-        
-        if(obj->i2c.dev->hw->raw_intr_stat & (I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS | I2C_IC_RAW_INTR_STAT_STOP_DET_BITS)) {
-            // Transaction ended
-            break;
         }
 
         if((obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_RD_REQ_BITS) && (bytes_written >= length)) {

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -58,7 +58,8 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     /* Verify if both pins belong to the same I2C peripheral. */
     I2CName const i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
     I2CName const i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
-    MBED_ASSERT(i2c_sda == i2c_scl);
+    const I2CName i2c_peripheral = pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT(i2c_peripheral != NC);
 
 #if DEVICE_I2CSLAVE
     /** was_slave is used to decide which driver call we need
@@ -100,8 +101,87 @@ void i2c_frequency(i2c_t *obj, int hz)
     obj->i2c.baudrate = i2c_set_baudrate(obj->i2c.dev, hz);
 }
 
+int i2c_start(i2c_t *obj) {
+    (void)obj;
+    // No-op, we need to wait until we get the address to start
+    return 0;
+}
+
+int i2c_byte_write(i2c_t *obj, int data) {
+    int ret = 1;
+
+    if(obj->state == MBED_HAL_I2C_STATE_STARTED) {
+        // First byte (address). Save for now in TAR register (won't actually get sent until later)
+        obj->i2c.dev->hw->enable = 0;
+        obj->i2c.dev->hw->tar = data >> 1;
+        obj->i2c.dev->hw->enable = 1;
+    }
+    else {
+        // Write byte. Force transmission of a start condition if this is the first data byte.
+        obj->i2c.dev->hw->data_cmd = data | (obj->state == MBED_HAL_I2C_STATE_ADDRESSED ? I2C_IC_DATA_CMD_RESTART_BITS : 0);
+
+        // Wait until the transmission of the address/data from the internal
+        // shift register has completed. For this to function correctly, the
+        // TX_EMPTY_CTRL flag in IC_CON must be set. The TX_EMPTY_CTRL flag
+        // was set in pico_sdk_i2c_init.
+        do {
+            tight_loop_contents();
+        }
+        while (!(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_EMPTY_BITS));
+
+        // Did we encounter an error?
+        if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+            // Get the abort reason
+            uint32_t abort_reason = obj->i2c.dev->hw->tx_abrt_source;
+            if(abort_reason & (I2C_IC_TX_ABRT_SOURCE_ABRT_TXDATA_NOACK_BITS | I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR1_NOACK_BITS | I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR2_NOACK_BITS | I2C_IC_TX_ABRT_SOURCE_ABRT_7B_ADDR_NOACK_BITS)) {
+                ret = 0; // no ACK
+            }
+            else {
+                ret = 3; // other error
+            }
+
+            // Read register to clear abort
+            obj->i2c.dev->hw->clr_tx_abrt;
+        }
+    }
+
+    return ret;
+}
+
+int i2c_byte_read(i2c_t *obj, int last) {
+
+    // Trigger reading of a byte. Force generation of a start condition if this is the first byte.
+    // NOTE: As far as I can tell, there is not a way to make the hardware NACK this read byte.
+    (void)last;
+    obj->i2c.dev->hw->data_cmd = I2C_IC_DATA_CMD_CMD_BITS |
+        (obj->state == MBED_HAL_I2C_STATE_ADDRESSED ? I2C_IC_DATA_CMD_RESTART_BITS : 0);
+
+    // Wait until the transmission of the address/data from the internal
+    // shift register has completed. For this to function correctly, the
+    // TX_EMPTY_CTRL flag in IC_CON must be set. The TX_EMPTY_CTRL flag
+    // was set in pico_sdk_i2c_init.
+    do {
+        tight_loop_contents();
+    }
+    while (!(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) && !i2c_get_read_available(obj->i2c.dev));
+
+    // Did we encounter an error?
+    if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+        // Sadly no way to pass up the abort reason so no reason to read tx_abrt_source
+        // Also don't clear the abort yet!
+
+        return 0;
+    }
+
+    // Return data
+}
+
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
+    // Make sure a repeated start is correctly generated if we currently have the bus locked
+    obj->i2c.dev->restart_on_next = obj->state != MBED_HAL_I2C_STATE_IDLE;
+
+
     int const bytes_read = i2c_read_blocking(obj->i2c.dev,
                                              (uint8_t)(address >> 1),
                                              (uint8_t *)data,
@@ -113,16 +193,25 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
         return bytes_read;
 }
 
+int i2c_stop(i2c_t *obj)
+{
+    // If we didn't already generate a stop due to an error earlier in the transaction...
+    if(!(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS)) {
+        // ...then generate one now.
+        obj->i2c.dev->hw->enable |= I2C_IC_ENABLE_ABORT_BITS;
+        do {
+            tight_loop_contents();
+        }
+        while (!(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS));
+    }
+
+    return 0;
+}
+
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    if (length == 0) {
-        // From pico-sdk:
-        // static int i2c_write_blocking_internal(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
-        // Synopsys hw accepts start/stop flags alongside data items in the same
-        // FIFO word, so no 0 byte transfers.
-        // invalid_params_if(I2C, len == 0);
-        length = 1;
-    }
+    // Make sure a repeated start is correctly generated if we currently have the bus locked
+    obj->i2c.dev->restart_on_next = obj->state != MBED_HAL_I2C_STATE_IDLE;
 
     int const bytes_written = i2c_write_blocking(obj->i2c.dev,
                                                  address >> 1,
@@ -159,11 +248,6 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
-}
-
-int i2c_stop(i2c_t *obj)
-{
-    return 0;
 }
 
 #if DEVICE_I2CSLAVE

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -88,6 +88,10 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     gpio_pull_up(scl);
 }
 
+void i2c_free(i2c_t *obj) {
+    i2c_deinit(obj->i2c.dev);
+}
+
 void i2c_frequency(i2c_t *obj, int hz)
 {
     DEBUG_PRINTF("obj->i2c.is_slave: %d\r\n", obj->i2c.is_slave);
@@ -150,9 +154,12 @@ int i2c_byte_write(i2c_t *obj, int data) {
 
 int i2c_byte_read(i2c_t *obj, int last) {
 
-    // Trigger reading of a byte. Force generation of a start condition if this is the first byte.
-    // NOTE: As far as I can tell, there is not a way to make the hardware NACK this read byte.
+    // This I2C peripheral waits to generate the ACK/NACK after a read until either we try to read the
+    // next byte or we generate a stop/repeated start. This means it automatically uses the correct
+    // type of ACK or NACK and doesn't need (and can't accept) a flag on whether to do so.
     (void)last;
+
+    // Trigger reading of a byte. Force generation of a start condition if this is the first byte.
     obj->i2c.dev->hw->data_cmd = I2C_IC_DATA_CMD_CMD_BITS |
         (obj->state == MBED_HAL_I2C_STATE_ADDRESSED ? I2C_IC_DATA_CMD_RESTART_BITS : 0);
 
@@ -177,23 +184,6 @@ int i2c_byte_read(i2c_t *obj, int last) {
     return (uint8_t) obj->i2c.dev->hw->data_cmd;
 }
 
-int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
-{
-    // Make sure a repeated start is correctly generated if we currently have the bus locked
-    obj->i2c.dev->restart_on_next = obj->state != MBED_HAL_I2C_STATE_IDLE;
-
-
-    int const bytes_read = i2c_read_blocking(obj->i2c.dev,
-                                             (uint8_t)(address >> 1),
-                                             (uint8_t *)data,
-                                             (size_t)length,
-                                             /* nostop = */(stop == 0));
-    if (bytes_read < 0)
-        return I2C_ERROR_NO_SLAVE;
-    else
-        return bytes_read;
-}
-
 int i2c_stop(i2c_t *obj)
 {
     // If we didn't already generate a stop due to an error earlier in the transaction...
@@ -206,13 +196,46 @@ int i2c_stop(i2c_t *obj)
         while (!(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS));
     }
 
+    // Clear stop detection and abort reason flags (clear on read registers, ick!).
+    // If we don't clear these the SDK read/write functions will get stuck.
+    obj->i2c.dev->hw->clr_tx_abrt;
+    obj->i2c.dev->hw->clr_stop_det;
+
     return 0;
+}
+
+int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
+{
+    // Make sure a repeated start is correctly generated if we currently have the bus locked
+    obj->i2c.dev->restart_on_next = true;
+
+    // If we were previously doing a single byte transaction which aborted for any reason,
+    // ensure we clear that abort so that the Pico SDK function doesn't get stuck
+    if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+        i2c_stop(obj);
+    }
+
+    int const bytes_read = i2c_read_blocking(obj->i2c.dev,
+                                             (uint8_t)(address >> 1),
+                                             (uint8_t *)data,
+                                             (size_t)length,
+                                             /* nostop = */(stop == 0));
+    if (bytes_read < 0)
+        return I2C_ERROR_NO_SLAVE;
+    else
+        return bytes_read;
 }
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
     // Make sure a repeated start is correctly generated if we currently have the bus locked
-    obj->i2c.dev->restart_on_next = obj->state != MBED_HAL_I2C_STATE_IDLE;
+    obj->i2c.dev->restart_on_next = true;
+
+    // If we were previously doing a single byte transaction which aborted for any reason,
+    // ensure we clear that abort so that the Pico SDK function doesn't get stuck
+    if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+        i2c_stop(obj);
+    }
 
     int const bytes_written = i2c_write_blocking(obj->i2c.dev,
                                                  address >> 1,
@@ -255,7 +278,7 @@ const PinMap *i2c_slave_scl_pinmap()
 static const i2c_capabilities_t i2c_caps = {
     .single_byte_address_delayed = true,
     .single_byte_start_cond_delayed = true,
-    .supports_single_byte = false,
+    .supports_single_byte = true,
     .supports_zero_length_transfer_single_byte = false,
     .supports_zero_length_transfer_transaction = false
 };

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -327,54 +327,99 @@ int i2c_slave_receive(i2c_t *obj)
     return (retValue);
 }
 
-/** Configure I2C as slave or master.
- *  @param obj The I2C objecti2c_get_read_availableread
- *  @return non-zero if a value is available
- */
 int i2c_slave_read(i2c_t *obj, char *data, int length)
 {
     int bytes_read = 0;
-    for (size_t i = 0; i < (size_t)length; ++i) {
-        while (!i2c_get_read_available(obj->i2c.dev)) {
+
+    while(true) {
+        // Wait until something happens
+        while (!i2c_get_read_available(obj->i2c.dev) && !(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS)) {
             tight_loop_contents();
         }
 
-        *data = obj->i2c.dev->hw->data_cmd;
-        bytes_read++;
+        // Drain Rx FIFO while there is data
+        while(i2c_get_read_available(obj->i2c.dev)) {
+            if(bytes_read < length) {
+                data[bytes_read++] = obj->i2c.dev->hw->data_cmd;
+            }
+            else {
+                obj->i2c.dev->hw->data_cmd; // throw away data
+            }
+        }
 
-        // Check stop condition
-        bool stop = (obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS) != 0;
-        if (stop && !i2c_get_read_available(obj->i2c.dev)) {
+        // If we have received a stop, then bail
+        if((obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS)) {
+            // Race condition: did we get any data after exiting the while loop above? If so then loop again.
+            if(i2c_get_read_available(obj->i2c.dev)) {
+                continue;
+            }
+
             // Clear stop (by reading the register)
-            int clear_stop = obj->i2c.dev->hw->clr_stop_det;
-            (void)clear_stop;
+            obj->i2c.dev->hw->clr_stop_det;
+
             break;
-        } else {
-            data++;
         }
     }
 
     return bytes_read;
 }
 
-/** Configure I2C as slave or master.
- *  @param obj The I2C object
- *  @param data    The buffer for sending
- *  @param length  Number of bytes to write
- *  @return non-zero if a value is available
- */
 int i2c_slave_write(i2c_t *obj, const char *data, int length)
 {
     DEBUG_PRINTF("i2c_slave_write\r\n");
 
-    i2c_write_raw_blocking(obj->i2c.dev, (const uint8_t *)data, (size_t)length);
+    int bytes_written = 0;
 
-    // Clear interrupt (by reading the register)
-    int clear_read_req = i2c_get_hw(obj->i2c.dev)->clr_rd_req;
-    (void)clear_read_req;
-    DEBUG_PRINTF("clear_read_req: %d\n", clear_read_req);
+    while(true) {
+        // Wait for something to happen
+        while (!i2c_get_write_available(obj->i2c.dev) && 
+            !(obj->i2c.dev->hw->raw_intr_stat & (I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS | I2C_IC_RAW_INTR_STAT_STOP_DET_BITS | I2C_IC_RAW_INTR_STAT_RD_REQ_BITS))) {
+            tight_loop_contents();
+        }
 
-    return length;
+        // Feed more bytes into the FIFO if we have them and there's room
+        if(i2c_get_write_available(obj->i2c.dev) && bytes_written < length) {
+            obj->i2c.dev->hw->data_cmd = data[bytes_written++];
+
+            // Tell the hardware we gave it some data
+            obj->i2c.dev->hw->clr_rd_req;
+        }
+        
+        if(obj->i2c.dev->hw->raw_intr_stat & (I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS | I2C_IC_RAW_INTR_STAT_STOP_DET_BITS)) {
+            // Transaction ended
+            break;
+        }
+
+        if((obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_RD_REQ_BITS) && (bytes_written >= length)) {
+            // Out of data, and currently stretching the clock.
+            // To un-stick the master, for now we will just feed zeros into the FIFO.
+            // This error case could potentially be improved later.
+            obj->i2c.dev->hw->data_cmd = 0;
+            obj->i2c.dev->hw->clr_rd_req;
+        }
+    }
+
+    // Clear stop flag always
+    obj->i2c.dev->hw->clr_stop_det;
+
+    // Handle success vs failure
+    if(obj->i2c.dev->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+        if(obj->i2c.dev->hw->tx_abrt_source & I2C_IC_TX_ABRT_SOURCE_ABRT_SLVFLUSH_TXFIFO_BITS) {
+            // Master ended transaction early.
+            // Thankfully there is a useful field that shows the number of bytes
+            // written to the FIFO that were flushed due to transaction end.
+            const int bytes_actually_written = bytes_written - (obj->i2c.dev->hw->tx_abrt_source >> I2C_IC_TX_ABRT_SOURCE_TX_FLUSH_CNT_LSB);
+            obj->i2c.dev->hw->clr_tx_abrt;
+            return bytes_actually_written;
+        }
+        else {
+            // Other error
+            obj->i2c.dev->hw->clr_tx_abrt;
+            return -1;
+        }
+    }
+
+    return bytes_written;
 }
 
 /** Configure I2C address.

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/i2c_api.c
@@ -56,10 +56,10 @@ static unsigned int const DEFAULT_I2C_BAUDRATE = 100 * 1000; /* 100 kHz */
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
     /* Verify if both pins belong to the same I2C peripheral. */
-    I2CName const i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
-    I2CName const i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
-    const I2CName i2c_peripheral = pinmap_merge(i2c_sda, i2c_scl);
-    MBED_ASSERT(i2c_peripheral != NC);
+    uint32_t const i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
+    uint32_t const i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
+    const uint32_t i2c_peripheral = pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT(i2c_peripheral != ((uint32_t)NC));
 
 #if DEVICE_I2CSLAVE
     /** was_slave is used to decide which driver call we need
@@ -174,6 +174,7 @@ int i2c_byte_read(i2c_t *obj, int last) {
     }
 
     // Return data
+    return (uint8_t) obj->i2c.dev->hw->data_cmd;
 }
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
@@ -248,6 +249,19 @@ const PinMap *i2c_slave_sda_pinmap()
 const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
+}
+
+// Report I2C capabilities
+static const i2c_capabilities_t i2c_caps = {
+    .single_byte_address_delayed = true,
+    .single_byte_start_cond_delayed = true,
+    .supports_single_byte = false,
+    .supports_zero_length_transfer_single_byte = false,
+    .supports_zero_length_transfer_transaction = false
+};
+MBED_WEAK i2c_capabilities_t const * i2c_get_capabilities()
+{
+    return &i2c_caps;
 }
 
 #if DEVICE_I2CSLAVE

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8441,8 +8441,6 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "device_has_remove": [
             "ANALOGIN",
             "FLASH",
-            "I2C",
-            "I2CSLAVE",
             "PWMOUT",
             "SERIAL_FC",
             "SPI",


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR rewrites the I2C HAL driver used on RP2040 and RP2350. This driver seemed like it was a bit of a rush job by Arduino (gee, I'm _so_ surprised), and did not support single-byte I2C at all. The slave mode code also had major limitations so I rewrote that as well.

All things considered, the RP2xxx I2C peripheral is fairly straightforward to use. Making the single-byte API work was much easier than on certain other peripherals (e.g. STM32) as this I2C peripheral doesn't require managing any "remaining byte counts", and the operations correspond pretty well to the Mbed single-byte API. Probably the hardest part was that the datasheet docs were pretty limited about which registers to use in master mode, so I had to refer to the Pico SDK code a lot (which is thankfully pretty straightforward)

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

- RP2xxx devices support single-byte I2C
- RP235x supports I2C
- Several I2C slave bugs fixed on RP2xxx

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Ran on the CI shield, passes all I2C and I2C slave tests!
    
----------------------------------------------------------------------------------------------------------------
