### PR TITLE
RP2xxx: Fix SPI, add RAM function support to MPU configuration

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -259,6 +259,6 @@ jobs:
         name: Build and run unit tests
         run: |
           set -x     
-          ctest --output-on-failure --build-and-test . build --build-generator Ninja --build-options -DMBED_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON --test-command ctest        
+          ctest --build-and-test . build --build-generator Ninja --build-options -DMBED_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON --test-command ctest --output-on-failure        
           gcovr --gcov-executable gcov -r . ./build -s -e ".*\.h" --exclude-directories=${GITHUB_WORKSPACE}/build/UNITTESTS --exclude-directories=${GITHUB_WORKSPACE}/build/_deps
           ccache -s

--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -259,6 +259,6 @@ jobs:
         name: Build and run unit tests
         run: |
           set -x     
-          ctest --build-and-test . build --build-generator Ninja --build-options -DMBED_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON --test-command ctest        
+          ctest --output-on-failure --build-and-test . build --build-generator Ninja --build-options -DMBED_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON --test-command ctest        
           gcovr --gcov-executable gcov -r . ./build -s -e ".*\.h" --exclude-directories=${GITHUB_WORKSPACE}/build/UNITTESTS --exclude-directories=${GITHUB_WORKSPACE}/build/_deps
           ccache -s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ A message that notes the main changes in the update.
 - Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32F7, STM32H7, and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
+- MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.
 - MIMRT117x: Memory bank configuration is now supported in the linker script.
 - RP2xxx
   - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board with Mbed compared to the non-W version is limited).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ A message that notes the main changes in the update.
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
 - MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.
