### PR TITLE
STM32L: add upload methods for L475VG L476RG L496ZG L552ZE_Q

### DIFF
--- a/targets/upload_method_cfg/DISCO_L475VG_IOT01A.cmake
+++ b/targets/upload_method_cfg/DISCO_L475VG_IOT01A.cmake
@@ -1,0 +1,54 @@
+# Mbed OS upload method configuration file for target DISCO_L475VG_IOT01A (B-L475E-IOT01A).
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. For JLINK connect directly or convert its ST-LINK into a J-Link:
+#      https://kb.segger.com/Connecting_to_STM32_Nucleo_boards
+#      https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. For OpenOCD use Version 0.11 or newer
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L475VG)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32l475xg)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f board/st_b-l475e-iot01a.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/NUCLEO_L476RG.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L476RG.cmake
@@ -1,0 +1,55 @@
+# Mbed OS upload method configuration file for target NUCLEO_L476RG.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. For JLINK connect directly or convert its ST-LINK into a J-Link:
+#      https://kb.segger.com/Connecting_to_STM32_Nucleo_boards
+#      https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. To use this target with PyOCD, you need to install a pack:
+#      pyocd pack update && pyocd pack install STM32L476RGTx`
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L476RG)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32l476rgtx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f board/st_nucleo_l4.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/NUCLEO_L496ZG.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L496ZG.cmake
@@ -1,0 +1,56 @@
+# Mbed OS upload method configuration file for target NUCLEO_L496ZG.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. For JLINK connect directly or convert its ST-LINK into a J-Link:
+#      https://kb.segger.com/Connecting_to_STM32_Nucleo_boards
+#      https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. To use this target with PyOCD, you need to install a pack:
+#      `pyocd pack update && pyocd pack install STM32L496ZGTx`
+# 3. These settings work with a NUCLEO_L496ZG_P as well (same board with an SMPS supply)
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L496ZG)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32l496zgtx)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f board/st_nucleo_l4.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_ARGS --connect-under-reset)

--- a/targets/upload_method_cfg/NUCLEO_L552ZE_Q.cmake
+++ b/targets/upload_method_cfg/NUCLEO_L552ZE_Q.cmake
@@ -1,0 +1,57 @@
+# Mbed OS upload method configuration file for target NUCLEO_L552ZE_Q.
+# To change any of these parameters from their default values, set them in your build script between where you
+# include mbed_toolchain_setup and where you add mbed os as a subdirectory.
+
+# Notes:
+# 1. For JLINK connect directly or convert its ST-LINK into a J-Link:
+#      https://kb.segger.com/Connecting_to_STM32_Nucleo_boards
+#      https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/
+# 2. To use this target with PyOCD, you need to install a pack:
+#      `pyocd pack update && pyocd pack install STM32L552ZETxQ`
+# 3. For OpenOCD use Version 0.11 or newer
+# 4. For STLINK use Version 1.8.0 or newer
+
+# General config parameters
+# -------------------------------------------------------------
+set(UPLOAD_METHOD_DEFAULT MBED)
+
+# Config options for MBED
+# -------------------------------------------------------------
+
+set(MBED_UPLOAD_ENABLED TRUE)
+set(MBED_RESET_BAUDRATE 115200)
+
+# Config options for JLINK
+# -------------------------------------------------------------
+
+set(JLINK_UPLOAD_ENABLED TRUE)
+set(JLINK_CPU_NAME STM32L552ZE)
+set(JLINK_CLOCK_SPEED 4000)
+set(JLINK_UPLOAD_INTERFACE SWD)
+
+# Config options for PYOCD
+# -------------------------------------------------------------
+
+set(PYOCD_UPLOAD_ENABLED TRUE)
+set(PYOCD_TARGET_NAME stm32l552zetxq)
+set(PYOCD_CLOCK_SPEED 4000k)
+
+# Config options for OPENOCD
+# -------------------------------------------------------------
+
+set(OPENOCD_UPLOAD_ENABLED TRUE)
+set(OPENOCD_CHIP_CONFIG_COMMANDS
+    -f board/st_nucleo_l5.cfg)
+
+# Config options for STM32Cube
+# -------------------------------------------------------------
+
+set(STM32CUBE_UPLOAD_ENABLED TRUE)
+set(STM32CUBE_CONNECT_COMMAND -c port=SWD reset=HWrst)
+set(STM32CUBE_GDBSERVER_ARGS --swd)
+
+# Config options for stlink
+# -------------------------------------------------------------
+
+set(STLINK_UPLOAD_ENABLED TRUE)
+set(STLINK_ARGS --connect-under-reset)


### PR DESCRIPTION
### Summary of changes

Adds upload method configuration for four STM32L targets:
`DISCO_L475VG_IOT01A`, `NUCLEO_L476RG`, `NUCLEO_L496ZG` (also valid for `NUCLEO_L496ZG_P`), `NUCLEO_L552ZE_Q`.

