### PR TITLE
USBDevice: let a device class provide its own string descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ A message that notes the main changes in the update.
 - MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.'
 - Added Rx FIFO overflow flag to `BufferedSerial`. This allows detecting if the Rx buffer has overflowed (likely as a hint that its size should be increased)
 - Added `BufferedSerial::tx_buffer_size()` and `BufferedSerial::rx_buffer_size()` to check the current size of the Tx and Rx buffers.
-- Added a hook allowing `USBDevice` subclasses to send additional string descriptors, via the new `USBDevice::string_ext_desc()` virtual. This is needed by device classes whose descriptors reference a string of their own -- a HID report item's String Index, for instance. The base implementation returns NULL for every index, so an index the standard descriptors do not cover still fails exactly as before.
+- Added a hook allowing `USBDevice` subclasses to send additional string descriptors, via the new `USBDevice::string_ext_desc()` virtual.
 - EFM32 Giant Gecko Series 0:
   - `EFM32GG_STK3700` added upload method config
 - MIMXRT117x: Memory bank configuration is now supported in the linker script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ A message that notes the main changes in the update.
 - MPU configuration code gained the ability to create a noncached section and a ram function section (for code that has to be executed out of RAM). This RAM function section is an exception to the normal limitations on RAM execution.'
 - Added Rx FIFO overflow flag to `BufferedSerial`. This allows detecting if the Rx buffer has overflowed (likely as a hint that its size should be increased)
 - Added `BufferedSerial::tx_buffer_size()` and `BufferedSerial::rx_buffer_size()` to check the current size of the Tx and Rx buffers.
+- Added a hook allowing `USBDevice` subclasses to send additional string descriptors, via the new `USBDevice::string_ext_desc()` virtual. This is needed by device classes whose descriptors reference a string of their own -- a HID report item's String Index, for instance. The base implementation returns NULL for every index, so an index the standard descriptors do not cover still fails exactly as before.
 - EFM32 Giant Gecko Series 0:
   - `EFM32GG_STK3700` added upload method config
 - MIMXRT117x: Memory bank configuration is now supported in the linker script.

--- a/drivers/usb/include/usb/internal/USBDevice.h
+++ b/drivers/usb/include/usb/internal/USBDevice.h
@@ -320,6 +320,20 @@ public:
     */
     virtual const uint8_t *string_iinterface_desc();
 
+    /**
+    * Get a string descriptor the device class defines for itself
+    *
+    * Called for any string index the standard descriptors above do not
+    * cover, which lets a class serve strings referenced from its own
+    * descriptors -- a HID report item's String Index, for instance.
+    *
+    * @param index string descriptor index being requested
+    * @returns pointer to the string descriptor, or NULL if this index is
+    * not one the device defines. The default implementation returns NULL
+    * for every index, so the request fails exactly as it did before.
+    */
+    virtual const uint8_t *string_ext_desc(uint8_t index);
+
     /*
     * Get the length of the report descriptor
     *

--- a/drivers/usb/source/USBDevice.cpp
+++ b/drivers/usb/source/USBDevice.cpp
@@ -161,6 +161,17 @@ bool USBDevice::_request_get_descriptor()
                     _transfer.direction = Send;
                     success = true;
                     break;
+                default:
+                    // Any index the standard descriptors don't cover: let the
+                    // device class answer for itself. The base implementation
+                    // returns NULL, so an unknown index still fails as before.
+                    if (const uint8_t *desc = string_ext_desc(DESCRIPTOR_INDEX(_transfer.setup.wValue))) {
+                        _transfer.remaining = desc[0];
+                        _transfer.ptr = (uint8_t *)desc;
+                        _transfer.direction = Send;
+                        success = true;
+                    }
+                    break;
             }
             break;
         }
@@ -1684,6 +1695,13 @@ const uint8_t *USBDevice::string_iserial_desc()
         '0', 0, '1', 0, '2', 0, '3', 0, '4', 0, '5', 0, '6', 0, '7', 0, '8', 0, '9', 0, /*bString iSerial - 0123456789*/
     };
     return string_iserial_descriptor;
+}
+
+const uint8_t *USBDevice::string_ext_desc(uint8_t index)
+{
+    // No extra string descriptors by default.
+    (void)index;
+    return NULL;
 }
 
 const uint8_t *USBDevice::string_iconfiguration_desc()


### PR DESCRIPTION
Fixes #619.

`GET_DESCRIPTOR(STRING)` is handled by a closed switch over six indices with no
`default:` case, so a request for any other index falls through with `success` still
false and fails. A device class has no way to define a string descriptor of its own at
an index it chooses.

That matters for HID usage labels, where a report descriptor attaches a String Index to
an item and the host matches on the string. Open Pinball Device works that way: it
identifies its report structure and version by a string reading
`OpenPinballDeviceStruct/1.0`, and says explicitly that the interface is not identified
by VID/PID, so that any vendor can implement it. On Mbed that specification cannot be
implemented at all today.

`string_ext_desc()` is consulted only for indices the standard descriptors do not
cover, and the base implementation returns NULL for every index — so an unknown index
still fails exactly as it does now. The change is observable only to a class that
overrides the method, which should make it cheap to review: the behaviour of every
existing device is unchanged by construction.

Verified by building a USB device firmware for the FRDM-KL25Z against this branch;
20 bytes of flash, no RAM.

I'm not attached to this shape — a registered lookup table, or a per-class descriptor
list, would work as well. Happy to rework it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENsGGxgZ7pU5Z87YfBS2iY