-- MIMRT117x: Memory bank configuration is now supported in the linker script.
+- MIMXRT117x: Memory bank configuration is now supported in the linker script.
 - RP2xxx
   - `RASPBERRY_PI_PICO_W` board target added (though note that the wi-fi module on this board is not currently supported, and would take a huge amount of effort to support, so the utility of this board with Mbed compared to the non-W version is limited).
   - `SFE_THING_PLUS_RP2040` board target added for the [SparkFun Thing Plus RP2040 board](https://www.sparkfun.com/sparkfun-thing-plus-rp2040.html)
@@ -30,6 +30,7 @@ A message that notes the main changes in the update.
   - Support for single-byte i2c operations implemented (allowing features like the I2C EEPROM block device to work).
   - DEVICE_SLEEP support added, so RP2 chips can now go to sleep or deep sleep when not running any threads.
   - Per-device unique MAC addresses are now implemented, using the unique identifier built into the QSPI flash chip
+  - SPI driver now supports 16-bit word size
 - RP235x
   - RP235x target family added, containing two boards to start, `RASPBERRY_PI_PICO_2` and `OLIMEX_RP2350_PICO2_XL`
   - LP ticker support added using new POWMAN always-on timer peripheral
@@ -90,6 +91,7 @@ A message that notes the main changes in the update.
     more bytes than expected
   - Fixed issue where reading from an I2C master in slave mode could hang forever if the master ends the transaction early
   - Fixed issue where writing to an I2C master in slave mode would always return success regardless of success/failure
+  - Fixed assert failure when calling SPI::write() with a zero-length Tx or Rx buffer
 - Fixed issue where if the same setting was overridden in multiple different `target_override` blocks in mbed_app.json, only one of the overrides would be processed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ A message that notes the main changes in the update.
   - Fixed issue where reading from an I2C master in slave mode could hang forever if the master ends the transaction early
   - Fixed issue where writing to an I2C master in slave mode would always return success regardless of success/failure
   - Fixed assert failure when calling SPI::write() with a zero-length Tx or Rx buffer
+- RP2040:
+  - Fixed RTC not counting until the time was first set (just calling `RealTimeClock::init()` was not enough)
 - Fixed issue where if the same setting was overridden in multiple different `target_override` blocks in mbed_app.json, only one of the overrides would be processed
 
 ### Removed

--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -17,7 +17,7 @@ include(FetchContent)
 # Download and unpack googletest
 FetchContent_Declare(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG main
+    GIT_TAG v1.17.0
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/hal/include/hal/mpu_api.h
+++ b/hal/include/hal/mpu_api.h
@@ -103,9 +103,9 @@ static MSTD_CONSTEXPR_OBJ_11 size_t mbed_used_mpu_regions =
     4
 #else
     3
-#endif
 #if MBED_MPU_RAM_START < 0x20000000
     + 1
+#endif
 #endif
 #if __DCACHE_PRESENT
     + 1

--- a/hal/source/mpu/mbed_mpu_v7m.c
+++ b/hal/source/mpu/mbed_mpu_v7m.c
@@ -34,6 +34,15 @@ extern uint8_t __noncached_start[];
 extern uint8_t __noncached_end[];
 #endif
 
+#ifdef MBED_MPU_HAS_RAM_FUNCTION_REGION
+// Symbols defined in linker script for ram function region.
+// This region may be contained inside any other RAM region. Its start address and size must
+// be 32-byte aligned.
+extern uint8_t __ram_code_start[];
+extern uint8_t __ram_code_end[];
+#endif
+
+
 static_assert(
     MBED_MPU_ROM_END == 0x04000000 - 1 ||
     MBED_MPU_ROM_END == 0x08000000 - 1 ||
@@ -176,6 +185,9 @@ void mbed_mpu_init()
             ARM_MPU_REGION_SIZE_512MB)  // Size
     );
 
+    uint8_t next_ram_region = LAST_RAM_REGION + 1;
+    (void)next_ram_region; // silence unused warning
+
 #if __DCACHE_PRESENT
     ptrdiff_t noncached_region_size = __noncached_end - __noncached_start;
     if (noncached_region_size > 0) {
@@ -189,7 +201,7 @@ void mbed_mpu_init()
         // Select region 3/4 and use it for the non-cached region
         ARM_MPU_SetRegion(
             ARM_MPU_RBAR(
-                LAST_RAM_REGION + 1,             // Region
+                next_ram_region,                 // Region
                 ((uintptr_t)__noncached_start)), // Base
             ARM_MPU_RASR_EX(
                 1,                          // DisableExec
@@ -198,6 +210,35 @@ void mbed_mpu_init()
                 0U,                         // SubRegionDisable
                 region_size)                // Size
         );
+        ++next_ram_region;
+    }
+#endif
+
+#if MBED_MPU_HAS_RAM_FUNCTION_REGION
+    ptrdiff_t ram_code_region_size = __ram_code_end - __ram_code_start;
+    if (ram_code_region_size > 0) {
+        // Check configuration from linker script
+        MBED_ASSERT(mbed_is_power_of_two(ram_code_region_size));
+        MBED_ASSERT(((uintptr_t)__ram_code_start) % ram_code_region_size == 0);
+
+        // Region size constant is the log2 of the region size, offset by 1
+        const uint32_t region_size = mbed_integer_log_2(ram_code_region_size) - 1;
+
+        // Select region 3/4/5 and use it for the ram code region.
+        // Note that some target layers, like the RPi Pico SDK, actually modify the code in this section
+        // at runtime (e.g. for interrupt handler redirection). So, we cannot mark it read-only.
+        ARM_MPU_SetRegion(
+            ARM_MPU_RBAR(
+                next_ram_region,                 // Region
+                ((uintptr_t)__ram_code_start)),  // Base
+            ARM_MPU_RASR_EX(
+                0,                          // DisableExec
+                ARM_MPU_AP_FULL,            // AccessPermission
+                ARM_MPU_ACCESS_NORMAL(ARM_MPU_CACHEP_WB_WRA, ARM_MPU_CACHEP_WB_WRA, false), // Access and cache policy
+                0U,                         // SubRegionDisable
+                region_size)                // Size
+        );
+        ++next_ram_region;
     }
 #endif
 

--- a/hal/source/mpu/mbed_mpu_v8m.c
+++ b/hal/source/mpu/mbed_mpu_v8m.c
@@ -49,8 +49,8 @@ extern uint8_t __noncached_end[];
 // Symbols defined in linker script for ram function region.
 // This region may be contained inside any other RAM region. Its start address and size must
 // be 32-byte aligned.
-extern uint8_t __ram_function_start[];
-extern uint8_t __ram_function_end[];
+extern uint8_t __ram_code_start[];
+extern uint8_t __ram_code_end[];
 #endif
 
 static_assert(MBED_MPU_ROM_END <= 0x20000000 - 1,
@@ -167,6 +167,7 @@ void mbed_mpu_init()
     );
 
     uint8_t next_ram_region = LAST_RAM_REGION + 1;
+    (void)next_ram_region; // silence unused warning
 
 #if __DCACHE_PRESENT
     // Region addresses must be 32-byte aligned.
@@ -191,20 +192,20 @@ void mbed_mpu_init()
 
 #if MBED_MPU_HAS_RAM_FUNCTION_REGION
     // Region addresses must be 32-byte aligned.
-    MBED_ASSERT(((uintptr_t)__ram_function_start) % 32 == 0);
-    MBED_ASSERT(((uintptr_t)__ram_function_end) % 32 == 0);
+    MBED_ASSERT(((uintptr_t)__ram_code_start) % 32 == 0);
+    MBED_ASSERT(((uintptr_t)__ram_code_end) % 32 == 0);
 
     // Select region 4/5/6 and use it for the non-cached region
     ARM_MPU_SetRegion(
         next_ram_region,
         ARM_MPU_RBAR(
-            (uintptr_t)__ram_function_start, // Base
+            (uintptr_t)__ram_code_start, // Base
             ARM_MPU_SH_NON,                  // Sharability
             0,                               // Read-Write
             1,                               // Non-privileged
             0),                              // Execute Never disabled
         ARM_MPU_RLAR(
-            (uintptr_t)__ram_function_end - 1,     // Limit
+            (uintptr_t)__ram_code_end - 1,     // Limit
             MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH)
     );
 #endif

--- a/hal/source/mpu/mbed_mpu_v8m.c
+++ b/hal/source/mpu/mbed_mpu_v8m.c
@@ -40,15 +40,17 @@
 #endif
 
 #ifdef __DCACHE_PRESENT
-// Symbols defined in linker script for noncache region
+// Symbols defined in linker script for noncache region.
+// The region's size does not need to be a power of 2, but its size and address need to be
+// 32-byte aligned. It must either be after the end of normal RAM, or before the start.
 extern uint8_t __noncached_start[];
 extern uint8_t __noncached_end[];
 #endif
 
 #ifdef MBED_MPU_HAS_RAM_FUNCTION_REGION
 // Symbols defined in linker script for ram function region.
-// This region may be contained inside any other RAM region. Its start address and size must
-// be 32-byte aligned.
+// The region's size does not need to be a power of 2, but its size and address need to be
+// 32-byte aligned. It must either be after the end of normal RAM, or before the start.
 extern uint8_t __ram_code_start[];
 extern uint8_t __ram_code_end[];
 #endif
@@ -109,34 +111,46 @@ void mbed_mpu_init()
             MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH) // Attribute index - Write-Through, Read-allocate
     );
 
