### PR TITLE
BufferedSerial: add watermark function and queue size getters

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,5 +55,3 @@
     [] Covered by existing mbed-os tests (Greentea or Unittest)
     [] Tests / results supplied as part of this PR
     
-    
-----------------------------------------------------------------------------------------------------------------

--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -233,6 +233,7 @@ jobs:
           fetch-depth: 0
 
       - name: validate pins
+        shell: bash
         run: |
           set -x
           python3 -m venv .venv
@@ -256,5 +257,5 @@ jobs:
         run: |
           set -x
           ctest --build-and-test . build --build-generator Ninja --build-options -DMBED_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON --test-command ctest --output-on-failure
-          gcovr --gcov-executable gcov -r . ./build -s -e ".*\.h" --exclude-directories=${GITHUB_WORKSPACE}/build/UNITTESTS --exclude-directories=${GITHUB_WORKSPACE}/build/_deps
+          gcovr --gcov-executable gcov --merge-mode-functions separate -r . ./build -s -e ".*\.h" --exclude-directories=${GITHUB_WORKSPACE}/build/UNITTESTS --exclude-directories=${GITHUB_WORKSPACE}/build/_deps
           ccache -s

--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -21,7 +21,9 @@ jobs:
       # Note: For this CI job we use MBED_CREATE_PYTHON_VENV=FALSE so that we can make sure
       # this mode works.
       - name: Build the multiple_executables example
+        shell: bash
         run: |
+          source .venv/bin/activate
           cd tools/cmake/tests/multiple_executables/
           mkdir cmake_build
           cd cmake_build

--- a/.github/workflows/test_building_multiple_executables.yml
+++ b/.github/workflows/test_building_multiple_executables.yml
@@ -12,14 +12,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Python packages
-        # Note: pip>=20.3 is needed to install dependencies of cysecuretools
+        shell: bash
         run: |
-          python3 -m pip install --upgrade pip
-
-          python3 -m pip install -e ./tools
-
-          # Also install cysecuretools which is not installed automatically
-          python3 -m pip install 'cysecuretools~=6.1'
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -e ./tools
 
       # Note: For this CI job we use MBED_CREATE_PYTHON_VENV=FALSE so that we can make sure
       # this mode works.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ A message that notes the main changes in the update.
 - Added a new `MBED_NONCACHED` define which can be used to store global variables in non-cached memory on devices with a data cache. This is supported on STM32F7, STM32H7, and MIMXRT (which I believe are the only currently supported MCUs with a D-cache)
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
-- MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.
+- MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.'
+- Added Rx FIFO watermark to `BufferedSerial`. This allows detecting if the Rx buffer has overflowed (likely as a hint that its size should be increased)
+- Added `BufferedSerial::tx_buffer_size()` and `BufferedSerial::rx_buffer_size()` to check the current size of the Tx and Rx buffers.
 - EFM32 Giant Gecko Series 0:
   - `EFM32GG_STK3700` added upload method config
 - MIMXRT117x: Memory bank configuration is now supported in the linker script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ A message that notes the main changes in the update.
 - Added a new global, `mbed_used_mpu_regions`, which gives the number of MPU regions used by Mbed. This is intended to allow applications to also use the MPU without creating breakages in the future if Mbed uses additional MPU regions.
 - Added new header, `mbed_math_helpers.h`, containing some useful math functions. Currently this contains `mbed_integer_log_2()` and `mbed_is_power_of_two()`
 - MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.'
-- Added Rx FIFO watermark to `BufferedSerial`. This allows detecting if the Rx buffer has overflowed (likely as a hint that its size should be increased)
+- Added Rx FIFO overflow flag to `BufferedSerial`. This allows detecting if the Rx buffer has overflowed (likely as a hint that its size should be increased)
 - Added `BufferedSerial::tx_buffer_size()` and `BufferedSerial::rx_buffer_size()` to check the current size of the Tx and Rx buffers.
 - EFM32 Giant Gecko Series 0:
   - `EFM32GG_STK3700` added upload method config

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -270,27 +270,43 @@ public:
     /**
      * @brief Get the Rx full watermark, which indicates if the Rx buffer has completely filled at any point.
      *
-     * This flag is a sign that the buffer size of this buffered serial should be increased.
+     * When the Rx buffer becomes full, %BufferedSerial stops dequeuing data from the UART hardware until
+     * the application reads some data out of the buffer. If the hardware FIFO also runs out of space during
+     * this time, additional Rx data may be lost. So, this flag is a sign that either the application needs
+     * to read data from this %BufferedSerial more often, or the buffer size should be increased.
+     *
      * The watermark may be cleared by calling \c clear_rx_full_watermark() .
      *
-     * @return True iff the internal Rx buffer has been totally full since the last clear.
+     * @return True iff the internal Rx buffer has been totally full since initialization or the last clear.
      */
