### PR TITLE
Add new memory bank getter function suitable for generating the targets index

### DIFF
--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8472,6 +8472,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
 
     // Target for RP235x family MCU
     "MCU_RP235X": {
+        public: false,
         "inherits": ["MCU_RP2"],
         "core": "Cortex-M33FE",
         "is_mcu_family_target": true,
@@ -8497,6 +8498,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
 
     // Target for RP2350 family MCU
     "MCU_RP2350": {
+        public: false,
         "inherits": ["MCU_RP235X"],
         "device_name": "RP2350",
     },

--- a/tools/python/mbed_tools/build/_internal/memory_banks.py
+++ b/tools/python/mbed_tools/build/_internal/memory_banks.py
@@ -74,26 +74,46 @@ def incorporate_memory_bank_data_from_cmsis(target_attributes: dict[str, Any], p
         # No CMSIS device name for this target
         return
 
-    cmsis_mcu_descriptions = decode_json_file(program.mbed_os.cmsis_mcu_descriptions_json_file)
+    cmsis_mcu_descriptions_data = decode_json_file(program.mbed_os.cmsis_mcu_descriptions_json_file)
 
-    if target_attributes["device_name"] not in cmsis_mcu_descriptions:
-        msg = f"""Target specifies device_name {target_attributes["device_name"]} but this device is not
-listed in {program.mbed_os.cmsis_mcu_descriptions_json_file}.  Perhaps you need to use
+    target_attributes["memory_banks"] = incorporate_memory_bank_data_from_cmsis_preparsed(
+        target_attributes["device_name"],
+        cmsis_mcu_descriptions_data,
+        target_attributes.get("memory_banks", {})
+    )
+
+def incorporate_memory_bank_data_from_cmsis_preparsed(device_name: str, cmsis_mcu_description_data: dict[str, Any], target_existing_memory_banks: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """
+    Find the memory bank data for the given CMSIS device name in the CMSIS mcu description data.
+
+    Similar to ``incorporate_memory_bank_data_from_cmsis`` but for the case when you already have a parsed JSON file.
+
+    :param device_name: Name of the device to look up
+    :param cmsis_mcu_description_data: Decoded CMSIS MCU descriptions JSON file
+    :param target_existing_memory_banks: Existing memory banks for the target, e.g. from its JSON definition
+
+    :return: New dict with additional memory bank info from the CMSIS JSON
+    """
+
+    if device_name not in cmsis_mcu_description_data:
+        msg = f"""Target specifies device_name {device_name} but this device is not
+listed in the CMSIS MCU descriptions file.  Perhaps you need to use
 the 'python -m mbed_tools.cli.main cmsis-mcu-descr fetch-missing' command to download
-the missing MCU description?"""
+the missing MCU description? If this is a custom target, then the memory bank information
+should be inserted inline into the target JSON under 'memory_banks' and it should not declare
+a 'device_name' property."""
         raise MbedBuildError(msg)
 
-    mcu_description = cmsis_mcu_descriptions[target_attributes["device_name"]]
-    mcu_memory_description: dict[str, dict[str, Any]] = mcu_description["memories"]
+    mcu_description = cmsis_mcu_description_data[device_name]
 
     # If a memory bank is not already described in targets.json, import its description from the CMSIS
     # MCU description.
-    target_memory_banks_section = target_attributes.get("memory_banks", {})
-    for memory_bank_name, memory_bank in mcu_memory_description.items():
-        if memory_bank_name not in target_memory_banks_section:
-            target_memory_banks_section[memory_bank_name] = memory_bank
-    target_attributes["memory_banks"] = target_memory_banks_section
+    result = copy.deepcopy(target_existing_memory_banks)
+    for memory_bank_name, memory_bank in mcu_description["memories"].items():
+        if memory_bank_name not in result:
+            result[memory_bank_name] = memory_bank
 
+    return result
 
 def _apply_configured_overrides(banks_by_type: BanksByType, bank_config: dict[str, dict[str, int]]) -> BanksByType:
     """

--- a/tools/python/mbed_tools/build/_internal/memory_banks.py
+++ b/tools/python/mbed_tools/build/_internal/memory_banks.py
@@ -77,12 +77,15 @@ def incorporate_memory_bank_data_from_cmsis(target_attributes: dict[str, Any], p
     cmsis_mcu_descriptions_data = decode_json_file(program.mbed_os.cmsis_mcu_descriptions_json_file)
 
     target_attributes["memory_banks"] = incorporate_memory_bank_data_from_cmsis_preparsed(
-        target_attributes["device_name"],
-        cmsis_mcu_descriptions_data,
-        target_attributes.get("memory_banks", {})
+        target_attributes["device_name"], cmsis_mcu_descriptions_data, target_attributes.get("memory_banks", {})
     )
 
-def incorporate_memory_bank_data_from_cmsis_preparsed(device_name: str, cmsis_mcu_description_data: dict[str, Any], target_existing_memory_banks: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+
+def incorporate_memory_bank_data_from_cmsis_preparsed(
+    device_name: str,
+    cmsis_mcu_description_data: dict[str, Any],
+    target_existing_memory_banks: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     """
     Find the memory bank data for the given CMSIS device name in the CMSIS mcu description data.
 
@@ -94,7 +97,6 @@ def incorporate_memory_bank_data_from_cmsis_preparsed(device_name: str, cmsis_mc
 
     :return: New dict with additional memory bank info from the CMSIS JSON
     """
-
     if device_name not in cmsis_mcu_description_data:
         msg = f"""Target specifies device_name {device_name} but this device is not
 listed in the CMSIS MCU descriptions file.  Perhaps you need to use
@@ -114,6 +116,7 @@ a 'device_name' property."""
             result[memory_bank_name] = memory_bank
 
     return result
+
 
 def _apply_configured_overrides(banks_by_type: BanksByType, bank_config: dict[str, dict[str, int]]) -> BanksByType:
     """


### PR DESCRIPTION
### Summary of changes <!-- Required -->
Noticed that the target index (e.g. [here](https://mbed-ce.github.io/mbed-ce-test-tools/targets/MCU_RP235X.html)) was not showing memory banks defined inline in targets.json (just those in the CMSIS MCU description). Turns out I just never went and integrated that generator with the new memory bank system. Fixing this requires some python tweaks here in Mbed so that the website generator can get this information for all targets in an efficient way.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

Ran locally with a new version of the website generator and confirmed correct output now
    
----------------------------------------------------------------------------------------------------------------