-#if MBED_MPU_RAM_START < 0x20000000
-    ARM_MPU_SetRegion(
-        4,                          // Region
-        ARM_MPU_RBAR(
-            MBED_MPU_RAM_START,     // Base
-            ARM_MPU_SH_NON,         // Non-shareable
-            0,                      // Read-Write
-            1,                      // Non-Privileged
-            1),                     // Execute Never enabled
-        ARM_MPU_RLAR(
-            0x1FFFFFFF,             // Limit
-            MBED_MPU_ATTR_INDEX_NORMAL_WRITE_THROUGH) // Attribute index - Write-Through, Read-allocate
-    );
-#define LAST_RAM_REGION 4
-#else
-#define LAST_RAM_REGION 3
+    // MBED_MPU_RAM_START contains the start of the physical RAM address range on the chip.
+    // However, because MPU regions cannot overlap, we may need to adjust the RAM region addresses
+    // to account for the noncached and ram_code regions.
+    uintptr_t sram_region_start = MBED_MPU_RAM_START;
+    uintptr_t sram_region_limit = 0x3FFFFFFF;
+#if __DCACHE_PRESENT
+    if (((uintptr_t)__noncached_end <= sram_region_start) || ((uintptr_t)__noncached_start > sram_region_limit)) {
+        // OK - noncached region outside normal SRAM
+    } else if ((uintptr_t)__noncached_start == sram_region_start) {
+        // OK - noncached region at start of SRAM. Move sram start back.
+        sram_region_start = (uintptr_t)__noncached_end;
+    } else {
+        // Assume noncached region at end of SRAM.
+        sram_region_limit = (uintptr_t)__noncached_start - 1;
+    }
 #endif
+#if MBED_MPU_HAS_RAM_FUNCTION_REGION
+    if (((uintptr_t)__ram_code_end <= sram_region_start) || ((uintptr_t)__ram_code_start > sram_region_limit)) {
+        // OK - ram_code region outside normal SRAM
+    } else if ((uintptr_t)__ram_code_start == sram_region_start) {
+        // OK - ram_code region at start of SRAM. Move sram start back.
+        sram_region_start = (uintptr_t)__ram_code_end;
+    } else {
+        // Assume ram_code region at end of SRAM.
+        sram_region_limit = (uintptr_t)__ram_code_start - 1;
+    }
+#endif
+
+#define LAST_RAM_REGION 3
 
     ARM_MPU_SetRegion(
         1,                          // Region
         ARM_MPU_RBAR(
-            0x20000000,             // Base
+            sram_region_start,      // Base
             ARM_MPU_SH_NON,         // Non-shareable
             0,                      // Read-Write
             1,                      // Non-Privileged
             1),                     // Execute Never enabled
         ARM_MPU_RLAR(
-            0x3FFFFFFF,             // Limit
+            sram_region_limit,      // Limit
             MBED_MPU_ATTR_INDEX_NORMAL_WRITE_BACK) // Attribute index - Write-Back, Write-allocate
     );
 
@@ -174,7 +188,7 @@ void mbed_mpu_init()
     MBED_ASSERT(((uintptr_t)__noncached_start) % 32 == 0);
     MBED_ASSERT(((uintptr_t)__noncached_end) % 32 == 0);
 
