### PR TITLE
Fix zero-size realloc with heap stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ A message that notes the main changes in the update.
 ### Deprecated
 
 ### Fixed
+- Fixed `realloc(ptr, 0)` leaking the original allocation when heap statistics are enabled
 - Added fixes aimed at improving Greentea stability for KV/FlashIAP (STM32F7) and USBSerial paths.
 - MIMXRT105x:
   - MIMXRT1050_EVK: Fixed build error due to typos

--- a/platform/source/mbed_alloc_wrappers.cpp
+++ b/platform/source/mbed_alloc_wrappers.cpp
@@ -164,8 +164,11 @@ extern "C" void *__wrap__realloc_r(struct _reent *r, void *ptr, size_t size)
         old_size = alloc_info->size;
     }
 
-    // Allocate space
-    if (size != 0) {
+    // A zero-sized reallocation frees the original allocation.
+    if (size == 0) {
+        free(ptr);
+    } else {
+        // Allocate space
         new_ptr = malloc(size);
     }
 

--- a/platform/tests/TESTS/mbed_platform/stats_heap/main.cpp
+++ b/platform/tests/TESTS/mbed_platform/stats_heap/main.cpp
@@ -188,11 +188,37 @@ void test_case_realloc_size()
     TEST_ASSERT_EQUAL_UINT32(stats_start.current_size, stats_current.current_size);
 }
 
+void test_case_realloc_zero()
+{
+    mbed_stats_heap_t stats_start;
+    mbed_stats_heap_t stats_allocated;
+    mbed_stats_heap_t stats_current;
+
+    mbed_stats_heap_get(&stats_start);
+
+    void *data = malloc(ALLOCATION_SIZE_DEFAULT);
+    TEST_ASSERT_NOT_NULL(data);
+    mbed_stats_heap_get(&stats_allocated);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.current_size + ALLOCATION_SIZE_DEFAULT, stats_allocated.current_size);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt + 1, stats_allocated.alloc_cnt);
+
+    data = realloc(data, 0);
+    TEST_ASSERT_NULL(data);
+
+    mbed_stats_heap_get(&stats_current);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.current_size, stats_current.current_size);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt, stats_current.alloc_cnt);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.overhead_size, stats_current.overhead_size);
+    TEST_ASSERT_EQUAL_UINT32(stats_allocated.total_size, stats_current.total_size);
+    TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt, stats_current.alloc_fail_cnt);
+}
+
 Case cases[] = {
     Case("malloc and free size", test_case_malloc_free_size),
     Case("allocate size zero", test_case_allocate_zero),
     Case("allocation failure", test_case_allocate_fail),
     Case("realloc size", test_case_realloc_size),
+    Case("realloc size zero", test_case_realloc_zero),
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)


### PR DESCRIPTION
### Summary of changes

Fixes a memory leak in the GCC `realloc` wrapper when heap statistics are enabled.

When `__wrap__realloc_r()` receives an existing allocation with a requested size of zero, it returns `NULL` but previously did not free the original allocation. Newlib defines `realloc(ptr, 0)` as freeing `ptr` and returning `NULL`.

The wrapper now frees the original allocation for a zero-sized reallocation.

A Greentea regression test was added that:

- Allocates a nonzero block.
- Calls `realloc(ptr, 0)`.
- Verifies that the result is `NULL`.
- Verifies that `current_size`, `alloc_cnt`, and `overhead_size` return to their initial values.
- Verifies that the operation does not increment `alloc_fail_cnt`.

The issue was found while reviewing the heap-stat allocation wrappers and comparing their behavior with newlib's documented allocation semantics.

#### Impact of changes

Applications built with `MBED_HEAP_STATS_ENABLED` or `MBED_ALL_STATS_ENABLED` will no longer leak the original allocation when calling `realloc(ptr, 0)`.

The behavior now matches newlib's documented semantics. Applications without heap statistics enabled are unaffected.

A release note was added to `CHANGELOG.md`.

#### Migration actions required

None.

### Documentation

None. This change corrects allocator behavior and does not introduce or change a public API.

----------------------------------------------------------------------------------------------------------------

### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

Added the `realloc size zero` case to the existing `mbed-platform-stats-heap` Greentea test suite.

The test target was compile-checked successfully using:

- Target: `K64F`
- Configuration: `TESTS/configs/greentea_full.json5`
- Toolchain: GCC Arm 14.3.1
- Build target: `test-mbed-platform-stats-heap`

The test executable linked successfully and generated its ELF, BIN, and HEX outputs.

Hardware testing completed on a NUCLEO-F401RE using GCC_ARM.
test-mbed-platform-stats-heap passed all 5 test cases, including the new realloc size zero regression test.
Result: 5 passed, 0 failed.