-    bool get_rx_full_watermark() const { return _rx_full_watermark;}
+    bool get_rx_full_watermark() const
+    {
+        return _rx_full_watermark;
+    }
 
     /// Clear the Rx full watermark. See \c get_rx_full_watermark() for details.
-    void clear_rx_full_watermark() { _rx_full_watermark = false; }
+    void clear_rx_full_watermark()
+    {
+        _rx_full_watermark = false;
+    }
 
     /// @brief Get the number of bytes currently queued in the Rx buffer in this BufferedSerial instance.
     ///
     /// This does NOT include any bytes queued in the hardware UART peripheral and not added to the buffer yet.
     /// So, there may be more than this number of total bytes that have been received from the line so far.
-    size_t rx_buffer_size() const { return _rxbuf.size(); }
+    size_t rx_buffer_size() const
+    {
+        return _rxbuf.size();
+    }
 
     /// @brief Get the number of bytes currently queued in the Tx buffer in this BufferedSerial instance.
     ///
     /// This does NOT include any bytes queued in the hardware UART peripheral waiting to be sent out.
     /// So, there may be more than this number of total bytes queued to be sent out.
-    size_t tx_buffer_size() const { return _txbuf.size(); }
+    size_t tx_buffer_size() const
+    {
+        return _txbuf.size();
+    }
 
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -380,7 +380,7 @@ private:
     bool _tx_irq_enabled = false;
     bool _rx_irq_enabled = false;
     InterruptIn *_dcd_irq = nullptr;
-    mstd::atomic<bool> _rx_overflow_flag = false;
+    mstd::atomic<bool> _rx_overflow_flag{};
 
     /** Device Hanged up
      *  Determines if the device hanged up on us.

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -267,6 +267,31 @@ public:
         int bits = 8, Parity parity = BufferedSerial::None, int stop_bits = 1
     );
 
+    /**
+     * @brief Get the Rx full watermark, which indicates if the Rx buffer has completely filled at any point.
+     *
+     * This flag is a sign that the buffer size of this buffered serial should be increased.
+     * The watermark may be cleared by calling \c clear_rx_full_watermark() .
+     *
+     * @return True iff the internal Rx buffer has been totally full since the last clear.
+     */
+    bool get_rx_full_watermark() const { return _rx_full_watermark;}
+
+    /// Clear the Rx full watermark. See \c get_rx_full_watermark() for details.
+    void clear_rx_full_watermark() { _rx_full_watermark = false; }
+
+    /// @brief Get the number of bytes currently queued in the Rx buffer in this BufferedSerial instance.
+    ///
+    /// This does NOT include any bytes queued in the hardware UART peripheral and not added to the buffer yet.
+    /// So, there may be more than this number of total bytes that have been received from the line so far.
+    size_t rx_buffer_size() const { return _rxbuf.size(); }
+
+    /// @brief Get the number of bytes currently queued in the Tx buffer in this BufferedSerial instance.
+    ///
+    /// This does NOT include any bytes queued in the hardware UART peripheral waiting to be sent out.
+    /// So, there may be more than this number of total bytes queued to be sent out.
+    size_t tx_buffer_size() const { return _txbuf.size(); }
+
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.
@@ -338,6 +363,7 @@ private:
     bool _tx_irq_enabled = false;
     bool _rx_irq_enabled = false;
     InterruptIn *_dcd_irq = nullptr;
+    bool _rx_full_watermark = false;
 
     /** Device Hanged up
      *  Determines if the device hanged up on us.

--- a/drivers/include/drivers/BufferedSerial.h
+++ b/drivers/include/drivers/BufferedSerial.h
@@ -28,6 +28,7 @@
 #include "rtos/Mutex.h"
 #include "platform/CircularBuffer.h"
 #include "platform/NonCopyable.h"
+#include <mstd_atomic>
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE
 #define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE  256
@@ -268,26 +269,26 @@ public:
     );
 
     /**
-     * @brief Get the Rx full watermark, which indicates if the Rx buffer has completely filled at any point.
+     * @brief Get the Rx overflow flag, which indicates if the Rx buffer has completely filled at any point.
      *
      * When the Rx buffer becomes full, %BufferedSerial stops dequeuing data from the UART hardware until
      * the application reads some data out of the buffer. If the hardware FIFO also runs out of space during
      * this time, additional Rx data may be lost. So, this flag is a sign that either the application needs
      * to read data from this %BufferedSerial more often, or the buffer size should be increased.
      *
-     * The watermark may be cleared by calling \c clear_rx_full_watermark() .
+     * The flag may be cleared by calling \c clear_rx_overflow_flag() .
      *
      * @return True iff the internal Rx buffer has been totally full since initialization or the last clear.
      */