-    // Select region 4/5 and use it for the non-cached region
+    // Select region 4 and use it for the non-cached region
     ARM_MPU_SetRegion(
         next_ram_region,
         ARM_MPU_RBAR(
@@ -195,7 +209,7 @@ void mbed_mpu_init()
     MBED_ASSERT(((uintptr_t)__ram_code_start) % 32 == 0);
     MBED_ASSERT(((uintptr_t)__ram_code_end) % 32 == 0);
 
-    // Select region 4/5/6 and use it for the non-cached region
+    // Select region 4/5 and use it for the non-cached region
     ARM_MPU_SetRegion(
         next_ram_region,
         ARM_MPU_RBAR(

--- a/hal/tests/TESTS/mbed_hal/sleep_manager/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep_manager/main.cpp
@@ -329,24 +329,24 @@ utest::v1::status_t testsuite_setup(const size_t number_of_cases)
 
 Case cases[] = {
     Case("deep sleep lock/unlock",
-    (utest::v1::case_setup_handler_t) testcase_setup,
-    test_lock_unlock,
-    (utest::v1::case_teardown_handler_t) testcase_teardown),
+         (utest::v1::case_setup_handler_t) testcase_setup,
+         test_lock_unlock,
+         (utest::v1::case_teardown_handler_t) testcase_teardown),
     Case("deep sleep locked USHRT_MAX times",
-    (utest::v1::case_setup_handler_t) testcase_setup,
-    test_lock_eq_ushrt_max,
-    (utest::v1::case_teardown_handler_t) testcase_teardown),
+         (utest::v1::case_setup_handler_t) testcase_setup,
+         test_lock_eq_ushrt_max,
+         (utest::v1::case_teardown_handler_t) testcase_teardown),
 #if DEVICE_LPTICKER
 #if DEVICE_USTICKER
     Case("sleep_auto calls sleep/deep sleep based on lock",
-    (utest::v1::case_setup_handler_t) testcase_setup,
-    test_sleep_auto,
-    (utest::v1::case_teardown_handler_t) testcase_teardown),
+         (utest::v1::case_setup_handler_t) testcase_setup,
+         test_sleep_auto,
+         (utest::v1::case_teardown_handler_t) testcase_teardown),
 #endif
     Case("deep sleep lock/unlock test_check",
-    (utest::v1::case_setup_handler_t) testcase_setup,
-    test_lock_unlock_test_check,
-    (utest::v1::case_teardown_handler_t) testcase_teardown)
+         (utest::v1::case_setup_handler_t) testcase_setup,
+         test_lock_unlock_test_check,
+         (utest::v1::case_teardown_handler_t) testcase_teardown)
 #endif
 };
 

--- a/hal/tests/TESTS/mbed_hal/sleep_manager/main.cpp
+++ b/hal/tests/TESTS/mbed_hal/sleep_manager/main.cpp
@@ -329,24 +329,24 @@ utest::v1::status_t testsuite_setup(const size_t number_of_cases)
 
 Case cases[] = {
     Case("deep sleep lock/unlock",
-         (utest::v1::case_setup_handler_t) testcase_setup,
-         test_lock_unlock,
-         (utest::v1::case_teardown_handler_t) testcase_teardown),
+    (utest::v1::case_setup_handler_t) testcase_setup,
+    test_lock_unlock,
+    (utest::v1::case_teardown_handler_t) testcase_teardown),
     Case("deep sleep locked USHRT_MAX times",
-         (utest::v1::case_setup_handler_t) testcase_setup,
-         test_lock_eq_ushrt_max,
-         (utest::v1::case_teardown_handler_t) testcase_teardown),
+    (utest::v1::case_setup_handler_t) testcase_setup,
+    test_lock_eq_ushrt_max,
+    (utest::v1::case_teardown_handler_t) testcase_teardown),
 #if DEVICE_LPTICKER
 #if DEVICE_USTICKER
     Case("sleep_auto calls sleep/deep sleep based on lock",
-         (utest::v1::case_setup_handler_t) testcase_setup,
-         test_sleep_auto,
-         (utest::v1::case_teardown_handler_t) testcase_teardown),
+    (utest::v1::case_setup_handler_t) testcase_setup,
+    test_sleep_auto,
+    (utest::v1::case_teardown_handler_t) testcase_teardown),
 #endif
     Case("deep sleep lock/unlock test_check",
-         (utest::v1::case_setup_handler_t) testcase_setup,
-         test_lock_unlock_test_check,
-         (utest::v1::case_teardown_handler_t) testcase_teardown)
+    (utest::v1::case_setup_handler_t) testcase_setup,
+    test_lock_unlock_test_check,
+    (utest::v1::case_teardown_handler_t) testcase_teardown)
 #endif
 };
 

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -87,7 +87,7 @@ SECTIONS
         /* For the MPU configuration, we need to align the size of this section up to
          * the next power of two. Also note that the MPU does not support regions
          * smaller than 32 bytes so round up if smaller than that. */
-        __noncached_data_size = (. - __noncached_start);
+        __noncached_data_size = ABSOLUTE(. - __noncached_start);
         __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
 
         . += (__noncached_aligned_size - __noncached_data_size);

