### PR TITLE
Fix RAM Vector Table address in STM32F7

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/linker_scripts/STM32F7_COMMON.ld
@@ -134,9 +134,9 @@ SECTIONS
     __etext = .;
     _sidata = .;
 
-    /* Stick the vector table at start of SRAM */
     .vector_ram (NOLOAD) :
     {
+        . = ALIGN(512);
         __vector_ram_start__ = .;
         . += __vector_table_size__;
         __vector_ram_end__ = .;


### PR DESCRIPTION
### Summary of changes <!-- Required -->

A .noncached section has recently been added to the STM32F7 linker script. It is placed before the existing .vector_ram section, causing .vector_ram to no longer be 512-byte aligned by default. However, the STM32F7 requires VTOR to be aligned to a 512-byte boundary; when a non-aligned address is written to VTOR, the lower bits of the address are simply ignored. For example, if the .noncached section has a size of 0x20 bytes, __vector_ram_start__ will be located at address 0x20000020. The interrupt vector table is copied from Flash to this address, yet the effective VTOR value remains 0x20000000. This results in a misaligned interrupt vector table, rendering virtually all programs that include a .noncached section non-functional.

To solve this, we can simply add a ALIGN(512) specifier before the __vector_ram_start__ symbol.

#### Impact of changes <!-- Optional -->

None

#### Migration actions required <!-- Optional -->

None

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------

### Pull request type <!-- Required -->

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------

### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
This PR is verified to work on DISCO-F746NG.
