### PR TITLE
Fix overrides being discarded if the same one appears in multiple target override blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ A message that notes the main changes in the update.
     more bytes than expected
   - Fixed issue where reading from an I2C master in slave mode could hang forever if the master ends the transaction early
   - Fixed issue where writing to an I2C master in slave mode would always return success regardless of success/failure
+- Fixed issue where if the same setting was overridden in multiple different `target_override` blocks in mbed_app.json, only one of the overrides would be processed
 
 ### Removed
 - Target Uhuru Raven (STM32F7) has been removed due to market availability (it is still possible to use it with release Mbed-os 7)

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -37,15 +37,5 @@
         // adapter connected.
         "target.console-usb": false,
         "target.console-uart": true
-    },
-
-    "target_overrides":
-    {
-        "*": {
-            "target.components_add": ["SPIF"]
-        },
-        "MIMXRT1060_EVK": {
-            "target.components_add": ["ESPRESSIF_ESP32"]
-        }
     }
 }

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -37,5 +37,15 @@
         // adapter connected.
         "target.console-usb": false,
         "target.console-uart": true
+    },
+
+    "target_overrides":
+    {
+        "*": {
+            "target.components_add": ["SPIF"]
+        },
+        "MIMXRT1060_EVK": {
+            "target.components_add": ["ESPRESSIF_ESP32"]
+        }
     }
 }

--- a/tools/python/mbed_tools/build/_internal/config/source.py
+++ b/tools/python/mbed_tools/build/_internal/config/source.py
@@ -343,12 +343,12 @@ def _extract_target_overrides(
     target_override_data: dict[str, dict[str, schemas.ConfigSettingValue]],
     allowed_target_labels: Iterable[str],
 ) -> List[Override]:
-    valid_target_data = {}
-    for target_type, override in target_override_data.items():
+    overrides = []
+    for target_type, target_overrides in target_override_data.items():
         if target_type == "*" or target_type in allowed_target_labels:
-            valid_target_data.update(override)
+            overrides.extend(_extract_overrides(context, namespace, target_overrides))
 
-    return _extract_overrides(context, namespace, valid_target_data)
+    return overrides
 
 
 def _extract_overrides(


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

@zhiyong-ft found a bug: If you have content like this in your mbed_app.json, where it tries to add components from multiple blocks:

```json
    "target_overrides":
    {
        "*": {
            "target.components_add": ["SPIF"]
        },
        "YOUR_TARGET": {
            "target.components_add": ["ESPRESSIF_ESP32"]
        }
    }
```

then only one of the components will be added, and the other will be ignored.

I dug into this, and found that there's a bit of an error in the Python code that handles target overrides. It basically condenses all the different blocks within `target_overrides` into a single dict, in a way that causes identical keys to just get overwritten instead of being merged. 

While I don't know if this behavior was ever explicitly specified to work, it seems better to change the code to better handle this case -- especially since it DOES work to add components within both `overrides` and `target_overrides`. So, I updated it to process the overrides from each block individually and then condense them to a list, so that they can properly interact with each other based on the defined override rules.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Ran the config system with the JSON snippet above and verified that both components are added. 

----------------------------------------------------------------------------------------------------------------
