### PR TITLE
Add non-cached section support and use it for RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ A message that notes the main changes in the update.
 - Added support for Real-Time Transfer (RTT), a method of transferring text from a target device using a debugger connection. RTT allows getting UART console-like behavior at a higher speed and with no additional wires to the target.
   - RTT can be used automatically by Mbed via the `target.console-rtt` JSON option, or manually in code by linking the `mbed-rtt` CMake library and using the `RTTHandle` class.
   - RTT is supported in the JLINK, OPENOCD, and PYOCD upload methods. RTT can be used with command-line development and VS Code, but not with CLion at this time.
-- Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32H7 and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
+- Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32F7, STM32H7, and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
 - MIMRT117x: Memory bank configuration is now supported in the linker script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A message that notes the main changes in the update.
 - Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32H7 and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
+- MIMRT117x: Memory bank configuration is now supported in the linker script.
 - RP2xxx
   - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board with Mbed compared to the non-W version is limited).
   - `SFE_THING_PLUS_RP2040` board target added for the [SparkFun Thing Plus RP2040 board](https://www.sparkfun.com/sparkfun-thing-plus-rp2040.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ A message that notes the main changes in the update.
 - Added support for Real-Time Transfer (RTT), a method of transferring text from a target device using a debugger connection. RTT allows getting UART console-like behavior at a higher speed and with no additional wires to the target.
   - RTT can be used automatically by Mbed via the `target.console-rtt` JSON option, or manually in code by linking the `mbed-rtt` CMake library and using the `RTTHandle` class.
   - RTT is supported in the JLINK, OPENOCD, and PYOCD upload methods. RTT can be used with command-line development and VS Code, but not with CLion at this time.
+- Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32H7 and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
+- Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
+- Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
 - RP2xxx
-  - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board compared to the non-W version is limited).
+  - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board with Mbed compared to the non-W version is limited).
   - `SFE_THING_PLUS_RP2040` board target added for the [SparkFun Thing Plus RP2040 board](https://www.sparkfun.com/sparkfun-thing-plus-rp2040.html)
   - MPU configuration support added
   - Support for single-byte i2c operations implemented (allowing features like the I2C EEPROM block device to work).
@@ -33,7 +36,8 @@ A message that notes the main changes in the update.
 - Reworked targets CMake code to only recurse into the subdir for the current target family, which should speed up the CMake configure a bit
 - The `I2C` class now keeps track of the I2C bus state and prevents you from doing operations that are obviously wrong, such as calling `start()` before `stop()` or calling `write_byte()` before `start()`. Previously these operations would get passed down to the HAL API which may or may not have appropriate error handling for them.
 - The `I2C` class now detects and rejects attempts to perform a zero-length transaction on hardware which does not support it.
-- Use `-Werror=return-type` in the default GCC flags so that a missing return statement in a function becomes a fatal error 
+- Use `-Werror=return-type` in the default GCC flags so that a missing return statement in a function becomes a fatal error
+- On targets with a data cache (`__DCACHE_PRESENT` is defined), one additional MPU region is used to implement the new non-cacheable memory support.
 - STM32F4
   - HAL driver update to `stm32f4xx-hal-driver` v1.8.5 (2025), now integrated as a submodule.
   - CMSIS device update to `cmsis-device-f4` v2.6.11 (2025), now integrated as a submodule.
@@ -50,7 +54,7 @@ A message that notes the main changes in the update.
   - Standardized ROM names in `cmsis_mcu_descriptions` across STM32F7 targets.
   - Replaced per-target linker scripts with one common STM32F7 linker script.
   - Replaced most STM32F7 `system_clock.c` files with one common clock configuration.
-  - Added target metadata cleanup (`adc-vref`, `hse-value for all F7 targets).
+  - Added target metadata cleanup (`adc-vref`, `hse-value` for all F7 targets).
   - Updated STM32F7 config/init files by consolidating Mbed changes with latest upstream templates. Removed unused Ethernet HAL sections from config (Mbed does not use ST Ethernet stack here)
   - Applied interim local HAL fixes until upstream release includes them: https://github.com/STMicroelectronics/stm32f7xx-hal-driver/issues/23
   - F7 Vector table size and vector start is now covered by linker script and all cmsis_nvic.h files were removed

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -36,6 +36,7 @@
         // This assumes that such boards (e.g. RASPBERRY_PI_PICO) have an external USB-serial
         // adapter connected.
         "target.console-usb": false,
-        "target.console-uart": true
+        "target.console-uart": false,
+        "target.console-rtt": true
     }
 }

--- a/TESTS/configs/greentea_full.json5
+++ b/TESTS/configs/greentea_full.json5
@@ -36,7 +36,7 @@
         // This assumes that such boards (e.g. RASPBERRY_PI_PICO) have an external USB-serial
         // adapter connected.
         "target.console-usb": false,
-        "target.console-uart": false,
-        "target.console-rtt": true
+        "target.console-uart": true,
+        "target.console-rtt": false
     }
 }

--- a/doxyfile_options
+++ b/doxyfile_options
@@ -2356,7 +2356,8 @@ PREDEFINED             = DOXYGEN_ONLY \
                          BLE_FEATURE_WHITELIST=1 \
                          BLE_FEATURE_PRIVACY=1 \
                          BLE_FEATURE_PERIODIC_ADVERTISING=1 \
-                         BLE_FEATURE_EXTENDED_ADVERTISING=1
+                         BLE_FEATURE_EXTENDED_ADVERTISING=1 \
+                         __DCACHE_PRESENT=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/features/frameworks/rtt/RTTHandle.h
+++ b/features/frameworks/rtt/RTTHandle.h
@@ -75,8 +75,8 @@ public:
      * @param down_buffer_size Size of the down buffer in bytes.
      * @param name Optional name to give this channel.
      *
-     * @warning On targets with a data cache, the up and down buffer memory needs to be declared in the section
-     *    defined by \c SEGGER_RTT_SECTION, or otherwise placed into non-cachable memory. The same is true for
+     * @warning On targets with a data cache, the up and down buffer memory needs to be declared as \c MBED_NONCACHED ,
+     *     or otherwise placed into non-cachable memory. The same is true for
      *    \c name if it is not a string constant in flash.
      */
     RTTHandle(unsigned int buffer_index, char * up_buffer, size_t up_buffer_size, char * down_buffer, size_t down_buffer_size, char const * name = nullptr);

--- a/features/frameworks/rtt/SEGGER_RTT_Conf.h
+++ b/features/frameworks/rtt/SEGGER_RTT_Conf.h
@@ -21,6 +21,7 @@
 #ifndef __ASSEMBLER__
 #include "device.h" // for __DCACHE_PRESENT
 #include "mbed_critical.h"
+#include "mbed_toolchain.h"
 #endif
 
 // Buffer counts and sizes
@@ -38,6 +39,7 @@
 // Cache setup
 #if __DCACHE_PRESENT
 // NOTE: On targets with a data cache, the RTT control block and buffers must be put in an uncached section of memory.
-// This requires that the linker script contain logic to place the ".rtt" section.
-#define SEGGER_RTT_SECTION ".rtt"
+// This requires that the linker script contain logic to place the ".noncached" section.
+#define SEGGER_RTT_SECTION MBED_NONCACHED_SECTION_NAME
+#define SEGGER_RTT_BUFFER_SECTION MBED_NONCACHED_SECTION_NAME
 #endif

--- a/features/frameworks/rtt/mbed_lib.json5
+++ b/features/frameworks/rtt/mbed_lib.json5
@@ -29,15 +29,15 @@
       "cb-search-range-start": 0x24000000,
       "cb-search-range-end": 0x2407FFFF
     },
-    "MIMXRT1060": {
-      // RTT lives in OCRAM
-      "cb-search-range-start": 0x20280000,
-      "cb-search-range-end": 0x2029FFFF
+    "MIMXRT105X": {
+      // RTT lives in DTCM
+      "cb-search-range-start": 0x20000000,
+      "cb-search-range-end": 0x2023FFFF
     },
-    "MIMXRT1050": {
-      // RTT lives in OCRAM
-      "cb-search-range-start": 0x20200000,
-      "cb-search-range-end": 0x2021FFFF
+    "MIMXRT1170": {
+      // RTT lives in OCRAM combined
+      "cb-search-range-start": 0x20240000,
+      "cb-search-range-end": 0x2035FFFF
     }
   }
 }

--- a/features/frameworks/rtt/mbed_lib.json5
+++ b/features/frameworks/rtt/mbed_lib.json5
@@ -12,6 +12,32 @@
     "max-channels": {
       help: "Maximum number of channels supported by RTT. This controls the size of some static arrays within the RTT code. Note that this does NOT, by itself, allocate space for the buffers.",
       value: 3
+    },
+    "cb-search-range-start": {
+      help: "Override the start (first address) of the search range that will be used when a debugger searches for the RTT control block.",
+      value: null
+    },
+    "cb-search-range-end": {
+      help: "Override the end (last address) of the search range that will be used when a debugger searches for the RTT control block.",
+      value: null
+    }
+  },
+  target_overrides: {
+    "MCU_STM32H7": {
+      // STM32H7 has an ITCM bank at address 0, which then causes OpenOCD to fault out when searching for the RTT control
+      // block between the end of that bank and the start of the next one. So, manually target SRAM_D1
+      "cb-search-range-start": 0x24000000,
+      "cb-search-range-end": 0x2407FFFF
+    },
+    "MIMXRT1060": {
+      // RTT lives in OCRAM
+      "cb-search-range-start": 0x20280000,
+      "cb-search-range-end": 0x2029FFFF
+    },
+    "MIMXRT1050": {
+      // RTT lives in OCRAM
+      "cb-search-range-start": 0x20200000,
+      "cb-search-range-end": 0x2021FFFF
     }
   }
 }

--- a/hal/include/hal/mpu_api.h
+++ b/hal/include/hal/mpu_api.h
@@ -60,6 +60,18 @@ extern "C" {
  *     mbed test -t <toolchain> -m <target> -n tests-mbed_hal-mpu*
  */
 
+#ifndef MBED_MPU_CUSTOM
+/// Number of MPU regions that will be used by Mbed OS's MPU configuration.
+/// The application is generally free to use regions above this number.
+static const size_t mbed_used_mpu_regions = 3
+#if MBED_MPU_RAM_START != 0x20000000
+  + 1
+#endif
+#if __DCACHE_PRESENT
+  + 1
+#endif
+;
+#endif
 
 /**
  * Initialize the MPU
@@ -78,9 +90,9 @@ void mbed_mpu_init(void);
  *
  * By default writes to ROM are disabled.
  *
- * @param enable true to disable writes to ROM, false otherwise
+ * @param disable true to disable writes to ROM, false otherwise
  */
-void mbed_mpu_enable_rom_wn(bool enable);
+void mbed_mpu_enable_rom_wn(bool disable);
 
 /**
  * Enable or disable ram MPU protection
@@ -90,9 +102,9 @@ void mbed_mpu_enable_rom_wn(bool enable);
  *
  * By default execution from RAM is disabled.
  *
- * @param enable true to disable execution from RAM, false otherwise
+ * @param disable true to disable execution from RAM, false otherwise
  */
-void mbed_mpu_enable_ram_xn(bool enable);
+void mbed_mpu_enable_ram_xn(bool disable);
 
 /** Deinitialize the MPU
  *

--- a/hal/include/hal/mpu_api.h
+++ b/hal/include/hal/mpu_api.h
@@ -22,6 +22,9 @@
 
 #include "device.h"
 #include <stdbool.h>
+#include "cmsis.h"
+
+#include <mstd_cstddef>
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,17 +63,54 @@ extern "C" {
  *     mbed test -t <toolchain> -m <target> -n tests-mbed_hal-mpu*
  */
 
-#ifndef MBED_MPU_CUSTOM
+#if !defined(MBED_MPU_CUSTOM)
+
+#ifdef MBED_CONF_TARGET_MPU_ROM_END
+#define MBED_MPU_ROM_END             MBED_CONF_TARGET_MPU_ROM_END
+#else
+#define MBED_MPU_ROM_END             (0x10000000 - 1)
+#endif
+
+#ifdef MBED_CONF_TARGET_MPU_RAM_START
+#define MBED_MPU_RAM_START             MBED_CONF_TARGET_MPU_RAM_START
+#else
+// Default to the end of ROM
+#define MBED_MPU_RAM_START           (MBED_MPU_ROM_END + 1)
+#endif
+
+#if ((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U) || (__ARM_ARCH_8_1M_MAIN__ == 1U))
+/// On ARMv8 cores, MPU regions must use one of 8 global "attribute registers", which give the attributes
+/// for one or more memory regions. This enum gives the attribute registers (i.e. the first arg to
+/// \c ARM_MPU_SetMemAttr() ) that are defined by Mbed.
+/// The application is free to use attribute registers above this number.
+enum mbed_mpu_attr_index {
+    /// Normal memory, write-through (i.e. writes are always sent immediately to main memory)
+    MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH = 0,
+
+    /// Normal memory, write-back (i.e. writes may only write to the cache immediately, and get synced to main memory later)
+    MBED_MPU_ATTR_INDEX_NORMAL_WRITE_BACK = 1,
+
+    /// Non-cacheable: Reads and writes hit main memory directly.
+    /// Note that this is still normal memory, not device, so the CPU can still reorder accesses.
+    MBED_MPU_ATTR_INDEX_NON_CACHEABLE = 2,
+};
+#endif
+
 /// Number of MPU regions that will be used by Mbed OS's MPU configuration.
 /// The application is generally free to use regions above this number.
-static const size_t mbed_used_mpu_regions = 3
-#if MBED_MPU_RAM_START != 0x20000000
-  + 1
+static MSTD_CONSTEXPR_OBJ_11 size_t mbed_used_mpu_regions =
+#if ((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U) || (__ARM_ARCH_8_1M_MAIN__ == 1U))
+    4
+#else
+    3
+#endif
+#if MBED_MPU_RAM_START < 0x20000000
+    + 1
 #endif
 #if __DCACHE_PRESENT
-  + 1
+    + 1
 #endif
-;
+    ;
 #endif
 
 /**

--- a/hal/source/mpu/mbed_mpu_v7m.c
+++ b/hal/source/mpu/mbed_mpu_v7m.c
@@ -28,19 +28,6 @@
 #error "Device has v7m MPU but it is not enabled. Add 'MPU' to device_has in targets.json"
 #endif
 
-#ifdef MBED_CONF_TARGET_MPU_ROM_END
-#define MBED_MPU_ROM_END             MBED_CONF_TARGET_MPU_ROM_END
-#else
-#define MBED_MPU_ROM_END             (0x10000000 - 1)
-#endif
-
-#ifdef MBED_CONF_TARGET_MPU_RAM_START
-#define MBED_MPU_RAM_START             MBED_CONF_TARGET_MPU_RAM_START
-#else
-// Default to the end of ROM
-#define MBED_MPU_RAM_START           (MBED_MPU_ROM_END + 1)
-#endif
-
 #ifdef __DCACHE_PRESENT
 // Symbols defined in linker script for noncache region
 extern uint8_t __noncached_start[];
@@ -191,7 +178,7 @@ void mbed_mpu_init()
 
 #if __DCACHE_PRESENT
     ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
-    if(noncached_region_size > 0) {
+    if (noncached_region_size > 0) {
         // Check configuration from linker script
         MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
         MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);

--- a/hal/source/mpu/mbed_mpu_v7m.c
+++ b/hal/source/mpu/mbed_mpu_v7m.c
@@ -18,6 +18,8 @@
 #include "platform/mbed_assert.h"
 #include "cmsis.h"
 
+#include <mbed_math_helpers.h>
+
 #if ((__ARM_ARCH_7M__ == 1U) || (__ARM_ARCH_7EM__ == 1U) || (__ARM_ARCH_6M__ == 1U)) && \
     defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U) && \
     !defined(MBED_MPU_CUSTOM)
@@ -37,6 +39,12 @@
 #else
 // Default to the end of ROM
 #define MBED_MPU_RAM_START           (MBED_MPU_ROM_END + 1)
+#endif
+
+#ifdef __DCACHE_PRESENT
+// Symbols defined in linker script for noncache region
+extern uint8_t __noncached_start[];
+extern uint8_t __noncached_end[];
 #endif
 
 static_assert(
@@ -59,11 +67,7 @@ void mbed_mpu_init()
 
     // Our MPU setup requires 3 or 4 regions - if this assert is hit, remove
     // a region by setting MPU_ROM_END to 0x1fffffff, or remove MPU from device_has
-#if MBED_MPU_RAM_START == 0x20000000
-    MBED_ASSERT(regions >= 3);
-#else
-    MBED_ASSERT(regions >= 4);
-#endif
+    MBED_ASSERT(regions >= mbed_used_mpu_regions);
 
     // Disable the MPU
     MPU->CTRL = 0;
@@ -185,6 +189,31 @@ void mbed_mpu_init()
             ARM_MPU_REGION_SIZE_512MB)  // Size
     );
 
+#if __DCACHE_PRESENT
+    ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
+    if(noncached_region_size > 0) {
+        // Check configuration from linker script
+        MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
+        MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);
+
+        // Region size constant is the log2 of the region size, offset by 1
+        const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
+
+        // Select region 3/4 and use it for the non-cached region
+        ARM_MPU_SetRegion(
+            ARM_MPU_RBAR(
+                LAST_RAM_REGION + 1,             // Region
+                ((uintptr_t)__noncached_start)), // Base
+            ARM_MPU_RASR_EX(
+                1,                          // DisableExec
+                ARM_MPU_AP_FULL,            // AccessPermission
+                ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
+                0U,                         // SubRegionDisable
+                region_size)                // Size
+        );
+    }
+#endif
+
     // Enable the MPU
     MPU->CTRL =
         (1 << MPU_CTRL_PRIVDEFENA_Pos) |            // Use the default memory map for unmapped addresses
@@ -215,25 +244,25 @@ static void enable_region(bool enable, uint32_t region)
     MPU->RASR = (MPU->RASR & ~MPU_RASR_ENABLE_Msk) | (enable << MPU_RASR_ENABLE_Pos);
 }
 
-void mbed_mpu_enable_rom_wn(bool enable)
+void mbed_mpu_enable_rom_wn(bool disable)
 {
     // Flush memory writes before configuring the MPU.
     __DMB();
 
-    enable_region(enable, 0);
+    enable_region(disable, 0);
 
     // Ensure changes take effect
     __DSB();
     __ISB();
 }
 
-void mbed_mpu_enable_ram_xn(bool enable)
+void mbed_mpu_enable_ram_xn(bool disable)
 {
     // Flush memory writes before configuring the MPU.
     __DMB();
 
     for (uint32_t region = 1; region <= LAST_RAM_REGION; region++) {
-        enable_region(enable, region);
+        enable_region(disable, region);
     }
 
     // Ensure changes take effect

--- a/hal/source/mpu/mbed_mpu_v8m.c
+++ b/hal/source/mpu/mbed_mpu_v8m.c
@@ -39,6 +39,12 @@
 #define MBED_MPU_RAM_START           (MBED_MPU_ROM_END + 1)
 #endif
 
+#ifdef __DCACHE_PRESENT
+// Symbols defined in linker script for noncache region
+extern uint8_t __noncached_start[];
+extern uint8_t __noncached_end[];
+#endif
+
 static_assert(MBED_MPU_ROM_END <= 0x20000000 - 1,
               "Unsupported value for MBED_MPU_ROM_END");
 
@@ -49,13 +55,9 @@ void mbed_mpu_init()
 
     const uint32_t regions = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
 
-    // Our MPU setup requires 4 or 5 regions - if this assert is hit, remove
+    // Our MPU setup requires 4-6 regions - if this assert is hit, remove
     // a region by setting MPU_ROM_END to 0x1fffffff, or remove MPU from device_has
-#if MBED_MPU_RAM_START == 0x20000000
-    MBED_ASSERT(regions >= 4);
-#else
-    MBED_ASSERT(regions >= 5);
-#endif
+    MBED_ASSERT(regions >= mbed_used_mpu_regions);
 
     // Disable the MCU
     MPU->CTRL = 0;
@@ -81,13 +83,10 @@ void mbed_mpu_init()
 
     const uint8_t WTRA = ARM_MPU_ATTR_MEMORY_(1, 0, 1, 0);      // Non-transient, Write-Through, Read-allocate, Not Write-allocate
     const uint8_t WBWARA = ARM_MPU_ATTR_MEMORY_(1, 1, 1, 1);    // Non-transient, Write-Back, Read-allocate, Write-allocate
-    enum {
-        AttrIndex_WTRA,
-        AttrIndex_WBWARA,
-    };
 
-    ARM_MPU_SetMemAttr(AttrIndex_WTRA, ARM_MPU_ATTR(WTRA, WTRA));
-    ARM_MPU_SetMemAttr(AttrIndex_WBWARA, ARM_MPU_ATTR(WBWARA, WBWARA));
+    ARM_MPU_SetMemAttr(MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH, ARM_MPU_ATTR(WTRA, WTRA));
+    ARM_MPU_SetMemAttr(MBED_MPU_ATTR_INDEX_NORMAL_WRITE_BACK, ARM_MPU_ATTR(WBWARA, WBWARA));
+    ARM_MPU_SetMemAttr(MBED_MPU_ATTR_INDEX_NON_CACHEABLE, ARM_MPU_ATTR(MPU_ATTR_NORMAL_OUTER_NON_CACHEABLE, MPU_ATTR_NORMAL_INNER_NON_CACHEABLE));
 
     ARM_MPU_SetRegion(
         0,                          // Region
@@ -99,10 +98,10 @@ void mbed_mpu_init()
             0),                     // Execute Never disabled
         ARM_MPU_RLAR(
             MBED_MPU_ROM_END,       // Limit
-            AttrIndex_WTRA)         // Attribute index - Write-Through, Read-allocate
+            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH) // Attribute index - Write-Through, Read-allocate
     );
 
-#if MBED_MPU_RAM_START != 0x20000000
+#if MBED_MPU_RAM_START < 0x20000000
     ARM_MPU_SetRegion(
         4,                          // Region
         ARM_MPU_RBAR(
@@ -113,7 +112,7 @@ void mbed_mpu_init()
             1),                     // Execute Never enabled
         ARM_MPU_RLAR(
             0x1FFFFFFF,             // Limit
-            AttrIndex_WTRA)         // Attribute index - Write-Through, Read-allocate
+            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH) // Attribute index - Write-Through, Read-allocate
     );
 #define LAST_RAM_REGION 4
 #else
@@ -130,7 +129,7 @@ void mbed_mpu_init()
             1),                     // Execute Never enabled
         ARM_MPU_RLAR(
             0x3FFFFFFF,             // Limit
-            AttrIndex_WBWARA)       // Attribute index - Write-Back, Write-allocate
+            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_BACK) // Attribute index - Write-Back, Write-allocate
     );
 
     ARM_MPU_SetRegion(
@@ -143,7 +142,7 @@ void mbed_mpu_init()
             1),                     // Execute Never enabled
         ARM_MPU_RLAR(
             0x7FFFFFFF,             // Limit
-            AttrIndex_WBWARA)       // Attribute index - Write-Back, Write-allocate
+            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_BACK) // Attribute index - Write-Back, Write-allocate
     );
 
     ARM_MPU_SetRegion(
@@ -156,8 +155,28 @@ void mbed_mpu_init()
             1),                     // Execute Never enabled
         ARM_MPU_RLAR(
             0x9FFFFFFF,             // Limit
-            AttrIndex_WTRA)         // Attribute index - Write-Through, Read-allocate
+            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH) // Attribute index - Write-Through, Read-allocate
     );
+
+#if __DCACHE_PRESENT
+    // Region addresses must be 32-byte aligned.
+    MBED_ASSERT(((uintptr_t)__noncached_start) % 32 == 0);
+    MBED_ASSERT(((uintptr_t)__noncached_end) % 32 == 0);
+
+    // Select region 4/5 and use it for the non-cached region
+    ARM_MPU_SetRegion(
+        LAST_RAM_REGION + 1,
+        ARM_MPU_RBAR(
+            __noncached_start,          // Base
+            ARM_MPU_SH_OUTER,           // Sharability
+            0,                          // Read-Write
+            1,                          // Non-privileged
+            1),                         // Execute Never
+        ARM_MPU_RLAR(
+            __noncached_end - 1,        // Limit
+            MBED_MPU_ATTR_INDEX_NON_CACHEABLE)
+    );
+#endif
 
     // Enable the MPU
     MPU->CTRL =
@@ -189,25 +208,25 @@ static void enable_region(bool enable, uint32_t region)
     MPU->RLAR = (MPU->RLAR & ~MPU_RLAR_EN_Msk) | (enable << MPU_RLAR_EN_Pos);
 }
 
-void mbed_mpu_enable_rom_wn(bool enable)
+void mbed_mpu_enable_rom_wn(bool disable)
 {
     // Flush memory writes before configuring the MPU.
     __DMB();
 
-    enable_region(enable, 0);
+    enable_region(disable, 0);
 
     // Ensure changes take effect
     __DSB();
     __ISB();
 }
 
-void mbed_mpu_enable_ram_xn(bool enable)
+void mbed_mpu_enable_ram_xn(bool disable)
 {
     // Flush memory writes before configuring the MPU.
     __DMB();
 
     for (uint32_t region = 1; region <= LAST_RAM_REGION; region++) {
-        enable_region(enable, region);
+        enable_region(disable, region);
     }
 
     // Ensure changes take effect

--- a/platform/cxxsupport/mstd_cstddef
+++ b/platform/cxxsupport/mstd_cstddef
@@ -59,6 +59,8 @@ using std::max_align_t;
 
 #else // __cplusplus
 
+#include <stddef.h>
+
 #define MSTD_CONSTEXPR_FN_14 inline
 #define MSTD_CONSTEXPR_OBJ_14 const
 #define MSTD_CONSTEXPR_FN_11 inline

--- a/platform/include/platform/mbed_math_helpers.h
+++ b/platform/include/platform/mbed_math_helpers.h
@@ -33,6 +33,7 @@ static inline bool mbed_is_power_of_two(const uint32_t x)
  *
  * Rounds down to the nearest power of 2, i.e. \c mbed_integer_log_2(3) is 1.
  */
-static inline uint32_t mbed_integer_log_2(uint32_t x) {
-    return sizeof(uint32_t)*8 - 1 - __builtin_clz(x);
+static inline uint32_t mbed_integer_log_2(uint32_t x)
+{
+    return sizeof(uint32_t) * 8 - 1 - __builtin_clz(x);
 }

--- a/platform/include/platform/mbed_math_helpers.h
+++ b/platform/include/platform/mbed_math_helpers.h
@@ -1,0 +1,38 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2026 Jamie Smith
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Check whether an integer is an exact power of two.
+ */
+// from https://stackoverflow.com/a/600306/7083698
+static inline bool mbed_is_power_of_two(const uint32_t x)
+{
+    return x > 0 && (x & (x - 1)) == 0;
+}
+
+/**
+ * @brief Get the log2 of an integer.
+ *
+ * Rounds down to the nearest power of 2, i.e. \c mbed_integer_log_2(3) is 1.
+ */
+static inline uint32_t mbed_integer_log_2(uint32_t x) {
+    return sizeof(uint32_t)*8 - 1 - __builtin_clz(x);
+}

--- a/platform/include/platform/mbed_toolchain.h
+++ b/platform/include/platform/mbed_toolchain.h
@@ -484,6 +484,9 @@
 /// Note that this section is always zero-initialized at boot, and any initial value assigned to
 /// noncached values is ignored.
 #define MBED_NONCACHED MBED_SECTION(MBED_NONCACHED_SECTION_NAME)
+#else
+// empty define for compatibility
+#define MBED_NONCACHED
 #endif
 
 #ifndef MBED_PRINTF

--- a/platform/include/platform/mbed_toolchain.h
+++ b/platform/include/platform/mbed_toolchain.h
@@ -481,7 +481,8 @@
 #define MBED_NONCACHED_SECTION_NAME ".noncached"
 
 /// Attach to a global variable to put it in the noncached section.
-/// Note that this section is always zero-initialized at boot.
+/// Note that this section is always zero-initialized at boot, and any initial value assigned to
+/// noncached values is ignored.
 #define MBED_NONCACHED MBED_SECTION(MBED_NONCACHED_SECTION_NAME)
 #endif
 

--- a/platform/include/platform/mbed_toolchain.h
+++ b/platform/include/platform/mbed_toolchain.h
@@ -45,6 +45,8 @@
 #warning "This compiler is not yet supported."
 #endif
 
+#include "cmsis.h"
+
 /** \addtogroup platform-public-api */
 /** @{*/
 
@@ -472,6 +474,15 @@
  */
 #ifndef MBED_PRETTY_FUNCTION
 #define MBED_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+#if __DCACHE_PRESENT
+/// Name of the section where non-cached data is stored.
+#define MBED_NONCACHED_SECTION_NAME ".noncached"
+
+/// Attach to a global variable to put it in the noncached section.
+/// Note that this section is always zero-initialized at boot.
+#define MBED_NONCACHED MBED_SECTION(MBED_NONCACHED_SECTION_NAME)
 #endif
 
 #ifndef MBED_PRINTF

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -76,6 +76,25 @@ M_VECTOR_RAM_SIZE = NVIC_VECTORS_SIZE;
 
 SECTIONS
 {
+     /* Non-cached data section.
+      * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+      * We put this first in SRAM so it's very, very aligned. */
+    .noncached (NOLOAD):
+    {
+        __noncached_start = .;
+        *(.noncached)
+
+        /* For the MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __noncached_data_size = (. - __noncached_start);
+        __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+        . += (__noncached_aligned_size - __noncached_data_size);
+
+        __noncached_end = .;
+    } > RAM
+
     .isr_vector :
     {
         __vector_table = .;

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -348,6 +348,25 @@ SECTIONS
   __StackLimit = __StackTop - STACK_SIZE;
   PROVIDE(__stack = __StackTop);
 
+  /* Non-cached data section.
+   * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+   * We put this first in OCRAM so it's very, very aligned. */
+  .noncached (NOLOAD):
+  {
+      __noncached_start = .;
+      *(.noncached)
+
+      /* For the MPU configuration, we need to align the size of this section up to
+       * the next power of two. Also note that the MPU does not support regions
+       * smaller than 32 bytes so round up if smaller than that. */
+      __noncached_data_size = (. - __noncached_start);
+      __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+      . += (__noncached_aligned_size - __noncached_data_size);
+
+      __noncached_end = .;
+  } > m_ocram
+
   /* Store crash data RAM at the end of OCRAM (which is otherwise unused).
      Note that the ROM bootloader clobbers the first part of OCRAM, so we have to put this at the end. */
   __CRASH_DATA_RAM_START__ = ORIGIN(m_ocram) + LENGTH(m_ocram) - M_CRASH_DATA_RAM_SIZE; /* Create a global symbol at data start */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/device/TOOLCHAIN_GCC_ARM/MIMXRT1052xxxxx.ld
@@ -282,6 +282,7 @@ SECTIONS
   .ncache :
   {
     *(NonCacheable)
+    *(.noncached)
     . = ALIGN(8);
     __noncachedata_end__ = .;     /* define a global symbol at ncache data end */
   } > m_dtcm :ram_ncache_noinit
@@ -347,25 +348,6 @@ SECTIONS
   __StackTop   = ORIGIN(m_dtcm) + LENGTH(m_dtcm);
   __StackLimit = __StackTop - STACK_SIZE;
   PROVIDE(__stack = __StackTop);
-
-  /* Non-cached data section.
-   * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
-   * We put this first in OCRAM so it's very, very aligned. */
-  .noncached (NOLOAD):
-  {
-      __noncached_start = .;
-      *(.noncached)
-
-      /* For the MPU configuration, we need to align the size of this section up to
-       * the next power of two. Also note that the MPU does not support regions
-       * smaller than 32 bytes so round up if smaller than that. */
-      __noncached_data_size = (. - __noncached_start);
-      __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
-
-      . += (__noncached_aligned_size - __noncached_data_size);
-
-      __noncached_end = .;
-  } > m_ocram
 
   /* Store crash data RAM at the end of OCRAM (which is otherwise unused).
      Note that the ROM bootloader clobbers the first part of OCRAM, so we have to put this at the end. */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
@@ -28,6 +28,9 @@
 #include "us_ticker_api.h"
 #include "flash_api.h"
 
+#include <mbed_math_helpers.h>
+#include <mbed_assert.h>
+
 #if DEVICE_FLASH
 #include "mimxrt_flash_api.h"
 #endif
@@ -42,6 +45,10 @@
 
 uint8_t mbed_otp_mac_address(char *mac);
 void mbed_default_mac_address(char *mac);
+
+// Symbols defined in linker script for noncache region
+extern uint8_t __noncached_start[];
+extern uint8_t __noncached_end[];
 
 /* MPU configuration. */
 void BOARD_ConfigMPU(void)
@@ -127,8 +134,6 @@ void BOARD_ConfigMPU(void)
 
 #endif
 
-
-
 /* The define sets the cacheable memory to shareable,
  * this suggestion is referred from chapter 2.2.1 Memory regions,
  * types and attributes in Cortex-M7 Devices, Generic User Guide */
@@ -141,6 +146,26 @@ void BOARD_ConfigMPU(void)
     MPU->RBAR = ARM_MPU_RBAR(8, 0x80000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 1, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_32MB);
 #endif
+
+    /* Region 9: Noncached memory. */
+    ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
+    if(noncached_region_size > 0) {
+        // Check configuration from linker script
+        MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
+        MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);
+
+        // Region size constant is the log2 of the region size, offset by 1
+        const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
+
+        MPU->RBAR = ARM_MPU_RBAR(9, ((uintptr_t)__noncached_start));
+        MPU->RASR =
+            ARM_MPU_RASR_EX(
+                1,                          // DisableExec
+                ARM_MPU_AP_FULL,            // AccessPermission
+                ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
+                0U,                         // SubRegionDisable
+                region_size);               // Size
+    }
 
     /* Enable MPU */
     ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
@@ -147,25 +147,25 @@ void BOARD_ConfigMPU(void)
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 1, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_32MB);
 #endif
 
-    /* Region 9: Noncached memory. */
-    ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
-    if(noncached_region_size > 0) {
-        // Check configuration from linker script
-        MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
-        MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);
-
-        // Region size constant is the log2 of the region size, offset by 1
-        const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
-
-        MPU->RBAR = ARM_MPU_RBAR(9, ((uintptr_t)__noncached_start));
-        MPU->RASR =
-            ARM_MPU_RASR_EX(
-                1,                          // DisableExec
-                ARM_MPU_AP_FULL,            // AccessPermission
-                ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
-                0U,                         // SubRegionDisable
-                region_size);               // Size
-    }
+    // /* Region 9: Noncached memory. */
+    // ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
+    // if(noncached_region_size > 0) {
+    //     // Check configuration from linker script
+    //     MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
+    //     MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);
+    //
+    //     // Region size constant is the log2 of the region size, offset by 1
+    //     const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
+    //
+    //     MPU->RBAR = ARM_MPU_RBAR(9, ((uintptr_t)__noncached_start));
+    //     MPU->RASR =
+    //         ARM_MPU_RASR_EX(
+    //             1,                          // DisableExec
+    //             ARM_MPU_AP_FULL,            // AccessPermission
+    //             ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
+    //             0U,                         // SubRegionDisable
+    //             region_size);               // Size
+    // }
 
     /* Enable MPU */
     ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT105x/mbed_overrides.c
@@ -147,26 +147,6 @@ void BOARD_ConfigMPU(void)
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 1, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_32MB);
 #endif
 
-    // /* Region 9: Noncached memory. */
-    // ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
-    // if(noncached_region_size > 0) {
-    //     // Check configuration from linker script
-    //     MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
-    //     MBED_ASSERT(((uintptr_t)__noncached_start) % noncached_region_size == 0);
-    //
-    //     // Region size constant is the log2 of the region size, offset by 1
-    //     const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
-    //
-    //     MPU->RBAR = ARM_MPU_RBAR(9, ((uintptr_t)__noncached_start));
-    //     MPU->RASR =
-    //         ARM_MPU_RASR_EX(
-    //             1,                          // DisableExec
-    //             ARM_MPU_AP_FULL,            // AccessPermission
-    //             ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
-    //             0U,                         // SubRegionDisable
-    //             region_size);               // Size
-    // }
-
     /* Enable MPU */
     ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/TARGET_EVK/mbed_overrides.c
@@ -21,7 +21,12 @@
 #include "fsl_gpio.h"
 #include "fsl_xbara.h"
 
+#include <mbed_assert.h>
+#include <mbed_math_helpers.h>
 
+// Symbols defined in linker script for noncache region
+extern uint8_t __noncachedata_start__[];
+extern uint8_t __noncachedata_end__[];
 
 void BOARD_ConfigMPU(void)
 {
@@ -37,66 +42,85 @@ void BOARD_ConfigMPU(void)
         SCB_DisableDCache();
     }
 
-ARM_MPU_Disable();
+    ARM_MPU_Disable();
 
+    /*
+     * Add default region to deny access to whole address space to workaround speculative prefetch.
+     * Refer to Arm errata 1013783-B for more details.
+     */
     /* Region 0 setting: No data access permission. */
     MPU->RBAR = ARM_MPU_RBAR(0, 0x00000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_NONE, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_4GB);
 
-    /* Region 1 setting: Memory with Device type, not shareable, non-cacheable. */
+    /* Region 1 setting: Memory with Device type, not shareable, non-cacheable (SEMC0-SEMC1) */
     MPU->RBAR = ARM_MPU_RBAR(1, 0x80000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_512MB);
 
-    /* Region 2 setting: Memory with Device type, not shareable,  non-cacheable. */
-    MPU->RBAR = ARM_MPU_RBAR(2, 0x60000000U);
-    MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_512MB);
-
-    /* Region 3 setting: Memory with Device type, not shareable, non-cacheable. */
-    MPU->RBAR = ARM_MPU_RBAR(3, 0x00000000U);
+    /* Region 2 setting: Memory with Device type, not shareable, non-cacheable. (CAAM Secure RAM, FlexSPI1 control registers) */
+    MPU->RBAR = ARM_MPU_RBAR(2, 0x00000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_1GB);
 
-    /* Region 4 setting: Memory with Normal type, not shareable, outer/inner write back */
-    MPU->RBAR = ARM_MPU_RBAR(4, 0x00000000U);
+    /* Region 3 setting: Memory with Normal type, not shareable, outer/inner write back (ITCM) */
+    MPU->RBAR = ARM_MPU_RBAR(3, 0x00000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_256KB);
 
-    /* Region 5 setting: Memory with Normal type, not shareable, outer/inner write back */
-    MPU->RBAR = ARM_MPU_RBAR(5, 0x20000000U);
+    /* Region 4 setting: Memory with Normal type, not shareable, outer/inner write back (DTCM) */
+    MPU->RBAR = ARM_MPU_RBAR(4, 0x20000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_256KB);
 
-    /* Region 6 setting: Memory with Normal type, not shareable, outer/inner write back */
-    MPU->RBAR = ARM_MPU_RBAR(6, 0x20200000U);
+    /* Region 5 setting: Memory with Normal type, not shareable, outer/inner write back (CM4 TCM, OCRAM1, OCRAM2) */
+    MPU->RBAR = ARM_MPU_RBAR(5, 0x20200000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_1MB);
 
-    /* Region 7 setting: Memory with Normal type, not shareable, outer/inner write back */
-    MPU->RBAR = ARM_MPU_RBAR(7, 0x20300000U);
+    /* Region 6 setting: Memory with Normal type, not shareable, outer/inner write back (ORCAM1 ECC, OCRAM2 ECC, OCRAM M7) */
+    MPU->RBAR = ARM_MPU_RBAR(6, 0x20300000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_512KB);
 
-    /* Region 8 setting: Memory with Normal type, not shareable, outer/inner write back. */
+    /* Region 7: Noncached memory. */
+    ptrdiff_t noncached_region_size = __noncachedata_end__ - __noncachedata_start__;
+    if(noncached_region_size > 0) {
+        // Check configuration from linker script
+        MBED_ASSERT(mbed_is_power_of_two(noncached_region_size));
+        MBED_ASSERT(((uintptr_t)__noncachedata_start__) % noncached_region_size == 0);
+
+        // Region size constant is the log2 of the region size, offset by 1
+        const uint32_t region_size = mbed_integer_log_2(noncached_region_size) - 1;
+
+        MPU->RBAR = ARM_MPU_RBAR(7, ((uintptr_t)__noncachedata_start__));
+        MPU->RASR =
+            ARM_MPU_RASR_EX(
+                1,                          // DisableExec
+                ARM_MPU_AP_FULL,            // AccessPermission
+                ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_NOCACHE, ARM_MPU_CACHEP_NOCACHE, true), // Access and cache policy
+                0U,                         // SubRegionDisable
+                region_size);               // Size
+    }
+
+    /* Region 8 setting: Memory with Normal type, not shareable, outer/inner write back. (FlexSPI1) */
     MPU->RBAR = ARM_MPU_RBAR(8, 0x30000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_RO, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_16MB);
 
-
-    /* Region 9 setting: Memory with Normal type, not shareable, outer/inner write back */
+    /* Region 9 setting: Memory with Normal type, not shareable, outer/inner write back (SEMC0) */
     MPU->RBAR = ARM_MPU_RBAR(9, 0x80000000U);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_64MB);
    
-    /* Region 11 setting: Memory with Device type, not shareable, non-cacheable */
+    /* Region 11 setting: Memory with Device type, not shareable, non-cacheable (AIPS peripherals) */
     MPU->RBAR = ARM_MPU_RBAR(11, 0x40000000);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_16MB);
 
-    /* Region 12 setting: Memory with Device type, not shareable, non-cacheable */
+    /* Region 12 setting: Memory with Device type, not shareable, non-cacheable (SIM_M/SIM_DISP) */
     MPU->RBAR = ARM_MPU_RBAR(12, 0x41000000);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_2MB);
 
-    /* Region 13 setting: Memory with Device type, not shareable, non-cacheable */
+    /* Region 13 setting: Memory with Device type, not shareable, non-cacheable (SIM_M7) */
     MPU->RBAR = ARM_MPU_RBAR(13, 0x41400000);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_1MB);
 
-    /* Region 14 setting: Memory with Device type, not shareable, non-cacheable */
+    /* Region 14 setting: Memory with Device type, not shareable, non-cacheable (GPU2D) */
     MPU->RBAR = ARM_MPU_RBAR(14, 0x41800000);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_1MB);
 
-    /* Region 15 setting: Memory with Device type, not shareable, non-cacheable */
+    /* Region 15 setting: Memory with Device type, not shareable, non-cacheable (AIPS M7) */
     MPU->RBAR = ARM_MPU_RBAR(15, 0x42000000);
     MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 2, 0, 0, 0, 0, ARM_MPU_REGION_SIZE_1MB);
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/device/TOOLCHAIN_GCC_ARM/MIMXRT1170xxxxx.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1170/device/TOOLCHAIN_GCC_ARM/MIMXRT1170xxxxx.ld
@@ -29,12 +29,12 @@ ENTRY(Reset_Handler)
 
 __ram_vector_table__ = 1;
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x30000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x1000000
+/* If we are not configured to execute out of the start of ROM, then a bootloader is
+ * present.  This tells us whether we need to add the Flash Configuration Field at the start of flash. */
+#if MBED_CONFIGURED_ROM_BANK_EXT_FLASH_START == MBED_ROM_BANK_EXT_FLASH_START
+#define IS_BOOTLOADER_PRESENT 0
+#else
+#define IS_BOOTLOADER_PRESENT 1
 #endif
 
 #if !defined(MBED_CONF_TARGET_BOOT_STACK_SIZE)
@@ -49,56 +49,70 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-#if !defined(MBED_APP_COMPILE)
-  m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x0400, LENGTH = 0x00000C00
-  m_ivt                 (RX)  : ORIGIN = MBED_APP_START + 0x1000, LENGTH = 0x00001000
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START + 0x2000, LENGTH = 0x00000400
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x2400, LENGTH = MBED_APP_SIZE - 0x2400
-#else
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x00000400
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = MBED_APP_SIZE - 0x400
+  m_text                (RX)  : ORIGIN = MBED_CONFIGURED_ROM_BANK_EXT_FLASH_START, LENGTH = MBED_CONFIGURED_ROM_BANK_EXT_FLASH_SIZE
+  m_dtcm                (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_DTC_START, LENGTH = MBED_RAM_BANK_SRAM_DTC_SIZE
+  m_itcm                (RX)  : ORIGIN = MBED_RAM_BANK_SRAM_ITC_START, LENGTH = MBED_RAM_BANK_SRAM_ITC_SIZE
+
+  m_ocram_combined      (RW)  : ORIGIN = MBED_RAM_BANK_SRAM_OC_1_2_COMBINED_START, LENGTH = MBED_RAM_BANK_SRAM_OC_1_2_COMBINED_SIZE
+
+ /* External SDRAM, if available */
+#ifdef MBED_RAM_BANK_SDRAM_SIZE
+  m_sdram               (RW)  : ORIGIN = MBED_RAM_BANK_SDRAM_START, LENGTH = MBED_RAM_BANK_SDRAM_SIZE
 #endif
-  m_text2               (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00020000
-  m_data                (RW)  : ORIGIN = 0x80000000, LENGTH = 0x03000000
-  m_ncache              (RW)  : ORIGIN = 0x81E00000, LENGTH = 0x01000000
-  m_data2               (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00040000
-  m_data3               (RW)  : ORIGIN = 0x202C0000, LENGTH = 0x00080000
 }
 
 /* Define output sections */
 SECTIONS
 {
 
-#if !defined(MBED_APP_COMPILE)
+#if !defined(IS_BOOTLOADER_PRESENT)
+  /* Flash config goes first, at the start of flash */
   .flash_config :
   {
     . = ALIGN(8);
     __FLASH_BASE = .;
     KEEP(* (.boot_hdr.conf))     /* flash config section */
     . = ALIGN(8);
-  } > m_flash_config
+  } > m_text
 
-  ivt_begin = ORIGIN(m_flash_config) + LENGTH(m_flash_config);
-
-  .ivt : AT(ivt_begin)
+  /* Then IVT at offset 0x1000 */
+  .ivt MBED_ROM_BANK_EXT_FLASH_START + 0x1000 :
   {
     . = ALIGN(8);
     KEEP(* (.boot_hdr.ivt))           /* ivt section */
     KEEP(* (.boot_hdr.boot_data))     /* boot section */
     KEEP(* (.boot_hdr.dcd_data))      /* dcd section */
     . = ALIGN(8);
-  } > m_ivt
+  } > m_text
+  /* Note that we do not want to use AT> above, because that would result in this section being
+   * placed in flash immediately after .flash_config.  Instead we don't use AT> to set the LMA equal
+   * to the VMA. */
+
+  /* Interrupts go after that */
+  #define INTERRUPT_TABLE_ADDR MBED_ROM_BANK_EXT_FLASH_START + 0x2000
+#else
+  /* We have a bootloader so we don't need the flash config or IVT */
+  /DISCARD/ : {
+    *(.boot_hdr.conf)
+    *(.boot_hdr.ivt)
+    *(.boot_hdr.boot_data)
+    *(.boot_hdr.dcd_data)
+  }
+
+  /* Interrupts go at the start of configured flash area */
+  #define INTERRUPT_TABLE_ADDR MBED_CONFIGURED_ROM_BANK_EXT_FLASH_START
 #endif
+
   /* The startup code goes first into internal RAM */
-  .interrupts :
+  .interrupts INTERRUPT_TABLE_ADDR :
   {
     __VECTOR_TABLE = .;
     . = ALIGN(8);
     KEEP(*(.isr_vector))     /* Startup code */
     . = ALIGN(8);
-  } > m_interrupts
+  } > m_text
 
-  /* The program code and other data goes into internal RAM */
+  /* The program code and other data goes into FlexSPI */
   .text :
   {
     . = ALIGN(8);
@@ -196,12 +210,42 @@ SECTIONS
     . += M_VECTOR_RAM_SIZE;
     . = ALIGN(8);
     __interrupts_ram_end__ = .; /* Define a global symbol at data end */
-  } > m_data2
+  } > m_dtcm
 
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
 
-  .data : AT(__DATA_ROM)
+  /* Note: MIMXRT1170 has a major errata (ERR050396) which causes many DMA-enabled peripherals to be unable to write to
+   * DTCM. So, we currently do not use DTCM, even though this does hurt performance a fair bit. */
+
+   /* Non-cached data section.
+    * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+    * We put this first in OCRAM so it's very, very aligned. */
+   .ncache.init : AT(__NDATA_ROM)
+   {
+     __noncachedata_start__ = .;   /* create a global symbol at ncache data start */
+     *(NonCacheable.init)
+     . = ALIGN(8);
+     __noncachedata_init_end__ = .;   /* create a global symbol at initialized ncache data end */
+   } > m_ocram_combined
+   . = __noncachedata_init_end__;
+   .ncache :
+   {
+     *(NonCacheable)
+     *(.noncached)
+
+     /* For the MPU configuration, we need to align the size of this section up to
+      * the next power of two. Also note that the MPU does not support regions
+      * smaller than 32 bytes so round up if smaller than that. */
+     __noncached_data_size = (. - __noncachedata_start__);
+     __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+     . += (__noncached_aligned_size - __noncached_data_size);
+
+     __noncachedata_end__ = .;     /* define a global symbol at ncache data end */
+   } > m_ocram_combined
+
+  .data :
   {
     . = ALIGN(8);
     __DATA_RAM = .;
@@ -212,36 +256,21 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_data
+  } > m_ocram_combined AT> m_text
   __ram_function_flash_start = __DATA_ROM + (__data_end__ - __data_start__); /* Symbol is used by startup for TCM data initialization */
 
-  .ram_function : AT(__ram_function_flash_start)
+  .ram_function :
   {
     . = ALIGN(32);
     __ram_function_start__ = .;
     *(CodeQuickAccess)
     . = ALIGN(128);
     __ram_function_end__ = .;
-  } > m_text2
+  } > m_itcm AT> m_text
 
   __ram_function_size = SIZEOF(.ram_function);
 
   __NDATA_ROM = __ram_function_flash_start + SIZEOF(.ram_function);
-
-  .ncache.init : AT(__NDATA_ROM)
-  {
-    __noncachedata_start__ = .;   /* create a global symbol at ncache data start */
-    *(NonCacheable.init)
-    . = ALIGN(8);
-    __noncachedata_init_end__ = .;   /* create a global symbol at initialized ncache data end */
-  } > m_ncache
-  . = __noncachedata_init_end__;
-  .ncache :
-  {
-    *(NonCacheable)
-    . = ALIGN(8);
-    __noncachedata_end__ = .;     /* define a global symbol at ncache data end */
-  } > m_ncache
 
   __DATA_END = __NDATA_ROM + (__noncachedata_init_end__ - __noncachedata_start__);
   text_end = ORIGIN(m_text) + LENGTH(m_text);
@@ -261,7 +290,7 @@ SECTIONS
     . = ALIGN(8);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data
+  } > m_ocram_combined
 
   .heap :
   {
@@ -269,24 +298,24 @@ SECTIONS
     __end__ = .;
     PROVIDE(end = .);
     __HeapBase = .;
-    . =  ORIGIN(m_data) + LENGTH(m_data) - STACK_SIZE;
+    . =  ORIGIN(m_ocram_combined) + LENGTH(m_ocram_combined) - STACK_SIZE;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
-  } > m_data
+  } > m_ocram_combined
 
   .stack :
   {
     . = ALIGN(8);
     . += STACK_SIZE;
-  } > m_data
+  } > m_ocram_combined
 
   /* Initializes stack on the end of block */
-  __StackTop   = ORIGIN(m_data) + LENGTH(m_data);
+  __StackTop   = ORIGIN(m_ocram_combined) + LENGTH(m_ocram_combined);
   __StackLimit = __StackTop - STACK_SIZE;
   PROVIDE(__stack = __StackTop);
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 
-  ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
+  ASSERT(__StackLimit >= __HeapLimit, "region m_ocram_combined overflowed with stack and heap")
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
@@ -70,6 +70,25 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    /* Non-cached data section.
+     * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+     * We put this first in SRAM so it's very, very aligned. */
+    .noncached (NOLOAD):
+    {
+        __noncached_start = .;
+        *(.noncached)
+
+        /* For the MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __noncached_data_size = (. - __noncached_start);
+        __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+        . += (__noncached_aligned_size - __noncached_data_size);
+
+        __noncached_end = .;
+    } > RAM
+
     .text :
     {
         __vector_flash_start__ = ABSOLUTE(.);

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
@@ -71,6 +71,25 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    /* Non-cached data section.
+     * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+     * We put this first in SRAM so it's very, very aligned. */
+    .noncached (NOLOAD):
+    {
+        __noncached_start = .;
+        *(.noncached)
+
+        /* For the MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __noncached_data_size = (. - __noncached_start);
+        __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+        . += (__noncached_aligned_size - __noncached_data_size);
+
+        __noncached_end = .;
+    } > SRAM
+
     .text :
     {
         KEEP(*(.isr_vector))

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
@@ -71,6 +71,25 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    /* Non-cached data section.
+     * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+     * We put this first in SRAM so it's very, very aligned. */
+    .noncached (NOLOAD):
+    {
+        __noncached_start = .;
+        *(.noncached)
+
+        /* For the MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __noncached_data_size = (. - __noncached_start);
+        __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+        . += (__noncached_aligned_size - __noncached_data_size);
+
+        __noncached_end = .;
+    } > SRAM
+
     .text :
     {
         KEEP(*(.isr_vector))

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
@@ -71,6 +71,25 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    /* Non-cached data section.
+     * This section is configured in the MPU as uncached, so reads and writes go directly through to memory.
+     * We put this first in SRAM so it's very, very aligned. */
+    .noncached (NOLOAD):
+    {
+        __noncached_start = .;
+        *(.noncached)
+
+        /* For the MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __noncached_data_size = (. - __noncached_start);
+        __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
+
+        . += (__noncached_aligned_size - __noncached_data_size);
+
+        __noncached_end = .;
+    } > SRAM
+
     .text :
     {
         KEEP(*(.isr_vector))

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -5065,6 +5065,39 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "USTICKER"
         ],
         "device_name": "MIMXRT1176DVMAA",
+
+        memory_banks: {
+            // EVK board has W25Q512NWEIQ flash mounted
+            "EXT_FLASH": {
+                "access": {
+                    "execute": true,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": false
+                },
+                "default": true,
+                "size": 0x4000000, // 64MiB (though NXP product page says 16MiB...)
+                "start": 0x30000000,
+                "startup": true
+            },
+
+            // EVK board has 2x W9825G6KH-5I mounted in parallel on SEMC0
+            "SDRAM": {
+                "access": {
+                    "execute": false,
+                    "peripheral": false,
+                    "read": true,
+                    "secure": false,
+                    "write": true
+                },
+                "default": false,
+                "size": 0x4000000, // 64MiB
+                "start": 0x80000000,
+                "startup": false
+            }
+        },
+
         "image_url": "https://www.nxp.com/assets/images/en/dev-board-image/MIMXRT1170-EVKB-TOP-IMG.jpg"
     },
 

--- a/tools/cmake/UploadMethodManager.cmake
+++ b/tools/cmake/UploadMethodManager.cmake
@@ -99,16 +99,33 @@ if("MBED_CONF_TARGET_CONSOLE_RTT=1" IN_LIST MBED_CONFIG_DEFINITIONS)
 	# on the device memory layout. So, we need to give them some more help.
 	# The alternative would be to put the RTT CB at a fixed address, but that would likely require
 	# specific configuration for each target, so it's probably a non-starter.
-	string(REGEX MATCH "MBED_RAM_RANGE_START=([^;]+)" RTT_RAM_RANGE_MATCH "${MBED_CONFIG_DEFINITIONS}")
 
-	# Handle old build configs that didn't provide this definition
-	if("${RTT_RAM_RANGE_MATCH}" STREQUAL "")
-		message(FATAL_ERROR "Memory bank information not available for this target, cannot configure RTT support. This may be caused by an old build directory -- try deleting and recreating it if you made it with an older version of Mbed.")
+	# Try to get start from JSON option, but fall back to start of all RAM banks
+	mbed_get_json_option_value("rtt.cb-search-range-start" MBED_RTT_RAM_RANGE_START)
+	if(NOT DEFINED MBED_RTT_RAM_RANGE_START)
+		mbed_get_config_definition_value(MBED_RAM_RANGE_START MBED_RTT_RAM_RANGE_START)
+
+		# Handle old build configs that didn't provide this definition
+		if("${MBED_RTT_RAM_RANGE_START}" STREQUAL "")
+			message(FATAL_ERROR "Memory bank information not available for this target, cannot configure RTT support. This may be caused by an old build directory -- try deleting and recreating it if you made it with an older version of Mbed.")
+		endif()
 	endif()
 
-	set(MBED_RTT_RAM_RANGE_START ${CMAKE_MATCH_1})
-	string(REGEX MATCH "MBED_RAM_RANGE_END=([^;]+)" _ "${MBED_CONFIG_DEFINITIONS}")
-	set(MBED_RTT_RAM_RANGE_END ${CMAKE_MATCH_1})
+	# Also get end
+	mbed_get_json_option_value("rtt.cb-search-range-end" MBED_RTT_RAM_RANGE_END)
+	if(NOT DEFINED MBED_RTT_RAM_RANGE_END)
+		mbed_get_config_definition_value(MBED_RAM_RANGE_END MBED_RTT_RAM_RANGE_END)
+	endif()
+
+	# For cleanliness, convert everything to hex
+	math(EXPR MBED_RTT_RAM_RANGE_START "${MBED_RTT_RAM_RANGE_START}" OUTPUT_FORMAT HEXADECIMAL)
+	math(EXPR MBED_RTT_RAM_RANGE_END "${MBED_RTT_RAM_RANGE_END}" OUTPUT_FORMAT HEXADECIMAL)
+
+	if(MBED_RTT_RAM_RANGE_END LESS MBED_RTT_RAM_RANGE_START)
+		message(FATAL_ERROR "RTT search range end (${MBED_RTT_RAM_RANGE_END}) cannot be less than search range start (${MBED_RTT_RAM_RANGE_START})!")
+	endif()
+
+	# Compute size
 	math(EXPR MBED_RTT_RAM_RANGE_SIZE "${MBED_RTT_RAM_RANGE_END} - ${MBED_RTT_RAM_RANGE_START} + 1" OUTPUT_FORMAT HEXADECIMAL)
 endif()
 

--- a/tools/cmake/mbed_generate_configuration.cmake
+++ b/tools/cmake/mbed_generate_configuration.cmake
@@ -156,3 +156,29 @@ include(${CMAKE_CURRENT_BINARY_DIR}/mbed_config.cmake)
 
 # Make it so that if any config JSON files are modified, CMake is rerun.
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${MBED_CONFIG_JSON_SOURCE_FILES})
+
+# Helper function to get config definition values.
+# Sets RESULT_VARIABLE to the value of DEF_NAME.
+# Does not set RESULT_VARIABLE if the setting is not in MBED_CONFIG_DEFINITIONS.
+function(mbed_get_config_definition_value DEF_NAME RESULT_VARIABLE)
+    if(MBED_CONFIG_DEFINITIONS MATCHES "${DEF_NAME}=([^;]+)")
+        set(${RESULT_VARIABLE} ${CMAKE_MATCH_1} PARENT_SCOPE)
+    endif()
+endfunction(mbed_get_config_definition_value)
+
+# Helper function to getthe value of a JSON option
+# Sets RESULT_VARIABLE to the value of the option described by OPT_NAME.
+# Does not set RESULT_VARIABLE if the setting is not in MBED_CONFIG_DEFINITIONS.
+function(mbed_get_json_option_value OPT_NAME RESULT_VARIABLE)
+    # Transform the JSON option name into the CMake option name.
+    # This mirrors the logic in mbed_config.tmpl.
+    string(TOUPPER ${OPT_NAME} OPT_NAME_UCASE)
+    string(REPLACE "-" "_" OPT_NAME_CMAKE ${OPT_NAME_UCASE})
+    string(REPLACE "." "_" OPT_NAME_CMAKE ${OPT_NAME_CMAKE})
+    set(OPT_NAME_CMAKE MBED_CONF_${OPT_NAME_CMAKE})
+
+    mbed_get_config_definition_value(${OPT_NAME_CMAKE} ${RESULT_VARIABLE})
+    if(DEFINED ${RESULT_VARIABLE})
+        set(${RESULT_VARIABLE} "${${RESULT_VARIABLE}}" PARENT_SCOPE)
+    endif()
+endfunction(mbed_get_json_option_value)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This MR addresses two issues in Mbed:
- There's no target-independent way to declare data in non-cached memory. This will only become more annoying in the future if we want to implement new multicore and DMA stuff
- RTT previously did not work on targets with data caches, as RTT requires a noncached memory section to operate in.

I added a new `MBED_NONCACHED` attribute that is used for RTT and can also be used for other stuff like DMA buffers if desired. To make this work, it required linker script changes for each target with a cache, and it also required updating the MPU configuration. (this actually required being quite creative as the ARMv7 MPU is really not set up for dynamically computed region sizes at all)

Unfortunately, this PR does increase the number of MPU regions used by Mbed. If there was any user code using the MPU that relied on being able to use, say, region 4, it will be broken by this PR. To help reduce the chances that this will happen again, I added new constants in the MPU headers that applications can use to know what MPU regions Mbed is using.

Also, I ended up having to do a bit of general cleanup work on MIMXRT1170, because its linker script did not use memory banks (making it very hard to understand) and every single MPU region was used in the NXP MPU config. I ended up removing the MPU region for FlexSPI 2 because that is not used in any Mbed code.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

- Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32H7 and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
- Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
- Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
- MIMRT117x: Memory bank configuration is now supported in the linker script.
- On targets with a data cache (`__DCACHE_PRESENT` is defined), one additional MPU region is used to implement the new non-cacheable memory support.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

If user code was using MPU regions on MCUs with a D-cache, it may need to increment which regions it was using.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
I manually tested RTT on STM32H7 and MIMXRT1060_EVK and it was able to correctly initialize on both. I did see a little bit of glitchiness on STM32H7, but not exactly sure why (perhaps it's just the usual RTT jankiness).

Unfortunately I do not have an MIMRT1170 board (they're expensive!) so I cannot actually test the changes I made there. Fingers crossed I did it right. I did at least build the code and check the memory map to make sure things were getting put in the right place.

----------------------------------------------------------------------------------------------------------------