--- a/targets/TARGET_RASPBERRYPI/CMakeLists.txt
+++ b/targets/TARGET_RASPBERRYPI/CMakeLists.txt
@@ -153,6 +153,9 @@ target_compile_definitions(mbed-mcu-rp2
 		LIB_CMSIS_CORE
 		PICO_CMSIS_RENAME_EXCEPTIONS
 
+		# Copy .ram_code section at startup
+		PICO_COPY_TO_RAM
+
 		# Don't automatically register init stuff as global constructors. We call these manually in mbed_sdk_init()
 		PICO_RUNTIME_SKIP_INIT_BOOTROM_RESET
 		PICO_RUNTIME_SKIP_INIT_PER_CORE_BOOTROM_RESET

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/TARGET_MCU_RP2040/rtc_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/TARGET_MCU_RP2040/rtc_api.c
@@ -25,7 +25,6 @@
 #include "mbed_mktime.h"
 #include "mbed_wait_api.h"
 
-static bool rtc_initted = false;
 
 void rtc_init(void)
 {
@@ -33,6 +32,7 @@ void rtc_init(void)
 
     // Calling _rtc_init() resets the current time.
     // So, if the RTC has already been initialized, we don't want to initialize it again.
+    static bool rtc_initted = false;
     if(!rtc_initted)
     {
         pico_sdk_rtc_init();

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/TARGET_MCU_RP2040/rtc_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/TARGET_MCU_RP2040/rtc_api.c
@@ -25,17 +25,26 @@
 #include "mbed_mktime.h"
 #include "mbed_wait_api.h"
 
+static bool rtc_initted = false;
+
 void rtc_init(void)
 {
     core_util_critical_section_enter();
 
     // Calling _rtc_init() resets the current time.
     // So, if the RTC has already been initialized, we don't want to initialize it again.
-    static bool rtc_initted = false;
     if(!rtc_initted)
     {
         pico_sdk_rtc_init();
         rtc_initted = true;
+
+        // RP2040 RTC does not keep time across resets, so we always need to set the time.
+        // The docs are a bit limited, but it appears this is needed so that the RTC shows as running.
+        datetime_t initTime = {};
+        initTime.year = 1970;
+        initTime.month = 1;
+        initTime.day = 1;
+        rtc_set_datetime(&initTime);
     }
 
     core_util_critical_section_exit();

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/device.h
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/device.h
@@ -35,4 +35,16 @@
 #include "objects.h"
 #include "us_ticker_defines.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Provide flash end address from linker script for FlashIAP.h
+extern uint8_t __flash_binary_end[];
+#define FLASHIAP_APP_ROM_END_ADDR ((uint32_t)__flash_binary_end)
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/memmap_default_mbed.ld
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/memmap_default_mbed.ld
@@ -200,15 +200,9 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-    /* End of .text-like segments */
-    __etext = .;
-
-    .ram_vector_table (NOLOAD): {
-        *(.ram_vector_table)
-    } > RAM
-
-    .ram_code ALIGN(32) : {
-        __ram_function_start = .;
+    /* RAM code section. This gets put right at the start of RAM so it's very, very aligned. */
+    .ram_code : {
+        __ram_code_start = .;
         
         *(.time_critical*)
 
@@ -219,8 +213,38 @@ SECTIONS
          */
          *irq_handler_chain.S.o*(.data)
 
+         __ram_code_data_size = (. - __ram_code_start);
+
+#ifdef PICO_RP2040
+        /* For the Cortex-M0+ MPU configuration, we need to align the size of this section up to
+         * the next power of two. Also note that the MPU does not support regions
+         * smaller than 32 bytes so round up if smaller than that. */
+        __ram_code_aligned_size = MAX(32, 1 << LOG2CEIL(__ram_code_data_size));
+
+        . += (__ram_code_aligned_size - __ram_code_data_size);
+#else
+        /* For the Cortex-M33 MPU it's way easier. */
         . = ALIGN(32);
-        __ram_function_end = .;
+#endif
+        __ram_code_end = .;
+    } > RAM AT> FLASH
+
+    /* Symbols for Pico SDK */
+    __ram_text_source__ = LOADADDR(.ram_code);
+    __ram_text_start__ = __ram_code_start;
+    __ram_text_end__ = __ram_code_start + __ram_code_data_size;
+
+    /*
+     * RAM vector table. Per the docs: https://developer.arm.com/documentation/ddi0403/d/System-Level-Architecture/System-Level-Programmers--Model/ARMv7-M-exception-model/The-vector-table
+     * this must be aligned to (the next power of 2 larger than 4*the number of vectors) or (128), whichever is greater.
+     */
+#if PICO_RP2040
+#define VTABLE_ALIGN 128
+#else
+#define VTABLE_ALIGN 256
+#endif
+    .ram_vector_table BLOCK(VTABLE_ALIGN) (NOLOAD) : {
+        *(.ram_vector_table)
     } > RAM
 
     .data : {
@@ -250,6 +274,9 @@ SECTIONS
 
         __data_end__ = .;
     } > RAM AT> FLASH
+
+    /* End of .text-like segments */
+    __etext = LOADADDR(.data);
 
     .uninitialized_data (NOLOAD): {
         . = ALIGN(4);

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/memmap_default_mbed.ld
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/memmap_default_mbed.ld
@@ -213,7 +213,7 @@ SECTIONS
          */
          *irq_handler_chain.S.o*(.data)
 
-         __ram_code_data_size = (. - __ram_code_start);
+         __ram_code_data_size = ABSOLUTE(. - __ram_code_start);
 
 #ifdef PICO_RP2040
         /* For the Cortex-M0+ MPU configuration, we need to align the size of this section up to
@@ -237,13 +237,10 @@ SECTIONS
     /*
      * RAM vector table. Per the docs: https://developer.arm.com/documentation/ddi0403/d/System-Level-Architecture/System-Level-Programmers--Model/ARMv7-M-exception-model/The-vector-table
      * this must be aligned to (the next power of 2 larger than 4*the number of vectors) or (128), whichever is greater.
+     * Oddly, though, RP2040 appears to crash if the vector table is not 256 byte aligned, even though it should only need 128 byte alignment.
+     * Not sure what's up with that but oh well.
      */
-#if PICO_RP2040
-#define VTABLE_ALIGN 128
-#else
-#define VTABLE_ALIGN 256
-#endif
-    .ram_vector_table BLOCK(VTABLE_ALIGN) (NOLOAD) : {
+    .ram_vector_table BLOCK(256) (NOLOAD) : {
         *(.ram_vector_table)
     } > RAM
 

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/objects.h
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/objects.h
@@ -112,6 +112,7 @@ struct i2c_s {
 
 struct spi_s {
     spi_inst_t * dev;
+    uint8_t bits; // Bits per word, usually 8 or 16
 };
 
 struct pwmout_s

--- a/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/spi_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_MCU_RP2/spi_api.c
@@ -93,6 +93,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
     /* Configure the SPI. */
     spi_set_format(obj->dev, bits, SPI_MODE[mode].cpol, SPI_MODE[mode].cpha, SPI_MSB_FIRST);
+    obj->bits = bits;
     /* Set's the SPI up as slave if the value of slave is different from 0, e.g. a value of 1 or -1 set's this SPI up as a slave. */
     spi_set_slave(obj->dev, slave != 0);
 }
@@ -104,18 +105,55 @@ void spi_frequency(spi_t *obj, int hz)
 
 int spi_master_write(spi_t *obj, int value)
 {
-    uint8_t rx;
-    uint8_t const tx = (uint8_t)value;
-    spi_write_read_blocking(obj->dev, &tx, &rx, sizeof(rx));
-    return rx;
+    // Logic based on spi_write_read_blocking() from pico SDK
+
+    while(!spi_is_writable(obj->dev)) {}
+
+    spi_get_hw(obj->dev)->dr = value;
+
+    while(!spi_is_readable(obj->dev)) {}
+
+    return spi_get_hw(obj->dev)->dr;
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)
 {
     /* The pico-sdk API does not support different length SPI buffers. */
-    MBED_ASSERT(tx_length == rx_length);
-    /* Perform the SPI transfer. */
-    return spi_write_read_blocking(obj->dev, (const uint8_t *)tx_buffer, (uint8_t *)rx_buffer, (size_t)tx_length);
+    MBED_ASSERT(tx_length == rx_length || tx_length == 0 || rx_length == 0);
+
+    if(obj->bits >= 9)
+    {
+        // note: Pico SDK uses number of uint16_ts, Mbed uses bytes, so we need a factor of 2
+        if(tx_length == 0)
+        {
+            const uint16_t tx_fill = ((uint16_t)write_fill << 8) | write_fill;
+            return spi_read16_blocking(obj->dev, tx_fill, (uint16_t *)rx_buffer, rx_length / 2) * 2;
+        }
+        else if(rx_length == 0)
+        {
+            return spi_write16_blocking(obj->dev, (const uint16_t *)tx_buffer, tx_length / 2) * 2;
+        }
+        else
+        {
+            return spi_write16_read16_blocking(obj->dev, (const uint16_t *)tx_buffer, (uint16_t *)rx_buffer, tx_length / 2) * 2;
+        }
+    }
+    else // 8 bits or less
+    {
+        if(tx_length == 0)
+        {
+            return spi_read_blocking(obj->dev, write_fill, (uint8_t *)rx_buffer, rx_length);
+        }
+        else if(rx_length == 0)
+        {
+            return spi_write_blocking(obj->dev, (const uint8_t *)tx_buffer, tx_length);
+        }
+        else
+        {
+            return spi_write_read_blocking(obj->dev, (const uint8_t *)tx_buffer, (uint8_t *)rx_buffer, (size_t)tx_length);
+        }
+        
+    }
 }
 
 const PinMap *spi_master_mosi_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
@@ -81,7 +81,7 @@ SECTIONS
         /* For the MPU configuration, we need to align the size of this section up to
          * the next power of two. Also note that the MPU does not support regions
          * smaller than 32 bytes so round up if smaller than that. */
-        __noncached_data_size = (. - __noncached_start);
+        __noncached_data_size = ABSOLUTE(. - __noncached_start);
         __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
 
         . += (__noncached_aligned_size - __noncached_data_size);

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H743_STM32H72x_FAMILIES/STM32H743_H72x.ld
@@ -82,7 +82,7 @@ SECTIONS
         /* For the MPU configuration, we need to align the size of this section up to
          * the next power of two. Also note that the MPU does not support regions
          * smaller than 32 bytes so round up if smaller than that. */
-        __noncached_data_size = (. - __noncached_start);
+        __noncached_data_size = ABSOLUTE(. - __noncached_start);
         __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
 
         . += (__noncached_aligned_size - __noncached_data_size);

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H745_47_FAMILY/CM7/STM32H745_H747_CM7.ld
@@ -82,7 +82,7 @@ SECTIONS
         /* For the MPU configuration, we need to align the size of this section up to
          * the next power of two. Also note that the MPU does not support regions
          * smaller than 32 bytes so round up if smaller than that. */
-        __noncached_data_size = (. - __noncached_start);
+        __noncached_data_size = ABSOLUTE(. - __noncached_start);
         __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
 
         . += (__noncached_aligned_size - __noncached_data_size);

--- a/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/linker_scripts/STM32H7Ax_FAMILY/STM32H7Ax.ld
@@ -82,7 +82,7 @@ SECTIONS
         /* For the MPU configuration, we need to align the size of this section up to
          * the next power of two. Also note that the MPU does not support regions
          * smaller than 32 bytes so round up if smaller than that. */
-        __noncached_data_size = (. - __noncached_start);
+        __noncached_data_size = ABSOLUTE(. - __noncached_start);
         __noncached_aligned_size = MAX(32, 1 << LOG2CEIL(__noncached_data_size));
 
         . += (__noncached_aligned_size - __noncached_data_size);

--- a/targets/targets.json5
+++ b/targets/targets.json5
@@ -8436,6 +8436,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
             "PICO_ON_DEVICE=1",
             "PICO_NO_HARDWARE=0",
             "PICO_32BIT=1",
+            "MBED_MPU_HAS_RAM_FUNCTION_REGION",
 
             // Do not translate CRLF to LF in UART Pico SDK driver
             "PICO_UART_ENABLE_CRLF_SUPPORT=0"
@@ -8477,8 +8478,7 @@ mode is recommended for target MCUs with small amounts of flash and RAM.",
         "core": "Cortex-M33FE",
         "is_mcu_family_target": true,
         "macros_add": [
-            "PICO_RP2350=1",
-            "MBED_MPU_HAS_RAM_FUNCTION_REGION"
+            "PICO_RP2350=1"
         ],
         "device_has_add": [
             "LPTICKER"

--- a/tools/python/mbed_host_tests/README.md
+++ b/tools/python/mbed_host_tests/README.md
@@ -501,8 +501,8 @@ int main() {
 
 ```python
 class GimmeAuto(BaseHostTest):
-    """ Simple, basic host test's test runner waiting for serial port
-        output from MUT, no supervision over test running in MUT is executed.
+    """Simple, basic host test's test runner waiting for serial port
+    output from MUT, no supervision over test running in MUT is executed.
     """
 
     __result = None
@@ -513,10 +513,10 @@ class GimmeAuto(BaseHostTest):
 
         # We will send DUT some data back...
         # And now decide about test case result
-        if value == 'some_stuff':
+        if value == "some_stuff":
             # Message payload/value was 'some_stuff'
             # We can for example return true from test
-            self.send_kv("print_this", "This is what I wanted %s"% value)
+            self.send_kv("print_this", "This is what I wanted %s" % value)
             self.notify_complete(True)
         else:
             self.send_kv("print_this", "This not what I wanted :(")
@@ -602,8 +602,8 @@ mbedgt: test suite results: 1 OK
 
 ```python
 class GimmeAuto(BaseHostTest):
-    """ Simple, basic host test's test runner waiting for serial port
-        output from MUT, no supervision over test running in MUT is executed.
+    """Simple, basic host test's test runner waiting for serial port
+    output from MUT, no supervision over test running in MUT is executed.
     """
 
     __result = None
@@ -614,10 +614,10 @@ class GimmeAuto(BaseHostTest):
 
         # We will send DUT some data back...
         # And now decide about test case result
-        if value == 'some_stuff':
+        if value == "some_stuff":
             # Message payload/value was 'some_stuff'
             # We can for example return true from test
-            self.send_kv("print_this", "This is what I wanted %s"% value)
+            self.send_kv("print_this", "This is what I wanted %s" % value)
             self.__result = True
         else:
             self.send_kv("print_this", "This not what I wanted :(")
@@ -770,11 +770,11 @@ int app_start(int, char*[]) {
 ```python
 from mbed_host_tests import BaseHostTest
 
+
 class YourCustomHostTest(BaseHostTest):
+    name = "my_host_test"  # Host test names used by GREENTEA_CLIENT(..., host_test_name)
 
-    name = "my_host_test"   # Host test names used by GREENTEA_CLIENT(..., host_test_name)
-
-    __result = False    # Result in case of timeout!
+    __result = False  # Result in case of timeout!
 
     def _callback_for_event(self, key, value, timestamp):
         #
@@ -891,8 +891,8 @@ You can register callbacks in ```setup()``` phase or decorate callback functions
 ```python
 from mbed_host_tests import BaseHostTest
 
-class DetectRuntimeError(BaseHostTest):
 
+class DetectRuntimeError(BaseHostTest):
     __result = False
 
     def callback_some_event(self, key, value, timeout):
@@ -901,7 +901,7 @@ class DetectRuntimeError(BaseHostTest):
 
     def setup(self):
         # Reagister call back for 'some_event' event
-        self.register_callback('some_event', self.callback_some_event)
+        self.register_callback("some_event", self.callback_some_event)
 
     def result(self):
         # Do some return calculations
@@ -915,11 +915,11 @@ Below the same callback registered using decorator:
 ```python
 from mbed_host_tests.host_tests import BaseHostTest, event_callback
 
-class DetectRuntimeError(BaseHostTest):
 
+class DetectRuntimeError(BaseHostTest):
     __result = False
 
-    @event_callback('some_event')
+    @event_callback("some_event")
     def callback_some_event(self, key, value, timeout):
         # Do something with 'some_event'
         pass
@@ -944,9 +944,9 @@ We will use allowed to override ```__rxd_line``` event to hook to DUT RXD channe
 from sys import stdout
 from mbed_host_tests import BaseHostTest
 
-class DetectRuntimeError(BaseHostTest):
 
-    name = 'detect_runtime_error'
+class DetectRuntimeError(BaseHostTest):
+    name = "detect_runtime_error"
 
     def test(self, selftest):
         result = selftest.RESULT_FAILURE
@@ -978,8 +978,9 @@ class DetectRuntimeError(BaseHostTest):
 ```python
 from mbed_host_tests import BaseHostTest
 
+
 class DetectRuntimeError(BaseHostTest):
-    """! We _expect_ to detect 'Runtime error' """
+    """! We _expect_ to detect 'Runtime error'"""
 
     __result = False
 
@@ -994,7 +995,7 @@ class DetectRuntimeError(BaseHostTest):
 
     def setup(self):
         # Force, we force callback registration even it is a restricted one (starts with '__')
-        self.register_callback('__rxd_line', self.callback__rxd_line, force=True)
+        self.register_callback("__rxd_line", self.callback__rxd_line, force=True)
 
     def result(self):
         # We will return here (False) when we reach timeout of the test

--- a/tools/python/mbed_lstools/README.md
+++ b/tools/python/mbed_lstools/README.md
@@ -226,7 +226,8 @@ As a normal function definition:
 
 ```python
 def filter_func(mbed):
-    return m['platform_name'] == 'K64F'
+    return m["platform_name"] == "K64F"
+
 
 mbeds.list_mbeds(filter_function=filter_func)
 ```
@@ -234,7 +235,7 @@ mbeds.list_mbeds(filter_function=filter_func)
 As a lambda function:
 
 ```python
-platforms = mbeds.list_mbeds(filter_function=lambda m: m['platform_name'] == 'K64F')
+platforms = mbeds.list_mbeds(filter_function=lambda m: m["platform_name"] == "K64F")
 ```
 
 #### `fs_interaction`


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

I discovered when trying to test SPI on RP235x that any attempt to use SPI was immediately resulting in a HardFault, because the SPI driver in the Pico SDK attempts to put some functions in RAM, but these functions are blocked from executing by the MPU configuration set up by Mbed. 

To fix this, just like how I set up the noncached MPU region, I added a new MPU region for RAM functions. This region is auto-sized to a power of 2, and gets a special exception in the MPU to allow RAM execution. This region can then be used for the ram functions in Pico SDK (it calls these ".time_critical"), as well as for its fancy shared IRQ handler mechanism that works by creating functions in RAM.

Once this was fixed, I also had to patch a couple other problems with the SPI driver. Until now, it couldn't handle doing Tx-only or Rx-only transactions -- it was limited to uses where the Tx and Rx buffers were exactly the same length! Plus, the logic for 16-bit data size was totally broken.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

SPI fixed on RP2xxx

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Did a full Greentea test run on RP2040 and RP2350. Only failures were known USB tests and rtc-reset test.

Also ran the CI shield tests with RP2350. All pass!

----------------------------------------------------------------------------------------------------------------