-    bool get_rx_full_watermark() const
+    bool get_rx_overflow_flag() const
     {
-        return _rx_full_watermark;
+        return _rx_overflow_flag;
     }
 
-    /// Clear the Rx full watermark. See \c get_rx_full_watermark() for details.
-    void clear_rx_full_watermark()
+    /// Clear the Rx overflow flag. See \c get_rx_overflow_flag() for details.
+    void clear_rx_overflow_flag()
     {
-        _rx_full_watermark = false;
+        _rx_overflow_flag = false;
     }
 
     /// @brief Get the number of bytes currently queued in the Rx buffer in this BufferedSerial instance.
@@ -379,7 +380,7 @@ private:
     bool _tx_irq_enabled = false;
     bool _rx_irq_enabled = false;
     InterruptIn *_dcd_irq = nullptr;
-    bool _rx_full_watermark = false;
+    mstd::atomic<bool> _rx_overflow_flag = false;
 
     /** Device Hanged up
      *  Determines if the device hanged up on us.

--- a/drivers/include/drivers/SerialBase.h
+++ b/drivers/include/drivers/SerialBase.h
@@ -75,7 +75,7 @@ public:
         /// When this flow control is active, the RTS signal will normally be asserted (low),
         /// but will go deasserted (high) if the Mbed MCU might not have Rx buffer space to store another byte.
         /// Note that in this configuration the RTS signal actually operates as a "ready to receive" (RTR) output,
-        /// not a true RTS.
+        /// not a true RTS. This is a misnomer that has (horrifyingly) persisted in the standard for decades.
         RTS,
 
         /// RS-232 CTS flow control. This is used to prevent the Mbed MCU from sending more bytes than the

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -282,7 +282,7 @@ void BufferedSerial::rx_irq(void)
     }
 
     if (_rx_irq_enabled && _rxbuf.full()) {
-        _rx_full_watermark = true;
+        _rx_overflow_flag = true;
         disable_rx_irq();
     }
 

--- a/drivers/source/BufferedSerial.cpp
+++ b/drivers/source/BufferedSerial.cpp
@@ -282,6 +282,7 @@ void BufferedSerial::rx_irq(void)
     }
 
     if (_rx_irq_enabled && _rxbuf.full()) {
+        _rx_full_watermark = true;
         disable_rx_irq();
     }
 

--- a/hal/include/hal/serial_api.h
+++ b/hal/include/hal/serial_api.h
@@ -147,6 +147,9 @@ extern "C" {
  * the ::serial_irq_handler is called instantly.
  * * ::serial_getc returns the character from serial buffer.
  * * ::serial_getc is a blocking call (waits for the character).
+ * * If ::serial_getc is not called often enough relative to incoming data, the UART's Rx register and/or FIFO may overflow.
+ *    If this does occur, data may be lost. However, calling \c serial_getc() again will read out
+ *    at least some of the received data, and reception can continue normally after the overflow.
  * * ::serial_putc sends a character.
  * * ::serial_putc is a blocking call (waits for a peripheral to be available).
  * * ::serial_readable returns non-zero value if a character can be read, 0 otherwise.

--- a/tools/test/ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/ci/doxy-spellchecker/ignore.en.pws
@@ -122,6 +122,7 @@ instantiations
 KVStore
 cpp
 PRIi
+dequeuing
 _doxy_
 nothrow
 conf


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This PR adds some new functionality to BufferedSerial for checking the queue size: a "watermark" function to detect if the Rx queue has overflowed, and getters to get the current queue sizes.

These were needed for new UART tests I'm adding with the CI shield, but also seem like useful functions to have in general.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    Please add a short summary of this field to the release notes at the top of CHANGELOG.md.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
    Again, please include this information in the changelog for the next release.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Added for new functions

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
Passes CI shield tests that use these functions: https://github.com/mbed-ce/mbed-ce-test-tools/blob/2d3c6b8bf15fd48b08cbc04fe71347fc46b2a7f0/CI-Shield-Tests/UARTTest.cpp#L261

----------------------------------------------------------------------------------------------------------------
