### PR TITLE
STM32: fix LPUART console hang after first deep sleep (HSI16 off)

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -182,6 +182,20 @@ __WEAK void hal_deepsleep(void)
 
     save_timer_ctx();
 
+    /* Stop mode stops HSI16 in hardware, and neither ForceOscOutofDeepSleep()
+     * nor SetSysClock() below re-enables it (both use an MSI-only oscillator
+     * mask). Any peripheral using HSI16 as its clock therefore loses that clock
+     * permanently after the first deep sleep. 
+     * This sets HSIASFS "HSI16 automatic start from Stop" before Stop entry when 
+     * HSI16 is on. So hardware restarts HSI16 in parallel with MSI during wake-up.*/
+#if defined(RCC_CR_HSIASFS)
+    if (READ_BIT(RCC->CR, RCC_CR_HSION) != 0U) {
+        SET_BIT(RCC->CR, RCC_CR_HSIASFS);
+    } else {
+        CLEAR_BIT(RCC->CR, RCC_CR_HSIASFS);
+    }
+#endif /* RCC_CR_HSIASFS */
+
     // Request to enter STOP mode with regulator in low power mode
     //PWR_CR1_LPMS_STOP2 -> STM32L4 ; PWR_LOWPOWERMODE_STOP2 -> STM32WL
 #if defined (PWR_CR1_LPMS_STOP2) || defined(PWR_LOWPOWERMODE_STOP2)


### PR DESCRIPTION
### Summary of changes

Fixes a hang of the stdio console after the first deep sleep on STM32L4/L5/WL targets whose peripherals are clocked from HSI16.

**Defect**
Entering Stop/Stop2 switches HSI16 off in hardware. The wake-up path in `hal_deepsleep()` (`ForceOscOutofDeepSleep()` + `ForcePeriphOutofDeepSleep()` + `SetSysClock()`) restores only the oscillators required by the selected system clock. With `clock-source = USE_PLL_MSI`, the `MCU_STM32L4` default, **HSI16 is never re-enabled after wake-up**, although peripherals may still use it.

**Symptom**
`MCU_STM32L475xG/L476xG/L486xG/L496xG` override `lpuart-clock-source = USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK`. AR 115200 baud (`baudrate <= HSI_VALUE/3`) `serial_api.c:432` selects HSI16 as LPUART1 clock, enabling HSI once at console init. On boards whose ST-LINK Serial is wired to LPUART1, like most STM32L4/L5 Nucleo-144 (NUCLEO_L496ZG etc.) the first `printf` after the first deep sleep then spins forever. The rest seems to keep running and only the console is dead.

**Fix**
Use the intended feature for this case **HSIASFS*** (HSI16 automatic start from Stop `RCC_CR` bit 11) in `hal_deepsleep()`, immediately before Stop entry:

```c
#if defined(RCC_CR_HSIASFS)
    if (READ_BIT(RCC->CR, RCC_CR_HSION) != 0U) {
        __HAL_RCC_HSIAUTOMATIC_START_ENABLE();
    } else {
        __HAL_RCC_HSIAUTOMATIC_START_DISABLE();
    }
#endif /* RCC_CR_HSIASFS */
```

**Reproduction.** mbed-ce hello-world, release build, deep sleep followed by a `printf`, with

```json5
"NUCLEO_L496ZG": {
    "target.clock-source": "USE_PLL_MSI",
    "target.lpuart-clock-source": "USE_LPUART_CLK_HSI"
}
```

The defect is invisible on `USE_PLL_HSI` configurations, because `SetSysClock_PLL_HSI()` re-enables HSI on every wake-up as a side effect, which is why app-level testing rarely hits it.

I stumbled across this while running tests with greentea on these boards. It seems that greentea, which ignores `mbed_app.json5`, runs the MSI default. Therefore, any test that prints after its first idle deep sleep will hang until the host times out. In my case, it was the test-mbed-rtos-heap-and-stack test. Once `ThisThread::sleep_for(10s)` has finished, the subsequent `printf("Total size dynamically allocated...")` never returns and the suite ends with `{{result;timeout}}`. Wrapping the sleep in a `DeepSleepLock` fixes the test, but only because stop mode is then never entered.

**Alternatives considered.**

- `"target.lpuart-clock-source": "USE_LPUART_CLK_SYSCLK"` per application/test config: verified to work, but is a per-project workaround, ties the baud rate to SYSCLK, and leaves every other HSI-clocked peripheral (UART, I2C etc. with `*_CLK_HSI`) broken across deep sleep.
- Software re-enable of HSI in `ForceOscOutofDeepSleep()`: equivalent in effect, but adds a busy-wait on every wake-up and duplicates what the hal provides.

#### Impact of changes

This should have no new configuration option nor behaviour change where HSI16 was off at Stop entry (a stale `HSIASFS` is cleared). And should effect **STM32L4, L5 and WL** who uses `hal_deepsleep()`. STM32WB uses its own `wb_sleep.c` and is not covered here.

The Nucleo_l552ZE_Q is similar, but is not impacted as the other boards since it does not set "lpuart-clock-source": "USE_LPUART_CLK_HSI|USE_LPUART_CLK_SYSCLK" in its target inheritance chain. It also outright disables the use of HSI in the SetSysClock_PLL_MSI function, but will still be affected if HSI is used for any peripheral.

#### Migration actions required

None.

### Documentation

None.

----------------------------------------------------------------------------------------------------------------

### Pull request type

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

----------------------------------------------------------------------------------------------------------------
