### PR TITLE
STM32L4: fix MemManage fault in rtos-heap-and-stack on dual-bank targets

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/linker_scripts/stm32l4_dual_flash_bank.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/linker_scripts/stm32l4_dual_flash_bank.ld
@@ -181,14 +181,14 @@ SECTIONS
         _ebss = .;
     } > SRAM1
     
-    /* Placeholder for heap 0 space */
+    /* Heap 1: all remaining SRAM1 below the boot/ISR stack */
     .heap (COPY):
     {
         __end__ = .;
         end = __end__;
         __mbed_sbrk_start = .;
         *(.heap*)
-        . += (ORIGIN(SRAM1) + LENGTH(SRAM1) - .);
+        . = ORIGIN(SRAM1) + LENGTH(SRAM1) - MBED_CONF_TARGET_BOOT_STACK_SIZE;
         __mbed_krbs_start = .;
         __HeapLimit = .;
     } > SRAM1
@@ -201,4 +201,7 @@ SECTIONS
 
     /* Check if bss exceeds SRAM1 */
     ASSERT(__bss_end__ < __StackLimit, "Size of static variables does not leave enough room for minimum stack size")
+
+    /* Check that the heap does not run into the boot/ISR stack */
+    ASSERT(__StackLimit >= __HeapLimit, "region SRAM1 overflowed with stack")
 }


### PR DESCRIPTION
### Summary of changes

Fixes a hard fault in `tests-mbed-rtos-heap-and-stack` on every STM32L4 target using `stm32l4_dual_flash_bank.ld`, caused by the SRAM1 heap and the boot/ISR stack occupying the same memory.

**Symptom**
Cases 1-4 pass; case 5, *Test heap allocation and free*, terminates the suite:

```log
    FaultType: MemManageFault
    MMFSR: 00000082      (DACCVIOL | MMARVALID)
    MMFAR: 00000110
    Error Status: 0x80FF013E Code: 318  "Fault exception"
    Current Thread: main  SP: 0x20001FE8 / 0x20002020
```

Reproduced on NUCLEO_L476RG and NUCLEO_L496ZG, `full` profile, GCC, STM32CUBE upload.

**Symptom** 

The SRAM1 `.heap` section extends to the top of the bank:
```
    .heap (COPY):
    {
        __mbed_sbrk_start = .;
        *(.heap*)
        . += (ORIGIN(SRAM1) + LENGTH(SRAM1) - .);   /* __HeapLimit == __StackTop */
        __mbed_krbs_start = .;
        __HeapLimit = .;
    } > SRAM1

    __StackTop   = ORIGIN(SRAM1) + LENGTH(SRAM1);
    __StackLimit = __StackTop - MBED_CONF_TARGET_BOOT_STACK_SIZE;
```

`__HeapLimit` and `__StackTop` coincide, so the top `MBED_CONF_TARGET_BOOT_STACK_SIZE` bytes are given to the allocator and simultaneously used as the boot/ISR stack. The two consumers collide only once allocation reaches the top of SRAM1, which is why the defect escapes the `Test heap in range` and `Test isr stack in range` checks and ordinary applications, and manifests as heap corruption: MSP pushes overwrite malloc chunk headers, and the mangled free-list pointer is dereferenced near 0x110. The observed MSP values confirm the aliasing. `MSP: 0x20017FC0` on L476 (SRAM1 ends at `0x20018000`) and `MSP: 0x2003FFC0` on L496 (SRAM1 ends at `0x20040000`).

**Fix**
In `targets/TARGET_STM/TARGET_STM32L4/linker_scripts/stm32l4_dual_flash_bank.ld`:

- Terminate `.heap` at `ORIGIN(SRAM1) + LENGTH(SRAM1) - MBED_CONF_TARGET_BOOT_STACK_SIZE`, giving `__HeapLimit == __StackLimit`. This is the form already used by the single-RAM-bank L4 scripts (`TARGET_STM32L412xB/TOOLCHAIN_GCC_ARM/stm32l412xb.ld`), the change aligns the dual-bank script with the established pattern rather than introducing a new one.
- Add `ASSERT(__StackLimit >= __HeapLimit, "region SRAM1 overflowed with stack")`, complementing the existing `.bss`/`__StackLimit` assertion, so any regression fails at link time.

#### Impact of changes

- Affects the nine targets bound to this script in `targets/TARGET_STM/TARGET_STM32L4/linker_scripts/CMakeLists.txt`: STM32L432xC, L433xC, L443xC, L452xE, L471xG, L475xG, L476xG, L486xG and L496xG
- Configurations in which heap and stack already overlapped will now fail at link time via the new `ASSERT` instead of faulting at run time

#### Migration actions required

None. Applications close to the SRAM1 ceiling may need `target.boot-stack-size` reviewed or their allocation footprint reduced.

### Documentation

None.

----------------------------------------------------------------------------------------------------------------

### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

`tests-mbed-rtos-heap-and-stack` on NUCLEO_L476RG and NUCLEO_L496ZG, hardware, `full` profile: fails on master, passes with this change. Logs attached (`greentea-log-l4{7,9}6-rtos-heap-and-stack{-fail,}.txt`).

[greentea-log-l476-rtos-heap-and-stack.txt](https://github.com/user-attachments/files/30421769/greentea-log-l476-rtos-heap-and-stack.txt)
[greentea-log-l476-rtos-heap-and-stack-fail.txt](https://github.com/user-attachments/files/30421770/greentea-log-l476-rtos-heap-and-stack-fail.txt)
[greentea-log-l496-rtos-heap-and-stack.txt](https://github.com/user-attachments/files/30421772/greentea-log-l496-rtos-heap-and-stack.txt)
[greentea-log-l496-rtos-heap-and-stack-fail.txt](https://github.com/user-attachments/files/30421773/greentea-log-l496-rtos-heap-and-stack-fail.txt)

Note: For a successful run on a NUCLEO_L496ZG target consider: https://github.com/mbed-ce/mbed-os/pull/591

----------------------------------------------------------------------------------------------------------------