Each config provides MBED (default), JLINK, PYOCD, OPENOCD, STM32CUBE and STLINK.

#### Impact of changes

None for other targets.

#### Migration actions required

None.

### Documentation

None. Requirements (ST-LINK to J-Link conversion, OpenOCD >= 0.11, stlink >= 1.8.0, needed PyOCD packs) are documented in each config file.

----------------------------------------------------------------------------------------------------------------

### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
 **L475:**
[L475_MBED-20260822-162629.log](https://github.com/user-attachments/files/31345784/L475_MBED-20260822-162629.log)
[L475_OPENOCD-20260822-162629.log](https://github.com/user-attachments/files/31345786/L475_OPENOCD-20260822-162629.log)
[L475_PYOCD-20260822-162629.log](https://github.com/user-attachments/files/31345787/L475_PYOCD-20260822-162629.log)
[L475_STLINK-20260822-162629.log](https://github.com/user-attachments/files/31345790/L475_STLINK-20260822-162629.log)
[L475_STM32CUBE-20260822-162629.log](https://github.com/user-attachments/files/31345792/L475_STM32CUBE-20260822-162629.log)
[L475_greentea-log-l475-20260822-170258.txt](https://github.com/user-attachments/files/31345798/L475_greentea-log-l475-20260822-170258.txt)
[L475_20260822-162629-openocd.log](https://github.com/user-attachments/files/31345796/L475_20260822-162629-openocd.log)

**L476:**
[L476_JLINK-20260822-144210.log](https://github.com/user-attachments/files/31345812/L476_JLINK-20260822-144210.log)
[L476_MBED-20260822-144210.log](https://github.com/user-attachments/files/31345814/L476_MBED-20260822-144210.log)
[L476_OPENOCD-20260822-144210.log](https://github.com/user-attachments/files/31345817/L476_OPENOCD-20260822-144210.log)
[L476_PYOCD-20260822-144554.log](https://github.com/user-attachments/files/31345819/L476_PYOCD-20260822-144554.log)
[L476_STLINK-20260822-144210.log](https://github.com/user-attachments/files/31345820/L476_STLINK-20260822-144210.log)
[L476_STM32CUBE-20260822-144210.log](https://github.com/user-attachments/files/31345821/L476_STM32CUBE-20260822-144210.log)
[L476_greentea-log-l476-20260822-155725.txt](https://github.com/user-attachments/files/31345822/L476_greentea-log-l476-20260822-155725.txt)
[L476_20260822-144210-openocd.log](https://github.com/user-attachments/files/31345823/L476_20260822-144210-openocd.log)

**L496:**
[L496_JLINK-20260822-140134.log](https://github.com/user-attachments/files/31345843/L496_JLINK-20260822-140134.log)
[L496_MBED-20260822-133846.log](https://github.com/user-attachments/files/31345844/L496_MBED-20260822-133846.log)
[L496_OPENOCD-20260822-133846.log](https://github.com/user-attachments/files/31345845/L496_OPENOCD-20260822-133846.log)
[L496_PYOCD-20260822-135503.log](https://github.com/user-attachments/files/31345846/L496_PYOCD-20260822-135503.log)
[L496_STLINK-20260822-133846.log](https://github.com/user-attachments/files/31345847/L496_STLINK-20260822-133846.log)
[L496_STM32CUBE-20260822-133846.log](https://github.com/user-attachments/files/31345848/L496_STM32CUBE-20260822-133846.log)
[L496_20260822-133846-openocd.log](https://github.com/user-attachments/files/31345850/L496_20260822-133846-openocd.log)
[L496_greentea-log-l496-20260822-140646.txt](https://github.com/user-attachments/files/31345849/L496_greentea-log-l496-20260822-140646.txt)

**L552:**
[L552_JLINK-20260822-121416.log](https://github.com/user-attachments/files/31345882/L552_JLINK-20260822-121416.log)
[L552_MBED-20260822-121416.log](https://github.com/user-attachments/files/31345883/L552_MBED-20260822-121416.log)
[L552_OPENOCD-20260822-121416.log](https://github.com/user-attachments/files/31345886/L552_OPENOCD-20260822-121416.log)
[L552_PYOCD-20260822-122245.log](https://github.com/user-attachments/files/31345888/L552_PYOCD-20260822-122245.log)
[L552_STLINK-20260822-121416.log](https://github.com/user-attachments/files/31345889/L552_STLINK-20260822-121416.log)
[L552_STM32CUBE-20260822-121416.log](https://github.com/user-attachments/files/31345890/L552_STM32CUBE-20260822-121416.log)
[L552_greentea-log-l552-20260822-123954.txt](https://github.com/user-attachments/files/31345892/L552_greentea-log-l552-20260822-123954.txt)