### PR TITLE
Kinetis USB: include <stddef.h> and <string.h>

### DIFF
--- a/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
+++ b/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
@@ -20,6 +20,9 @@
      defined(TARGET_KL46Z) | \
      defined(TARGET_K64F) | defined(TARGET_K22F) | defined(TARGET_K82F))
 
+#include <stddef.h>   // NULL
+#include <string.h>   // memset
+
 #if defined(TARGET_KSDK2_MCUS)
 #include "fsl_common.h"
 #endif


### PR DESCRIPTION
Fixes #617.

`USBPhy_Kinetis.cpp` uses `NULL` in five places and `memset` in two, but includes
neither `<stddef.h>` nor `<string.h>`, and nothing it does include pulls them in
transitively. The file does not compile.

The includes go outside the `TARGET_KSDK2_MCUS` guard on purpose: the targets that
reach this file without `fsl_common.h` are exactly the ones that need them.

Verified by building a USB device firmware for the FRDM-KL25Z against this branch —
a HID joystick + keyboard composite, which enumerates and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENsGGxgZ7pU5Z87YfBS2iY
